### PR TITLE
Fix a numerical issue in ciecam02.py which caused numpy warnings

### DIFF
--- a/colour/appearance/ciecam02.py
+++ b/colour/appearance/ciecam02.py
@@ -699,9 +699,8 @@ def post_adaptation_non_linear_response_compression_forward(RGB, F_L):
     RGB = np.asarray(RGB)
     F_L = np.asarray(F_L)
 
-    # TODO: Check for negative values and their handling.
-    RGB_c = ((((400 * (F_L[..., np.newaxis] * RGB / 100) ** 0.42) /
-               (27.13 + (F_L[..., np.newaxis] * RGB / 100) ** 0.42))) + 0.1)
+    RGB_c = ((((np.sign(RGB) * 400 * (F_L[..., np.newaxis] * abs(RGB) / 100) ** 0.42) /
+               (27.13 + (F_L[..., np.newaxis] * abs(RGB) / 100) ** 0.42))) + 0.1)
 
     return RGB_c
 


### PR DESCRIPTION
In post_adaptation_non_linear_response_compression_forward(), there was a TODO to check for and handle negative values. This has been implemented according to the formulas on pp. 50-51 of
https://4843ec7c-89cf-4d26-a36a-0e40ebc9a3a7.s3.amazonaws.com/97814419618
91-c1.pdf.
