### PR TITLE
Fix divide by zero in ciecam02.py temporary_magnitude_quantity_reverse()

### DIFF
--- a/colour/appearance/ciecam02.py
+++ b/colour/appearance/ciecam02.py
@@ -1177,7 +1177,7 @@ def temporary_magnitude_quantity_reverse(C, J, n):
    """
 
     C = np.asarray(C)
-    J = np.asarray(J)
+    J = np.maximum(np.asarray(J), np.finfo(np.float_).eps)
     n = np.asarray(n)
 
     t = (C / (np.sqrt(J / 100) * (1.64 - 0.29 ** n) ** 0.73)) ** (1 / 0.9)


### PR DESCRIPTION
Ensure J cannot be below 1e-16 in temporary_magnitude_quantity_reverse().