### PR TITLE
PR: Implement support for CCT to chromaticity coordinates computation from "Krystek (1985)".

### DIFF
--- a/colour/examples/temperature/examples_cct.py
+++ b/colour/examples/temperature/examples_cct.py
@@ -41,7 +41,7 @@ message_box(('Converting to "CIE UCS" colourspace "uv" chromaticity '
              '"Ohno (2013)" method:\n'
              '\n\t({0}, {1})'.format(CCT, D_uv)))
 print(colour.CCT_to_uv_Ohno2013(CCT, D_uv, cmfs=cmfs))
-print(colour.CCT_to_uv(CCT, D_uv, cmfs=cmfs))
+print(colour.CCT_to_uv(CCT, D_uv=D_uv, cmfs=cmfs))
 
 print('\n')
 
@@ -50,7 +50,15 @@ message_box(('Converting to "CIE UCS" colourspace "uv" chromaticity '
              '"Robertson (1968)" method:\n'
              '\n\t({0}, {1})'.format(CCT, D_uv)))
 print(colour.CCT_to_uv_Robertson1968(CCT, D_uv))
-print(colour.CCT_to_uv(CCT, D_uv, method='Robertson 1968'))
+print(colour.CCT_to_uv(CCT, D_uv=D_uv, method='Robertson 1968'))
+
+print('\n')
+
+message_box(('Converting to "CIE UCS" colourspace "uv" chromaticity '
+             'coordinates from given "CCT" using "Krystek (1985)" method:\n'
+             '\n\t({0})'.format(CCT)))
+print(colour.CCT_to_uv_Krystek1985(CCT))
+print(colour.CCT_to_uv(CCT, method='Krystek 1985'))
 
 print('\n')
 

--- a/colour/temperature/__init__.py
+++ b/colour/temperature/__init__.py
@@ -4,15 +4,29 @@
 from __future__ import absolute_import
 
 from .cct import CCT_TO_UV_METHODS, UV_TO_CCT_METHODS
-from .cct import CCT_to_uv, CCT_to_uv_Ohno2013, CCT_to_uv_Robertson1968
-from .cct import uv_to_CCT, uv_to_CCT_Ohno2013, uv_to_CCT_Robertson1968
+from .cct import CCT_to_uv
+from .cct import (
+    CCT_to_uv_Ohno2013,
+    CCT_to_uv_Robertson1968,
+    CCT_to_uv_Krystek1985)
+from .cct import uv_to_CCT
+from .cct import (
+    uv_to_CCT_Ohno2013,
+    uv_to_CCT_Robertson1968)
 from .cct import CCT_TO_XY_METHODS, XY_TO_CCT_METHODS
-from .cct import CCT_to_xy, CCT_to_xy_Kang2002, CCT_to_xy_CIE_D
-from .cct import xy_to_CCT, xy_to_CCT_McCamy1992, xy_to_CCT_Hernandez1999
+from .cct import CCT_to_xy
+from .cct import CCT_to_xy_Kang2002, CCT_to_xy_CIE_D
+from .cct import xy_to_CCT
+from .cct import xy_to_CCT_McCamy1992, xy_to_CCT_Hernandez1999
 
 __all__ = ['CCT_TO_UV_METHODS', 'UV_TO_CCT_METHODS',
-           'CCT_to_uv', 'CCT_to_uv_Ohno2013', 'CCT_to_uv_Robertson1968',
-           'uv_to_CCT', 'uv_to_CCT_Ohno2013', 'uv_to_CCT_Robertson1968',
+           'CCT_to_uv',
+           'CCT_to_uv_Ohno2013',
+           'CCT_to_uv_Robertson1968',
+           'CCT_to_uv_Krystek1985',
+           'uv_to_CCT',
+           'uv_to_CCT_Ohno2013',
+           'uv_to_CCT_Robertson1968',
            'CCT_TO_XY_METHODS', 'XY_TO_CCT_METHODS',
            'CCT_to_xy', 'CCT_to_xy_Kang2002', 'CCT_to_xy_CIE_D',
            'xy_to_CCT', 'xy_to_CCT_McCamy1992', 'xy_to_CCT_Hernandez1999']

--- a/colour/temperature/tests/tests_cct.py
+++ b/colour/temperature/tests/tests_cct.py
@@ -15,6 +15,7 @@ from colour.colorimetry import STANDARD_OBSERVERS_CMFS
 from colour.temperature import (
     CCT_to_uv_Ohno2013,
     CCT_to_uv_Robertson1968,
+    CCT_to_uv_Krystek1985,
     uv_to_CCT_Ohno2013,
     uv_to_CCT_Robertson1968,
     CCT_to_xy_Kang2002,
@@ -39,6 +40,7 @@ __all__ = ['TestPlanckianTable',
            'TestCCT_to_uv_Ohno2013',
            'Testuv_to_CCT_Robertson1968',
            'TestCCT_to_uv_Robertson1968',
+           'TestCCT_to_uv_Krystek1985',
            'Testxy_to_CCT_McCamy1992',
            'Testxy_to_CCT_Hernandez1999',
            'TestCCT_to_xy_Kang2002',
@@ -297,6 +299,72 @@ class TestCCT_to_uv_Robertson1968(unittest.TestCase):
                 CCT_to_uv_Robertson1968(*key),
                 value,
                 decimal=7)
+
+
+class TestCCT_to_uv_Krystek1985(unittest.TestCase):
+    """
+    Defines :func:`colour.temperature.cct.CCT_to_uv_Krystek1985` definition
+    units tests methods.
+    """
+
+    def test_CCT_to_uv_Krystek1985(self):
+        """
+        Tests :func:`colour.temperature.cct.CCT_to_uv_Krystek1985` definition.
+        """
+
+        np.testing.assert_almost_equal(
+            CCT_to_uv_Krystek1985(1000),
+            np.array([0.223421163527869, 0.499258998136231]),
+            decimal=7)
+
+        np.testing.assert_almost_equal(
+            CCT_to_uv_Krystek1985(7000),
+            np.array([0.183513095046506, 0.305827773965731]),
+            decimal=7)
+
+        np.testing.assert_almost_equal(
+            CCT_to_uv_Krystek1985(15000),
+            np.array([0.182148234861937, 0.281354360914682]),
+            decimal=7)
+
+    def test_n_dimensional_CCT_to_uv_Krystek1985(self):
+        """
+        Tests :func:`colour.temperature.cct.CCT_to_uv_Krystek1985` definition
+        n-dimensional arrays support.
+        """
+
+        CCT = 7000
+        xy = np.array([0.183513095046506, 0.305827773965731])
+        np.testing.assert_almost_equal(
+            CCT_to_uv_Krystek1985(CCT),
+            xy,
+            decimal=7)
+
+        CCT = np.tile(CCT, 6)
+        xy = np.tile(xy, (6, 1))
+        np.testing.assert_almost_equal(
+            CCT_to_uv_Krystek1985(CCT),
+            xy,
+            decimal=7)
+
+        CCT = np.reshape(CCT, (2, 3))
+        xy = np.reshape(xy, (2, 3, 2))
+        np.testing.assert_almost_equal(
+            CCT_to_uv_Krystek1985(CCT),
+            xy,
+            decimal=7)
+
+    @ignore_numpy_errors
+    def test_nan_CCT_to_uv_Krystek1985(self):
+        """
+        Tests :func:`colour.temperature.cct.CCT_to_uv_Krystek1985` definition
+        nan support.
+        """
+
+        cases = [-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan]
+        cases = set(permutations(cases * 3, r=2))
+        for case in cases:
+            CCT_to_uv_Krystek1985(case)
 
 
 class Testxy_to_CCT_McCamy1992(unittest.TestCase):


### PR DESCRIPTION
References #296.

As I just bought the Cloud version of the paper (and thus cannot save it), here are the relevant equations:

![image](https://cloud.githubusercontent.com/assets/99779/20961134/98d3f4ea-bcc8-11e6-87c9-38ce47b97461.png)

