### PR TITLE
PR: Fix typo in "colour.chromatic_adaptation_matrix_VonKries" definition docstring.

### DIFF
--- a/colour/adaptation/vonkries.py
+++ b/colour/adaptation/vonkries.py
@@ -53,7 +53,7 @@ def chromatic_adaptation_matrix_VonKries(XYZ_w, XYZ_wr, transform='CAT02'):
         Reference viewing condition *CIE XYZ* tristimulus values of whitepoint.
     transform : unicode, optional
         **{'CAT02', 'XYZ Scaling', 'Von Kries', 'Bradford', 'Sharp',
-        'Fairchild, 'CMCCAT97', 'CMCCAT2000', 'CAT02_BRILL_CAT', 'Bianco',
+        'Fairchild', 'CMCCAT97', 'CMCCAT2000', 'CAT02_BRILL_CAT', 'Bianco',
         'Bianco PC'}**,
         Chromatic adaptation transform.
 


### PR DESCRIPTION
fix typo in usage documentation

Added missing '  