### PR TITLE
PR: Implement support for "Recommendation ITU-R BT.1886" and "SMPTE ST 2084:2014".

### DIFF
--- a/colour/models/rgb/__init__.py
+++ b/colour/models/rgb/__init__.py
@@ -14,37 +14,8 @@ from .derivation import (
     RGB_luminance)
 from .dataset import *  # noqa
 from . import dataset
-from .conversion_functions import (
-    LINEAR_TO_LOG_METHODS,
-    LOG_TO_LINEAR_METHODS)
-from .conversion_functions import linear_to_log, log_to_linear
-from .conversion_functions import (
-    linear_to_cineon,
-    cineon_to_linear,
-    linear_to_panalog,
-    panalog_to_linear,
-    linear_to_red_log_film,
-    red_log_film_to_linear,
-    linear_to_viper_log,
-    viper_log_to_linear,
-    linear_to_pivoted_log,
-    pivoted_log_to_linear,
-    linear_to_c_log,
-    c_log_to_linear,
-    linear_to_aces_cc,
-    aces_cc_to_linear,
-    linear_to_alexa_log_c,
-    alexa_log_c_to_linear,
-    linear_to_dci_p3_log,
-    dci_p3_log_to_linear,
-    linear_to_s_log,
-    s_log_to_linear,
-    linear_to_s_log2,
-    s_log2_to_linear,
-    linear_to_s_log3,
-    s_log3_to_linear,
-    linear_to_v_log,
-    v_log_to_linear)
+from .conversion_functions import *  # noqa
+from . import conversion_functions
 from .common import XYZ_to_sRGB, sRGB_to_XYZ
 from .aces_it import spectral_to_aces_relative_exposure_values
 
@@ -57,33 +28,6 @@ __all__ += ['normalised_primary_matrix',
             'RGB_luminance_equation',
             'RGB_luminance']
 __all__ += dataset.__all__
-__all__ += ['LINEAR_TO_LOG_METHODS', 'LOG_TO_LINEAR_METHODS']
-__all__ += ['linear_to_log', 'log_to_linear']
-__all__ += ['linear_to_cineon',
-            'cineon_to_linear',
-            'linear_to_panalog',
-            'panalog_to_linear',
-            'linear_to_red_log_film',
-            'red_log_film_to_linear',
-            'linear_to_viper_log',
-            'viper_log_to_linear',
-            'linear_to_pivoted_log',
-            'pivoted_log_to_linear',
-            'linear_to_c_log',
-            'c_log_to_linear',
-            'linear_to_aces_cc',
-            'aces_cc_to_linear',
-            'linear_to_alexa_log_c',
-            'alexa_log_c_to_linear',
-            'linear_to_s_log',
-            'linear_to_dci_p3_log',
-            'dci_p3_log_to_linear',
-            's_log_to_linear',
-            'linear_to_s_log2',
-            's_log2_to_linear',
-            'linear_to_s_log3',
-            's_log3_to_linear',
-            'linear_to_v_log',
-            'v_log_to_linear']
+__all__ += conversion_functions.__all__
 __all__ += ['XYZ_to_sRGB', 'sRGB_to_XYZ']
 __all__ += ['spectral_to_aces_relative_exposure_values']

--- a/colour/models/rgb/conversion_functions/__init__.py
+++ b/colour/models/rgb/conversion_functions/__init__.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+
+from .log import (
+    LINEAR_TO_LOG_METHODS,
+    LOG_TO_LINEAR_METHODS)
+from .log import linear_to_log, log_to_linear
+from .log import (
+    linear_to_cineon,
+    cineon_to_linear,
+    linear_to_panalog,
+    panalog_to_linear,
+    linear_to_red_log_film,
+    red_log_film_to_linear,
+    linear_to_viper_log,
+    viper_log_to_linear,
+    linear_to_pivoted_log,
+    pivoted_log_to_linear,
+    linear_to_c_log,
+    c_log_to_linear,
+    linear_to_aces_cc,
+    aces_cc_to_linear,
+    linear_to_alexa_log_c,
+    alexa_log_c_to_linear,
+    linear_to_dci_p3_log,
+    dci_p3_log_to_linear,
+    linear_to_s_log,
+    s_log_to_linear,
+    linear_to_s_log2,
+    s_log2_to_linear,
+    linear_to_s_log3,
+    s_log3_to_linear,
+    linear_to_v_log,
+    v_log_to_linear)
+
+__all__ = ['LINEAR_TO_LOG_METHODS', 'LOG_TO_LINEAR_METHODS']
+__all__ += ['linear_to_log', 'log_to_linear']
+__all__ += ['linear_to_cineon',
+            'cineon_to_linear',
+            'linear_to_panalog',
+            'panalog_to_linear',
+            'linear_to_red_log_film',
+            'red_log_film_to_linear',
+            'linear_to_viper_log',
+            'viper_log_to_linear',
+            'linear_to_pivoted_log',
+            'pivoted_log_to_linear',
+            'linear_to_c_log',
+            'c_log_to_linear',
+            'linear_to_aces_cc',
+            'aces_cc_to_linear',
+            'linear_to_alexa_log_c',
+            'alexa_log_c_to_linear',
+            'linear_to_s_log',
+            'linear_to_dci_p3_log',
+            'dci_p3_log_to_linear',
+            's_log_to_linear',
+            'linear_to_s_log2',
+            's_log2_to_linear',
+            'linear_to_s_log3',
+            's_log3_to_linear',
+            'linear_to_v_log',
+            'v_log_to_linear']

--- a/colour/models/rgb/conversion_functions/__init__.py
+++ b/colour/models/rgb/conversion_functions/__init__.py
@@ -35,6 +35,7 @@ from .log import (
     s_log3_to_linear,
     linear_to_v_log,
     v_log_to_linear)
+from .st_2084 import ST_2084_EOCF, ST_2084_OECF
 
 __all__ = ['BT_1886_EOCF']
 __all__ += ['LINEAR_TO_LOG_METHODS', 'LOG_TO_LINEAR_METHODS']
@@ -65,3 +66,4 @@ __all__ += ['linear_to_cineon',
             's_log3_to_linear',
             'linear_to_v_log',
             'v_log_to_linear']
+__all__ += ['ST_2084_EOCF', 'ST_2084_OECF']

--- a/colour/models/rgb/conversion_functions/__init__.py
+++ b/colour/models/rgb/conversion_functions/__init__.py
@@ -3,6 +3,7 @@
 
 from __future__ import absolute_import
 
+from .bt_1886 import BT_1886_EOCF
 from .log import (
     LINEAR_TO_LOG_METHODS,
     LOG_TO_LINEAR_METHODS)
@@ -35,7 +36,8 @@ from .log import (
     linear_to_v_log,
     v_log_to_linear)
 
-__all__ = ['LINEAR_TO_LOG_METHODS', 'LOG_TO_LINEAR_METHODS']
+__all__ = ['BT_1886_EOCF']
+__all__ += ['LINEAR_TO_LOG_METHODS', 'LOG_TO_LINEAR_METHODS']
 __all__ += ['linear_to_log', 'log_to_linear']
 __all__ += ['linear_to_cineon',
             'cineon_to_linear',

--- a/colour/models/rgb/conversion_functions/bt_1886.py
+++ b/colour/models/rgb/conversion_functions/bt_1886.py
@@ -38,7 +38,7 @@ __all__ = ['BT_1886_EOCF']
 
 def BT_1886_EOCF(V, L_W=940, L_B=64):
     """
-    Defines *Recommendation ITU-R BT.1886* Electro-optical transfer function
+    Defines *Recommendation ITU-R BT.1886* electro-optical transfer function
     (EOTF / EOCF).
 
     Parameters

--- a/colour/models/rgb/conversion_functions/bt_1886.py
+++ b/colour/models/rgb/conversion_functions/bt_1886.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+ITU-R BT.1886 EOTF / EOCF
+=========================
+
+Defines *Recommendation ITU-R BT.1886* EOTF / EOCF:
+
+-   :func:`BT_1886_EOCF`
+
+See Also
+--------
+`ITU-R BT.1886 EOTF / EOCF IPython Notebook
+<http://nbviewer.ipython.org/github/colour-science/colour-ipython/\
+blob/master/notebooks/models/bt_1886.ipynb>`_
+
+References
+----------
+.. [1]  International Telecommunication Union. (2011). Recommendation ITU-R
+        BT.1886 - Reference electro-optical transfer function for flat panel
+        displays used in HDTV studio production BT Series Broadcasting service.
+"""
+
+from __future__ import division, unicode_literals
+
+import numpy as np
+
+__author__ = 'Colour Developers'
+__copyright__ = 'Copyright (C) 2013 - 2015 - Colour Developers'
+__license__ = 'New BSD License - http://opensource.org/licenses/BSD-3-Clause'
+__maintainer__ = 'Colour Developers'
+__email__ = 'colour-science@googlegroups.com'
+__status__ = 'Production'
+
+__all__ = ['BT_1886_EOCF']
+
+
+def BT_1886_EOCF(V, L_W=940, L_B=64):
+    """
+    Defines *Recommendation ITU-R BT.1886* Electro-optical transfer function
+    (EOTF / EOCF).
+
+    Parameters
+    ----------
+    V : numeric or array_like
+        Input video signal level (normalized, black at :math:`V = 0`, to white
+        at :math:`V = 1`. For content mastered per
+        *Recommendation ITU-R BT.709*, 10-bit digital code values :math:`D` map
+        into values of :math:`V` per the following equation:
+        :math:`V = (D–64)/876`
+    L_W : numeric, optional
+        Screen luminance for white.
+    L_B : numeric, optional
+        Screen luminance for black.
+
+    Returns
+    -------
+    numeric or ndarray
+        Screen luminance in :math:`cd/m^2`.
+
+    Examples
+    --------
+    >>> BT_1886_EOCF(0.5)  # doctest: +ELLIPSIS
+    350.8224951...
+    """
+
+    V = np.asarray(V)
+
+    gamma = 2.40
+    gamma_d = 1 / gamma
+
+    n = L_W ** gamma_d - L_B ** gamma_d
+    a = n ** gamma
+    b = L_B ** gamma_d / n
+    L = a * np.maximum(V + b, 0) ** gamma
+
+    return L

--- a/colour/models/rgb/conversion_functions/log.py
+++ b/colour/models/rgb/conversion_functions/log.py
@@ -2,10 +2,10 @@
 # -*- coding: utf-8 -*-
 
 """
-Conversion Functions
-====================
+Log Conversion Functions
+========================
 
-Defines various conversion functions:
+Defines various log conversion functions:
 
 -   :attr:`linear_to_cineon`
 -   :attr:`cineon_to_linear`
@@ -36,7 +36,7 @@ Defines various conversion functions:
 
 See Also
 --------
-`Conversion Functions IPython Notebook
+`Log Conversion Functions IPython Notebook
 <http://nbviewer.ipython.org/github/colour-science/colour-ipython/\
 blob/master/notebooks/models/log.ipynb>`_
 

--- a/colour/models/rgb/conversion_functions/st_2084.py
+++ b/colour/models/rgb/conversion_functions/st_2084.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+SMPTE ST 2084:2014 EOTF / EOCF and OETF / EOCF
+==============================================
+
+Defines *SMPTE ST 2084:2014* EOTF / EOCF and OETF / EOCF:
+
+-   :func:`ST_2084_EOCF`
+-   :func:`ST_2084_OECF`
+
+See Also
+--------
+`SMPTE ST 2084:2014 EOTF / EOCF and OETF / EOCF IPython Notebook
+<http://nbviewer.ipython.org/github/colour-science/colour-ipython/\
+blob/master/notebooks/models/st_2084.ipynb>`_
+
+References
+----------
+.. [1]  SMPTE. (2014). SMPTE ST 2084:2014 - Dynamic Range Electro-Optical
+        Transfer Function of Mastering Reference Displays.
+        doi:10.5594/SMPTE.ST2084.2014
+.. [2]  Miller, S., & Dolby Laboratories. (2014). A Perceptual EOTF for
+        Extended Dynamic Range Imagery, 1–17. Retrieved from
+        https://www.smpte.org/sites/default/files/\
+2014-05-06-EOTF-Miller-1-2-handout.pdf
+"""
+
+from __future__ import division, unicode_literals
+
+import numpy as np
+
+from colour.utilities import Structure
+
+__author__ = 'Colour Developers'
+__copyright__ = 'Copyright (C) 2013 - 2015 - Colour Developers'
+__license__ = 'New BSD License - http://opensource.org/licenses/BSD-3-Clause'
+__maintainer__ = 'Colour Developers'
+__email__ = 'colour-science@googlegroups.com'
+__status__ = 'Production'
+
+__all__ = ['ST_2084_CONSTANTS',
+           'ST_2084_EOCF',
+           'ST_2084_OECF']
+
+ST_2084_CONSTANTS = Structure(m_1=2610 / 4096 * (1 / 4),
+                              m_2=2523 / 4096 * 128,
+                              c_1=3424 / 4096,
+                              c_2=2413 / 4096 * 32,
+                              c_3=2392 / 4096 * 32)
+"""
+*SMPTE ST 2084:2014* EOTF / EOCF and OETF / EOCF constants.
+
+ST_2084_CONSTANTS : Structure
+"""
+
+
+def ST_2084_EOCF(V, L=10000):
+    """
+    Defines *SMPTE ST 2084:2014* optimised perceptual electro-optical transfer
+    function (EOTF / EOCF). This perceptual quantizer (PQ) has been modeled by
+    Dolby Laboratories by using Barten (1999) contrast sensitivity function.
+
+    Parameters
+    ----------
+    V : numeric or array_like
+        Input video signal level.
+    L : numeric, optional
+        Display peak luminance :math:`cd/m^2`.
+
+    Returns
+    -------
+    numeric or ndarray
+         Absolute display luminance levels in :math:`cd/m^2`.
+
+    Examples
+    --------
+    >>> ST_2084_EOCF(0.5)  # doctest: +ELLIPSIS
+    92.2457089...
+    """
+
+    V = np.asarray(V)
+    C = ST_2084_CONSTANTS
+
+    m_1_d = 1 / C.m_1
+    m_2_d = 1 / C.m_2
+
+    V_p = V ** m_2_d
+
+    n = V_p - C.c_1
+    # Preventing *nan*.
+    n = np.where(n < 0, 0, n)
+
+    Y = L * (n / (C.c_2 - C.c_3 * V_p)) ** m_1_d
+
+    return Y
+
+
+def ST_2084_OECF(Y, L=10000):
+    """
+    Defines *SMPTE ST 2084:2014* optimised perceptual opto-electronic transfer
+    function (OETF / OECF).
+
+    Parameters
+    ----------
+    Y : numeric or array_like
+        Absolute display luminance levels in :math:`cd/m^2`.
+    L : numeric, optional
+        Display peak luminance :math:`cd/m^2`.
+
+    Returns
+    -------
+    numeric or ndarray
+        Input video signal level.
+
+    Examples
+    --------
+    >>> ST_2084_OECF(92.245708994065268)  # doctest: +ELLIPSIS
+    0.5000000...
+    """
+
+    Y = np.asarray(Y)
+    C = ST_2084_CONSTANTS
+
+    Y_p = (Y / L) ** C.m_1
+
+    V = ((C.c_1 + C.c_2 * Y_p) / (C.c_3 * Y_p + 1)) ** C.m_2
+
+    return V

--- a/colour/models/rgb/conversion_functions/tests/__init__.py
+++ b/colour/models/rgb/conversion_functions/tests/__init__.py
@@ -1,0 +1,2 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-

--- a/colour/models/rgb/conversion_functions/tests/tests_bt_1886.py
+++ b/colour/models/rgb/conversion_functions/tests/tests_bt_1886.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Defines unit tests for :mod:`colour.models.rgb.conversion_functions.bt_1886`
+module.
+"""
+
+from __future__ import division, unicode_literals
+
+import numpy as np
+import unittest
+
+from colour.models.rgb.conversion_functions import BT_1886_EOCF
+from colour.utilities import ignore_numpy_errors
+
+__author__ = 'Colour Developers'
+__copyright__ = 'Copyright (C) 2013 - 2015 - Colour Developers'
+__license__ = 'New BSD License - http://opensource.org/licenses/BSD-3-Clause'
+__maintainer__ = 'Colour Developers'
+__email__ = 'colour-science@googlegroups.com'
+__status__ = 'Production'
+
+__all__ = ['TestBT_1886_EOCF']
+
+
+class TestBT_1886_EOCF(unittest.TestCase):
+    """
+    Defines :func:`colour.models.rgb.conversion_functions.bt_1886.BT_1886_EOCF`
+    definition unit tests methods.
+    """
+
+    def test_BT_1886_EOCF(self):
+        """
+        Tests :func:`colour.models.rgb.conversion_functions.bt_1886.\
+BT_1886_EOCF` definition.
+        """
+
+        self.assertAlmostEqual(
+            BT_1886_EOCF(0.00),
+            64.0,
+            places=7)
+
+        self.assertAlmostEqual(
+            BT_1886_EOCF(0.50),
+            350.82249515639683,
+            places=7)
+
+        self.assertAlmostEqual(
+            BT_1886_EOCF(1.00),
+            939.99999999999989,
+            places=7)
+
+    def test_n_dimensional_BT_1886_EOCF(self):
+        """
+        Tests :func:`colour.models.rgb.conversion_functions.bt_1886.\
+BT_1886_EOCF` definition n-dimensional arrays support.
+        """
+
+        V = 0.50
+        L = 350.82249515639683
+        np.testing.assert_almost_equal(
+            BT_1886_EOCF(V),
+            L,
+            decimal=7)
+
+        V = np.tile(V, 6)
+        L = np.tile(L, 6)
+        np.testing.assert_almost_equal(
+            BT_1886_EOCF(V),
+            L,
+            decimal=7)
+
+        V = np.reshape(V, (2, 3))
+        L = np.reshape(L, (2, 3))
+        np.testing.assert_almost_equal(
+            BT_1886_EOCF(V),
+            L,
+            decimal=7)
+
+        V = np.reshape(V, (2, 3, 1))
+        L = np.reshape(L, (2, 3, 1))
+        np.testing.assert_almost_equal(
+            BT_1886_EOCF(V),
+            L,
+            decimal=7)
+
+    @ignore_numpy_errors
+    def test_nan_BT_1886_EOCF(self):
+        """
+        Tests :func:`colour.models.rgb.conversion_functions.bt_1886.\
+BT_1886_EOCF` definition nan support.
+        """
+
+        BT_1886_EOCF(
+            np.array([-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan]))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/colour/models/rgb/conversion_functions/tests/tests_log.py
+++ b/colour/models/rgb/conversion_functions/tests/tests_log.py
@@ -2,7 +2,8 @@
 # -*- coding: utf-8 -*-
 
 """
-Defines unit tests for :mod:`colour.models.rgb.conversion_functions`odule.
+Defines unit tests for :mod:`colour.models.rgb.conversion_functions.log`
+module.
 """
 
 from __future__ import division, unicode_literals
@@ -10,7 +11,7 @@ from __future__ import division, unicode_literals
 import numpy as np
 import unittest
 
-from colour.models import (
+from colour.models.rgb.conversion_functions import (
     linear_to_cineon,
     cineon_to_linear,
     linear_to_panalog,
@@ -76,14 +77,14 @@ __all__ = ['TestLinearToCineon',
 
 class TestLinearToCineon(unittest.TestCase):
     """
-    Defines :func:`colour.models.rgb.conversion_functions.linear_to_cineon`
+    Defines :func:`colour.models.rgb.conversion_functions.log.linear_to_cineon`
     definition unit tests methods.
     """
 
     def test_linear_to_cineon(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.linear_to_cineon`
-        definition.
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
+linear_to_cineon` definition.
         """
 
         self.assertAlmostEqual(
@@ -103,8 +104,8 @@ class TestLinearToCineon(unittest.TestCase):
 
     def test_n_dimensional_linear_to_cineon(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.linear_to_cineon`
-        definition n-dimensional arrays support.
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
+linear_to_cineon` definition n-dimensional arrays support.
         """
 
         linear = 0.18
@@ -138,8 +139,8 @@ class TestLinearToCineon(unittest.TestCase):
     @ignore_numpy_errors
     def test_nan_linear_to_cineon(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.linear_to_cineon`
-        definition nan support.
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
+linear_to_cineon` definition nan support.
         """
 
         linear_to_cineon(
@@ -148,14 +149,14 @@ class TestLinearToCineon(unittest.TestCase):
 
 class TestCineonToLinear(unittest.TestCase):
     """
-    Defines :func:`colour.models.rgb.conversion_functions.cineon_to_linear`
+    Defines :func:`colour.models.rgb.conversion_functions.log.cineon_to_linear`
     definition unit tests methods.
     """
 
     def test_cineon_to_linear(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.cineon_to_linear`
-        definition.
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
+cineon_to_linear` definition.
         """
 
         self.assertAlmostEqual(
@@ -175,8 +176,8 @@ class TestCineonToLinear(unittest.TestCase):
 
     def test_n_dimensional_cineon_to_linear(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.cineon_to_linear`
-        definition n-dimensional arrays support.
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
+cineon_to_linear` definition n-dimensional arrays support.
         """
 
         log = 0.45731961308541841
@@ -210,8 +211,8 @@ class TestCineonToLinear(unittest.TestCase):
     @ignore_numpy_errors
     def test_nan_cineon_to_linear(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.cineon_to_linear`
-        definition nan support.
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
+cineon_to_linear` definition nan support.
         """
 
         cineon_to_linear(
@@ -220,14 +221,14 @@ class TestCineonToLinear(unittest.TestCase):
 
 class TestLinearToPanalog(unittest.TestCase):
     """
-    Defines :func:`colour.models.rgb.conversion_functions.linear_to_panalog`
-    definition unit tests methods.
+    Defines :func:`colour.models.rgb.conversion_functions.log.\
+linear_to_panalog` definition unit tests methods.
     """
 
     def test_linear_to_panalog(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.linear_to_panalog`
-        definition.
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
+linear_to_panalog` definition.
         """
 
         self.assertAlmostEqual(
@@ -247,8 +248,8 @@ class TestLinearToPanalog(unittest.TestCase):
 
     def test_n_dimensional_linear_to_panalog(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.linear_to_panalog`
-        definition n-dimensional arrays support.
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
+linear_to_panalog` definition n-dimensional arrays support.
         """
 
         linear = 0.18
@@ -282,8 +283,8 @@ class TestLinearToPanalog(unittest.TestCase):
     @ignore_numpy_errors
     def test_nan_linear_to_panalog(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.linear_to_panalog`
-        definition nan support.
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
+linear_to_panalog` definition nan support.
         """
 
         linear_to_panalog(
@@ -292,14 +293,14 @@ class TestLinearToPanalog(unittest.TestCase):
 
 class TestPanalogToLinear(unittest.TestCase):
     """
-    Defines :func:`colour.models.rgb.conversion_functions.panalog_to_linear`
-    definition unit tests methods.
+    Defines :func:`colour.models.rgb.conversion_functions.log.\
+panalog_to_linear` definition unit tests methods.
     """
 
     def test_panalog_to_linear(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.panalog_to_linear`
-        definition.
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
+panalog_to_linear` definition.
         """
 
         self.assertAlmostEqual(
@@ -319,8 +320,8 @@ class TestPanalogToLinear(unittest.TestCase):
 
     def test_n_dimensional_panalog_to_linear(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.panalog_to_linear`
-        definition n-dimensional arrays support.
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
+panalog_to_linear` definition n-dimensional arrays support.
         """
 
         log = 0.37457679138229816
@@ -354,8 +355,8 @@ class TestPanalogToLinear(unittest.TestCase):
     @ignore_numpy_errors
     def test_nan_panalog_to_linear(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.panalog_to_linear`
-        definition nan support.
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
+panalog_to_linear` definition nan support.
         """
 
         panalog_to_linear(
@@ -364,13 +365,13 @@ class TestPanalogToLinear(unittest.TestCase):
 
 class TestLinearToViperLog(unittest.TestCase):
     """
-    Defines :func:`colour.models.rgb.conversion_functions.linear_to_viper_log`
-    definition unit tests methods.
+    Defines :func:`colour.models.rgb.conversion_functions.log.\
+linear_to_viper_log` definition unit tests methods.
     """
 
     def test_linear_to_viper_log(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.\
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
 linear_to_viper_log` definition.
         """
 
@@ -391,7 +392,7 @@ linear_to_viper_log` definition.
 
     def test_n_dimensional_linear_to_viper_log(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.\
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
 linear_to_viper_log` definition n-dimensional arrays support.
         """
 
@@ -426,7 +427,7 @@ linear_to_viper_log` definition n-dimensional arrays support.
     @ignore_numpy_errors
     def test_nan_linear_to_viper_log(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.\
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
 linear_to_viper_log` definition nan support.
         """
 
@@ -436,13 +437,13 @@ linear_to_viper_log` definition nan support.
 
 class TestViperLogToLinear(unittest.TestCase):
     """
-    Defines :func:`colour.models.rgb.conversion_functions.viper_log_to_linear`
-    definition unit tests methods.
+    Defines :func:`colour.models.rgb.conversion_functions.log.\
+viper_log_to_linear` definition unit tests methods.
     """
 
     def test_viper_log_to_linear(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.\
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
 viper_log_to_linear` definition.
         """
 
@@ -463,7 +464,7 @@ viper_log_to_linear` definition.
 
     def test_n_dimensional_viper_log_to_linear(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.\
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
 viper_log_to_linear` definition n-dimensional arrays support.
         """
 
@@ -498,7 +499,7 @@ viper_log_to_linear` definition n-dimensional arrays support.
     @ignore_numpy_errors
     def test_nan_viper_log_to_linear(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.\
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
 viper_log_to_linear` definition nan support.
         """
 
@@ -508,13 +509,13 @@ viper_log_to_linear` definition nan support.
 
 class TestLinearToPivotedLog(unittest.TestCase):
     """
-    Defines :func:`colour.models.rgb.conversion_functions.\
+    Defines :func:`colour.models.rgb.conversion_functions.log.\
 linear_to_pivoted_log` definition unit tests methods.
     """
 
     def test_linear_to_pivoted_log(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.\
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
 linear_to_pivoted_log` definition.
         """
 
@@ -535,7 +536,7 @@ linear_to_pivoted_log` definition.
 
     def test_n_dimensional_linear_to_pivoted_log(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.\
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
 linear_to_pivoted_log` definition n-dimensional arrays support.
         """
 
@@ -570,7 +571,7 @@ linear_to_pivoted_log` definition n-dimensional arrays support.
     @ignore_numpy_errors
     def test_nan_linear_to_pivoted_log(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.\
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
 linear_to_pivoted_log` definition nan support.
         """
 
@@ -580,13 +581,13 @@ linear_to_pivoted_log` definition nan support.
 
 class TestPivotedLogToLinear(unittest.TestCase):
     """
-    Defines :func:`colour.models.rgb.conversion_functions.\
+    Defines :func:`colour.models.rgb.conversion_functions.log.\
 pivoted_log_to_linear` definition unit tests methods.
     """
 
     def test_pivoted_log_to_linear(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.\
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
 pivoted_log_to_linear` definition.
         """
 
@@ -607,7 +608,7 @@ pivoted_log_to_linear` definition.
 
     def test_n_dimensional_pivoted_log_to_linear(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.\
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
 pivoted_log_to_linear` definition n-dimensional arrays support.
         """
 
@@ -642,7 +643,7 @@ pivoted_log_to_linear` definition n-dimensional arrays support.
     @ignore_numpy_errors
     def test_nan_pivoted_log_to_linear(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.\
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
 pivoted_log_to_linear` definition nan support.
         """
 
@@ -652,14 +653,14 @@ pivoted_log_to_linear` definition nan support.
 
 class TestLinearToCLog(unittest.TestCase):
     """
-    Defines :func:`colour.models.rgb.conversion_functions.linear_to_c_log`
+    Defines :func:`colour.models.rgb.conversion_functions.log.linear_to_c_log`
     definition unit tests methods.
     """
 
     def test_linear_to_c_log(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.linear_to_c_log`
-        definition.
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
+linear_to_c_log` definition.
         """
 
         self.assertAlmostEqual(
@@ -679,8 +680,8 @@ class TestLinearToCLog(unittest.TestCase):
 
     def test_n_dimensional_linear_to_c_log(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.linear_to_c_log`
-        definition n-dimensional arrays support.
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
+linear_to_c_log` definition n-dimensional arrays support.
         """
 
         linear = 0.18
@@ -714,8 +715,8 @@ class TestLinearToCLog(unittest.TestCase):
     @ignore_numpy_errors
     def test_nan_linear_to_c_log(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.linear_to_c_log`
-        definition nan support.
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
+linear_to_c_log` definition nan support.
         """
 
         linear_to_c_log(
@@ -724,14 +725,14 @@ class TestLinearToCLog(unittest.TestCase):
 
 class TestCLogToLinear(unittest.TestCase):
     """
-    Defines :func:`colour.models.rgb.conversion_functions.c_log_to_linear`
+    Defines :func:`colour.models.rgb.conversion_functions.log.c_log_to_linear`
     definition unit tests methods.
     """
 
     def test_c_log_to_linear(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.c_log_to_linear`
-        definition.
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
+c_log_to_linear` definition.
         """
 
         self.assertAlmostEqual(
@@ -751,8 +752,8 @@ class TestCLogToLinear(unittest.TestCase):
 
     def test_n_dimensional_c_log_to_linear(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.c_log_to_linear`
-        definition n-dimensional arrays support.
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
+c_log_to_linear` definition n-dimensional arrays support.
         """
 
         log = 0.31201285555039493
@@ -786,8 +787,8 @@ class TestCLogToLinear(unittest.TestCase):
     @ignore_numpy_errors
     def test_nan_c_log_to_linear(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.c_log_to_linear`
-        definition nan support.
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
+c_log_to_linear` definition nan support.
         """
 
         c_log_to_linear(
@@ -796,14 +797,14 @@ class TestCLogToLinear(unittest.TestCase):
 
 class TestLinearToAcesCc(unittest.TestCase):
     """
-    Defines :func:`colour.models.rgb.conversion_functions.linear_to_aces_cc`
-    definition unit tests methods.
+    Defines :func:`colour.models.rgb.conversion_functions.log.\
+linear_to_aces_cc` definition unit tests methods.
     """
 
     def test_linear_to_aces_cc(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.linear_to_aces_cc`
-        definition.
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
+linear_to_aces_cc` definition.
         """
 
         self.assertAlmostEqual(
@@ -823,8 +824,8 @@ class TestLinearToAcesCc(unittest.TestCase):
 
     def test_n_dimensional_linear_to_aces_cc(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.linear_to_aces_cc`
-        definition n-dimensional arrays support.
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
+linear_to_aces_cc` definition n-dimensional arrays support.
         """
 
         linear = 0.18
@@ -858,8 +859,8 @@ class TestLinearToAcesCc(unittest.TestCase):
     @ignore_numpy_errors
     def test_nan_linear_to_aces_cc(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.linear_to_aces_cc`
-        definition nan support.
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
+linear_to_aces_cc` definition nan support.
         """
 
         linear_to_aces_cc(
@@ -868,14 +869,14 @@ class TestLinearToAcesCc(unittest.TestCase):
 
 class TestAcesCcToLinear(unittest.TestCase):
     """
-    Defines :func:`colour.models.rgb.conversion_functions.aces_cc_to_linear`
-    definition unit tests methods.
+    Defines :func:`colour.models.rgb.conversion_functions.log.\
+aces_cc_to_linear` definition unit tests methods.
     """
 
     def test_aces_cc_to_linear(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.aces_cc_to_linear`
-        definition.
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
+aces_cc_to_linear` definition.
         """
 
         self.assertAlmostEqual(
@@ -895,8 +896,8 @@ class TestAcesCcToLinear(unittest.TestCase):
 
     def test_n_dimensional_aces_cc_to_linear(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.aces_cc_to_linear`
-        definition n-dimensional arrays support.
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
+aces_cc_to_linear` definition n-dimensional arrays support.
         """
 
         log = 0.41358840249244228
@@ -930,8 +931,8 @@ class TestAcesCcToLinear(unittest.TestCase):
     @ignore_numpy_errors
     def test_nan_aces_cc_to_linear(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.aces_cc_to_linear`
-        definition nan support.
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
+aces_cc_to_linear` definition nan support.
         """
 
         aces_cc_to_linear(
@@ -940,13 +941,13 @@ class TestAcesCcToLinear(unittest.TestCase):
 
 class TestLinearToAlexaLogC(unittest.TestCase):
     """
-    Defines :func:`colour.models.rgb.conversion_functions.\
+    Defines :func:`colour.models.rgb.conversion_functions.log.\
 linear_to_alexa_log_c` definition unit tests methods.
     """
 
     def test_linear_to_alexa_log_c(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.\
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
 linear_to_alexa_log_c` definition.
         """
 
@@ -967,7 +968,7 @@ linear_to_alexa_log_c` definition.
 
     def test_n_dimensional_linear_to_alexa_log_c(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.\
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
 linear_to_alexa_log_c` definition n-dimensional arrays support.
         """
 
@@ -1002,7 +1003,7 @@ linear_to_alexa_log_c` definition n-dimensional arrays support.
     @ignore_numpy_errors
     def test_nan_linear_to_alexa_log_c(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.\
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
 linear_to_alexa_log_c` definition nan support.
         """
 
@@ -1012,13 +1013,13 @@ linear_to_alexa_log_c` definition nan support.
 
 class TestAlexaLogCToLinear(unittest.TestCase):
     """
-    Defines :func:`colour.models.rgb.conversion_functions.\
+    Defines :func:`colour.models.rgb.conversion_functions.log.\
 alexa_log_c_to_linear` definition unit tests methods.
     """
 
     def test_alexa_log_c_to_linear(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.\
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
 alexa_log_c_to_linear` definition.
         """
 
@@ -1039,7 +1040,7 @@ alexa_log_c_to_linear` definition.
 
     def test_n_dimensional_alexa_log_c_to_linear(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.\
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
 alexa_log_c_to_linear` definition n-dimensional arrays support.
         """
 
@@ -1074,7 +1075,7 @@ alexa_log_c_to_linear` definition n-dimensional arrays support.
     @ignore_numpy_errors
     def test_nan_alexa_log_c_to_linear(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.\
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
 alexa_log_c_to_linear` definition nan support.
         """
 
@@ -1084,13 +1085,13 @@ alexa_log_c_to_linear` definition nan support.
 
 class TestLinearToDciP3Log(unittest.TestCase):
     """
-    Defines :func:`colour.models.rgb.conversion_functions.\
+    Defines :func:`colour.models.rgb.conversion_functions.log.\
 linear_to_dci_p3_log` definition unit tests methods.
     """
 
     def test_linear_to_dci_p3_log(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.\
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
 linear_to_dci_p3_log` definition.
         """
 
@@ -1111,7 +1112,7 @@ linear_to_dci_p3_log` definition.
 
     def test_n_dimensional_linear_to_dci_p3_log(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.\
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
 linear_to_dci_p3_log` definition n-dimensional arrays support.
         """
 
@@ -1146,7 +1147,7 @@ linear_to_dci_p3_log` definition n-dimensional arrays support.
     @ignore_numpy_errors
     def test_nan_linear_to_dci_p3_log(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.\
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
 linear_to_dci_p3_log` definition nan support.
         """
 
@@ -1156,13 +1157,13 @@ linear_to_dci_p3_log` definition nan support.
 
 class TestDciP3LogToLinear(unittest.TestCase):
     """
-    Defines :func:`colour.models.rgb.conversion_functions.\
+    Defines :func:`colour.models.rgb.conversion_functions.log.\
 dci_p3_log_to_linear` definition unit tests methods.
     """
 
     def test_dci_p3_log_to_linear(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.\
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
 dci_p3_log_to_linear` definition.
         """
 
@@ -1183,7 +1184,7 @@ dci_p3_log_to_linear` definition.
 
     def test_n_dimensional_dci_p3_log_to_linear(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.\
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
 dci_p3_log_to_linear` definition n-dimensional arrays support.
         """
 
@@ -1218,7 +1219,7 @@ dci_p3_log_to_linear` definition n-dimensional arrays support.
     @ignore_numpy_errors
     def test_nan_dci_p3_log_to_linear(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.\
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
 dci_p3_log_to_linear` definition nan support.
         """
 
@@ -1228,13 +1229,13 @@ dci_p3_log_to_linear` definition nan support.
 
 class TestLinearToRedLogFilm(unittest.TestCase):
     """
-    Defines :func:`colour.models.rgb.conversion_functions.\
+    Defines :func:`colour.models.rgb.conversion_functions.log.\
 linear_to_red_log_film` definition unit tests methods.
     """
 
     def test_linear_to_red_log_film(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.\
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
 linear_to_red_log_film` definition.
         """
 
@@ -1255,7 +1256,7 @@ linear_to_red_log_film` definition.
 
     def test_n_dimensional_linear_to_red_log_film(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.\
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
 linear_to_red_log_film` definition n-dimensional arrays support.
         """
 
@@ -1290,7 +1291,7 @@ linear_to_red_log_film` definition n-dimensional arrays support.
     @ignore_numpy_errors
     def test_nan_linear_to_red_log_film(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.\
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
 linear_to_red_log_film` definition nan support.
         """
 
@@ -1300,13 +1301,13 @@ linear_to_red_log_film` definition nan support.
 
 class TestRedLogFilmToLinear(unittest.TestCase):
     """
-    Defines :func:`colour.models.rgb.conversion_functions.\
+    Defines :func:`colour.models.rgb.conversion_functions.log.\
 red_log_film_to_linear` definition unit tests methods.
     """
 
     def test_red_log_film_to_linear(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.\
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
 red_log_film_to_linear` definition.
         """
 
@@ -1327,7 +1328,7 @@ red_log_film_to_linear` definition.
 
     def test_n_dimensional_red_log_film_to_linear(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.\
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
 red_log_film_to_linear` definition n-dimensional arrays support.
         """
 
@@ -1362,7 +1363,7 @@ red_log_film_to_linear` definition n-dimensional arrays support.
     @ignore_numpy_errors
     def test_nan_red_log_film_to_linear(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.\
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
 red_log_film_to_linear` definition nan support.
         """
 
@@ -1372,14 +1373,14 @@ red_log_film_to_linear` definition nan support.
 
 class TestLinearToSLog(unittest.TestCase):
     """
-    Defines :func:`colour.models.rgb.conversion_functions.linear_to_s_log`
+    Defines :func:`colour.models.rgb.conversion_functions.log.linear_to_s_log`
     definition unit tests methods.
     """
 
     def test_linear_to_s_log(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.linear_to_s_log`
-        definition.
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
+linear_to_s_log` definition.
         """
 
         self.assertAlmostEqual(
@@ -1399,8 +1400,8 @@ class TestLinearToSLog(unittest.TestCase):
 
     def test_n_dimensional_linear_to_s_log(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.linear_to_s_log`
-        definition n-dimensional arrays support.
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
+linear_to_s_log` definition n-dimensional arrays support.
         """
 
         linear = 0.18
@@ -1434,8 +1435,8 @@ class TestLinearToSLog(unittest.TestCase):
     @ignore_numpy_errors
     def test_nan_linear_to_s_log(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.linear_to_s_log`
-        definition nan support.
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
+linear_to_s_log` definition nan support.
         """
 
         linear_to_s_log(
@@ -1444,14 +1445,14 @@ class TestLinearToSLog(unittest.TestCase):
 
 class TestSLogToLinear(unittest.TestCase):
     """
-    Defines :func:`colour.models.rgb.conversion_functions.s_log_to_linear`
+    Defines :func:`colour.models.rgb.conversion_functions.log.s_log_to_linear`
     definition unit tests methods.
     """
 
     def test_s_log_to_linear(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.s_log_to_linear`
-        definition.
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
+s_log_to_linear` definition.
         """
 
         self.assertAlmostEqual(
@@ -1471,8 +1472,8 @@ class TestSLogToLinear(unittest.TestCase):
 
     def test_n_dimensional_s_log_to_linear(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.s_log_to_linear`
-        definition n-dimensional arrays support.
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
+s_log_to_linear` definition n-dimensional arrays support.
         """
 
         log = 0.35998784642215442
@@ -1506,8 +1507,8 @@ class TestSLogToLinear(unittest.TestCase):
     @ignore_numpy_errors
     def test_nan_s_log_to_linear(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.s_log_to_linear`
-        definition nan support.
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
+s_log_to_linear` definition nan support.
         """
 
         s_log_to_linear(
@@ -1516,14 +1517,14 @@ class TestSLogToLinear(unittest.TestCase):
 
 class TestLinearToSLog2(unittest.TestCase):
     """
-    Defines :func:`colour.models.rgb.conversion_functions.linear_to_s_log2`
+    Defines :func:`colour.models.rgb.conversion_functions.log.linear_to_s_log2`
     definition unit tests methods.
     """
 
     def test_linear_to_s_log2(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.linear_to_s_log2`
-        definition.
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
+linear_to_s_log2` definition.
         """
 
         self.assertAlmostEqual(
@@ -1543,8 +1544,8 @@ class TestLinearToSLog2(unittest.TestCase):
 
     def test_n_dimensional_linear_to_s_log2(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.linear_to_s_log2`
-        definition n-dimensional arrays support.
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
+linear_to_s_log2` definition n-dimensional arrays support.
         """
 
         linear = 0.18
@@ -1578,8 +1579,8 @@ class TestLinearToSLog2(unittest.TestCase):
     @ignore_numpy_errors
     def test_nan_linear_to_s_log2(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.linear_to_s_log2`
-        definition nan support.
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
+linear_to_s_log2` definition nan support.
         """
 
         linear_to_s_log2(
@@ -1588,14 +1589,14 @@ class TestLinearToSLog2(unittest.TestCase):
 
 class TestSLog2ToLinear(unittest.TestCase):
     """
-    Defines :func:`colour.models.rgb.conversion_functions.s_log2_to_linear`
+    Defines :func:`colour.models.rgb.conversion_functions.log.s_log2_to_linear`
     definition unit tests methods.
     """
 
     def test_s_log2_to_linear(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.s_log2_to_linear`
-        definition.
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
+s_log2_to_linear` definition.
         """
 
         self.assertAlmostEqual(
@@ -1615,8 +1616,8 @@ class TestSLog2ToLinear(unittest.TestCase):
 
     def test_n_dimensional_s_log2_to_linear(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.s_log2_to_linear`
-        definition n-dimensional arrays support.
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
+s_log2_to_linear` definition n-dimensional arrays support.
         """
 
         log = 0.38497081592867027
@@ -1650,8 +1651,8 @@ class TestSLog2ToLinear(unittest.TestCase):
     @ignore_numpy_errors
     def test_nan_s_log2_to_linear(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.s_log2_to_linear`
-        definition nan support.
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
+s_log2_to_linear` definition nan support.
         """
 
         s_log2_to_linear(
@@ -1660,14 +1661,14 @@ class TestSLog2ToLinear(unittest.TestCase):
 
 class TestLinearToSLog3(unittest.TestCase):
     """
-    Defines :func:`colour.models.rgb.conversion_functions.linear_to_s_log3`
+    Defines :func:`colour.models.rgb.conversion_functions.log.linear_to_s_log3`
     definition unit tests methods.
     """
 
     def test_linear_to_s_log3(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.linear_to_s_log3`
-        definition.
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
+linear_to_s_log3` definition.
         """
 
         self.assertAlmostEqual(
@@ -1687,8 +1688,8 @@ class TestLinearToSLog3(unittest.TestCase):
 
     def test_n_dimensional_linear_to_s_log3(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.linear_to_s_log3`
-        definition n-dimensional arrays support.
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
+linear_to_s_log3` definition n-dimensional arrays support.
         """
 
         linear = 0.18
@@ -1722,8 +1723,8 @@ class TestLinearToSLog3(unittest.TestCase):
     @ignore_numpy_errors
     def test_nan_linear_to_s_log3(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.linear_to_s_log3`
-        definition nan support.
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
+linear_to_s_log3` definition nan support.
         """
 
         linear_to_s_log3(
@@ -1732,14 +1733,14 @@ class TestLinearToSLog3(unittest.TestCase):
 
 class TestSLog3ToLinear(unittest.TestCase):
     """
-    Defines :func:`colour.models.rgb.conversion_functions.s_log3_to_linear`
+    Defines :func:`colour.models.rgb.conversion_functions.log.s_log3_to_linear`
     definition unit tests methods.
     """
 
     def test_s_log3_to_linear(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.s_log3_to_linear`
-        definition.
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
+s_log3_to_linear` definition.
         """
 
         self.assertAlmostEqual(
@@ -1759,8 +1760,8 @@ class TestSLog3ToLinear(unittest.TestCase):
 
     def test_n_dimensional_s_log3_to_linear(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.s_log3_to_linear`
-        definition n-dimensional arrays support.
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
+s_log3_to_linear` definition n-dimensional arrays support.
         """
 
         log = 0.41055718475073316
@@ -1794,8 +1795,8 @@ class TestSLog3ToLinear(unittest.TestCase):
     @ignore_numpy_errors
     def test_nan_s_log3_to_linear(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.s_log3_to_linear`
-        definition nan support.
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
+s_log3_to_linear` definition nan support.
         """
 
         s_log3_to_linear(
@@ -1804,14 +1805,14 @@ class TestSLog3ToLinear(unittest.TestCase):
 
 class TestLinearToVLog(unittest.TestCase):
     """
-    Defines :func:`colour.models.rgb.conversion_functions.linear_to_v_log`
+    Defines :func:`colour.models.rgb.conversion_functions.log.linear_to_v_log`
     definition unit tests methods.
     """
 
     def test_linear_to_v_log(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.linear_to_v_log`
-        definition.
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
+linear_to_v_log` definition.
         """
 
         self.assertAlmostEqual(
@@ -1831,8 +1832,8 @@ class TestLinearToVLog(unittest.TestCase):
 
     def test_n_dimensional_linear_to_v_log(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.linear_to_v_log`
-        definition n-dimensional arrays support.
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
+linear_to_v_log` definition n-dimensional arrays support.
         """
 
         linear = 0.18
@@ -1866,8 +1867,8 @@ class TestLinearToVLog(unittest.TestCase):
     @ignore_numpy_errors
     def test_nan_linear_to_v_log(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.linear_to_v_log`
-        definition nan support.
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
+linear_to_v_log` definition nan support.
         """
 
         linear_to_v_log(
@@ -1876,14 +1877,14 @@ class TestLinearToVLog(unittest.TestCase):
 
 class TestVLogToLinear(unittest.TestCase):
     """
-    Defines :func:`colour.models.rgb.conversion_functions.v_log_to_linear`
+    Defines :func:`colour.models.rgb.conversion_functions.log.v_log_to_linear`
     definition unit tests methods.
     """
 
     def test_v_log_to_linear(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.v_log_to_linear`
-        definition.
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
+v_log_to_linear` definition.
         """
 
         self.assertAlmostEqual(
@@ -1903,8 +1904,8 @@ class TestVLogToLinear(unittest.TestCase):
 
     def test_n_dimensional_v_log_to_linear(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.v_log_to_linear`
-        definition n-dimensional arrays support.
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
+v_log_to_linear` definition n-dimensional arrays support.
         """
 
         log = 0.42331144876013616
@@ -1938,8 +1939,8 @@ class TestVLogToLinear(unittest.TestCase):
     @ignore_numpy_errors
     def test_nan_v_log_to_linear(self):
         """
-        Tests :func:`colour.models.rgb.conversion_functions.v_log_to_linear`
-        definition nan support.
+        Tests :func:`colour.models.rgb.conversion_functions.log.\
+v_log_to_linear` definition nan support.
         """
 
         v_log_to_linear(

--- a/colour/models/rgb/conversion_functions/tests/tests_st_2084.py
+++ b/colour/models/rgb/conversion_functions/tests/tests_st_2084.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Defines unit tests for :mod:`colour.models.rgb.conversion_functions.st_2084`
+module.
+"""
+
+from __future__ import division, unicode_literals
+
+import numpy as np
+import unittest
+
+from colour.models.rgb.conversion_functions import ST_2084_EOCF, ST_2084_OECF
+from colour.utilities import ignore_numpy_errors
+
+__author__ = 'Colour Developers'
+__copyright__ = 'Copyright (C) 2013 - 2015 - Colour Developers'
+__license__ = 'New BSD License - http://opensource.org/licenses/BSD-3-Clause'
+__maintainer__ = 'Colour Developers'
+__email__ = 'colour-science@googlegroups.com'
+__status__ = 'Production'
+
+__all__ = ['TestST_2084_EOCF']
+
+
+class TestST_2084_EOCF(unittest.TestCase):
+    """
+    Defines :func:`colour.models.rgb.conversion_functions.st_2084.ST_2084_EOCF`
+    definition unit tests methods.
+    """
+
+    def test_ST_2084_EOCF(self):
+        """
+        Tests :func:`colour.models.rgb.conversion_functions.st_2084.\
+ST_2084_EOCF` definition.
+        """
+
+        self.assertAlmostEqual(
+            ST_2084_EOCF(0.00),
+            0.0,
+            places=7)
+
+        self.assertAlmostEqual(
+            ST_2084_EOCF(0.50),
+            92.245708994065268,
+            places=7)
+
+        self.assertAlmostEqual(
+            ST_2084_EOCF(1.00),
+            10000.0,
+            places=7)
+
+    def test_n_dimensional_ST_2084_EOCF(self):
+        """
+        Tests :func:`colour.models.rgb.conversion_functions.st_2084.\
+ST_2084_EOCF` definition n-dimensional arrays support.
+        """
+
+        V = 0.50
+        Y = 92.245708994065268
+        np.testing.assert_almost_equal(
+            ST_2084_EOCF(V),
+            Y,
+            decimal=7)
+
+        V = np.tile(V, 6)
+        Y = np.tile(Y, 6)
+        np.testing.assert_almost_equal(
+            ST_2084_EOCF(V),
+            Y,
+            decimal=7)
+
+        V = np.reshape(V, (2, 3))
+        Y = np.reshape(Y, (2, 3))
+        np.testing.assert_almost_equal(
+            ST_2084_EOCF(V),
+            Y,
+            decimal=7)
+
+        V = np.reshape(V, (2, 3, 1))
+        Y = np.reshape(Y, (2, 3, 1))
+        np.testing.assert_almost_equal(
+            ST_2084_EOCF(V),
+            Y,
+            decimal=7)
+
+    @ignore_numpy_errors
+    def test_nan_ST_2084_EOCF(self):
+        """
+        Tests :func:`colour.models.rgb.conversion_functions.st_2084.\
+ST_2084_EOCF` definition nan support.
+        """
+
+        ST_2084_EOCF(
+            np.array([-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan]))
+
+
+class TestST_2084_OECF(unittest.TestCase):
+    """
+    Defines :func:`colour.models.rgb.conversion_functions.st_2084.ST_2084_OECF`
+    definition unit tests methods.
+    """
+
+    def test_ST_2084_OECF(self):
+        """
+        Tests :func:`colour.models.rgb.conversion_functions.st_2084.\
+ST_2084_OECF` definition.
+        """
+
+        self.assertAlmostEqual(
+            ST_2084_OECF(0.00),
+            7.3095590257839665e-07,
+            places=7)
+
+        self.assertAlmostEqual(
+            ST_2084_OECF(92.245708994065268),
+            0.50000000000000067,
+            places=7)
+
+        self.assertAlmostEqual(
+            ST_2084_OECF(10000),
+            1.0,
+            places=7)
+
+    def test_n_dimensional_ST_2084_OECF(self):
+        """
+        Tests :func:`colour.models.rgb.conversion_functions.st_2084.\
+ST_2084_OECF` definition n-dimensional arrays support.
+        """
+
+        Y = 92.245708994065268
+        V = 0.50000000000000067
+        np.testing.assert_almost_equal(
+            ST_2084_OECF(Y),
+            V,
+            decimal=7)
+
+        Y = np.tile(Y, 6)
+        V = np.tile(V, 6)
+        np.testing.assert_almost_equal(
+            ST_2084_OECF(Y),
+            V,
+            decimal=7)
+
+        Y = np.reshape(Y, (2, 3))
+        V = np.reshape(V, (2, 3))
+        np.testing.assert_almost_equal(
+            ST_2084_OECF(Y),
+            V,
+            decimal=7)
+
+        Y = np.reshape(Y, (2, 3, 1))
+        V = np.reshape(V, (2, 3, 1))
+        np.testing.assert_almost_equal(
+            ST_2084_OECF(Y),
+            V,
+            decimal=7)
+
+    @ignore_numpy_errors
+    def test_nan_ST_2084_OECF(self):
+        """
+        Tests :func:`colour.models.rgb.conversion_functions.st_2084.\
+ST_2084_OECF` definition nan support.
+        """
+
+        ST_2084_OECF(
+            np.array([-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan]))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/colour/models/rgb/conversion_functions/tests/tests_st_2084.py
+++ b/colour/models/rgb/conversion_functions/tests/tests_st_2084.py
@@ -51,38 +51,43 @@ ST_2084_EOCF` definition.
             10000.0,
             places=7)
 
+        self.assertAlmostEqual(
+            ST_2084_EOCF(0.5, 5000),
+            46.122854497032634,
+            places=7)
+
     def test_n_dimensional_ST_2084_EOCF(self):
         """
         Tests :func:`colour.models.rgb.conversion_functions.st_2084.\
 ST_2084_EOCF` definition n-dimensional arrays support.
         """
 
-        V = 0.50
-        Y = 92.245708994065268
+        N = 0.50
+        C = 92.245708994065268
         np.testing.assert_almost_equal(
-            ST_2084_EOCF(V),
-            Y,
+            ST_2084_EOCF(N),
+            C,
             decimal=7)
 
-        V = np.tile(V, 6)
-        Y = np.tile(Y, 6)
+        N = np.tile(N, 6)
+        C = np.tile(C, 6)
         np.testing.assert_almost_equal(
-            ST_2084_EOCF(V),
-            Y,
+            ST_2084_EOCF(N),
+            C,
             decimal=7)
 
-        V = np.reshape(V, (2, 3))
-        Y = np.reshape(Y, (2, 3))
+        N = np.reshape(N, (2, 3))
+        C = np.reshape(C, (2, 3))
         np.testing.assert_almost_equal(
-            ST_2084_EOCF(V),
-            Y,
+            ST_2084_EOCF(N),
+            C,
             decimal=7)
 
-        V = np.reshape(V, (2, 3, 1))
-        Y = np.reshape(Y, (2, 3, 1))
+        N = np.reshape(N, (2, 3, 1))
+        C = np.reshape(C, (2, 3, 1))
         np.testing.assert_almost_equal(
-            ST_2084_EOCF(V),
-            Y,
+            ST_2084_EOCF(N),
+            C,
             decimal=7)
 
     @ignore_numpy_errors
@@ -123,38 +128,43 @@ ST_2084_OECF` definition.
             1.0,
             places=7)
 
+        self.assertAlmostEqual(
+            ST_2084_OECF(92.245708994065268, 5000),
+            0.57071924098752402,
+            places=7)
+
     def test_n_dimensional_ST_2084_OECF(self):
         """
         Tests :func:`colour.models.rgb.conversion_functions.st_2084.\
 ST_2084_OECF` definition n-dimensional arrays support.
         """
 
-        Y = 92.245708994065268
-        V = 0.50000000000000067
+        C = 92.245708994065268
+        N = 0.50000000000000067
         np.testing.assert_almost_equal(
-            ST_2084_OECF(Y),
-            V,
+            ST_2084_OECF(C),
+            N,
             decimal=7)
 
-        Y = np.tile(Y, 6)
-        V = np.tile(V, 6)
+        C = np.tile(C, 6)
+        N = np.tile(N, 6)
         np.testing.assert_almost_equal(
-            ST_2084_OECF(Y),
-            V,
+            ST_2084_OECF(C),
+            N,
             decimal=7)
 
-        Y = np.reshape(Y, (2, 3))
-        V = np.reshape(V, (2, 3))
+        C = np.reshape(C, (2, 3))
+        N = np.reshape(N, (2, 3))
         np.testing.assert_almost_equal(
-            ST_2084_OECF(Y),
-            V,
+            ST_2084_OECF(C),
+            N,
             decimal=7)
 
-        Y = np.reshape(Y, (2, 3, 1))
-        V = np.reshape(V, (2, 3, 1))
+        C = np.reshape(C, (2, 3, 1))
+        N = np.reshape(N, (2, 3, 1))
         np.testing.assert_almost_equal(
-            ST_2084_OECF(Y),
-            V,
+            ST_2084_OECF(C),
+            N,
             decimal=7)
 
     @ignore_numpy_errors


### PR DESCRIPTION
References #244, #245.

Pending for discussion are still the various RGB colourspace *OECF* and *EOCF* naming convention.

https://docs.google.com/spreadsheets/d/1x_JZuSgZNEllzl6qxxbz7D-FJ47iF5ZKIIMSaRxPz0E/edit?usp=sharing