### PR TITLE
PR: Prevent extra line breaks on "Windows" when exporting CSV files.

### DIFF
--- a/colour/io/tabular.py
+++ b/colour/io/tabular.py
@@ -278,7 +278,7 @@ def write_spds_to_csv_file(spds,
                                 'with different shapes to CSV file!'))
 
     wavelengths = tuple(spds.values())[0].wavelengths
-    with open(path, 'w') as csv_file:
+    with open(path, 'wb') as csv_file:
         fields = list(fields) if fields is not None else sorted(spds.keys())
         writer = csv.DictWriter(csv_file,
                                 delimiter=str(delimiter),

--- a/colour/io/tabular.py
+++ b/colour/io/tabular.py
@@ -278,11 +278,12 @@ def write_spds_to_csv_file(spds,
                                 'with different shapes to CSV file!'))
 
     wavelengths = tuple(spds.values())[0].wavelengths
-    with open(path, 'wb') as csv_file:
+    with open(path, 'w') as csv_file:
         fields = list(fields) if fields is not None else sorted(spds.keys())
         writer = csv.DictWriter(csv_file,
                                 delimiter=str(delimiter),
-                                fieldnames=['wavelength'] + fields)
+                                fieldnames=['wavelength'] + fields,
+                                lineterminator='\n')
         # Python 2.7.x / 3.4.x only.
         # writer.writeheader()
         writer.writerow(dict((name, name) for name in writer.fieldnames))


### PR DESCRIPTION
There is an artifact when files are processed as a ASCII that creates an extra line feed at the end of a line in windows.  If the file is written as a binary this is not an issue.