### PR TITLE
Fix divide by zero warning in CIECAM02 reverse mode

### DIFF
--- a/colour/appearance/ciecam02.py
+++ b/colour/appearance/ciecam02.py
@@ -813,20 +813,22 @@ def opponent_colour_dimensions_reverse(P_n, h):
     a = np.zeros(hr.shape)
     b = np.zeros(hr.shape)
 
-    b = np.where(np.abs(sin_hr) >= np.abs(cos_hr),
+    b = np.where(np.isfinite(P_1) * np.abs(sin_hr) >= np.abs(cos_hr),
                  (n / (P_4 + (2 + P_3) * (220 / 1403) * (cos_hr / sin_hr) -
                        (27 / 1403) + P_3 * (6300 / 1403))),
                  b)
 
-    a = np.where(np.abs(sin_hr) >= np.abs(cos_hr), b * (cos_hr / sin_hr), a)
+    a = np.where(np.isfinite(P_1) * np.abs(sin_hr) >= np.abs(cos_hr),
+                 b * (cos_hr / sin_hr), a)
 
-    a = np.where(np.abs(sin_hr) < np.abs(cos_hr),
+    a = np.where(np.isfinite(P_1) * np.abs(sin_hr) < np.abs(cos_hr),
                  (n / (P_5 + (2 + P_3) * (220 / 1403) -
                        ((27 / 1403) - P_3 * (6300 / 1403)) *
                        (sin_hr / cos_hr))),
                  a)
 
-    b = np.where(np.abs(sin_hr) < np.abs(cos_hr), a * (sin_hr / cos_hr), b)
+    b = np.where(np.isfinite(P_1) * np.abs(sin_hr) < np.abs(cos_hr),
+                 a * (sin_hr / cos_hr), b)
 
     ab = tstack((a, b))
 
@@ -1344,7 +1346,8 @@ def P(N_c, N_cb, e_t, t, A, N_bb):
     A = np.asarray(A)
     N_bb = np.asarray(N_bb)
 
-    P_1 = ((50000 / 13) * N_c * N_cb * e_t) / t
+    with np.errstate(divide='ignore'):
+        P_1 = ((50000 / 13) * N_c * N_cb * e_t) / t
     P_2 = A / N_bb + 0.305
     P_3 = np.ones(P_1.shape) * (21 / 20)
 


### PR DESCRIPTION
When t=0 in CIECAM02 reverse mode (i.e. the user has input pure black) there will be a division by zero when computing P_1. Since P_1 may not be a scalar, I disable the division warning for that line and manually test for finite elements of P_1. According to "CIECAM02 and Its Recent Developments" (http://4843ec7c-89cf-4d26-a36a-0e40ebc9a3a7.s3.amazonaws.com/9781441961891-c1.pdf) p. 53, if t=0, then a=b=0 and as such I only write to elements of a and b where P_1 is finite.