### PR TITLE
PR: Implement support for "Y'CbCr" colourspace.

### DIFF
--- a/colour/models/rgb/__init__.py
+++ b/colour/models/rgb/__init__.py
@@ -18,6 +18,12 @@ from .dataset import *  # noqa
 from . import dataset
 from .common import XYZ_to_sRGB, sRGB_to_XYZ
 from .aces_it import spectral_to_aces_relative_exposure_values
+from .ycbcr import (
+    YCBCR_WEIGHTS,
+    RGB_to_YCbCr,
+    YCbCr_to_RGB,
+    RGB_to_YcCbcCrc,
+    YcCbcCrc_to_RGB)
 
 __all__ = ['RGB_Colourspace']
 __all__ += ['XYZ_to_RGB', 'RGB_to_XYZ']
@@ -31,3 +37,8 @@ __all__ += transfer_functions.__all__
 __all__ += dataset.__all__
 __all__ += ['XYZ_to_sRGB', 'sRGB_to_XYZ']
 __all__ += ['spectral_to_aces_relative_exposure_values']
+__all__ += ['YCBCR_WEIGHTS',
+            'RGB_to_YCbCr',
+            'YCbCr_to_RGB',
+            'RGB_to_YcCbcCrc',
+            'YcCbcCrc_to_RGB']

--- a/colour/models/rgb/tests/tests_ycbcr.py
+++ b/colour/models/rgb/tests/tests_ycbcr.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Defines unit tests for :mod:`colour.models.rgb.ycbcr` module.
+"""
+
+from __future__ import division, unicode_literals
+
+import numpy as np
+import unittest
+
+from colour.models.rgb.ycbcr import rgb_to_YCbCr, YCbCr_to_rgb, rgb_to_YcCbcCrc,
+        YcCbcCrc_to_rgb, RANGE, WEIGHT
+
+__author__ = 'Colour Developers'
+__copyright__ = 'Copyright (C) 2013 - 2016 - Colour Developers'
+__license__ = 'New BSD License - http://opensource.org/licenses/BSD-3-Clause'
+__maintainer__ = 'Colour Developers'
+__email__ = 'colour-science@googlegroups.com'
+__status__ = 'Development'
+
+__all__ = ['Testrgb_to_YCbCr', 'TestYCbCr_to_rgb', 'Testrgb_to_YcCbcCrc', 'TestYcCbcCrc_to_rgb']
+
+
+class Testrgb_to_YCbCr(unittest.TestCase):
+    """
+    Defines :func:`colour.models.rgb.ycbcr.rgb_to_YCbCr` definition unit tests
+    methods.
+    """
+
+    def test_rgb_to_YCbCr(self):
+        """
+        Tests :func:`colour.models.rgb.ycbcr.rgb_to_YCbCr` definition.
+        """
+
+        np.testing.assert_almost_equal(
+            rgb_to_YCbCr(np.array([0.75, 0.75, 0.0])),
+            np.array([ 0.65842092,  0.17204301,  0.53060532]),
+            decimal=7)
+            
+        np.testing.assert_almost_equal(
+            rgb_to_YCbCr(np.array([0.25, 0.5, 0.75]), outRange=RANGE['legal_10_YC_int']),
+            np.array([471, 650, 390]),
+            decimal=7)
+
+
+class TestYCbCr_to_rgb(unittest.TestCase):
+    """
+    Defines :func:`colour.models.rgb.ycbcr.YCbCr_to_rgb` definition unit tests
+    methods.
+    """
+
+    def test_YCbCr_to_rgb(self):
+        """
+        Tests :func:`colour.models.rgb.ycbcr.YCbCr_to_rgb` definition.
+        """
+
+        np.testing.assert_almost_equal(
+            YCbCr_to_rgb(np.array([ 0.65842092,  0.17204301,  0.53060532])),
+            np.array([0.75, 0.75, 0.0]),
+            decimal=7)
+            
+        np.testing.assert_almost_equal(
+            YCbCr_to_rgb(np.array([ 471, 650, 390]), inRange=RANGE['legal_10_YC_int']),
+            np.array([ 0.25018598,  0.49950072,  0.75040741]),
+            decimal=7)
+            
+
+class Testrgb_to_YcCbcCrc(unittest.TestCase):
+    """
+    Defines :func:`colour.models.rgb.ycbcr.rgb_to_YcCbcCrc` definition unit tests
+    methods.
+    """
+
+    def test_rgb_to_YcCbcCrc(self):
+        """
+        Tests :func:`colour.models.rgb.ycbcr.rgb_to_YcCbcCrc` definition.
+        """
+
+        np.testing.assert_almost_equal(
+            rgb_to_YcCbcCrc(np.array([0.123, 0.456, 0.789])),
+            np.array([ 0.59258892,  0.64993099,  0.35269847]),
+            decimal=7)
+            
+        np.testing.assert_almost_equal(
+            rgb_to_YcCbcCrc(np.array([0.18, 0.18, 0.18]), outRange=RANGE['legal_10_YC_int'], is_10_bits_system = True),
+            np.array([422, 512, 512]),
+            decimal=7)
+
+
+class TestYcCbcCrc_to_rgb(unittest.TestCase):
+    """
+    Defines :func:`colour.models.rgb.ycbcr.YCbCr_to_rgb` definition unit tests
+    methods.
+    """
+
+    def test_YcCbcCrc_to_rgb(self):
+        """
+        Tests :func:`colour.models.rgb.ycbcr.YCbCr_to_rgb` definition.
+        """
+
+        np.testing.assert_almost_equal(
+            YcCbcCrc_to_rgb(np.array([1689, 2048, 2048]), inRange=RANGE['legal_12_YC_int'], is_10_bits_system = False),
+            np.array([ 0.18009037,  0.18009037,  0.18009037]),
+            decimal=7)
+            
+        np.testing.assert_almost_equal(
+            YcCbcCrc_to_rgb(np.array([0.678, 0.4, 0.6])),
+            np.array([ 0.69100667,  0.47450469,  0.25583733]),
+            decimal=7)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/colour/models/rgb/tests/tests_ycbcr.py
+++ b/colour/models/rgb/tests/tests_ycbcr.py
@@ -10,8 +10,9 @@ from __future__ import division, unicode_literals
 import numpy as np
 import unittest
 
-from colour.models.rgb.ycbcr import rgb_to_YCbCr, YCbCr_to_rgb, rgb_to_YcCbcCrc,
-        YcCbcCrc_to_rgb, RANGE, WEIGHT
+from colour.models.rgb.ycbcr import (rgb_to_YCbCr, YCbCr_to_rgb,
+                                     rgb_to_YcCbcCrc, YcCbcCrc_to_rgb,
+                                     RANGE, WEIGHT)
 
 __author__ = 'Colour Developers'
 __copyright__ = 'Copyright (C) 2013 - 2016 - Colour Developers'
@@ -20,7 +21,10 @@ __maintainer__ = 'Colour Developers'
 __email__ = 'colour-science@googlegroups.com'
 __status__ = 'Development'
 
-__all__ = ['Testrgb_to_YCbCr', 'TestYCbCr_to_rgb', 'Testrgb_to_YcCbcCrc', 'TestYcCbcCrc_to_rgb']
+__all__ = ['Testrgb_to_YCbCr',
+           'TestYCbCr_to_rgb',
+           'Testrgb_to_YcCbcCrc',
+           'TestYcCbcCrc_to_rgb']
 
 
 class Testrgb_to_YCbCr(unittest.TestCase):
@@ -36,12 +40,14 @@ class Testrgb_to_YCbCr(unittest.TestCase):
 
         np.testing.assert_almost_equal(
             rgb_to_YCbCr(np.array([0.75, 0.75, 0.0])),
-            np.array([ 0.65842092,  0.17204301,  0.53060532]),
+            np.array([0.65842092, 0.17204301, 0.53060532]),
             decimal=7)
-            
+
         np.testing.assert_almost_equal(
-            rgb_to_YCbCr(np.array([0.25, 0.5, 0.75]), outRange=RANGE['legal_10_YC_int']),
-            np.array([471, 650, 390]),
+            rgb_to_YCbCr(np.array([0.25, 0.5, 0.75]),
+                         K=WEIGHT['Rec.601'],
+                         outRange=RANGE['legal_10_YC_int']),
+            np.array([461, 662, 382]),
             decimal=7)
 
 
@@ -57,20 +63,21 @@ class TestYCbCr_to_rgb(unittest.TestCase):
         """
 
         np.testing.assert_almost_equal(
-            YCbCr_to_rgb(np.array([ 0.65842092,  0.17204301,  0.53060532])),
+            YCbCr_to_rgb(np.array([0.65842092, 0.17204301, 0.53060532])),
             np.array([0.75, 0.75, 0.0]),
             decimal=7)
-            
+
         np.testing.assert_almost_equal(
-            YCbCr_to_rgb(np.array([ 471, 650, 390]), inRange=RANGE['legal_10_YC_int']),
-            np.array([ 0.25018598,  0.49950072,  0.75040741]),
+            YCbCr_to_rgb(np.array([471, 650, 390]),
+                         inRange=RANGE['legal_10_YC_int']),
+            np.array([0.25018598, 0.49950072, 0.75040741]),
             decimal=7)
-            
+
 
 class Testrgb_to_YcCbcCrc(unittest.TestCase):
     """
-    Defines :func:`colour.models.rgb.ycbcr.rgb_to_YcCbcCrc` definition unit tests
-    methods.
+    Defines :func:`colour.models.rgb.ycbcr.rgb_to_YcCbcCrc` definition unit
+    tests methods.
     """
 
     def test_rgb_to_YcCbcCrc(self):
@@ -80,11 +87,13 @@ class Testrgb_to_YcCbcCrc(unittest.TestCase):
 
         np.testing.assert_almost_equal(
             rgb_to_YcCbcCrc(np.array([0.123, 0.456, 0.789])),
-            np.array([ 0.59258892,  0.64993099,  0.35269847]),
+            np.array([0.59258892, 0.64993099, 0.35269847]),
             decimal=7)
-            
+
         np.testing.assert_almost_equal(
-            rgb_to_YcCbcCrc(np.array([0.18, 0.18, 0.18]), outRange=RANGE['legal_10_YC_int'], is_10_bits_system = True),
+            rgb_to_YcCbcCrc(np.array([0.18, 0.18, 0.18]),
+                            outRange=RANGE['legal_10_YC_int'],
+                            is_10_bits_system=True),
             np.array([422, 512, 512]),
             decimal=7)
 
@@ -101,13 +110,15 @@ class TestYcCbcCrc_to_rgb(unittest.TestCase):
         """
 
         np.testing.assert_almost_equal(
-            YcCbcCrc_to_rgb(np.array([1689, 2048, 2048]), inRange=RANGE['legal_12_YC_int'], is_10_bits_system = False),
-            np.array([ 0.18009037,  0.18009037,  0.18009037]),
+            YcCbcCrc_to_rgb(np.array([1689, 2048, 2048]),
+                            inRange=RANGE['legal_12_YC_int'],
+                            is_10_bits_system=False),
+            np.array([0.18009037, 0.18009037, 0.18009037]),
             decimal=7)
-            
+
         np.testing.assert_almost_equal(
             YcCbcCrc_to_rgb(np.array([0.678, 0.4, 0.6])),
-            np.array([ 0.69100667,  0.47450469,  0.25583733]),
+            np.array([0.69100667, 0.47450469, 0.25583733]),
             decimal=7)
 
 

--- a/colour/models/rgb/tests/tests_ycbcr.py
+++ b/colour/models/rgb/tests/tests_ycbcr.py
@@ -82,9 +82,9 @@ class TestRGB_to_YCbCr(unittest.TestCase):
             YCbCr)
 
         rgb = np.tile(rgb, 4)
-        rgb = np.reshape(rgb, (4,3))
+        rgb = np.reshape(rgb, (4, 3))
         YCbCr = np.tile(YCbCr, 4)
-        YCbCr = np.reshape(YCbCr, (4,3))
+        YCbCr = np.reshape(YCbCr, (4, 3))
         np.testing.assert_almost_equal(
             RGB_to_YCbCr(rgb),
             YCbCr)
@@ -150,7 +150,6 @@ class TestYCbCr_to_RGB(unittest.TestCase):
             np.array([208, 131, 99]),
             decimal=7)
 
-
     def test_n_dimensional_YCbCr_to_RGB(self):
         """
         Tests :func:`colour.models.rgb.ycbcr.YCbCr_to_RGB` definition
@@ -163,9 +162,9 @@ class TestYCbCr_to_RGB(unittest.TestCase):
             rgb)
 
         rgb = np.tile(rgb, 4)
-        rgb = np.reshape(rgb, (4,3))
+        rgb = np.reshape(rgb, (4, 3))
         YCbCr = np.tile(YCbCr, 4)
-        YCbCr = np.reshape(YCbCr, (4,3))
+        YCbCr = np.reshape(YCbCr, (4, 3))
         np.testing.assert_almost_equal(
             YCbCr_to_RGB(YCbCr),
             rgb)
@@ -233,9 +232,9 @@ class TestRGB_to_YcCbcCrc(unittest.TestCase):
             YcCbcCrc)
 
         rgb = np.tile(rgb, 4)
-        rgb = np.reshape(rgb, (4,3))
+        rgb = np.reshape(rgb, (4, 3))
         YcCbcCrc = np.tile(YcCbcCrc, 4)
-        YcCbcCrc = np.reshape(YcCbcCrc, (4,3))
+        YcCbcCrc = np.reshape(YcCbcCrc, (4, 3))
         np.testing.assert_almost_equal(
             RGB_to_YcCbcCrc(rgb),
             YcCbcCrc)
@@ -303,9 +302,9 @@ class TestYcCbcCrc_to_RGB(unittest.TestCase):
             rgb)
 
         rgb = np.tile(rgb, 4)
-        rgb = np.reshape(rgb, (4,3))
+        rgb = np.reshape(rgb, (4, 3))
         YcCbcCrc = np.tile(YcCbcCrc, 4)
-        YcCbcCrc = np.reshape(YcCbcCrc, (4,3))
+        YcCbcCrc = np.reshape(YcCbcCrc, (4, 3))
         np.testing.assert_almost_equal(
             YcCbcCrc_to_RGB(YcCbcCrc),
             rgb)

--- a/colour/models/rgb/tests/tests_ycbcr.py
+++ b/colour/models/rgb/tests/tests_ycbcr.py
@@ -10,9 +10,11 @@ from __future__ import division, unicode_literals
 import numpy as np
 import unittest
 
-from colour.models.rgb.ycbcr import (rgb_to_YCbCr, YCbCr_to_rgb,
-                                     rgb_to_YcCbcCrc, YcCbcCrc_to_rgb,
-                                     RANGE, WEIGHT)
+from colour.models.rgb.ycbcr import (RGB_to_YCbCr,
+                                     YCbCr_to_RGB,
+                                     RGB_to_YcCbcCrc,
+                                     YcCbcCrc_to_RGB,
+                                     YCBCR_WEIGHTS)
 
 __author__ = 'Colour Developers'
 __copyright__ = 'Copyright (C) 2013 - 2016 - Colour Developers'
@@ -21,104 +23,127 @@ __maintainer__ = 'Colour Developers'
 __email__ = 'colour-science@googlegroups.com'
 __status__ = 'Development'
 
-__all__ = ['Testrgb_to_YCbCr',
-           'TestYCbCr_to_rgb',
-           'Testrgb_to_YcCbcCrc',
-           'TestYcCbcCrc_to_rgb']
+__all__ = ['TestRGB_to_YCbCr',
+           'TestYCbCr_to_RGB',
+           'TestRGB_to_YcCbcCrc',
+           'TestYcCbcCrc_to_RGB']
 
 
-class Testrgb_to_YCbCr(unittest.TestCase):
+class TestRGB_to_YCbCr(unittest.TestCase):
     """
-    Defines :func:`colour.models.rgb.ycbcr.rgb_to_YCbCr` definition unit tests
+    Defines :func:`colour.models.rgb.ycbcr.RGB_to_YCbCr` definition unit tests
     methods.
     """
 
-    def test_rgb_to_YCbCr(self):
+    def test_RGB_to_YCbCr(self):
         """
-        Tests :func:`colour.models.rgb.ycbcr.rgb_to_YCbCr` definition.
+        Tests :func:`colour.models.rgb.ycbcr.RGB_to_YCbCr` definition.
         """
 
         np.testing.assert_almost_equal(
-            rgb_to_YCbCr(np.array([0.75, 0.75, 0.0])),
-            np.array([0.65842092, 0.17204301, 0.53060532]),
+            RGB_to_YCbCr(np.array([0.75, 0.75, 0.0])),
+            np.array([0.66035745, 0.17254902, 0.53216593]),
             decimal=7)
 
         np.testing.assert_almost_equal(
-            rgb_to_YCbCr(np.array([0.25, 0.5, 0.75]),
-                         K=WEIGHT['Rec.601'],
-                         outRange=RANGE['legal_10_YC_int']),
+            RGB_to_YCbCr(np.array([0.25, 0.5, 0.75]),
+                         K=YCBCR_WEIGHTS['Rec. 601'],
+                         out_int=True,
+                         out_legal=True,
+                         out_bits=10),
             np.array([461, 662, 382]),
             decimal=7)
 
+        np.testing.assert_almost_equal(
+            RGB_to_YCbCr(np.array([0.0, 0.75, 0.75]),
+                         K=YCBCR_WEIGHTS['Rec. 2020'],
+                         out_int=False,
+                         out_legal=False),
+            np.array([0.552975, 0.10472255, -0.375]),
+            decimal=7)
 
-class TestYCbCr_to_rgb(unittest.TestCase):
+        np.testing.assert_almost_equal(
+            RGB_to_YCbCr(np.array([0.75, 0.0, 0.75]),
+                         K=YCBCR_WEIGHTS['Rec. 709'],
+                         out_range=(16./255, 235./255, 15.5/255, 239.5/255)),
+            np.array([0.2461898 , 0.75392897, 0.79920662]),
+            decimal=7)
+
+
+class TestYCbCr_to_RGB(unittest.TestCase):
     """
-    Defines :func:`colour.models.rgb.ycbcr.YCbCr_to_rgb` definition unit tests
+    Defines :func:`colour.models.rgb.ycbcr.YCbCr_to_RGB` definition unit tests
     methods.
     """
 
-    def test_YCbCr_to_rgb(self):
+    def test_YCbCr_to_RGB(self):
         """
-        Tests :func:`colour.models.rgb.ycbcr.YCbCr_to_rgb` definition.
+        Tests :func:`colour.models.rgb.ycbcr.YCbCr_to_RGB` definition.
         """
 
         np.testing.assert_almost_equal(
-            YCbCr_to_rgb(np.array([0.65842092, 0.17204301, 0.53060532])),
+            YCbCr_to_RGB(np.array([0.66035745, 0.17254902, 0.53216593])),
             np.array([0.75, 0.75, 0.0]),
             decimal=7)
 
         np.testing.assert_almost_equal(
-            YCbCr_to_rgb(np.array([471, 650, 390]),
-                         inRange=RANGE['legal_10_YC_int']),
+            YCbCr_to_RGB(np.array([471, 650, 390]),
+                         in_bits=10,
+                         in_legal=True,
+                         in_int=True),
             np.array([0.25018598, 0.49950072, 0.75040741]),
             decimal=7)
 
 
-class Testrgb_to_YcCbcCrc(unittest.TestCase):
+class TestRGB_to_YcCbcCrc(unittest.TestCase):
     """
-    Defines :func:`colour.models.rgb.ycbcr.rgb_to_YcCbcCrc` definition unit
+    Defines :func:`colour.models.rgb.ycbcr.RGB_to_YcCbcCrc` definition unit
     tests methods.
     """
 
-    def test_rgb_to_YcCbcCrc(self):
+    def test_RGB_to_YcCbcCrc(self):
         """
-        Tests :func:`colour.models.rgb.ycbcr.rgb_to_YcCbcCrc` definition.
+        Tests :func:`colour.models.rgb.ycbcr.RGB_to_YcCbcCrc` definition.
         """
 
         np.testing.assert_almost_equal(
-            rgb_to_YcCbcCrc(np.array([0.123, 0.456, 0.789])),
-            np.array([0.59258892, 0.64993099, 0.35269847]),
+            RGB_to_YcCbcCrc(np.array([0.123, 0.456, 0.789])),
+            np.array([0.59433183, 0.65184256, 0.35373582]),
             decimal=7)
 
         np.testing.assert_almost_equal(
-            rgb_to_YcCbcCrc(np.array([0.18, 0.18, 0.18]),
-                            outRange=RANGE['legal_10_YC_int'],
+            RGB_to_YcCbcCrc(np.array([0.18, 0.18, 0.18]),
+                            out_bits=10,
+                            out_legal=True,
+                            out_int=True,
                             is_10_bits_system=True),
             np.array([422, 512, 512]),
             decimal=7)
 
 
-class TestYcCbcCrc_to_rgb(unittest.TestCase):
+class TestYcCbcCrc_to_RGB(unittest.TestCase):
     """
-    Defines :func:`colour.models.rgb.ycbcr.YCbCr_to_rgb` definition unit tests
+    Defines :func:`colour.models.rgb.ycbcr.YCbCr_to_RGB` definition unit tests
     methods.
     """
 
-    def test_YcCbcCrc_to_rgb(self):
+    def test_YcCbcCrc_to_RGB(self):
         """
-        Tests :func:`colour.models.rgb.ycbcr.YCbCr_to_rgb` definition.
+        Tests :func:`colour.models.rgb.ycbcr.YCbCr_to_RGB` definition.
         """
 
         np.testing.assert_almost_equal(
-            YcCbcCrc_to_rgb(np.array([1689, 2048, 2048]),
-                            inRange=RANGE['legal_12_YC_int'],
+            YcCbcCrc_to_RGB(np.array([1689, 2048, 2048]),
+                            in_bits=12,
+                            in_legal=True,
+                            in_int=True,
                             is_10_bits_system=False),
             np.array([0.18009037, 0.18009037, 0.18009037]),
             decimal=7)
 
         np.testing.assert_almost_equal(
-            YcCbcCrc_to_rgb(np.array([0.678, 0.4, 0.6])),
-            np.array([0.69100667, 0.47450469, 0.25583733]),
+            YcCbcCrc_to_RGB(np.array([0.678, 0.4, 0.6])),
+            np.array([0.68390184, 0.47285022, 0.25116003]),
             decimal=7)
 
 

--- a/colour/models/rgb/tests/tests_ycbcr.py
+++ b/colour/models/rgb/tests/tests_ycbcr.py
@@ -47,26 +47,29 @@ class TestRGB_to_YCbCr(unittest.TestCase):
             decimal=7)
 
         np.testing.assert_almost_equal(
-            RGB_to_YCbCr(np.array([0.25, 0.5, 0.75]),
-                         K=YCBCR_WEIGHTS['Rec. 601'],
-                         out_int=True,
-                         out_legal=True,
-                         out_bits=10),
+            RGB_to_YCbCr(
+                np.array([0.25, 0.5, 0.75]),
+                K=YCBCR_WEIGHTS['Rec. 601'],
+                out_int=True,
+                out_legal=True,
+                out_bits=10),
             np.array([461, 662, 382]),
             decimal=7)
 
         np.testing.assert_almost_equal(
-            RGB_to_YCbCr(np.array([0.0, 0.75, 0.75]),
-                         K=YCBCR_WEIGHTS['Rec. 2020'],
-                         out_int=False,
-                         out_legal=False),
+            RGB_to_YCbCr(
+                np.array([0.0, 0.75, 0.75]),
+                K=YCBCR_WEIGHTS['Rec. 2020'],
+                out_int=False,
+                out_legal=False),
             np.array([0.552975, 0.10472255, -0.375]),
             decimal=7)
 
         np.testing.assert_almost_equal(
-            RGB_to_YCbCr(np.array([0.75, 0.0, 0.75]),
-                         K=YCBCR_WEIGHTS['Rec. 709'],
-                         out_range=(16/255, 235/255, 15.5/255, 239.5/255)),
+            RGB_to_YCbCr(
+                np.array([0.75, 0.0, 0.75]),
+                K=YCBCR_WEIGHTS['Rec. 709'],
+                out_range=(16 / 255, 235 / 255, 15.5 / 255, 239.5 / 255)),
             np.array([0.2461898, 0.75392897, 0.79920662]),
             decimal=7)
 
@@ -75,34 +78,35 @@ class TestRGB_to_YCbCr(unittest.TestCase):
         Tests :func:`colour.models.rgb.ycbcr.RGB_to_YCbCr` definition
         n-dimensional arrays support.
         """
-        rgb = np.array([0.75, 0.5, 0.25])
+
+        RGB = np.array([0.75, 0.5, 0.25])
         YCbCr = np.array([0.52230157, 0.36699593, 0.62183309])
         np.testing.assert_almost_equal(
-            RGB_to_YCbCr(rgb),
+            RGB_to_YCbCr(RGB),
             YCbCr)
 
-        rgb = np.tile(rgb, 4)
-        rgb = np.reshape(rgb, (4, 3))
+        RGB = np.tile(RGB, 4)
+        RGB = np.reshape(RGB, (4, 3))
         YCbCr = np.tile(YCbCr, 4)
         YCbCr = np.reshape(YCbCr, (4, 3))
         np.testing.assert_almost_equal(
-            RGB_to_YCbCr(rgb),
+            RGB_to_YCbCr(RGB),
             YCbCr)
 
-        rgb = np.tile(rgb, 4)
-        rgb = np.reshape(rgb, (4, 4, 3))
+        RGB = np.tile(RGB, 4)
+        RGB = np.reshape(RGB, (4, 4, 3))
         YCbCr = np.tile(YCbCr, 4)
         YCbCr = np.reshape(YCbCr, (4, 4, 3))
         np.testing.assert_almost_equal(
-            RGB_to_YCbCr(rgb),
+            RGB_to_YCbCr(RGB),
             YCbCr)
 
-        rgb = np.tile(rgb, 4)
-        rgb = np.reshape(rgb, (4, 4, 4, 3))
+        RGB = np.tile(RGB, 4)
+        RGB = np.reshape(RGB, (4, 4, 4, 3))
         YCbCr = np.tile(YCbCr, 4)
         YCbCr = np.reshape(YCbCr, (4, 4, 4, 3))
         np.testing.assert_almost_equal(
-            RGB_to_YCbCr(rgb),
+            RGB_to_YCbCr(RGB),
             YCbCr)
 
     @ignore_numpy_errors
@@ -132,21 +136,23 @@ class TestYCbCr_to_RGB(unittest.TestCase):
             decimal=7)
 
         np.testing.assert_almost_equal(
-            YCbCr_to_RGB(np.array([471, 650, 390]),
-                         in_bits=10,
-                         in_legal=True,
-                         in_int=True),
+            YCbCr_to_RGB(
+                np.array([471, 650, 390]),
+                in_bits=10,
+                in_legal=True,
+                in_int=True),
             np.array([0.25018598, 0.49950072, 0.75040741]),
             decimal=7)
 
         np.testing.assert_almost_equal(
-            YCbCr_to_RGB(np.array([150, 99, 175]),
-                         in_bits=8,
-                         in_legal=False,
-                         in_int=True,
-                         out_bits=8,
-                         out_legal=True,
-                         out_int=True),
+            YCbCr_to_RGB(
+                np.array([150, 99, 175]),
+                in_bits=8,
+                in_legal=False,
+                in_int=True,
+                out_bits=8,
+                out_legal=True,
+                out_int=True),
             np.array([208, 131, 99]),
             decimal=7)
 
@@ -155,35 +161,36 @@ class TestYCbCr_to_RGB(unittest.TestCase):
         Tests :func:`colour.models.rgb.ycbcr.YCbCr_to_RGB` definition
         n-dimensional arrays support.
         """
+
         YCbCr = np.array([0.52230157, 0.36699593, 0.62183309])
-        rgb = np.array([0.75, 0.5, 0.25])
+        RGB = np.array([0.75, 0.5, 0.25])
         np.testing.assert_almost_equal(
             YCbCr_to_RGB(YCbCr),
-            rgb)
+            RGB)
 
-        rgb = np.tile(rgb, 4)
-        rgb = np.reshape(rgb, (4, 3))
+        RGB = np.tile(RGB, 4)
+        RGB = np.reshape(RGB, (4, 3))
         YCbCr = np.tile(YCbCr, 4)
         YCbCr = np.reshape(YCbCr, (4, 3))
         np.testing.assert_almost_equal(
             YCbCr_to_RGB(YCbCr),
-            rgb)
+            RGB)
 
-        rgb = np.tile(rgb, 4)
-        rgb = np.reshape(rgb, (4, 4, 3))
+        RGB = np.tile(RGB, 4)
+        RGB = np.reshape(RGB, (4, 4, 3))
         YCbCr = np.tile(YCbCr, 4)
         YCbCr = np.reshape(YCbCr, (4, 4, 3))
         np.testing.assert_almost_equal(
             YCbCr_to_RGB(YCbCr),
-            rgb)
+            RGB)
 
-        rgb = np.tile(rgb, 4)
-        rgb = np.reshape(rgb, (4, 4, 4, 3))
+        RGB = np.tile(RGB, 4)
+        RGB = np.reshape(RGB, (4, 4, 4, 3))
         YCbCr = np.tile(YCbCr, 4)
         YCbCr = np.reshape(YCbCr, (4, 4, 4, 3))
         np.testing.assert_almost_equal(
             YCbCr_to_RGB(YCbCr),
-            rgb)
+            RGB)
 
     @ignore_numpy_errors
     def test_nan_YCbCr_to_RGB(self):
@@ -212,11 +219,12 @@ class TestRGB_to_YcCbcCrc(unittest.TestCase):
             decimal=7)
 
         np.testing.assert_almost_equal(
-            RGB_to_YcCbcCrc(np.array([0.18, 0.18, 0.18]),
-                            out_bits=10,
-                            out_legal=True,
-                            out_int=True,
-                            is_10_bits_system=True),
+            RGB_to_YcCbcCrc(
+                np.array([0.18, 0.18, 0.18]),
+                out_bits=10,
+                out_legal=True,
+                out_int=True,
+                is_10_bits_system=True),
             np.array([422, 512, 512]),
             decimal=7)
 
@@ -225,34 +233,35 @@ class TestRGB_to_YcCbcCrc(unittest.TestCase):
         Tests :func:`colour.models.rgb.ycbcr.RGB_to_YcCbcCrc` definition
         n-dimensional arrays support.
         """
-        rgb = np.array([0.75, 0.5, 0.25])
+
+        RGB = np.array([0.75, 0.5, 0.25])
         YcCbcCrc = np.array([0.69943807, 0.38814348, 0.61264549])
         np.testing.assert_almost_equal(
-            RGB_to_YcCbcCrc(rgb),
+            RGB_to_YcCbcCrc(RGB),
             YcCbcCrc)
 
-        rgb = np.tile(rgb, 4)
-        rgb = np.reshape(rgb, (4, 3))
+        RGB = np.tile(RGB, 4)
+        RGB = np.reshape(RGB, (4, 3))
         YcCbcCrc = np.tile(YcCbcCrc, 4)
         YcCbcCrc = np.reshape(YcCbcCrc, (4, 3))
         np.testing.assert_almost_equal(
-            RGB_to_YcCbcCrc(rgb),
+            RGB_to_YcCbcCrc(RGB),
             YcCbcCrc)
 
-        rgb = np.tile(rgb, 4)
-        rgb = np.reshape(rgb, (4, 4, 3))
+        RGB = np.tile(RGB, 4)
+        RGB = np.reshape(RGB, (4, 4, 3))
         YcCbcCrc = np.tile(YcCbcCrc, 4)
         YcCbcCrc = np.reshape(YcCbcCrc, (4, 4, 3))
         np.testing.assert_almost_equal(
-            RGB_to_YcCbcCrc(rgb),
+            RGB_to_YcCbcCrc(RGB),
             YcCbcCrc)
 
-        rgb = np.tile(rgb, 4)
-        rgb = np.reshape(rgb, (4, 4, 4, 3))
+        RGB = np.tile(RGB, 4)
+        RGB = np.reshape(RGB, (4, 4, 4, 3))
         YcCbcCrc = np.tile(YcCbcCrc, 4)
         YcCbcCrc = np.reshape(YcCbcCrc, (4, 4, 4, 3))
         np.testing.assert_almost_equal(
-            RGB_to_YcCbcCrc(rgb),
+            RGB_to_YcCbcCrc(RGB),
             YcCbcCrc)
 
     @ignore_numpy_errors
@@ -277,11 +286,12 @@ class TestYcCbcCrc_to_RGB(unittest.TestCase):
         """
 
         np.testing.assert_almost_equal(
-            YcCbcCrc_to_RGB(np.array([1689, 2048, 2048]),
-                            in_bits=12,
-                            in_legal=True,
-                            in_int=True,
-                            is_10_bits_system=False),
+            YcCbcCrc_to_RGB(
+                np.array([1689, 2048, 2048]),
+                in_bits=12,
+                in_legal=True,
+                in_int=True,
+                is_10_bits_system=False),
             np.array([0.18009037, 0.18009037, 0.18009037]),
             decimal=7)
 
@@ -295,35 +305,36 @@ class TestYcCbcCrc_to_RGB(unittest.TestCase):
         Tests :func:`colour.models.rgb.ycbcr.YcCbcCrc_to_RGB` definition
         n-dimensional arrays support.
         """
+
         YcCbcCrc = np.array([0.69943807, 0.38814348, 0.61264549])
-        rgb = np.array([0.75, 0.5, 0.25])
+        RGB = np.array([0.75, 0.5, 0.25])
         np.testing.assert_almost_equal(
             YcCbcCrc_to_RGB(YcCbcCrc),
-            rgb)
+            RGB)
 
-        rgb = np.tile(rgb, 4)
-        rgb = np.reshape(rgb, (4, 3))
+        RGB = np.tile(RGB, 4)
+        RGB = np.reshape(RGB, (4, 3))
         YcCbcCrc = np.tile(YcCbcCrc, 4)
         YcCbcCrc = np.reshape(YcCbcCrc, (4, 3))
         np.testing.assert_almost_equal(
             YcCbcCrc_to_RGB(YcCbcCrc),
-            rgb)
+            RGB)
 
-        rgb = np.tile(rgb, 4)
-        rgb = np.reshape(rgb, (4, 4, 3))
+        RGB = np.tile(RGB, 4)
+        RGB = np.reshape(RGB, (4, 4, 3))
         YcCbcCrc = np.tile(YcCbcCrc, 4)
         YcCbcCrc = np.reshape(YcCbcCrc, (4, 4, 3))
         np.testing.assert_almost_equal(
             YcCbcCrc_to_RGB(YcCbcCrc),
-            rgb)
+            RGB)
 
-        rgb = np.tile(rgb, 4)
-        rgb = np.reshape(rgb, (4, 4, 4, 3))
+        RGB = np.tile(RGB, 4)
+        RGB = np.reshape(RGB, (4, 4, 4, 3))
         YcCbcCrc = np.tile(YcCbcCrc, 4)
         YcCbcCrc = np.reshape(YcCbcCrc, (4, 4, 4, 3))
         np.testing.assert_almost_equal(
             YcCbcCrc_to_RGB(YcCbcCrc),
-            rgb)
+            RGB)
 
     @ignore_numpy_errors
     def test_nan_YcCbcCrc_to_RGB(self):

--- a/colour/models/rgb/tests/tests_ycbcr.py
+++ b/colour/models/rgb/tests/tests_ycbcr.py
@@ -15,6 +15,7 @@ from colour.models.rgb.ycbcr import (RGB_to_YCbCr,
                                      RGB_to_YcCbcCrc,
                                      YcCbcCrc_to_RGB,
                                      YCBCR_WEIGHTS)
+from colour.utilities import ignore_numpy_errors
 
 __author__ = 'Colour Developers'
 __copyright__ = 'Copyright (C) 2013 - 2016 - Colour Developers'
@@ -69,6 +70,50 @@ class TestRGB_to_YCbCr(unittest.TestCase):
             np.array([0.2461898, 0.75392897, 0.79920662]),
             decimal=7)
 
+    def test_n_dimensional_RGB_to_YCbCr(self):
+        """
+        Tests :func:`colour.models.rgb.ycbcr.RGB_to_YCbCr` definition
+        n-dimensional arrays support.
+        """
+        rgb = np.array([0.75, 0.5, 0.25])
+        YCbCr = np.array([0.52230157, 0.36699593, 0.62183309])
+        np.testing.assert_almost_equal(
+            RGB_to_YCbCr(rgb),
+            YCbCr)
+
+        rgb = np.tile(rgb, 4)
+        rgb = np.reshape(rgb, (4,3))
+        YCbCr = np.tile(YCbCr, 4)
+        YCbCr = np.reshape(YCbCr, (4,3))
+        np.testing.assert_almost_equal(
+            RGB_to_YCbCr(rgb),
+            YCbCr)
+
+        rgb = np.tile(rgb, 4)
+        rgb = np.reshape(rgb, (4, 4, 3))
+        YCbCr = np.tile(YCbCr, 4)
+        YCbCr = np.reshape(YCbCr, (4, 4, 3))
+        np.testing.assert_almost_equal(
+            RGB_to_YCbCr(rgb),
+            YCbCr)
+
+        rgb = np.tile(rgb, 4)
+        rgb = np.reshape(rgb, (4, 4, 4, 3))
+        YCbCr = np.tile(YCbCr, 4)
+        YCbCr = np.reshape(YCbCr, (4, 4, 4, 3))
+        np.testing.assert_almost_equal(
+            RGB_to_YCbCr(rgb),
+            YCbCr)
+
+    @ignore_numpy_errors
+    def test_nan_RGB_to_YCbCr(self):
+        """
+        Tests :func:`colour.models.rgb.ycbcr.RGB_to_YCbCr` definition nan
+        support.
+        """
+
+        RGB_to_YCbCr(np.array([-np.inf, np.inf, np.nan]))
+
 
 class TestYCbCr_to_RGB(unittest.TestCase):
     """
@@ -93,6 +138,62 @@ class TestYCbCr_to_RGB(unittest.TestCase):
                          in_int=True),
             np.array([0.25018598, 0.49950072, 0.75040741]),
             decimal=7)
+
+        np.testing.assert_almost_equal(
+            YCbCr_to_RGB(np.array([150, 99, 175]),
+                         in_bits=8,
+                         in_legal=False,
+                         in_int=True,
+                         out_bits=8,
+                         out_legal=True,
+                         out_int=True),
+            np.array([208, 131, 99]),
+            decimal=7)
+
+
+    def test_n_dimensional_YCbCr_to_RGB(self):
+        """
+        Tests :func:`colour.models.rgb.ycbcr.YCbCr_to_RGB` definition
+        n-dimensional arrays support.
+        """
+        YCbCr = np.array([0.52230157, 0.36699593, 0.62183309])
+        rgb = np.array([0.75, 0.5, 0.25])
+        np.testing.assert_almost_equal(
+            YCbCr_to_RGB(YCbCr),
+            rgb)
+
+        rgb = np.tile(rgb, 4)
+        rgb = np.reshape(rgb, (4,3))
+        YCbCr = np.tile(YCbCr, 4)
+        YCbCr = np.reshape(YCbCr, (4,3))
+        np.testing.assert_almost_equal(
+            YCbCr_to_RGB(YCbCr),
+            rgb)
+
+        rgb = np.tile(rgb, 4)
+        rgb = np.reshape(rgb, (4, 4, 3))
+        YCbCr = np.tile(YCbCr, 4)
+        YCbCr = np.reshape(YCbCr, (4, 4, 3))
+        np.testing.assert_almost_equal(
+            YCbCr_to_RGB(YCbCr),
+            rgb)
+
+        rgb = np.tile(rgb, 4)
+        rgb = np.reshape(rgb, (4, 4, 4, 3))
+        YCbCr = np.tile(YCbCr, 4)
+        YCbCr = np.reshape(YCbCr, (4, 4, 4, 3))
+        np.testing.assert_almost_equal(
+            YCbCr_to_RGB(YCbCr),
+            rgb)
+
+    @ignore_numpy_errors
+    def test_nan_YCbCr_to_RGB(self):
+        """
+        Tests :func:`colour.models.rgb.ycbcr.YCbCr_to_RGB` definition nan
+        support.
+        """
+
+        YCbCr_to_RGB(np.array([-np.inf, np.inf, np.nan]))
 
 
 class TestRGB_to_YcCbcCrc(unittest.TestCase):
@@ -120,6 +221,50 @@ class TestRGB_to_YcCbcCrc(unittest.TestCase):
             np.array([422, 512, 512]),
             decimal=7)
 
+    def test_n_dimensional_RGB_to_YcCbcCrc(self):
+        """
+        Tests :func:`colour.models.rgb.ycbcr.RGB_to_YcCbcCrc` definition
+        n-dimensional arrays support.
+        """
+        rgb = np.array([0.75, 0.5, 0.25])
+        YcCbcCrc = np.array([0.69943807, 0.38814348, 0.61264549])
+        np.testing.assert_almost_equal(
+            RGB_to_YcCbcCrc(rgb),
+            YcCbcCrc)
+
+        rgb = np.tile(rgb, 4)
+        rgb = np.reshape(rgb, (4,3))
+        YcCbcCrc = np.tile(YcCbcCrc, 4)
+        YcCbcCrc = np.reshape(YcCbcCrc, (4,3))
+        np.testing.assert_almost_equal(
+            RGB_to_YcCbcCrc(rgb),
+            YcCbcCrc)
+
+        rgb = np.tile(rgb, 4)
+        rgb = np.reshape(rgb, (4, 4, 3))
+        YcCbcCrc = np.tile(YcCbcCrc, 4)
+        YcCbcCrc = np.reshape(YcCbcCrc, (4, 4, 3))
+        np.testing.assert_almost_equal(
+            RGB_to_YcCbcCrc(rgb),
+            YcCbcCrc)
+
+        rgb = np.tile(rgb, 4)
+        rgb = np.reshape(rgb, (4, 4, 4, 3))
+        YcCbcCrc = np.tile(YcCbcCrc, 4)
+        YcCbcCrc = np.reshape(YcCbcCrc, (4, 4, 4, 3))
+        np.testing.assert_almost_equal(
+            RGB_to_YcCbcCrc(rgb),
+            YcCbcCrc)
+
+    @ignore_numpy_errors
+    def test_nan_RGB_to_YcCbcCrc(self):
+        """
+        Tests :func:`colour.models.rgb.ycbcr.RGB_to_YcCbcCrc` definition nan
+        support.
+        """
+
+        RGB_to_YcCbcCrc(np.array([-np.inf, np.inf, np.nan]))
+
 
 class TestYcCbcCrc_to_RGB(unittest.TestCase):
     """
@@ -145,6 +290,50 @@ class TestYcCbcCrc_to_RGB(unittest.TestCase):
             YcCbcCrc_to_RGB(np.array([0.678, 0.4, 0.6])),
             np.array([0.68390184, 0.47285022, 0.25116003]),
             decimal=7)
+
+    def test_n_dimensional_YcCbcCrc_to_RGB(self):
+        """
+        Tests :func:`colour.models.rgb.ycbcr.YcCbcCrc_to_RGB` definition
+        n-dimensional arrays support.
+        """
+        YcCbcCrc = np.array([0.69943807, 0.38814348, 0.61264549])
+        rgb = np.array([0.75, 0.5, 0.25])
+        np.testing.assert_almost_equal(
+            YcCbcCrc_to_RGB(YcCbcCrc),
+            rgb)
+
+        rgb = np.tile(rgb, 4)
+        rgb = np.reshape(rgb, (4,3))
+        YcCbcCrc = np.tile(YcCbcCrc, 4)
+        YcCbcCrc = np.reshape(YcCbcCrc, (4,3))
+        np.testing.assert_almost_equal(
+            YcCbcCrc_to_RGB(YcCbcCrc),
+            rgb)
+
+        rgb = np.tile(rgb, 4)
+        rgb = np.reshape(rgb, (4, 4, 3))
+        YcCbcCrc = np.tile(YcCbcCrc, 4)
+        YcCbcCrc = np.reshape(YcCbcCrc, (4, 4, 3))
+        np.testing.assert_almost_equal(
+            YcCbcCrc_to_RGB(YcCbcCrc),
+            rgb)
+
+        rgb = np.tile(rgb, 4)
+        rgb = np.reshape(rgb, (4, 4, 4, 3))
+        YcCbcCrc = np.tile(YcCbcCrc, 4)
+        YcCbcCrc = np.reshape(YcCbcCrc, (4, 4, 4, 3))
+        np.testing.assert_almost_equal(
+            YcCbcCrc_to_RGB(YcCbcCrc),
+            rgb)
+
+    @ignore_numpy_errors
+    def test_nan_YcCbcCrc_to_RGB(self):
+        """
+        Tests :func:`colour.models.rgb.ycbcr.YcCbcCrc_to_RGB` definition nan
+        support.
+        """
+
+        YcCbcCrc_to_RGB(np.array([-np.inf, np.inf, np.nan]))
 
 
 if __name__ == '__main__':

--- a/colour/models/rgb/tests/tests_ycbcr.py
+++ b/colour/models/rgb/tests/tests_ycbcr.py
@@ -66,7 +66,7 @@ class TestRGB_to_YCbCr(unittest.TestCase):
         np.testing.assert_almost_equal(
             RGB_to_YCbCr(np.array([0.75, 0.0, 0.75]),
                          K=YCBCR_WEIGHTS['Rec. 709'],
-                         out_range=(16./255, 235./255, 15.5/255, 239.5/255)),
+                         out_range=(16/255, 235/255, 15.5/255, 239.5/255)),
             np.array([0.2461898, 0.75392897, 0.79920662]),
             decimal=7)
 

--- a/colour/models/rgb/tests/tests_ycbcr.py
+++ b/colour/models/rgb/tests/tests_ycbcr.py
@@ -66,7 +66,7 @@ class TestRGB_to_YCbCr(unittest.TestCase):
             RGB_to_YCbCr(np.array([0.75, 0.0, 0.75]),
                          K=YCBCR_WEIGHTS['Rec. 709'],
                          out_range=(16./255, 235./255, 15.5/255, 239.5/255)),
-            np.array([0.2461898 , 0.75392897, 0.79920662]),
+            np.array([0.2461898, 0.75392897, 0.79920662]),
             decimal=7)
 
 

--- a/colour/models/rgb/ycbcr.py
+++ b/colour/models/rgb/ycbcr.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Y'CbCr Colour Encoding
+======================
+
+Defines the Y'CbCr colour encoding (Y'CbCr is not a colour space) transformations:
+
+-   :func:`rgb_to_YCbCr`
+-   :func:`YCbCr_to_rgb`
+-   :func:`rgb_to_YcCbcCrc`
+-   :func:`YcCbcCrc_to_rgb`
+
+References
+----------
+.. [1]  Wikipedia. YCbCr. Retrieved February 29, 2016, from
+        https://en.wikipedia.org/wiki/YCbCr
+.. [2]  Recommendation ITU-R BT.709-6(06/2015). Retrieved February 29, 2016, from
+        https://www.itu.int/dms_pubrec/itu-r/rec/bt/R-REC-BT.709-6-201506-I!!PDF-E.pdf
+.. [3]  Recommendation ITU-R BT.2020(08/2012). Retrieved February 29, 2016, from
+        https://www.itu.int/dms_pubrec/itu-r/rec/bt/R-REC-BT.2020-0-201208-S!!PDF-E.pdf
+"""
+
+import numpy as np
+
+from colour.utilities import tsplit, tstack, CaseInsensitiveMapping
+from colour.models.rgb import *
+
+__author__ = 'Colour Developers'
+__copyright__ = 'Copyright (C) 2013 - 2016 - Colour Developers'
+__license__ = 'New BSD License - http://opensource.org/licenses/BSD-3-Clause'
+__maintainer__ = 'Colour Developers'
+__email__ = 'colour-science@googlegroups.com'
+__status__ = 'Development'
+
+__all__ = ['WEIGHT',
+           'RANGE',
+           'rgb_to_YCbCr',
+           'YCbCr_to_rgb',
+           'rgb_to_YcCbcCrc',
+           'YcCbcCrc_to_rgb']
+
+WEIGHT = (CaseInsensitiveMapping(
+        {'Rec.601' : [0.299, 0.114],
+         'Rec.709' : [0.2126, 0.0722],
+         'Rec.2020' : [0.2627, 0.0593]}))
+"""
+List of preset luma weightings:
+    'Rec.601' : [0.299, 0.114]
+    'Rec.709' : [0.2126, 0.0722]
+    'Rec.2020' : [0.2627, 0.0593]
+"""
+
+RANGE = (CaseInsensitiveMapping(
+        {'legal_12' : [256./4095, 3760./4095],
+         'legal_12_YC' : [256./4095, 3760./4095, 256./4095, 3840./4095],
+         'legal_12_int' : [256, 3760],
+         'legal_12_YC_int' : [256, 3760, 256, 3840],
+         'legal_10' : [64./1023, 940./1023],
+         'legal_10_YC' : [64./1023, 940./1023, 64./1023, 960./1023],
+         'legal_10_int' : [64, 940],
+         'legal_10_YC_int' : [64, 940, 64, 960],
+         'legal_8' : [16./255, 235./255],
+         'legal_8_YC' : [16./255, 235./255, 16./255, 240./255],
+         'legal_8_int' : [16, 235],
+         'legal_8_YC_int' : [16, 235, 16, 240],
+         'full' : [0.0, 1.0],
+         'YPbPr' : [0.0, 1.0, -0.5, 0.5]}))
+"""
+List of preset ranges:
+    'legal_12' : [256./4095, 3760./4095]
+    'legal_12_YC' : [256./4095, 3760./4095, 256./4095, 3840./4095]
+    'legal_12_int' : [256, 3760]
+    'legal_12_YC_int' : [256, 3760, 256, 3840]
+    'legal_10' : [64./1023, 940./1023]
+    'legal_10_YC' : [64./1023, 940./1023, 64./1023, 960./1023]
+    'legal_10_int' : [64, 940]
+    'legal_10_YC_int' : [64, 940, 64, 960]
+    'legal_8' : [16./255, 235./255]
+    'legal_8_YC' : [16./255, 235./255, 16./255, 240./255]
+    'legal_8_int' : [16, 235]
+    'legal_8_YC_int' : [16, 235, 16, 240]
+    'full' : [0.0, 1.0]
+    'YPbPr' : [0.0, 1.0, -0.5, 0.5]
+"""
+
+def rgb_to_YCbCr(rgb, K = WEIGHT['Rec.709'], inRange = RANGE['full'], outRange = RANGE['legal_10_YC']):
+    """
+    Converts an array of R'G'B' values to the corresponding Y'CbCr values.
+    
+    Note: For ITU-R BT.2020 (Rec.2020) the rgb_to_YCbCr function is only applicable to
+    the non-constant luminance implementation.
+    The rgb_to_YcCbcCrc function should be used for the constant luminance case.
+    See https://www.itu.int/dms_pubrec/itu-r/rec/bt/R-REC-BT.2020-0-201208-S!!PDF-E.pdf
+    
+    Parameters
+    ----------
+    rgb : array_like
+        Input R'G'B' values. These may be floats or integers.
+    K : array of two values
+        The luma weighting coefficients of red and blue.
+        Default: WEIGHT['Rec.709']
+    inRange : array of two values (optional)
+        The values of R', G' and B' corresponding to 0 IRE and 100 IRE.
+        These may be floats or integer code values.
+        Default: RANGE['full']
+    outRange : array of four values (optional)
+        The values of Y' corresponding to 0 IRE and 100 IRE
+        and the minimum and maximum values of Cb and Cr.
+        These may be floats or integer code values.
+        Default: RANGE['legal_10_YC']
+    
+    Returns
+    -------
+    ndarray
+        Y'CbCr array.
+        These may be floats or integer code values, depending on the parameter values
+        given for outRange.
+    
+    Examples
+    --------
+    >>> RGB = np.array([1.0, 1.0, 1.0])
+    >>> rgb_to_YCbCr(RGB)
+    array([ 0.91886608,  0.50048876,  0.50048876])
+    >>> rgb_to_YCbCr(RGB, outRange=RANGE['legal_10_YC_int'])
+    array([940, 512, 512])
+    
+    For the JFIF JPEG conversion shown on https://en.wikipedia.org/wiki/YCbCr:
+    
+    >>> RGB = np.array([102, 0, 51])
+    >>> rgb_to_YCbCr(RGB, K=WEIGHT['Rec.601'], inRange=[0, 255], outRange=[0, 255, 0, 256])
+    array([ 36, 136, 175])
+    
+    Note the use of 256 for the max Cb/Cr value, which is required so that the Cb and Cr
+    output is centred about 128. Using 255 would centre them about 127.5 meaning that
+    there was no integer code value to represent neutral colours. This does however create
+    the possibility of output values of 256, which cannot be stored in an 8-bit integer.
+    """
+    Kr = K[0]
+    Kb = K[1]
+    intOut = isinstance(outRange[0], int) and isinstance(outRange[1], int) and isinstance(outRange[2], int) and isinstance(outRange[3], int)
+    rgb_float = (rgb.astype(float) - inRange[0])
+    rgb_float *= 1.0/(inRange[1] - inRange[0])
+    r, g, b = tsplit(rgb_float)
+    Y = Kr*r + (1.0 - Kr - Kb)*g + Kb*b
+    Cb = 0.5*(b - Y)/(1.0 - Kb)
+    Cr = 0.5*(r - Y)/(1.0 - Kr)
+    Y *= outRange[1] - outRange[0]
+    Y += outRange[0]
+    Cb *= outRange[3] - outRange[2]
+    Cr *= outRange[3] - outRange[2]
+    Cb += (outRange[3] + outRange[2])/2
+    Cr += (outRange[3] + outRange[2])/2
+    if intOut:
+        Y = np.round(Y).astype(int)
+        Cb = np.round(Cb).astype(int)
+        Cr = np.round(Cr).astype(int)
+    YCbCr = tstack((Y, Cb, Cr))
+    return YCbCr
+
+def YCbCr_to_rgb(YCbCr, K = WEIGHT['Rec.709'], inRange = RANGE['legal_10_YC'], outRange = RANGE['full']):
+    """
+    Converts an array of Y'CbCr values to the corresponding R'G'B' values.
+    
+    Note: For ITU-R BT.2020 (Rec.2020) the YCbCr_to_rgb function is only applicable to
+    the non-constant luminance implementation.
+    The YcCbcCrc_to_rgb function should be used for the constant luminance case.
+    See https://www.itu.int/dms_pubrec/itu-r/rec/bt/R-REC-BT.2020-0-201208-S!!PDF-E.pdf
+    
+    Parameters
+    ----------
+    YCbCr : array_like
+        Input Y'CbCr values. These may be floats or integers.
+    K : array of two values (optional)
+        The luma weighting coefficients of red and blue.
+        Default: WEIGHT['Rec.709']
+    inRange : array of four values (optional)
+        The values of Y' corresponding to 0 IRE and 100 IRE,
+        and the minimum and maximum values of Cb and Cr.
+        These may be floats or integer code values.
+        Default: RANGE['legal_10_YC']
+    outRange : array of two values (optional)
+        The values of R', G' and B' corresponding to 0 IRE and 100 IRE.
+        These may be floats or integer code values.
+        Default: RANGE['full']
+    
+    Returns
+    -------
+    ndarray
+        R'G'B' array.
+        These may be floats or integer code values, depending on the parameter values
+        given for outRange.
+    
+    Examples
+    --------
+    >>> YCbCr = np.array([502, 512, 512])
+    >>> YCbCr_to_rgb(YCbCr, inRange=RANGE['legal_10_YC_int'])
+    array([ 0.5,  0.5,  0.5])
+    """
+    Kr = K[0]
+    Kb = K[1]
+    intOut = isinstance(outRange[0], int) and isinstance(outRange[1], int)
+    Y, Cb, Cr = tsplit(YCbCr.astype(float))
+    Y -= inRange[0]
+    Cb -= (inRange[3] + inRange[2])/2.0
+    Cr -= (inRange[3] + inRange[2])/2.0
+    Y *= 1.0/(inRange[1] - inRange[0])
+    Cb *= 1.0/(inRange[3] - inRange[2])
+    Cr *= 1.0/(inRange[3] - inRange[2])
+    r = Y + (2.0 - 2.0*Kr)*Cr
+    b = Y + (2.0 - 2.0*Kb)*Cb
+    g = (Y - Kr*r - Kb*b)/(1.0 - Kr -Kb)
+    r *= outRange[1] - outRange[0]
+    g *= outRange[1] - outRange[0]
+    b *= outRange[1] - outRange[0]
+    r += outRange[0]
+    g += outRange[0]
+    b += outRange[0]
+    if intOut:
+        r = np.round(r).astype(int)
+        g = np.round(g).astype(int)
+        b = np.round(b).astype(int)
+    rgb = tstack((r, g, b))
+    return rgb
+
+def rgb_to_YcCbcCrc(rgb, outRange = RANGE['legal_10_YC'], is_10_bits_system = True):
+    """
+    Converts an array of RGB (linear) values to the corresponding Yc'Cbc'Crc' values.
+    
+    Note: This fuction is specifically for use with ITU-R BT.2020 (Rec.2020) when using
+    the constant luminance implementation.
+    See https://www.itu.int/dms_pubrec/itu-r/rec/bt/R-REC-BT.2020-0-201208-S!!PDF-E.pdf
+    
+    Parameters
+    ----------
+    rgb : array_like
+        Input RGB floating point linear values.
+    outRange : array of four values (optional)
+        The values of Y' corresponding to 0 IRE and 100 IRE,
+        and the minimum and maximum values of Cb and Cr.
+        These may be floats or integer code values.
+        Default: RANGE['legal_10_YC']
+    is_10_bits_system : bool (optional)
+        The Rec.2020 OECF varies slightly for 10 and 12 bit systems.
+        Default: True
+    
+    Returns
+    -------
+    ndarray
+        Yc'Cbc'Crc' array.
+        These may be floats or integer code values, depending on the parameter values
+        given for outRange.
+    
+    Examples
+    --------
+    >>> rgb = np.array([0.18, 0.18, 0.18])
+    >>> rgb_to_YcCbcCrc(rgb, outRange=RANGE['legal_10_YC_int'], is_10_bits_system = True)
+    array([422, 512, 512])
+    """
+    intOut = isinstance(outRange[0], int) and isinstance(outRange[1], int) and isinstance(outRange[2], int) and isinstance(outRange[3], int)
+    r, g, b = tsplit(rgb)
+    Yc = 0.2627*r + 0.6780*g + 0.0593*b
+    Yc = REC_2020_COLOURSPACE.OECF(Yc, is_10_bits_system=is_10_bits_system)
+    r = REC_2020_COLOURSPACE.OECF(r, is_10_bits_system=is_10_bits_system)
+    b = REC_2020_COLOURSPACE.OECF(b, is_10_bits_system=is_10_bits_system)
+    Cbc = np.where((b - Yc) <= 0.0, (b - Yc)/1.9404, (b - Yc)/1.5816)
+    Crc = np.where((r - Yc) <= 0.0, (r - Yc)/1.7184, (r - Yc)/0.9936)
+    Yc *= outRange[1] - outRange[0]
+    Yc += outRange[0]
+    Cbc *= outRange[3] - outRange[2]
+    Crc *= outRange[3] - outRange[2]
+    Cbc += (outRange[3] + outRange[2])/2
+    Crc += (outRange[3] + outRange[2])/2
+    if intOut:
+        Yc = np.round(Yc).astype(int)
+        Cbc = np.round(Cbc).astype(int)
+        Crc = np.round(Crc).astype(int)
+    YcCbcCrc = tstack((Yc, Cbc, Crc))
+    return YcCbcCrc
+
+def YcCbcCrc_to_rgb(YcCbcCrc, inRange = RANGE['legal_10_YC'], is_10_bits_system = True):
+    """
+    Converts an array of Yc'Cbc'Crc' values to the corresponding RGB (linear) values.
+    
+    Note: This fuction is specifically for use with ITU-R BT.2020 (Rec.2020) when using
+    the constant luminance implementation.
+    See https://www.itu.int/dms_pubrec/itu-r/rec/bt/R-REC-BT.2020-0-201208-S!!PDF-E.pdf
+    
+    Parameters
+    ----------
+    YcCbcCrc : array_like
+        Input Yc'Cbc'Crc' values. These may be floats or integers.
+    inRange : array of four values (optional)
+        The values of Yc' corresponding to 0 IRE and 100 IRE,
+        and the minimum and maximum values of Cbc' and Crc'.
+        These may be floats or integer code values.
+        Default = RANGE['legal_10_YC']
+    is_10_bits_system : bool (optional)
+        The Rec.2020 EOCF varies slightly for 10 and 12 bit systems.
+        Default: True
+
+    
+    Returns
+    -------
+    ndarray
+        RGB values corresponding to the input colour.
+        These will be floating point linear values.
+    
+    Examples
+    --------
+    >>> YcCbcCrc = np.array([1689, 2048, 2048])
+    >>> YcCbcCrc_to_rgb(YcCbcCrc, inRange=RANGE['legal_12_YC_int'], is_10_bits_system = False)
+    array([ 0.18009037,  0.18009037,  0.18009037])
+    """
+    Yc, Cbc, Crc = tsplit(YcCbcCrc.astype(float))
+    Yc -= inRange[0]
+    Cbc -= (inRange[3] + inRange[2])/2.0
+    Crc -= (inRange[3] + inRange[2])/2.0
+    Yc *= 1.0/(inRange[1] - inRange[0])
+    Cbc *= 1.0/(inRange[3] - inRange[2])
+    Crc *= 1.0/(inRange[3] - inRange[2])
+    b = np.where(Cbc <= 0.0, Cbc*1.9404 + Yc, Cbc*1.5816 + Yc)
+    r = np.where(Crc <= 0.0, Crc*1.7184 + Yc, Crc*0.9936 + Yc)
+    Yc = REC_2020_COLOURSPACE.EOCF(Yc, is_10_bits_system=is_10_bits_system)
+    b = REC_2020_COLOURSPACE.EOCF(b, is_10_bits_system=is_10_bits_system)
+    r = REC_2020_COLOURSPACE.EOCF(r, is_10_bits_system=is_10_bits_system)
+    g = (Yc - 0.0593*b - 0.2627*r)/0.6780
+    rgb = tstack((r, g, b))
+    return rgb
+    

--- a/colour/models/rgb/ycbcr.py
+++ b/colour/models/rgb/ycbcr.py
@@ -5,27 +5,41 @@
 Y'CbCr Colour Encoding
 ======================
 
-Defines the Y'CbCr encoding (Y'CbCr is not an absolute colourspace)
-transformations:
+Defines the *Y'CbCr* colour encoding related transformations:
 
 -   :func:`RGB_to_YCbCr`
 -   :func:`YCbCr_to_RGB`
 -   :func:`RGB_to_YcCbcCrc`
 -   :func:`YcCbcCrc_to_RGB`
 
+Notes
+-----
+-   *Y'CbCr* is not an absolute colourspace.
+
 References
 ----------
-.. [1]  Wikipedia. YCbCr. Retrieved February 29, 2016, from
+.. [1]  Wikipedia. (n.d.). YCbCr. Retrieved February 29, 2016, from
         https://en.wikipedia.org/wiki/YCbCr
-.. [2]  Recommendation ITU-R BT.709-6(06/2015). Retrieved February 29, 2016,
-        from https://www.itu.int/dms_pubrec/itu-r/rec/bt/\
-        R-REC-BT.709-6-201506-I!!PDF-E.pdf
-.. [3]  Recommendation ITU-R BT.2020(08/2012). Retrieved February 29, 2016,
-        from https://www.itu.int/dms_pubrec/itu-r/rec/bt/\
-        R-REC-BT.2020-0-201208-S!!PDF-E.pdf
-.. [4]  Ford, A., & Roberts, A. (1998). Colour Space Converions. Retrieved
-        April 29, 2016, from http://www.poynton.com/PDFs/coloureq.pdf
+.. [2]  International Telecommunication Union. (2015). Parameter values for
+        the HDTV standards for production and international programme exchange
+        BT Series Broadcasting service. In Recommendation ITU-R BT.709-6
+        (Vol. 5, pp. 1–32). Retrieved from https://www.itu.int/dms_pubrec/\
+itu-r/rec/bt/R-REC-BT.709-6-201506-I!!PDF-E.pdf
+.. [3]  International Telecommunication Union. (2015). Parameter values for
+        ultra-high definition television systems for production and
+        international programme exchange. In *Recommendation ITU-R BT.2020*
+        (Vol. 1, pp. 1–8). Retrieved from https://www.itu.int/dms_pubrec/\
+itu-r/rec/bt/R-REC-BT.2020-2-201510-I!!PDF-E.pdf
+.. [4]  Ford, A., & Roberts, A. (1998). Colour space conversions. Westminster
+        University, London, 1998, 1–31. Retrieved from
+        http://herakles.fav.zcu.cz/research/night_road/westminster.pdf
+.. [5]  International Telecommunication Union. (2011). Recommendation ITU-T
+        T.871 - Information technology – Digital compression and coding of
+        continuous-tone still images: JPEG File Interchange Format (JFIF).
+        Retrieved from https://www.itu.int/rec/dologin_pub.asp?lang=e&\
+id=T-REC-T.871-201105-I!!PDF-E&type=items
 """
+from __future__ import division, unicode_literals
 
 import numpy as np
 
@@ -40,55 +54,117 @@ __email__ = 'colour-science@googlegroups.com'
 __status__ = 'Development'
 
 __all__ = ['YCBCR_WEIGHTS',
-           'RGB_RANGE',
-           'YCBCR_RANGES',
+           'RGB_ranges',
+           'YCbCr_ranges',
            'RGB_to_YCbCr',
            'YCbCr_to_RGB',
            'RGB_to_YcCbcCrc',
            'YcCbcCrc_to_RGB']
 
 YCBCR_WEIGHTS = CaseInsensitiveMapping(
-        {'Rec. 601': (0.299, 0.114),
-         'Rec. 709': (0.2126, 0.0722),
-         'Rec. 2020': (0.2627, 0.0593),
-         'SMPTE-240M': (0.2122, 0.0865)})
+    {'Rec. 601': (0.2990, 0.1140),
+     'Rec. 709': (0.2126, 0.0722),
+     'Rec. 2020': (0.2627, 0.0593),
+     'SMPTE-240M': (0.2122, 0.0865)})
 """
-List of preset luma weightings:
-    'Rec. 601' : (0.299, 0.114)
-    'Rec. 709' : (0.2126, 0.0722)
-    'Rec. 2020' : (0.2627, 0.0593)
-    'SMPTE-240M': (0.2122, 0.0865)
+Luma weightings presets.
+
+YCBCR_WEIGHTS : dict
+    **{'Rec. 601', 'Rec. 709', 'Rec. 2020', 'SMPTE-240M}**
 """
 
 
-def RGB_RANGE(bits, is_legal, is_int):
+def RGB_ranges(bits, is_legal, is_int):
+    """"
+    Returns the *RGB* ranges array for given bit depth, range legality and
+    representation.
+
+    Parameters
+    ----------
+    bits : int
+        Bit depth of the *RGB* output ranges array.
+    is_legal : bool
+        Whether the *RGB* output ranges array is legal.
+    is_int : bool
+        Whether the *RGB* output ranges array represents integer code values.
+
+    Returns
+    -------
+    ndarray
+        *RGB* ranges array.
+
+    Examples
+    --------
+    >>> RGB_ranges(8, True, True)
+    array([ 16, 235])
+    >>> RGB_ranges(8, True, False)  # doctest: +ELLIPSIS
+    array([ 0.0627451...,  0.9215686...])
+    >>> RGB_ranges(10, False, False)
+    array([ 0.,  1.])
+    """
+
     if is_legal:
-        range = np.array([16, 235])
-        range *= 2**(bits - 8)
+        ranges = np.array([16, 235])
+        ranges *= 2 ** (bits - 8)
     else:
-        range = np.array([0, 2**bits - 1])
-    if not(is_int):
-        range = range.astype(float)/(2**bits - 1)
-    return tuple(range)
+        ranges = np.array([0, 2 ** bits - 1])
+
+    if not is_int:
+        ranges = ranges.astype(np.float_) / (2 ** bits - 1)
+
+    return ranges
 
 
-def YCBCR_RANGES(bits, is_legal, is_int):
+def YCbCr_ranges(bits, is_legal, is_int):
+    """"
+    Returns the *Y'CbCr* colour encoding ranges array for given bit depth,
+    range legality and representation.
+
+    Parameters
+    ----------
+    bits : int
+        Bit depth of the *Y'CbCr* colour encoding ranges array.
+    is_legal : bool
+        Whether the *Y'CbCr* colour encoding ranges array is legal.
+    is_int : bool
+        Whether the *Y'CbCr* colour encoding ranges array represents integer
+        code values.
+
+    Returns
+    -------
+    ndarray
+        *Y'CbCr* colour encoding ranges array.
+
+    Examples
+    --------
+    >>> YCbCr_ranges(8, True, True)
+    array([ 16, 235,  16, 240])
+    >>> YCbCr_ranges(8, True, False)  # doctest: +ELLIPSIS
+    array([ 0.0627451...,  0.9215686...,  0.0627451...,  0.9411764...])
+    >>> YCbCr_ranges(10, False, False)
+    array([ 0. ,  1. , -0.5,  0.5])
+    """
+
     if is_legal:
         ranges = np.array([16, 235, 16, 240])
-        ranges *= 2**(bits - 8)
+        ranges *= 2 ** (bits - 8)
     else:
-        ranges = np.array([0, 2**bits - 1, 0, 2**bits - 1])
-    if not(is_int):
-        ranges = ranges.astype(float)/(2**bits - 1)
-    if (is_int and not(is_legal)):
-        ranges[3] = 2**bits
-    if (not(is_int) and not(is_legal)):
+        ranges = np.array([0, 2 ** bits - 1, 0, 2 ** bits - 1])
+
+    if not is_int:
+        ranges = ranges.astype(np.float_) / (2 ** bits - 1)
+
+    if is_int and not is_legal:
+        ranges[3] = 2 ** bits
+
+    if not is_int and not is_legal:
         ranges[2] = -0.5
         ranges[3] = 0.5
-    return tuple(ranges)
+
+    return ranges
 
 
-def RGB_to_YCbCr(rgb,
+def RGB_to_YCbCr(RGB,
                  K=YCBCR_WEIGHTS['Rec. 709'],
                  in_bits=10,
                  in_legal=False,
@@ -98,127 +174,144 @@ def RGB_to_YCbCr(rgb,
                  out_int=False,
                  **kwargs):
     """
-    Converts an array of R'G'B' values to the corresponding Y'CbCr values.
+    Converts an array of *R'G'B'* values to the corresponding *Y'CbCr* colour
+    encoding values array.
 
     Parameters
     ----------
-    rgb : array_like
-        Input R'G'B' values. These may be floats or integers.
-    K : tuple (optional)
-        The luma weighting coefficients of red and blue. Use the function
-        YCBCR_WEIGHTS(colourspace) for presets
-        **{'Rec. 601', 'Rec. 709', 'Rec. 2020','SMPTE-240M'}**
-        Default: YCBCR_WEIGHTS['Rec. 709']
-    in_bits : int (optional)
-        The bit depth for integer input, or used in the calculation of the
-        denominator for legal range float values, i.e. 8 bit means the float
-        value for legal white is 235/255.
-        Default : 10
-    in_legal : bool (optional)
-        Whether to treat the input values as legal range.
-        Default : False
-    in_int : bool (optional)
-        Whether to treat the input values as in_bits integer code values.
-        Default : False
-    out_bits : int (optional)
-        The bit depth for integer output, or used in the calculation of the
-        denominator for legal range float values, i.e. 8 bit means the float
-        value for legal white is 235/255. Ignored if out_legal and out_int are
-        both False.
-        Default : 8
-    out_legal : bool (optional)
-        Whether to return legal range data.
-        Default : True
-    out_int : bool (optional)
-        Whether to return values as out_bits integer code values.
-        Default : False
+    RGB : array_like
+        Input *R'G'B'* array of floats or integer values.
+    K : array_like, optional
+        Luma weighting coefficients of red and blue. See :attr:
+        `YCBCR_WEIGHTS` for presets. Default is `(0.2126, 0.0722)`.
+    in_bits : int, optional
+        Bit depth for integer input, or used in the calculation of the
+        denominator for legal range float values, i.e. 8-bit means the float
+        value for legal white is `235 / 255`. Default is `10`.
+    in_legal : bool, optional
+        Whether to treat the input values as legal range. Default is `False`.
+    in_int : bool, optional
+        Whether to treat the input values as `in_bits` integer code values.
+        Default is `False`.
+    out_bits : int, optional
+        Bit depth for integer output, or used in the calculation of the
+        denominator for legal range float values, i.e. 8-bit means the float
+        value for legal white is `235 / 255`. Ignored if `out_legal` and
+        `out_int` are both False. Default is `8`.
+    out_legal : bool, optional
+        Whether to return legal range values. Default is `True`.
+    out_int : bool, optional
+        Whether to return values as `out_bits` integer code values. Default is
+        `False`.
     \**kwargs : dict, optional
         **{'in_range', 'out_range'}**
-        Keyword arguments to override the calculated ranges. RGB ranges are a
-        tuple of two values (RGBMin, RGBMax) and Y'CbCr ranges are a tuple of
-        four values (YMin, YMax, CMin, CMax)
+        Keyword arguments to override the calculated ranges such as
+        ``{'in_range' : array_like (RGB_min, RGB_max), 'out_range' :
+        array_like (Y_min, Y_max, C_min, C_max)}``.
 
     Returns
     -------
     ndarray
-        Y'CbCr array.
-        These may be floats or integer code values, depending on parameters.
+        *Y'CbCr* colour encoding array of integer or float values.
+
+    Warning
+    -------
+    For *Recommendation ITU-R BT.2020*, :func:`RGB_to_YCbCr` definition is only
+    applicable to the non-constant luminance implementation.
+    :func:`RGB_to_YcCbcCrc` definition should be used for the constant
+    luminance case as per [3]_.
 
     Notes
     -----
-    -   For ITU-R BT.2020 (Rec.2020) the RGB_to_YCbCr function is only
-        applicable to the non-constant luminance implementation. The
-        RGB_to_YcCbcCrc function should be used for the constant luminance case
-        See https://www.itu.int/dms_pubrec/itu-r/rec/bt/\
-        R-REC-BT.2020-0-201208-S!!PDF-E.pdf
-
-    -   The default settings of (in_bits=10, in_legal=False, in_int=False,
-        out_bits=8, out_legal=True, out_int=False) will transform float RGB
-        input ranged 0.0-1.0 (in_bits is ignored) to float Y'CbCr output where
-        Y' is ranged 16./255 to 235./255 and Cb and Cr are ranged 16./255 to
-        240./255. So the float values are calculated based on an integer range
-        from 0-255. But no 8-bit quantisation is applied, and neither is any
-        clamping.
-
-    -   To match the float output of Nuke's Colorspace node set to YCbCr,
-        set out_range=(16./255, 235./255, 15.5/255, 239.5/255)
-
-    -   To match the float output of Nuke's Colorspace node set to YPbPr,
-        set (out_legal=False, out_int=False)
-
-    -   To create integer code values as per standard 10-bit SDI, set
-        (out_bits=10, out_legal=True, out_int=True)
+    -   The default arguments, ``**{'in_bits': 10, 'in_legal': False,
+        'in_int': False, 'out_bits': 8, 'out_legal': True, 'out_int': False}``
+        transform a float *R'G'B'* input array in range [0, 1] (`in_bits` is
+        ignored) to a float *Y'CbCr* output array where *Y'* is in range
+        [16 / 255, 235 / 255] and *Cb* and *Cr* are in range
+        [16 / 255, 240./255]. The float values are calculated based on an
+        [0, 255] integer range, but no 8-bit quantisation or clamping are
+        performed.
 
     Examples
     --------
-    >>> rgb = np.array([1.0, 1.0, 1.0])
-    >>> RGB_to_YCbCr(  # doctest: +ELLIPSIS
-    ...              rgb)
+    >>> RGB = np.array([1.0, 1.0, 1.0])
+    >>> RGB_to_YCbCr(RGB)  # doctest: +ELLIPSIS
     array([ 0.9215686...,  0.5019607...,  0.5019607...])
-    >>> RGB_to_YCbCr(rgb, out_legal=True, out_bits=10, out_int=True)
+
+    Matching float output of The Foundry Nuke's Colorspace node set to YCbCr:
+
+    >>> RGB_to_YCbCr(  # doctest: +ELLIPSIS
+    ...     RGB,
+    ...     out_range=(16 / 255, 235 / 255, 15.5 / 255, 239.5 / 255))
+    array([ 0.9215686...,  0.5       ,  0.5       ])
+
+    Matching float output of The Foundry Nuke's Colorspace node set to YPbPr:
+
+    >>> RGB_to_YCbCr(  # doctest: +ELLIPSIS
+    ...     RGB,
+    ...     out_legal=False,
+    ...     out_int=False)
+    array([ 1.,  0.,  0.])
+
+    Creating integer code values as per standard 10-bit SDI:
+
+    >>> RGB_to_YCbCr(RGB, out_legal=True, out_bits=10, out_int=True)
     array([940, 512, 512])
 
-    For JFIF JPEG conversion as per http://www.w3.org/Graphics/JPEG/jfif3.pdf:
+    For JFIF JPEG conversion as per ITU-T T.871 [5]_:
 
-    >>> rgb = np.array([102, 0, 51])
-    >>> RGB_to_YCbCr(rgb,
-    ...              K=YCBCR_WEIGHTS['Rec. 601'],
-    ...              in_range=(0, 255),
-    ...              out_range=(0, 255, 0, 256),
-    ...              out_int=True)
+    >>> RGB = np.array([102, 0, 51])
+    >>> RGB_to_YCbCr(
+    ...     RGB,
+    ...     K=YCBCR_WEIGHTS['Rec. 601'],
+    ...     in_range=(0, 255),
+    ...     out_range=(0, 255, 0, 256),
+    ...     out_int=True)
     array([ 36, 136, 175])
 
-    Note the use of 256 for the max Cb/Cr value, which is required so that the
-    Cb and Cr output is centred about 128. Using 255 would centre them about
-    127.5 meaning that there was no integer code value to represent neutral
-    colours. This does however create the possibility of output values of 256,
-    which cannot be stored in an 8-bit integer. The JPEG document specifies
-    these should be clamped to 255.
+    Note the use of 256 for the max *Cb / Cr* value, which is required so that
+    the *Cb* and *Cr* output is centered about 128. Using 255 centres it
+    about 127.5, meaning that there is no integer code value to represent
+    achromatic colours. This does however create the possibility of output
+    integer codes with value of 256, which cannot be stored in 8-bit integer
+    representation. Recommendation ITU-T T.871 specifies these should be
+    clamped to 255.
 
-    These JFIF JPEG ranges are also the result of using:
-    in_bits=8, in_int=True, out_legal=False, out_int=True
+    These JFIF JPEG ranges are also obtained as follows:
+
+    >>> RGB_to_YCbCr(
+    ...     RGB,
+    ...     K=YCBCR_WEIGHTS['Rec. 601'],
+    ...     in_bits=8,
+    ...     in_int=True,
+    ...     out_legal=False,
+    ...     out_int=True)
+    array([ 36, 136, 175])
     """
-    Kr = K[0]
-    Kb = K[1]
-    in_range = kwargs.get('in_range',
-                          RGB_RANGE(in_bits, in_legal, in_int))
-    out_range = kwargs.get('out_range',
-                           YCBCR_RANGES(out_bits, out_legal, out_int))
-    rgb_float = (rgb.astype(float) - in_range[0])
-    rgb_float *= 1.0/(in_range[1] - in_range[0])
-    r, g, b = tsplit(rgb_float)
-    Y = Kr*r + (1.0 - Kr - Kb)*g + Kb*b
-    Cb = 0.5*(b - Y)/(1.0 - Kb)
-    Cr = 0.5*(r - Y)/(1.0 - Kr)
-    Y *= out_range[1] - out_range[0]
-    Y += out_range[0]
-    Cb *= out_range[3] - out_range[2]
-    Cr *= out_range[3] - out_range[2]
-    Cb += (out_range[3] + out_range[2])/2
-    Cr += (out_range[3] + out_range[2])/2
+
+    Kr, Kb = K
+    RGB_min, RGB_max = kwargs.get(
+        'in_range', RGB_ranges(in_bits, in_legal, in_int))
+    Y_min, Y_max, C_min, C_max = kwargs.get(
+        'out_range', YCbCr_ranges(out_bits, out_legal, out_int))
+
+    RGB_float = RGB.astype(np.float_) - RGB_min
+    RGB_float *= 1 / (RGB_max - RGB_min)
+    R, G, B = tsplit(RGB_float)
+
+    Y = Kr * R + (1 - Kr - Kb) * G + Kb * B
+    Cb = 0.5 * (B - Y) / (1 - Kb)
+    Cr = 0.5 * (R - Y) / (1 - Kr)
+    Y *= Y_max - Y_min
+    Y += Y_min
+    Cb *= C_max - C_min
+    Cr *= C_max - C_min
+    Cb += (C_max + C_min) / 2
+    Cr += (C_max + C_min) / 2
+
     YCbCr = tstack((Y, Cb, Cr))
-    if out_int:
-        YCbCr = np.round(YCbCr).astype(int)
+    YCbCr = np.round(YCbCr).astype(np.int_) if out_int else YCbCr
+
     return YCbCr
 
 
@@ -232,168 +325,164 @@ def YCbCr_to_RGB(YCbCr,
                  out_int=False,
                  **kwargs):
     """
-    Converts an array of Y'CbCr values to the corresponding R'G'B' values.
+    Converts an array of *Y'CbCr* colour encoding values to the corresponding
+    *R'G'B'* values array.
 
     Parameters
     ----------
     YCbCr : array_like
-        Input Y'CbCr values. These may be floats or integers.
-    K : tuple (optional)
-        The luma weighting coefficients of red and blue. Use the function
-        YCBCR_WEIGHTS(colourspace) for presets
-        **{'Rec. 601', 'Rec. 709', 'Rec. 2020','SMPTE-240M'}**
-        Default: YCBCR_WEIGHTS['Rec. 709']
-    in_bits : int (optional)
-        The bit depth for integer input, or used in the calculation of the
-        denominator for legal range float values, i.e. 8 bit means the float
-        value for legal white is 235/255.
-        Default : 8
-    in_legal : bool (optional)
-        Whether to treat the input values as legal range.
-        Default : True
-    in_int : bool (optional)
-        Whether to treat the input values as in_bits integer code values.
-        Default : False
-    out_bits : int (optional)
-        The bit depth for integer output, or used in the calculation of the
-        denominator for legal range float values, i.e. 8 bit means the float
-        value for legal white is 235/255. Ignored if out_legal and out_int are
-        both False.
-        Default : 10
-    out_legal : bool (optional)
-        Whether to return legal range data.
-        Default : False
-    out_int : bool (optional)
-        Whether to return values as out_bits integer code values.
-        Default : False
+        Input *Y'CbCr* colour encoding array of integer or float values.
+    K : array_like, optional
+        Luma weighting coefficients of red and blue. See :attr:
+        `YCBCR_WEIGHTS` for presets. Default is `(0.2126, 0.0722)`.
+    in_bits : int, optional
+        Bit depth for integer input, or used in the calculation of the
+        denominator for legal range float values, i.e. 8-bit means the float
+        value for legal white is `235 / 255`. Default is `10`.
+    in_legal : bool, optional
+        Whether to treat the input values as legal range. Default is `False`.
+    in_int : bool, optional
+        Whether to treat the input values as `in_bits` integer code values.
+        Default is `False`.
+    out_bits : int, optional
+        Bit depth for integer output, or used in the calculation of the
+        denominator for legal range float values, i.e. 8-bit means the float
+        value for legal white is `235 / 255`. Ignored if `out_legal` and
+        `out_int` are both False. Default is `8`.
+    out_legal : bool, optional
+        Whether to return legal range values. Default is `True`.
+    out_int : bool, optional
+        Whether to return values as `out_bits` integer code values. Default is
+        `False`.
     \**kwargs : dict, optional
         **{'in_range', 'out_range'}**
-        Keyword arguments to override the calculated ranges. RGB ranges are a
-        tuple of two values (RGBMin, RGBMax) and Y'CbCr ranges are a tuple of
-        four values (YMin, YMax, CMin, CMax)
+        Keyword arguments to override the calculated ranges such as
+        ``{'in_range' : array_like (Y_min, Y_max, C_min, C_max), 'out_range' :
+        array_like (RGB_min, RGB_max)}``.
 
     Returns
     -------
     ndarray
-        R'G'B' array.
-        These may be floats or integer code values, depending on parameters.
+        *R'G'B'* array of integer or float values.
 
-    Notes
-    -----
-    -   For ITU-R BT.2020 (Rec.2020) the YCbCr_to_RGB function is only
-        applicable tothe non-constant luminance implementation. The
-        YcCbcCrc_to_RGB function should be used for the constant luminance case
-        See https://www.itu.int/dms_pubrec/itu-r/rec/bt/\
-        R-REC-BT.2020-0-201208-S!!PDF-E.pdf
+    Warning
+    -------
+    For *Recommendation ITU-R BT.2020*, :func:`YCbCr_to_RGB`
+    definition is only applicable to the non-constant luminance implementation.
+    :func:`YcCbcCrc_to_RGB` definition should be used for the constant
+    luminance case as per [3]_.
 
     Examples
     --------
     >>> YCbCr = np.array([502, 512, 512])
-    >>> YCbCr_to_RGB(YCbCr,
-    ...              in_bits=10,
-    ...              in_legal=True,
-    ...              in_int=True)
+    >>> YCbCr_to_RGB(
+    ...     YCbCr,
+    ...     in_bits=10,
+    ...     in_legal=True,
+    ...     in_int=True)
     array([ 0.5,  0.5,  0.5])
     """
-    Kr = K[0]
-    Kb = K[1]
-    in_range = kwargs.get('in_range',
-                          YCBCR_RANGES(in_bits, in_legal, in_int))
-    out_range = kwargs.get('out_range',
-                           RGB_RANGE(out_bits, out_legal, out_int))
-    Y, Cb, Cr = tsplit(YCbCr.astype(float))
-    Y -= in_range[0]
-    Cb -= (in_range[3] + in_range[2])/2.0
-    Cr -= (in_range[3] + in_range[2])/2.0
-    Y *= 1.0/(in_range[1] - in_range[0])
-    Cb *= 1.0/(in_range[3] - in_range[2])
-    Cr *= 1.0/(in_range[3] - in_range[2])
-    r = Y + (2.0 - 2.0*Kr)*Cr
-    b = Y + (2.0 - 2.0*Kb)*Cb
-    g = (Y - Kr*r - Kb*b)/(1.0 - Kr - Kb)
-    rgb = tstack((r, g, b))
-    rgb *= out_range[1] - out_range[0]
-    rgb += out_range[0]
-    if out_int:
-        rgb = np.round(rgb).astype(int)
-    return rgb
+
+    Y, Cb, Cr = tsplit(YCbCr.astype(np.float_))
+    Kr, Kb = K
+    Y_min, Y_max, C_min, C_max = kwargs.get(
+        'in_range', YCbCr_ranges(in_bits, in_legal, in_int))
+    RGB_min, RGB_max = kwargs.get(
+        'out_range', RGB_ranges(out_bits, out_legal, out_int))
+
+    Y -= Y_min
+    Cb -= (C_max + C_min) / 2
+    Cr -= (C_max + C_min) / 2
+    Y *= 1 / (Y_max - Y_min)
+    Cb *= 1 / (C_max - C_min)
+    Cr *= 1 / (C_max - C_min)
+    R = Y + (2 - 2 * Kr) * Cr
+    B = Y + (2 - 2 * Kb) * Cb
+    G = (Y - Kr * R - Kb * B) / (1 - Kr - Kb)
+
+    RGB = tstack((R, G, B))
+    RGB *= RGB_max - RGB_min
+    RGB += RGB_min
+    RGB = np.round(RGB).astype(np.int_) if out_int else RGB
+
+    return RGB
 
 
-def RGB_to_YcCbcCrc(rgb,
+def RGB_to_YcCbcCrc(RGB,
                     out_bits=8,
                     out_legal=True,
                     out_int=False,
                     is_10_bits_system=True,
                     **kwargs):
     """
-    Converts an array of RGB (linear) values to the corresponding Yc'Cbc'Crc'
-    values.
+    Converts an array of *RGB* linear values to the corresponding *Yc'Cbc'Crc'*
+    colour encoding values array.
 
     Parameters
     ----------
-    rgb : array_like
-        Input RGB floating point linear values.
-    out_bits : int (optional)
-        The bit depth for integer output, or used in the calculation of the
-        denominator for legal range float values, i.e. 8 bit means the float
-        value for legal white is 235/255. Ignored if out_legal and out_int are
-        both False.
-        Default : 8
-    out_legal : bool (optional)
-        Whether to return legal range data.
-        Default : True
-    out_int : bool (optional)
-        Whether to return values as out_bits integer code values.
-        Default : False
-    is_10_bits_system : bool (optional)
-        The Rec.2020 OECF varies slightly for 10 and 12 bit systems.
-        Default: True
+    RGB : array_like
+        Input *RGB* array of linear float values.
+    out_bits : int, optional
+        Bit depth for integer output, or used in the calculation of the
+        denominator for legal range float values, i.e. 8-bit means the float
+        value for legal white is `235 / 255`. Ignored if `out_legal` and
+        `out_int` are both False. Default is `8`.
+    out_legal : bool, optional
+        Whether to return legal range values. Default is `True`.
+    out_int : bool, optional
+        Whether to return values as `out_bits` integer code values. Default is
+        `False`.
+    is_10_bits_system : bool, optional
+        *Recommendation ITU-R BT.2020* OETF (OECF) adopts different parameters
+        for 10 and 12 bit systems. Default is `True`.
     \**kwargs : dict, optional
         **{'out_range'}**
-        Keyword argument to override the calculated ranges.
-        Use ``out_range=(YMin, YMax, CMin, CMax)``
+        Keyword arguments to override the calculated ranges such as
+        ``{'out_range' : array_like (Y_min, Y_max, C_min, C_max)}``
 
     Returns
     -------
     ndarray
-        Yc'Cbc'Crc' array.
-        These may be floats or integer code values, depending on parameters.
+        *Yc'Cbc'Crc'* colour encoding array of integer or float values.
 
-    Notes
-    -----
-    -   This fuction is specifically for use with ITU-R BT.2020 (Rec.2020)
-        when using the constant luminance implementation.
-        See https://www.itu.int/dms_pubrec/itu-r/rec/bt/\
-        R-REC-BT.2020-0-201208-S!!PDF-E.pdf
+    Warning
+    -------
+    This definition is specifically for usage with
+    *Recommendation ITU-R BT.2020* [3]_ when adopting the constant luminance
+    implementation.
 
     Examples
     --------
-    >>> rgb = np.array([0.18, 0.18, 0.18])
-    >>> RGB_to_YcCbcCrc(rgb,
-    ...                 out_legal=True,
-    ...                 out_bits=10,
-    ...                 out_int=True,
-    ...                 is_10_bits_system = True)
+    >>> RGB = np.array([0.18, 0.18, 0.18])
+    >>> RGB_to_YcCbcCrc(
+    ...     RGB,
+    ...     out_legal=True,
+    ...     out_bits=10,
+    ...     out_int=True,
+    ...     is_10_bits_system = True)
     array([422, 512, 512])
     """
-    out_range = kwargs.get('out_range',
-                           YCBCR_RANGES(out_bits, out_legal, out_int))
-    r, g, b = tsplit(rgb)
-    Yc = 0.2627*r + 0.6780*g + 0.0593*b
+
+    R, G, B = tsplit(RGB)
+    Y_min, Y_max, C_min, C_max = kwargs.get(
+        'out_range', YCbCr_ranges(out_bits, out_legal, out_int))
+
+    Yc = 0.2627 * R + 0.6780 * G + 0.0593 * B
     Yc = REC_2020_COLOURSPACE.OECF(Yc, is_10_bits_system=is_10_bits_system)
-    r = REC_2020_COLOURSPACE.OECF(r, is_10_bits_system=is_10_bits_system)
-    b = REC_2020_COLOURSPACE.OECF(b, is_10_bits_system=is_10_bits_system)
-    Cbc = np.where((b - Yc) <= 0.0, (b - Yc)/1.9404, (b - Yc)/1.5816)
-    Crc = np.where((r - Yc) <= 0.0, (r - Yc)/1.7184, (r - Yc)/0.9936)
-    Yc *= out_range[1] - out_range[0]
-    Yc += out_range[0]
-    Cbc *= out_range[3] - out_range[2]
-    Crc *= out_range[3] - out_range[2]
-    Cbc += (out_range[3] + out_range[2])/2
-    Crc += (out_range[3] + out_range[2])/2
+    R = REC_2020_COLOURSPACE.OECF(R, is_10_bits_system=is_10_bits_system)
+    B = REC_2020_COLOURSPACE.OECF(B, is_10_bits_system=is_10_bits_system)
+    Cbc = np.where((B - Yc) <= 0, (B - Yc) / 1.9404, (B - Yc) / 1.5816)
+    Crc = np.where((R - Yc) <= 0, (R - Yc) / 1.7184, (R - Yc) / 0.9936)
+    Yc *= Y_max - Y_min
+    Yc += Y_min
+    Cbc *= C_max - C_min
+    Crc *= C_max - C_min
+    Cbc += (C_max + C_min) / 2
+    Crc += (C_max + C_min) / 2
+
     YcCbcCrc = tstack((Yc, Cbc, Crc))
-    if out_int:
-        YcCbcCrc = np.round(YcCbcCrc).astype(int)
+    YcCbcCrc = np.round(YcCbcCrc).astype(np.int_) if out_int else YcCbcCrc
+
     return YcCbcCrc
 
 
@@ -404,72 +493,70 @@ def YcCbcCrc_to_RGB(YcCbcCrc,
                     is_10_bits_system=True,
                     **kwargs):
     """
-    Converts an array of Yc'Cbc'Crc' values to the corresponding RGB (linear)
-    values.
+    Converts an array of *Yc'Cbc'Crc'* colour encoding values to the
+    corresponding *RGB* array of linear values.
 
     Parameters
     ----------
     YcCbcCrc : array_like
-        Input Yc'Cbc'Crc' values. These may be floats or integers.
-    out_bits : int (optional)
-        The bit depth for integer output, or used in the calculation of the
-        denominator for legal range float values, i.e. 8 bit means the float
-        value for legal white is 235/255. Ignored if out_legal and out_int are
-        both False.
-        Default : 10
-    out_legal : bool (optional)
-        Whether to return legal range data.
-        Default : False
-    out_int : bool (optional)
-        Whether to return values as out_bits integer code values.
-        Default : False
-    is_10_bits_system : bool (optional)
-        The Rec.2020 EOCF varies slightly for 10 and 12 bit systems.
-        Default: True
+        Input *Yc'Cbc'Crc'* colour encoding array of linear float values.
+    in_bits : int, optional
+        Bit depth for integer input, or used in the calculation of the
+        denominator for legal range float values, i.e. 8-bit means the float
+        value for legal white is `235 / 255`. Default is `10`.
+    in_legal : bool, optional
+        Whether to treat the input values as legal range. Default is `False`.
+    in_int : bool, optional
+        Whether to treat the input values as `in_bits` integer code values.
+        Default is `False`.
+    is_10_bits_system : bool, optional
+        *Recommendation ITU-R BT.2020* EOTF (EOCF) adopts different parameters
+        for 10 and 12 bit systems. Default is `True`.
     \**kwargs : dict, optional
         **{'in_range'}**
-        Keyword argument to override the calculated ranges.
-        Use ``in_range=(YMin, YMax, CMin, CMax)``
-
+        Keyword arguments to override the calculated ranges such as
+        ``{'in_range' : array_like (Y_min, Y_max, C_min, C_max)}``
 
     Returns
     -------
     ndarray
-        RGB values corresponding to the input colour.
-        These will be floating point linear values.
+        *RGB* array of linear float values.
 
-    Notes
-    -----
-    -   This fuction is specifically for use with ITU-R BT.2020 (Rec.2020)
-        when using the constant luminance implementation.
-        See https://www.itu.int/dms_pubrec/itu-r/rec/bt/\
-        R-REC-BT.2020-0-201208-S!!PDF-E.pdf
+    Warning
+    -------
+    This definition is specifically for usage with
+    *Recommendation ITU-R BT.2020* [3]_ when adopting the constant luminance
+    implementation.
 
     Examples
     --------
     >>> YcCbcCrc = np.array([1689, 2048, 2048])
     >>> YcCbcCrc_to_RGB(  # doctest: +ELLIPSIS
-    ...                 YcCbcCrc,
-    ...                 in_legal=True,
-    ...                 in_bits=12,
-    ...                 in_int=True,
-    ...                 is_10_bits_system=False)
-    array([ 0.1800903..., 0.1800903..., 0.1800903...])
+    ...     YcCbcCrc,
+    ...     in_legal=True,
+    ...     in_bits=12,
+    ...     in_int=True,
+    ...     is_10_bits_system=False)
+    array([ 0.1800903...,  0.1800903...,  0.1800903...])
     """
-    in_range = kwargs.get('out_range',
-                          YCBCR_RANGES(in_bits, in_legal, in_int))
-    Yc, Cbc, Crc = tsplit(YcCbcCrc.astype(float))
-    Yc -= in_range[0]
-    Cbc -= (in_range[3] + in_range[2])/2.0
-    Crc -= (in_range[3] + in_range[2])/2.0
-    Yc *= 1.0/(in_range[1] - in_range[0])
-    Cbc *= 1.0/(in_range[3] - in_range[2])
-    Crc *= 1.0/(in_range[3] - in_range[2])
-    b = np.where(Cbc <= 0.0, Cbc*1.9404 + Yc, Cbc*1.5816 + Yc)
-    r = np.where(Crc <= 0.0, Crc*1.7184 + Yc, Crc*0.9936 + Yc)
+
+    Yc, Cbc, Crc = tsplit(YcCbcCrc.astype(np.float_))
+    Y_min, Y_max, C_min, C_max = kwargs.get(
+        'in_range', YCbCr_ranges(in_bits, in_legal, in_int))
+
+    Yc -= Y_min
+    Cbc -= (C_max + C_min) / 2
+    Crc -= (C_max + C_min) / 2
+    Yc *= 1 / (Y_max - Y_min)
+    Cbc *= 1 / (C_max - C_min)
+    Crc *= 1 / (C_max - C_min)
+    B = np.where(Cbc <= 0, Cbc * 1.9404 + Yc, Cbc * 1.5816 + Yc)
+    R = np.where(Crc <= 0, Crc * 1.7184 + Yc, Crc * 0.9936 + Yc)
     Yc = REC_2020_COLOURSPACE.EOCF(Yc, is_10_bits_system=is_10_bits_system)
-    b = REC_2020_COLOURSPACE.EOCF(b, is_10_bits_system=is_10_bits_system)
-    r = REC_2020_COLOURSPACE.EOCF(r, is_10_bits_system=is_10_bits_system)
-    g = (Yc - 0.0593*b - 0.2627*r)/0.6780
-    rgb = tstack((r, g, b))
-    return rgb
+    B = REC_2020_COLOURSPACE.EOCF(B, is_10_bits_system=is_10_bits_system)
+    R = REC_2020_COLOURSPACE.EOCF(R, is_10_bits_system=is_10_bits_system)
+    G = (Yc - 0.0593 * B - 0.2627 * R) / 0.6780
+
+    RGB = tstack((R, G, B))
+
+    return RGB

--- a/colour/models/rgb/ycbcr.py
+++ b/colour/models/rgb/ycbcr.py
@@ -5,7 +5,7 @@
 Y'CbCr Colour Encoding
 ======================
 
-Defines the Y'CbCr colour encoding (Y'CbCr is not a colour space) transformations:
+Defines the Y'CbCr encoding (Y'CbCr is not a colour space) transformations:
 
 -   :func:`rgb_to_YCbCr`
 -   :func:`YCbCr_to_rgb`
@@ -16,16 +16,18 @@ References
 ----------
 .. [1]  Wikipedia. YCbCr. Retrieved February 29, 2016, from
         https://en.wikipedia.org/wiki/YCbCr
-.. [2]  Recommendation ITU-R BT.709-6(06/2015). Retrieved February 29, 2016, from
-        https://www.itu.int/dms_pubrec/itu-r/rec/bt/R-REC-BT.709-6-201506-I!!PDF-E.pdf
-.. [3]  Recommendation ITU-R BT.2020(08/2012). Retrieved February 29, 2016, from
-        https://www.itu.int/dms_pubrec/itu-r/rec/bt/R-REC-BT.2020-0-201208-S!!PDF-E.pdf
+.. [2]  Recommendation ITU-R BT.709-6(06/2015). Retrieved February 29, 2016,
+        from https://www.itu.int/dms_pubrec/itu-r/rec/bt/\
+        R-REC-BT.709-6-201506-I!!PDF-E.pdf
+.. [3]  Recommendation ITU-R BT.2020(08/2012). Retrieved February 29, 2016,
+        from https://www.itu.int/dms_pubrec/itu-r/rec/bt/\
+        R-REC-BT.2020-0-201208-S!!PDF-E.pdf
 """
 
 import numpy as np
 
 from colour.utilities import tsplit, tstack, CaseInsensitiveMapping
-from colour.models.rgb import *
+from colour.models.rgb import REC_2020_COLOURSPACE
 
 __author__ = 'Colour Developers'
 __copyright__ = 'Copyright (C) 2013 - 2016 - Colour Developers'
@@ -42,9 +44,9 @@ __all__ = ['WEIGHT',
            'YcCbcCrc_to_rgb']
 
 WEIGHT = (CaseInsensitiveMapping(
-        {'Rec.601' : [0.299, 0.114],
-         'Rec.709' : [0.2126, 0.0722],
-         'Rec.2020' : [0.2627, 0.0593]}))
+        {'Rec.601': [0.299, 0.114],
+         'Rec.709': [0.2126, 0.0722],
+         'Rec.2020': [0.2627, 0.0593]}))
 """
 List of preset luma weightings:
     'Rec.601' : [0.299, 0.114]
@@ -53,20 +55,20 @@ List of preset luma weightings:
 """
 
 RANGE = (CaseInsensitiveMapping(
-        {'legal_12' : [256./4095, 3760./4095],
-         'legal_12_YC' : [256./4095, 3760./4095, 256./4095, 3840./4095],
-         'legal_12_int' : [256, 3760],
-         'legal_12_YC_int' : [256, 3760, 256, 3840],
-         'legal_10' : [64./1023, 940./1023],
-         'legal_10_YC' : [64./1023, 940./1023, 64./1023, 960./1023],
-         'legal_10_int' : [64, 940],
-         'legal_10_YC_int' : [64, 940, 64, 960],
-         'legal_8' : [16./255, 235./255],
-         'legal_8_YC' : [16./255, 235./255, 16./255, 240./255],
-         'legal_8_int' : [16, 235],
-         'legal_8_YC_int' : [16, 235, 16, 240],
-         'full' : [0.0, 1.0],
-         'YPbPr' : [0.0, 1.0, -0.5, 0.5]}))
+        {'legal_12': [256./4095, 3760./4095],
+         'legal_12_YC': [256./4095, 3760./4095, 256./4095, 3840./4095],
+         'legal_12_int': [256, 3760],
+         'legal_12_YC_int': [256, 3760, 256, 3840],
+         'legal_10': [64./1023, 940./1023],
+         'legal_10_YC': [64./1023, 940./1023, 64./1023, 960./1023],
+         'legal_10_int': [64, 940],
+         'legal_10_YC_int': [64, 940, 64, 960],
+         'legal_8': [16./255, 235./255],
+         'legal_8_YC': [16./255, 235./255, 16./255, 240./255],
+         'legal_8_int': [16, 235],
+         'legal_8_YC_int': [16, 235, 16, 240],
+         'full': [0.0, 1.0],
+         'YPbPr': [0.0, 1.0, -0.5, 0.5]}))
 """
 List of preset ranges:
     'legal_12' : [256./4095, 3760./4095]
@@ -85,15 +87,18 @@ List of preset ranges:
     'YPbPr' : [0.0, 1.0, -0.5, 0.5]
 """
 
-def rgb_to_YCbCr(rgb, K = WEIGHT['Rec.709'], inRange = RANGE['full'], outRange = RANGE['legal_10_YC']):
+
+def rgb_to_YCbCr(rgb, K=WEIGHT['Rec.709'], inRange=RANGE['full'],
+                 outRange=RANGE['legal_10_YC']):
     """
     Converts an array of R'G'B' values to the corresponding Y'CbCr values.
-    
-    Note: For ITU-R BT.2020 (Rec.2020) the rgb_to_YCbCr function is only applicable to
-    the non-constant luminance implementation.
-    The rgb_to_YcCbcCrc function should be used for the constant luminance case.
-    See https://www.itu.int/dms_pubrec/itu-r/rec/bt/R-REC-BT.2020-0-201208-S!!PDF-E.pdf
-    
+
+    Note: For ITU-R BT.2020 (Rec.2020) the rgb_to_YCbCr function is only
+    applicable tothe non-constant luminance implementation.
+    The rgb_to_YcCbcCrc function should be used for the constant luminance case
+    See https://www.itu.int/dms_pubrec/itu-r/rec/bt/\
+    R-REC-BT.2020-0-201208-S!!PDF-E.pdf
+
     Parameters
     ----------
     rgb : array_like
@@ -110,36 +115,41 @@ def rgb_to_YCbCr(rgb, K = WEIGHT['Rec.709'], inRange = RANGE['full'], outRange =
         and the minimum and maximum values of Cb and Cr.
         These may be floats or integer code values.
         Default: RANGE['legal_10_YC']
-    
+
     Returns
     -------
     ndarray
         Y'CbCr array.
-        These may be floats or integer code values, depending on the parameter values
-        given for outRange.
-    
+        These may be floats or integer code values, depending on the parameter
+        values given for outRange.
+
     Examples
     --------
     >>> RGB = np.array([1.0, 1.0, 1.0])
-    >>> rgb_to_YCbCr(RGB)
+    >>> rgb_to_YCbCr(RGB)  # doctest: +ELLIPSIS
     array([ 0.91886608,  0.50048876,  0.50048876])
     >>> rgb_to_YCbCr(RGB, outRange=RANGE['legal_10_YC_int'])
     array([940, 512, 512])
-    
+
     For the JFIF JPEG conversion shown on https://en.wikipedia.org/wiki/YCbCr:
-    
+
     >>> RGB = np.array([102, 0, 51])
-    >>> rgb_to_YCbCr(RGB, K=WEIGHT['Rec.601'], inRange=[0, 255], outRange=[0, 255, 0, 256])
+    >>> rgb_to_YCbCr(RGB,
+    ...              K=WEIGHT['Rec.601'],
+    ...              inRange=[0, 255],
+    ...              outRange=[0, 255, 0, 256])  # doctest: +ELLIPSIS
     array([ 36, 136, 175])
-    
-    Note the use of 256 for the max Cb/Cr value, which is required so that the Cb and Cr
-    output is centred about 128. Using 255 would centre them about 127.5 meaning that
-    there was no integer code value to represent neutral colours. This does however create
-    the possibility of output values of 256, which cannot be stored in an 8-bit integer.
+
+    Note the use of 256 for the max Cb/Cr value, which is required so that the
+    Cb and Cr output is centred about 128. Using 255 would centre them about
+    127.5 meaning that there was no integer code value to represent neutral
+    colours. This does however create the possibility of output values of 256,
+    which cannot be stored in an 8-bit integer.
     """
     Kr = K[0]
     Kb = K[1]
-    intOut = isinstance(outRange[0], int) and isinstance(outRange[1], int) and isinstance(outRange[2], int) and isinstance(outRange[3], int)
+    intOut = (isinstance(outRange[0], int) and isinstance(outRange[1], int) and
+              isinstance(outRange[2], int) and isinstance(outRange[3], int))
     rgb_float = (rgb.astype(float) - inRange[0])
     rgb_float *= 1.0/(inRange[1] - inRange[0])
     r, g, b = tsplit(rgb_float)
@@ -159,15 +169,18 @@ def rgb_to_YCbCr(rgb, K = WEIGHT['Rec.709'], inRange = RANGE['full'], outRange =
     YCbCr = tstack((Y, Cb, Cr))
     return YCbCr
 
-def YCbCr_to_rgb(YCbCr, K = WEIGHT['Rec.709'], inRange = RANGE['legal_10_YC'], outRange = RANGE['full']):
+
+def YCbCr_to_rgb(YCbCr, K=WEIGHT['Rec.709'], inRange=RANGE['legal_10_YC'],
+                 outRange=RANGE['full']):
     """
     Converts an array of Y'CbCr values to the corresponding R'G'B' values.
-    
-    Note: For ITU-R BT.2020 (Rec.2020) the YCbCr_to_rgb function is only applicable to
-    the non-constant luminance implementation.
-    The YcCbcCrc_to_rgb function should be used for the constant luminance case.
-    See https://www.itu.int/dms_pubrec/itu-r/rec/bt/R-REC-BT.2020-0-201208-S!!PDF-E.pdf
-    
+
+    Note: For ITU-R BT.2020 (Rec.2020) the YCbCr_to_rgb function is only
+    applicable to the non-constant luminance implementation.
+    The YcCbcCrc_to_rgb function should be used for the constant luminance case
+    See https://www.itu.int/dms_pubrec/itu-r/rec/bt/\
+    R-REC-BT.2020-0-201208-S!!PDF-E.pdf
+
     Parameters
     ----------
     YCbCr : array_like
@@ -184,18 +197,19 @@ def YCbCr_to_rgb(YCbCr, K = WEIGHT['Rec.709'], inRange = RANGE['legal_10_YC'], o
         The values of R', G' and B' corresponding to 0 IRE and 100 IRE.
         These may be floats or integer code values.
         Default: RANGE['full']
-    
+
     Returns
     -------
     ndarray
         R'G'B' array.
-        These may be floats or integer code values, depending on the parameter values
-        given for outRange.
-    
+        These may be floats or integer code values, depending on the parameter
+        values given for outRange.
+
     Examples
     --------
     >>> YCbCr = np.array([502, 512, 512])
-    >>> YCbCr_to_rgb(YCbCr, inRange=RANGE['legal_10_YC_int'])
+    >>> YCbCr_to_rgb(YCbCr,
+    ...              inRange=RANGE['legal_10_YC_int'])  # doctest: +ELLIPSIS
     array([ 0.5,  0.5,  0.5])
     """
     Kr = K[0]
@@ -210,7 +224,7 @@ def YCbCr_to_rgb(YCbCr, K = WEIGHT['Rec.709'], inRange = RANGE['legal_10_YC'], o
     Cr *= 1.0/(inRange[3] - inRange[2])
     r = Y + (2.0 - 2.0*Kr)*Cr
     b = Y + (2.0 - 2.0*Kb)*Cb
-    g = (Y - Kr*r - Kb*b)/(1.0 - Kr -Kb)
+    g = (Y - Kr*r - Kb*b)/(1.0 - Kr - Kb)
     r *= outRange[1] - outRange[0]
     g *= outRange[1] - outRange[0]
     b *= outRange[1] - outRange[0]
@@ -224,14 +238,18 @@ def YCbCr_to_rgb(YCbCr, K = WEIGHT['Rec.709'], inRange = RANGE['legal_10_YC'], o
     rgb = tstack((r, g, b))
     return rgb
 
-def rgb_to_YcCbcCrc(rgb, outRange = RANGE['legal_10_YC'], is_10_bits_system = True):
+
+def rgb_to_YcCbcCrc(rgb, outRange=RANGE['legal_10_YC'],
+                    is_10_bits_system=True):
     """
-    Converts an array of RGB (linear) values to the corresponding Yc'Cbc'Crc' values.
-    
-    Note: This fuction is specifically for use with ITU-R BT.2020 (Rec.2020) when using
-    the constant luminance implementation.
-    See https://www.itu.int/dms_pubrec/itu-r/rec/bt/R-REC-BT.2020-0-201208-S!!PDF-E.pdf
-    
+    Converts an array of RGB (linear) values to the corresponding Yc'Cbc'Crc'
+    values.
+
+    Note: This fuction is specifically for use with ITU-R BT.2020 (Rec.2020)
+    when using the constant luminance implementation.
+    See https://www.itu.int/dms_pubrec/itu-r/rec/bt/\
+    R-REC-BT.2020-0-201208-S!!PDF-E.pdf
+
     Parameters
     ----------
     rgb : array_like
@@ -244,21 +262,26 @@ def rgb_to_YcCbcCrc(rgb, outRange = RANGE['legal_10_YC'], is_10_bits_system = Tr
     is_10_bits_system : bool (optional)
         The Rec.2020 OECF varies slightly for 10 and 12 bit systems.
         Default: True
-    
+
     Returns
     -------
     ndarray
         Yc'Cbc'Crc' array.
-        These may be floats or integer code values, depending on the parameter values
-        given for outRange.
-    
+        These may be floats or integer code values, depending on the parameter
+        values given for outRange.
+
     Examples
     --------
     >>> rgb = np.array([0.18, 0.18, 0.18])
-    >>> rgb_to_YcCbcCrc(rgb, outRange=RANGE['legal_10_YC_int'], is_10_bits_system = True)
+    >>> rgb_to_YcCbcCrc(rgb,
+    ...                 outRange=RANGE['legal_10_YC_int'],
+    ...                 is_10_bits_system = True)  # doctest: +ELLIPSIS
     array([422, 512, 512])
     """
-    intOut = isinstance(outRange[0], int) and isinstance(outRange[1], int) and isinstance(outRange[2], int) and isinstance(outRange[3], int)
+    intOut = (isinstance(outRange[0], int) and
+              isinstance(outRange[1], int) and
+              isinstance(outRange[2], int) and
+              isinstance(outRange[3], int))
     r, g, b = tsplit(rgb)
     Yc = 0.2627*r + 0.6780*g + 0.0593*b
     Yc = REC_2020_COLOURSPACE.OECF(Yc, is_10_bits_system=is_10_bits_system)
@@ -279,14 +302,18 @@ def rgb_to_YcCbcCrc(rgb, outRange = RANGE['legal_10_YC'], is_10_bits_system = Tr
     YcCbcCrc = tstack((Yc, Cbc, Crc))
     return YcCbcCrc
 
-def YcCbcCrc_to_rgb(YcCbcCrc, inRange = RANGE['legal_10_YC'], is_10_bits_system = True):
+
+def YcCbcCrc_to_rgb(YcCbcCrc, inRange=RANGE['legal_10_YC'],
+                    is_10_bits_system=True):
     """
-    Converts an array of Yc'Cbc'Crc' values to the corresponding RGB (linear) values.
-    
-    Note: This fuction is specifically for use with ITU-R BT.2020 (Rec.2020) when using
-    the constant luminance implementation.
-    See https://www.itu.int/dms_pubrec/itu-r/rec/bt/R-REC-BT.2020-0-201208-S!!PDF-E.pdf
-    
+    Converts an array of Yc'Cbc'Crc' values to the corresponding RGB (linear)
+    values.
+
+    Note: This fuction is specifically for use with ITU-R BT.2020 (Rec.2020)
+    when using the constant luminance implementation.
+    See https://www.itu.int/dms_pubrec/itu-r/rec/bt/\
+    R-REC-BT.2020-0-201208-S!!PDF-E.pdf
+
     Parameters
     ----------
     YcCbcCrc : array_like
@@ -300,17 +327,19 @@ def YcCbcCrc_to_rgb(YcCbcCrc, inRange = RANGE['legal_10_YC'], is_10_bits_system 
         The Rec.2020 EOCF varies slightly for 10 and 12 bit systems.
         Default: True
 
-    
+
     Returns
     -------
     ndarray
         RGB values corresponding to the input colour.
         These will be floating point linear values.
-    
+
     Examples
     --------
     >>> YcCbcCrc = np.array([1689, 2048, 2048])
-    >>> YcCbcCrc_to_rgb(YcCbcCrc, inRange=RANGE['legal_12_YC_int'], is_10_bits_system = False)
+    >>> YcCbcCrc_to_rgb(YcCbcCrc,
+    ...                 inRange=RANGE['legal_12_YC_int'],
+    ...                 is_10_bits_system=False)  # doctest: +ELLIPSIS
     array([ 0.18009037,  0.18009037,  0.18009037])
     """
     Yc, Cbc, Crc = tsplit(YcCbcCrc.astype(float))
@@ -328,4 +357,3 @@ def YcCbcCrc_to_rgb(YcCbcCrc, inRange = RANGE['legal_10_YC'], is_10_bits_system 
     g = (Yc - 0.0593*b - 0.2627*r)/0.6780
     rgb = tstack((r, g, b))
     return rgb
-    

--- a/colour/models/rgb/ycbcr.py
+++ b/colour/models/rgb/ycbcr.py
@@ -5,7 +5,8 @@
 Y'CbCr Colour Encoding
 ======================
 
-Defines the Y'CbCr encoding (Y'CbCr is not a colour space) transformations:
+Defines the Y'CbCr encoding (Y'CbCr is not an absolute colourspace)
+transformations:
 
 -   :func:`rgb_to_YCbCr`
 -   :func:`YCbCr_to_rgb`
@@ -22,11 +23,13 @@ References
 .. [3]  Recommendation ITU-R BT.2020(08/2012). Retrieved February 29, 2016,
         from https://www.itu.int/dms_pubrec/itu-r/rec/bt/\
         R-REC-BT.2020-0-201208-S!!PDF-E.pdf
+.. [4]  Ford, A., & Roberts, A. (1998). Colour Space Converions. Retrieved
+        April 29, 2016, from http://www.poynton.com/PDFs/coloureq.pdf
 """
 
 import numpy as np
 
-from colour.utilities import tsplit, tstack, CaseInsensitiveMapping
+from colour.utilities import CaseInsensitiveMapping, tsplit, tstack
 from colour.models.rgb import REC_2020_COLOURSPACE
 
 __author__ = 'Colour Developers'
@@ -36,229 +39,326 @@ __maintainer__ = 'Colour Developers'
 __email__ = 'colour-science@googlegroups.com'
 __status__ = 'Development'
 
-__all__ = ['WEIGHT',
-           'RANGE',
-           'rgb_to_YCbCr',
-           'YCbCr_to_rgb',
-           'rgb_to_YcCbcCrc',
-           'YcCbcCrc_to_rgb']
+__all__ = ['YCBCR_WEIGHTS',
+           'RGB_RANGE',
+           'YCBCR_RANGES',
+           'RGB_to_YCbCr',
+           'YCbCr_to_RGB',
+           'RGB_to_YcCbcCrc',
+           'YcCbcCrc_to_RGB']
 
-WEIGHT = (CaseInsensitiveMapping(
-        {'Rec.601': [0.299, 0.114],
-         'Rec.709': [0.2126, 0.0722],
-         'Rec.2020': [0.2627, 0.0593]}))
+YCBCR_WEIGHTS = CaseInsensitiveMapping(
+        {'Rec. 601': (0.299, 0.114),
+         'Rec. 709': (0.2126, 0.0722),
+         'Rec. 2020': (0.2627, 0.0593),
+         'SMPTE-240M': (0.2122, 0.0865)})
 """
 List of preset luma weightings:
-    'Rec.601' : [0.299, 0.114]
-    'Rec.709' : [0.2126, 0.0722]
-    'Rec.2020' : [0.2627, 0.0593]
-"""
-
-RANGE = (CaseInsensitiveMapping(
-        {'legal_12': [256./4095, 3760./4095],
-         'legal_12_YC': [256./4095, 3760./4095, 256./4095, 3840./4095],
-         'legal_12_int': [256, 3760],
-         'legal_12_YC_int': [256, 3760, 256, 3840],
-         'legal_10': [64./1023, 940./1023],
-         'legal_10_YC': [64./1023, 940./1023, 64./1023, 960./1023],
-         'legal_10_int': [64, 940],
-         'legal_10_YC_int': [64, 940, 64, 960],
-         'legal_8': [16./255, 235./255],
-         'legal_8_YC': [16./255, 235./255, 16./255, 240./255],
-         'legal_8_int': [16, 235],
-         'legal_8_YC_int': [16, 235, 16, 240],
-         'full': [0.0, 1.0],
-         'YPbPr': [0.0, 1.0, -0.5, 0.5]}))
-"""
-List of preset ranges:
-    'legal_12' : [256./4095, 3760./4095]
-    'legal_12_YC' : [256./4095, 3760./4095, 256./4095, 3840./4095]
-    'legal_12_int' : [256, 3760]
-    'legal_12_YC_int' : [256, 3760, 256, 3840]
-    'legal_10' : [64./1023, 940./1023]
-    'legal_10_YC' : [64./1023, 940./1023, 64./1023, 960./1023]
-    'legal_10_int' : [64, 940]
-    'legal_10_YC_int' : [64, 940, 64, 960]
-    'legal_8' : [16./255, 235./255]
-    'legal_8_YC' : [16./255, 235./255, 16./255, 240./255]
-    'legal_8_int' : [16, 235]
-    'legal_8_YC_int' : [16, 235, 16, 240]
-    'full' : [0.0, 1.0]
-    'YPbPr' : [0.0, 1.0, -0.5, 0.5]
+    'Rec. 601' : (0.299, 0.114)
+    'Rec. 709' : (0.2126, 0.0722)
+    'Rec. 2020' : (0.2627, 0.0593)
+    'SMPTE-240M': (0.2122, 0.0865)
 """
 
 
-def rgb_to_YCbCr(rgb, K=WEIGHT['Rec.709'], inRange=RANGE['full'],
-                 outRange=RANGE['legal_10_YC']):
+def RGB_RANGE(bits, is_legal, is_int):
+    if is_legal:
+        range = np.array([16, 235])
+        range *= 2**(bits - 8)
+    else:
+        range = np.array([0, 2**bits - 1])
+    if not(is_int):
+        range = range.astype(float)/(2**bits - 1)
+    return range
+
+
+def YCBCR_RANGES(bits, is_legal, is_int):
+    if is_legal:
+        ranges = np.array([16, 235, 16, 240])
+        ranges *= 2**(bits - 8)
+    else:
+        ranges = np.array([0, 2**bits - 1, 0, 2**bits - 1])
+    if not(is_int):
+        ranges = ranges.astype(float)/(2**bits - 1)
+    if (is_int and not(is_legal)):
+        ranges[3] = 2**bits
+    if (not(is_int) and not(is_legal)):
+        ranges[2] = -0.5
+        ranges[3] = 0.5
+    return ranges
+
+
+def RGB_to_YCbCr(rgb,
+                 K=YCBCR_WEIGHTS['Rec. 709'],
+                 in_range=None,
+                 out_range=None,
+                 in_bits=10,
+                 in_legal=False,
+                 in_int=False,
+                 out_bits=8,
+                 out_legal=True,
+                 out_int=False):
     """
     Converts an array of R'G'B' values to the corresponding Y'CbCr values.
-
-    Note: For ITU-R BT.2020 (Rec.2020) the rgb_to_YCbCr function is only
-    applicable tothe non-constant luminance implementation.
-    The rgb_to_YcCbcCrc function should be used for the constant luminance case
-    See https://www.itu.int/dms_pubrec/itu-r/rec/bt/\
-    R-REC-BT.2020-0-201208-S!!PDF-E.pdf
 
     Parameters
     ----------
     rgb : array_like
         Input R'G'B' values. These may be floats or integers.
-    K : array of two values
-        The luma weighting coefficients of red and blue.
-        Default: WEIGHT['Rec.709']
-    inRange : array of two values (optional)
+    K : tuple (optional)
+        The luma weighting coefficients of red and blue. Use the function
+        YCBCR_WEIGHTS(colourspace) for presets
+        **{'Rec. 601', 'Rec. 709', 'Rec. 2020','SMPTE-240M'}**
+        Default: YCBCR_WEIGHTS['Rec. 709']
+    in_range : array_like (optional)
         The values of R', G' and B' corresponding to 0 IRE and 100 IRE.
-        These may be floats or integer code values.
-        Default: RANGE['full']
-    outRange : array of four values (optional)
+        These may be floats or integer code values. If values are given here
+        they take precedence over values calculated from in_legal, in_float
+        and in_bits.
+    out_range : array_like (optional)
         The values of Y' corresponding to 0 IRE and 100 IRE
         and the minimum and maximum values of Cb and Cr.
-        These may be floats or integer code values.
-        Default: RANGE['legal_10_YC']
+        These may be floats or integer code values. If values are given here
+        they take precedence over values calculated from out_legal, out_float
+        and out_bits.
+    in_bits : int (optional)
+        The bit depth for integer input, or used in the calculation of the
+        denominator for legal range float values, i.e. 8 bit means the float
+        value for legal white is 235/255.
+        Default : 10
+    in_legal : bool (optional)
+        Whether to treat the input values as legal range.
+        Default : False
+    in_int : bool (optional)
+        Whether to treat the input values as in_bits integer code values.
+        Default : False
+    out_bits : int (optional)
+        The bit depth for integer output, or used in the calculation of the
+        denominator for legal range float values, i.e. 8 bit means the float
+        value for legal white is 235/255. Ignored if out_legal and out_int are
+        both False.
+        Default : 8
+    out_legal : bool (optional)
+        Whether to return legal range data.
+        Default : True
+    out_int : bool (optional)
+        Whether to return values as out_bits integer code values.
+        Default : False
 
     Returns
     -------
     ndarray
         Y'CbCr array.
-        These may be floats or integer code values, depending on the parameter
-        values given for outRange.
+        These may be floats or integer code values, depending on parameters.
+
+    Notes
+    -----
+    -   For ITU-R BT.2020 (Rec.2020) the RGB_to_YCbCr function is only
+        applicable tothe non-constant luminance implementation. The
+        rgb_to_YcCbcCrc function should be used for the constant luminance case
+        See https://www.itu.int/dms_pubrec/itu-r/rec/bt/\
+        R-REC-BT.2020-0-201208-S!!PDF-E.pdf
+
+    -   The default settings of (in_bits=10, in_legal=False, in_int=False,
+        out_bits=8, out_legal=True, out_int=False) will transform float RGB
+        input ranged 0.0-1.0 (in_bits is ignored) to float Y'CbCr output where
+        Y' is ranged 16./255 to 235./255 and Cb and Cr are ranged 16./255 to
+        240./255. So the float values are calculated based on an integer range
+        from 0-255. But no 8-bit quantisation is applied, and neither is any
+        clamping.
+
+    -   To match the float output of Nuke's Colorspace node set to YCbCr,
+        set out_range=(16./255, 235./255, 15.5/255, 239.5/255)
+
+    -   To match the float output of Nuke's Colorspace node set to YPbPr,
+        set (out_legal=False, out_int=False)
+
+    -   To create integer code values as per standard 10-bit SDI, set
+        (out_bits=8, out_legal=True, out_int=True)
 
     Examples
     --------
-    >>> RGB = np.array([1.0, 1.0, 1.0])
-    >>> rgb_to_YCbCr(RGB)  # doctest: +ELLIPSIS
-    array([ 0.91886608,  0.50048876,  0.50048876])
-    >>> rgb_to_YCbCr(RGB, outRange=RANGE['legal_10_YC_int'])
+    >>> rgb = np.array([1.0, 1.0, 1.0])
+    >>> RGB_to_YCbCr(rgb)  # doctest: +ELLIPSIS
+    array([ 0.9188660...,  0.5004887...,  0.5004887...])
+    >>> rgb_to_YCbCr(RGB, out_range=RANGE['legal_10_YC_int'])
     array([940, 512, 512])
 
-    For the JFIF JPEG conversion shown on https://en.wikipedia.org/wiki/YCbCr:
+    For JFIF JPEG conversion as per http://www.w3.org/Graphics/JPEG/jfif3.pdf:
 
-    >>> RGB = np.array([102, 0, 51])
-    >>> rgb_to_YCbCr(RGB,
-    ...              K=WEIGHT['Rec.601'],
-    ...              inRange=[0, 255],
-    ...              outRange=[0, 255, 0, 256])  # doctest: +ELLIPSIS
+    >>> rgb = np.array([102, 0, 51])
+    >>> RGB_to_YCbCr(rgb,
+    ...              K=YCBCR_WEIGHTS['Rec. 601'],
+    ...              in_range=(0, 255),
+    ...              out_range=(0, 255, 0, 256),
+    ...              out_int=True)
     array([ 36, 136, 175])
 
     Note the use of 256 for the max Cb/Cr value, which is required so that the
     Cb and Cr output is centred about 128. Using 255 would centre them about
     127.5 meaning that there was no integer code value to represent neutral
     colours. This does however create the possibility of output values of 256,
-    which cannot be stored in an 8-bit integer.
+    which cannot be stored in an 8-bit integer. The JPEG document specifies
+    these should be clamped to 255.
     """
     Kr = K[0]
     Kb = K[1]
-    intOut = (isinstance(outRange[0], int) and isinstance(outRange[1], int) and
-              isinstance(outRange[2], int) and isinstance(outRange[3], int))
-    rgb_float = (rgb.astype(float) - inRange[0])
-    rgb_float *= 1.0/(inRange[1] - inRange[0])
+    if in_range is None:
+        in_range = RGB_RANGE(in_bits, in_legal, in_int)
+    if out_range is None:
+        out_range = YCBCR_RANGES(out_bits, out_legal, out_int)
+    rgb_float = (rgb.astype(float) - in_range[0])
+    rgb_float *= 1.0/(in_range[1] - in_range[0])
     r, g, b = tsplit(rgb_float)
     Y = Kr*r + (1.0 - Kr - Kb)*g + Kb*b
     Cb = 0.5*(b - Y)/(1.0 - Kb)
     Cr = 0.5*(r - Y)/(1.0 - Kr)
-    Y *= outRange[1] - outRange[0]
-    Y += outRange[0]
-    Cb *= outRange[3] - outRange[2]
-    Cr *= outRange[3] - outRange[2]
-    Cb += (outRange[3] + outRange[2])/2
-    Cr += (outRange[3] + outRange[2])/2
-    if intOut:
-        Y = np.round(Y).astype(int)
-        Cb = np.round(Cb).astype(int)
-        Cr = np.round(Cr).astype(int)
+    Y *= out_range[1] - out_range[0]
+    Y += out_range[0]
+    Cb *= out_range[3] - out_range[2]
+    Cr *= out_range[3] - out_range[2]
+    Cb += (out_range[3] + out_range[2])/2
+    Cr += (out_range[3] + out_range[2])/2
     YCbCr = tstack((Y, Cb, Cr))
+    if out_int:
+        YCbCr = np.round(YCbCr).astype(int)
     return YCbCr
 
 
-def YCbCr_to_rgb(YCbCr, K=WEIGHT['Rec.709'], inRange=RANGE['legal_10_YC'],
-                 outRange=RANGE['full']):
+def YCbCr_to_RGB(YCbCr,
+                 K=YCBCR_WEIGHTS['Rec. 709'],
+                 in_range=None,
+                 out_range=None,
+                 in_bits=8,
+                 in_legal=True,
+                 in_int=False,
+                 out_bits=10,
+                 out_legal=False,
+                 out_int=False):
     """
     Converts an array of Y'CbCr values to the corresponding R'G'B' values.
-
-    Note: For ITU-R BT.2020 (Rec.2020) the YCbCr_to_rgb function is only
-    applicable to the non-constant luminance implementation.
-    The YcCbcCrc_to_rgb function should be used for the constant luminance case
-    See https://www.itu.int/dms_pubrec/itu-r/rec/bt/\
-    R-REC-BT.2020-0-201208-S!!PDF-E.pdf
 
     Parameters
     ----------
     YCbCr : array_like
         Input Y'CbCr values. These may be floats or integers.
-    K : array of two values (optional)
-        The luma weighting coefficients of red and blue.
-        Default: WEIGHT['Rec.709']
-    inRange : array of four values (optional)
-        The values of Y' corresponding to 0 IRE and 100 IRE,
+    K : tuple (optional)
+        The luma weighting coefficients of red and blue. Use the function
+        YCBCR_WEIGHTS(colourspace) for presets
+        **{'Rec. 601', 'Rec. 709', 'Rec. 2020','SMPTE-240M'}**
+        Default: YCBCR_WEIGHTS['Rec. 709']
+    in_range : array_like (optional)
+        The values of Y' corresponding to 0 IRE and 100 IRE
         and the minimum and maximum values of Cb and Cr.
-        These may be floats or integer code values.
-        Default: RANGE['legal_10_YC']
-    outRange : array of two values (optional)
+        These may be floats or integer code values. If values are given here
+        they take precedence over values calculated from in_legal, in_float
+        and in_bits.
+    out_range : array_like (optional)
         The values of R', G' and B' corresponding to 0 IRE and 100 IRE.
-        These may be floats or integer code values.
-        Default: RANGE['full']
+        These may be floats or integer code values. If values are given here
+        they take precedence over values calculated from out_legal, out_float
+        and out_bits.
+    in_bits : int (optional)
+        The bit depth for integer input, or used in the calculation of the
+        denominator for legal range float values, i.e. 8 bit means the float
+        value for legal white is 235/255.
+        Default : 8
+    in_legal : bool (optional)
+        Whether to treat the input values as legal range.
+        Default : True
+    in_int : bool (optional)
+        Whether to treat the input values as in_bits integer code values.
+        Default : False
+    out_bits : int (optional)
+        The bit depth for integer output, or used in the calculation of the
+        denominator for legal range float values, i.e. 8 bit means the float
+        value for legal white is 235/255. Ignored if out_legal and out_int are
+        both False.
+        Default : 10
+    out_legal : bool (optional)
+        Whether to return legal range data.
+        Default : False
+    out_int : bool (optional)
+        Whether to return values as out_bits integer code values.
+        Default : False
 
     Returns
     -------
     ndarray
         R'G'B' array.
-        These may be floats or integer code values, depending on the parameter
-        values given for outRange.
+        These may be floats or integer code values, depending on parameters.
+
+    Notes
+    -----
+    -   For ITU-R BT.2020 (Rec.2020) the YCbCr_to_RGB function is only
+        applicable tothe non-constant luminance implementation. The
+        YcCbcCrc_to_RGB function should be used for the constant luminance case
+        See https://www.itu.int/dms_pubrec/itu-r/rec/bt/\
+        R-REC-BT.2020-0-201208-S!!PDF-E.pdf
 
     Examples
     --------
     >>> YCbCr = np.array([502, 512, 512])
     >>> YCbCr_to_rgb(YCbCr,
-    ...              inRange=RANGE['legal_10_YC_int'])  # doctest: +ELLIPSIS
+    ...              in_range=RANGE['legal_10_YC_int'])
     array([ 0.5,  0.5,  0.5])
     """
     Kr = K[0]
     Kb = K[1]
-    intOut = isinstance(outRange[0], int) and isinstance(outRange[1], int)
+    if out_range is None:
+        out_range = RGB_RANGE(out_bits, out_legal, out_int)
+    if in_range is None:
+        in_range = YCBCR_RANGES(in_bits, in_legal, in_int)
     Y, Cb, Cr = tsplit(YCbCr.astype(float))
-    Y -= inRange[0]
-    Cb -= (inRange[3] + inRange[2])/2.0
-    Cr -= (inRange[3] + inRange[2])/2.0
-    Y *= 1.0/(inRange[1] - inRange[0])
-    Cb *= 1.0/(inRange[3] - inRange[2])
-    Cr *= 1.0/(inRange[3] - inRange[2])
+    Y -= in_range[0]
+    Cb -= (in_range[3] + in_range[2])/2.0
+    Cr -= (in_range[3] + in_range[2])/2.0
+    Y *= 1.0/(in_range[1] - in_range[0])
+    Cb *= 1.0/(in_range[3] - in_range[2])
+    Cr *= 1.0/(in_range[3] - in_range[2])
     r = Y + (2.0 - 2.0*Kr)*Cr
     b = Y + (2.0 - 2.0*Kb)*Cb
     g = (Y - Kr*r - Kb*b)/(1.0 - Kr - Kb)
-    r *= outRange[1] - outRange[0]
-    g *= outRange[1] - outRange[0]
-    b *= outRange[1] - outRange[0]
-    r += outRange[0]
-    g += outRange[0]
-    b += outRange[0]
-    if intOut:
-        r = np.round(r).astype(int)
-        g = np.round(g).astype(int)
-        b = np.round(b).astype(int)
     rgb = tstack((r, g, b))
+    rgb *= out_range[1] - out_range[0]
+    rgb += out_range[0]
+    if out_int:
+        rgb = np.round(rgb).astype(int)
     return rgb
 
 
-def rgb_to_YcCbcCrc(rgb, outRange=RANGE['legal_10_YC'],
+def RGB_to_YcCbcCrc(rgb,
+                    out_range=None,
+                    out_bits=8,
+                    out_legal=True,
+                    out_int=False,
                     is_10_bits_system=True):
     """
     Converts an array of RGB (linear) values to the corresponding Yc'Cbc'Crc'
     values.
 
-    Note: This fuction is specifically for use with ITU-R BT.2020 (Rec.2020)
-    when using the constant luminance implementation.
-    See https://www.itu.int/dms_pubrec/itu-r/rec/bt/\
-    R-REC-BT.2020-0-201208-S!!PDF-E.pdf
-
     Parameters
     ----------
     rgb : array_like
         Input RGB floating point linear values.
-    outRange : array of four values (optional)
-        The values of Y' corresponding to 0 IRE and 100 IRE,
+    out_range : array_like (optional)
+        The values of Y' corresponding to 0 IRE and 100 IRE
         and the minimum and maximum values of Cb and Cr.
-        These may be floats or integer code values.
-        Default: RANGE['legal_10_YC']
+        These may be floats or integer code values. If values are given here
+        they take precedence over values calculated from out_legal, out_float
+        and out_bits.
+    out_bits : int (optional)
+        The bit depth for integer output, or used in the calculation of the
+        denominator for legal range float values, i.e. 8 bit means the float
+        value for legal white is 235/255. Ignored if out_legal and out_int are
+        both False.
+        Default : 8
+    out_legal : bool (optional)
+        Whether to return legal range data.
+        Default : True
+    out_int : bool (optional)
+        Whether to return values as out_bits integer code values.
+        Default : False
     is_10_bits_system : bool (optional)
         The Rec.2020 OECF varies slightly for 10 and 12 bit systems.
         Default: True
@@ -267,21 +367,25 @@ def rgb_to_YcCbcCrc(rgb, outRange=RANGE['legal_10_YC'],
     -------
     ndarray
         Yc'Cbc'Crc' array.
-        These may be floats or integer code values, depending on the parameter
-        values given for outRange.
+        These may be floats or integer code values, depending on parameters.
+
+    Notes
+    -----
+    -   This fuction is specifically for use with ITU-R BT.2020 (Rec.2020)
+        when using the constant luminance implementation.
+        See https://www.itu.int/dms_pubrec/itu-r/rec/bt/\
+        R-REC-BT.2020-0-201208-S!!PDF-E.pdf
 
     Examples
     --------
     >>> rgb = np.array([0.18, 0.18, 0.18])
     >>> rgb_to_YcCbcCrc(rgb,
-    ...                 outRange=RANGE['legal_10_YC_int'],
-    ...                 is_10_bits_system = True)  # doctest: +ELLIPSIS
+    ...                 out_range=RANGE['legal_10_YC_int'],
+    ...                 is_10_bits_system = True)
     array([422, 512, 512])
     """
-    intOut = (isinstance(outRange[0], int) and
-              isinstance(outRange[1], int) and
-              isinstance(outRange[2], int) and
-              isinstance(outRange[3], int))
+    if out_range is None:
+        out_range = YCBCR_RANGES(out_bits, out_legal, out_int)
     r, g, b = tsplit(rgb)
     Yc = 0.2627*r + 0.6780*g + 0.0593*b
     Yc = REC_2020_COLOURSPACE.OECF(Yc, is_10_bits_system=is_10_bits_system)
@@ -289,40 +393,50 @@ def rgb_to_YcCbcCrc(rgb, outRange=RANGE['legal_10_YC'],
     b = REC_2020_COLOURSPACE.OECF(b, is_10_bits_system=is_10_bits_system)
     Cbc = np.where((b - Yc) <= 0.0, (b - Yc)/1.9404, (b - Yc)/1.5816)
     Crc = np.where((r - Yc) <= 0.0, (r - Yc)/1.7184, (r - Yc)/0.9936)
-    Yc *= outRange[1] - outRange[0]
-    Yc += outRange[0]
-    Cbc *= outRange[3] - outRange[2]
-    Crc *= outRange[3] - outRange[2]
-    Cbc += (outRange[3] + outRange[2])/2
-    Crc += (outRange[3] + outRange[2])/2
-    if intOut:
-        Yc = np.round(Yc).astype(int)
-        Cbc = np.round(Cbc).astype(int)
-        Crc = np.round(Crc).astype(int)
+    Yc *= out_range[1] - out_range[0]
+    Yc += out_range[0]
+    Cbc *= out_range[3] - out_range[2]
+    Crc *= out_range[3] - out_range[2]
+    Cbc += (out_range[3] + out_range[2])/2
+    Crc += (out_range[3] + out_range[2])/2
     YcCbcCrc = tstack((Yc, Cbc, Crc))
+    if out_int:
+        YcCbcCrc = np.round(YcCbcCrc).astype(int)
     return YcCbcCrc
 
 
-def YcCbcCrc_to_rgb(YcCbcCrc, inRange=RANGE['legal_10_YC'],
+def YcCbcCrc_to_RGB(YcCbcCrc,
+                    in_range=None,
+                    in_bits=8,
+                    in_legal=True,
+                    in_int=False,
                     is_10_bits_system=True):
     """
     Converts an array of Yc'Cbc'Crc' values to the corresponding RGB (linear)
     values.
 
-    Note: This fuction is specifically for use with ITU-R BT.2020 (Rec.2020)
-    when using the constant luminance implementation.
-    See https://www.itu.int/dms_pubrec/itu-r/rec/bt/\
-    R-REC-BT.2020-0-201208-S!!PDF-E.pdf
-
     Parameters
     ----------
     YcCbcCrc : array_like
         Input Yc'Cbc'Crc' values. These may be floats or integers.
-    inRange : array of four values (optional)
-        The values of Yc' corresponding to 0 IRE and 100 IRE,
-        and the minimum and maximum values of Cbc' and Crc'.
-        These may be floats or integer code values.
-        Default = RANGE['legal_10_YC']
+    in_range : array_like (optional)
+        The values of Y' corresponding to 0 IRE and 100 IRE
+        and the minimum and maximum values of Cb and Cr.
+        These may be floats or integer code values. If values are given here
+        they take precedence over values calculated from in_legal, in_float
+        and in_bits.
+    out_bits : int (optional)
+        The bit depth for integer output, or used in the calculation of the
+        denominator for legal range float values, i.e. 8 bit means the float
+        value for legal white is 235/255. Ignored if out_legal and out_int are
+        both False.
+        Default : 10
+    out_legal : bool (optional)
+        Whether to return legal range data.
+        Default : False
+    out_int : bool (optional)
+        Whether to return values as out_bits integer code values.
+        Default : False
     is_10_bits_system : bool (optional)
         The Rec.2020 EOCF varies slightly for 10 and 12 bit systems.
         Default: True
@@ -334,21 +448,30 @@ def YcCbcCrc_to_rgb(YcCbcCrc, inRange=RANGE['legal_10_YC'],
         RGB values corresponding to the input colour.
         These will be floating point linear values.
 
+    Notes
+    -----
+    -   This fuction is specifically for use with ITU-R BT.2020 (Rec.2020)
+        when using the constant luminance implementation.
+        See https://www.itu.int/dms_pubrec/itu-r/rec/bt/\
+        R-REC-BT.2020-0-201208-S!!PDF-E.pdf
+
     Examples
     --------
     >>> YcCbcCrc = np.array([1689, 2048, 2048])
     >>> YcCbcCrc_to_rgb(YcCbcCrc,
-    ...                 inRange=RANGE['legal_12_YC_int'],
+    ...                 in_range=RANGE['legal_12_YC_int'],
     ...                 is_10_bits_system=False)  # doctest: +ELLIPSIS
     array([ 0.18009037,  0.18009037,  0.18009037])
     """
+    if in_range is None:
+        in_range = YCBCR_RANGES(in_bits, in_legal, in_int)
     Yc, Cbc, Crc = tsplit(YcCbcCrc.astype(float))
-    Yc -= inRange[0]
-    Cbc -= (inRange[3] + inRange[2])/2.0
-    Crc -= (inRange[3] + inRange[2])/2.0
-    Yc *= 1.0/(inRange[1] - inRange[0])
-    Cbc *= 1.0/(inRange[3] - inRange[2])
-    Crc *= 1.0/(inRange[3] - inRange[2])
+    Yc -= in_range[0]
+    Cbc -= (in_range[3] + in_range[2])/2.0
+    Crc -= (in_range[3] + in_range[2])/2.0
+    Yc *= 1.0/(in_range[1] - in_range[0])
+    Cbc *= 1.0/(in_range[3] - in_range[2])
+    Crc *= 1.0/(in_range[3] - in_range[2])
     b = np.where(Cbc <= 0.0, Cbc*1.9404 + Yc, Cbc*1.5816 + Yc)
     r = np.where(Crc <= 0.0, Crc*1.7184 + Yc, Crc*0.9936 + Yc)
     Yc = REC_2020_COLOURSPACE.EOCF(Yc, is_10_bits_system=is_10_bits_system)

--- a/colour/models/rgb/ycbcr.py
+++ b/colour/models/rgb/ycbcr.py
@@ -8,10 +8,10 @@ Y'CbCr Colour Encoding
 Defines the Y'CbCr encoding (Y'CbCr is not an absolute colourspace)
 transformations:
 
--   :func:`rgb_to_YCbCr`
--   :func:`YCbCr_to_rgb`
--   :func:`rgb_to_YcCbcCrc`
--   :func:`YcCbcCrc_to_rgb`
+-   :func:`RGB_to_YCbCr`
+-   :func:`YCbCr_to_RGB`
+-   :func:`RGB_to_YcCbcCrc`
+-   :func:`YcCbcCrc_to_RGB`
 
 References
 ----------
@@ -155,7 +155,7 @@ def RGB_to_YCbCr(rgb,
     -----
     -   For ITU-R BT.2020 (Rec.2020) the RGB_to_YCbCr function is only
         applicable tothe non-constant luminance implementation. The
-        rgb_to_YcCbcCrc function should be used for the constant luminance case
+        RGB_to_YcCbcCrc function should be used for the constant luminance case
         See https://www.itu.int/dms_pubrec/itu-r/rec/bt/\
         R-REC-BT.2020-0-201208-S!!PDF-E.pdf
 
@@ -179,9 +179,10 @@ def RGB_to_YCbCr(rgb,
     Examples
     --------
     >>> rgb = np.array([1.0, 1.0, 1.0])
-    >>> RGB_to_YCbCr(rgb)  # doctest: +ELLIPSIS
-    array([ 0.9188660...,  0.5004887...,  0.5004887...])
-    >>> rgb_to_YCbCr(RGB, out_range=RANGE['legal_10_YC_int'])
+    >>> RGB_to_YCbCr(  # doctest: +ELLIPSIS
+    ...              rgb)
+    array([ 0.9215686...,  0.5019607...,  0.5019607...])
+    >>> RGB_to_YCbCr(rgb, out_legal=True, out_bits=10, out_int=True)
     array([940, 512, 512])
 
     For JFIF JPEG conversion as per http://www.w3.org/Graphics/JPEG/jfif3.pdf:
@@ -299,8 +300,10 @@ def YCbCr_to_RGB(YCbCr,
     Examples
     --------
     >>> YCbCr = np.array([502, 512, 512])
-    >>> YCbCr_to_rgb(YCbCr,
-    ...              in_range=RANGE['legal_10_YC_int'])
+    >>> YCbCr_to_RGB(YCbCr,
+    ...              in_bits=10,
+    ...              in_legal=True,
+    ...              in_int=True)
     array([ 0.5,  0.5,  0.5])
     """
     Kr = K[0]
@@ -379,8 +382,10 @@ def RGB_to_YcCbcCrc(rgb,
     Examples
     --------
     >>> rgb = np.array([0.18, 0.18, 0.18])
-    >>> rgb_to_YcCbcCrc(rgb,
-    ...                 out_range=RANGE['legal_10_YC_int'],
+    >>> RGB_to_YcCbcCrc(rgb,
+    ...                 out_legal=True,
+    ...                 out_bits=10,
+    ...                 out_int=True,
     ...                 is_10_bits_system = True)
     array([422, 512, 512])
     """
@@ -458,10 +463,13 @@ def YcCbcCrc_to_RGB(YcCbcCrc,
     Examples
     --------
     >>> YcCbcCrc = np.array([1689, 2048, 2048])
-    >>> YcCbcCrc_to_rgb(YcCbcCrc,
-    ...                 in_range=RANGE['legal_12_YC_int'],
-    ...                 is_10_bits_system=False)  # doctest: +ELLIPSIS
-    array([ 0.18009037,  0.18009037,  0.18009037])
+    >>> YcCbcCrc_to_RGB(  # doctest: +ELLIPSIS
+    ...                 YcCbcCrc,
+    ...                 in_legal=True,
+    ...                 in_bits=12,
+    ...                 in_int=True,
+    ...                 is_10_bits_system=False)
+    array([ 0.1800903..., 0.1800903..., 0.1800903...])
     """
     if in_range is None:
         in_range = YCBCR_RANGES(in_bits, in_legal, in_int)

--- a/colour/models/rgb/ycbcr.py
+++ b/colour/models/rgb/ycbcr.py
@@ -30,9 +30,10 @@ itu-r/rec/bt/R-REC-BT.709-6-201506-I!!PDF-E.pdf
         international programme exchange. In *Recommendation ITU-R BT.2020*
         (Vol. 1, pp. 1–8). Retrieved from https://www.itu.int/dms_pubrec/\
 itu-r/rec/bt/R-REC-BT.2020-2-201510-I!!PDF-E.pdf
-.. [4]  Ford, A., & Roberts, A. (1998). Colour space conversions. Westminster
-        University, London, 1998, 1–31. Retrieved from
-        http://herakles.fav.zcu.cz/research/night_road/westminster.pdf
+.. [4]  ANSI/SMPTE 240M-1995: Television – Signal Parameters – 1125-Line
+        High-Definition Production Systems.
+        Retrieved from http://car.france3.mars.free.fr/HD/\
+        INA-%2026%20jan%2006/SMPTE%20normes%20et%20confs/s240m.pdf
 .. [5]  International Telecommunication Union. (2011). Recommendation ITU-T
         T.871 - Information technology – Digital compression and coding of
         continuous-tone still images: JPEG File Interchange Format (JFIF).
@@ -54,7 +55,7 @@ __email__ = 'colour-science@googlegroups.com'
 __status__ = 'Development'
 
 __all__ = ['YCBCR_WEIGHTS',
-           'RGB_ranges',
+           'RGB_range',
            'YCbCr_ranges',
            'RGB_to_YCbCr',
            'YCbCr_to_RGB',
@@ -74,7 +75,7 @@ YCBCR_WEIGHTS : dict
 """
 
 
-def RGB_ranges(bits, is_legal, is_int):
+def RGB_range(bits, is_legal, is_int):
     """"
     Returns the *RGB* ranges array for given bit depth, range legality and
     representation.
@@ -95,11 +96,11 @@ def RGB_ranges(bits, is_legal, is_int):
 
     Examples
     --------
-    >>> RGB_ranges(8, True, True)
+    >>> RGB_range(8, True, True)
     array([ 16, 235])
-    >>> RGB_ranges(8, True, False)  # doctest: +ELLIPSIS
+    >>> RGB_range(8, True, False)  # doctest: +ELLIPSIS
     array([ 0.0627451...,  0.9215686...])
-    >>> RGB_ranges(10, False, False)
+    >>> RGB_range(10, False, False)
     array([ 0.,  1.])
     """
 
@@ -183,7 +184,8 @@ def RGB_to_YCbCr(RGB,
         Input *R'G'B'* array of floats or integer values.
     K : array_like, optional
         Luma weighting coefficients of red and blue. See :attr:
-        `YCBCR_WEIGHTS` for presets. Default is `(0.2126, 0.0722)`.
+        `YCBCR_WEIGHTS` for presets. Default is `(0.2126, 0.0722)`, the
+        weightings for Rec. 709.
     in_bits : int, optional
         Bit depth for integer input, or used in the calculation of the
         denominator for legal range float values, i.e. 8-bit means the float
@@ -291,7 +293,7 @@ def RGB_to_YCbCr(RGB,
 
     Kr, Kb = K
     RGB_min, RGB_max = kwargs.get(
-        'in_range', RGB_ranges(in_bits, in_legal, in_int))
+        'in_range', RGB_range(in_bits, in_legal, in_int))
     Y_min, Y_max, C_min, C_max = kwargs.get(
         'out_range', YCbCr_ranges(out_bits, out_legal, out_int))
 
@@ -334,7 +336,8 @@ def YCbCr_to_RGB(YCbCr,
         Input *Y'CbCr* colour encoding array of integer or float values.
     K : array_like, optional
         Luma weighting coefficients of red and blue. See :attr:
-        `YCBCR_WEIGHTS` for presets. Default is `(0.2126, 0.0722)`.
+        `YCBCR_WEIGHTS` for presets. Default is `(0.2126, 0.0722)`, the
+        weightings for Rec. 709.
     in_bits : int, optional
         Bit depth for integer input, or used in the calculation of the
         denominator for legal range float values, i.e. 8-bit means the float
@@ -388,7 +391,7 @@ def YCbCr_to_RGB(YCbCr,
     Y_min, Y_max, C_min, C_max = kwargs.get(
         'in_range', YCbCr_ranges(in_bits, in_legal, in_int))
     RGB_min, RGB_max = kwargs.get(
-        'out_range', RGB_ranges(out_bits, out_legal, out_int))
+        'out_range', RGB_range(out_bits, out_legal, out_int))
 
     Y -= Y_min
     Cb -= (C_max + C_min) / 2

--- a/colour/models/rgb/ycbcr.py
+++ b/colour/models/rgb/ycbcr.py
@@ -45,7 +45,7 @@ from __future__ import division, unicode_literals
 import numpy as np
 
 from colour.utilities import CaseInsensitiveMapping, tsplit, tstack
-from colour.models.rgb import REC_2020_COLOURSPACE
+from colour.models.rgb.transfer_functions import oetf_BT2020, eotf_BT2020
 
 __author__ = 'Colour Developers'
 __copyright__ = 'Copyright (C) 2013 - 2016 - Colour Developers'
@@ -471,9 +471,9 @@ def RGB_to_YcCbcCrc(RGB,
         'out_range', YCbCr_ranges(out_bits, out_legal, out_int))
 
     Yc = 0.2627 * R + 0.6780 * G + 0.0593 * B
-    Yc = REC_2020_COLOURSPACE.OECF(Yc, is_10_bits_system=is_10_bits_system)
-    R = REC_2020_COLOURSPACE.OECF(R, is_10_bits_system=is_10_bits_system)
-    B = REC_2020_COLOURSPACE.OECF(B, is_10_bits_system=is_10_bits_system)
+    Yc = oetf_BT2020(Yc, is_10_bits_system=is_10_bits_system)
+    R = oetf_BT2020(R, is_10_bits_system=is_10_bits_system)
+    B = oetf_BT2020(B, is_10_bits_system=is_10_bits_system)
     Cbc = np.where((B - Yc) <= 0, (B - Yc) / 1.9404, (B - Yc) / 1.5816)
     Crc = np.where((R - Yc) <= 0, (R - Yc) / 1.7184, (R - Yc) / 0.9936)
     Yc *= Y_max - Y_min
@@ -555,9 +555,9 @@ def YcCbcCrc_to_RGB(YcCbcCrc,
     Crc *= 1 / (C_max - C_min)
     B = np.where(Cbc <= 0, Cbc * 1.9404 + Yc, Cbc * 1.5816 + Yc)
     R = np.where(Crc <= 0, Crc * 1.7184 + Yc, Crc * 0.9936 + Yc)
-    Yc = REC_2020_COLOURSPACE.EOCF(Yc, is_10_bits_system=is_10_bits_system)
-    B = REC_2020_COLOURSPACE.EOCF(B, is_10_bits_system=is_10_bits_system)
-    R = REC_2020_COLOURSPACE.EOCF(R, is_10_bits_system=is_10_bits_system)
+    Yc = eotf_BT2020(Yc, is_10_bits_system=is_10_bits_system)
+    B = eotf_BT2020(B, is_10_bits_system=is_10_bits_system)
+    R = eotf_BT2020(R, is_10_bits_system=is_10_bits_system)
     G = (Yc - 0.0593 * B - 0.2627 * R) / 0.6780
 
     RGB = tstack((R, G, B))


### PR DESCRIPTION
First version of a set of functions for converting between RGB and Y'CbCr or Yc'Cbc'Cbr' (the 'constant luminance' variant for ITU-R BT.2020 – Rec.2020).

The functions are designed to be as flexible as possible, so they can take input and return values in various integer and floating point ranges, and can use various preset matrices (or user ones) to do the conversion.

The unit tests are not yet sufficiently comprehensive, but this is put out there for feedback before being taken any further.