### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/BIBLIOGRAPHY.bib
+++ b/BIBLIOGRAPHY.bib
@@ -520,7 +520,7 @@ year = {2015}
 }
 @article{Davis2010a,
 abstract = {The color rendering index (CRI) has been shown to have deficiencies when applied to white light-emitting-diode–based sources. Furthermore, evidence suggests that the restricted scope of the CRI unnecessarily penalizes some light sources with desirable color qualities. To solve the problems of the CRI and include other dimensions of color quality, the color quality scale (CQS) has been developed. Although the CQS uses many of elements of the CRI, there are a number of fundamental differences. Like the CRI, the CQS is a test-samples method that compares the appearance of a set of reflective samples when illuminated by the test lamp to their appearance under a reference illuminant. The CQS uses a larger set of reflective samples, all of high chroma, and combines the color differences of the samples with a root mean square. Additionally, the CQS does not penalize light sources for causing increases in the chroma of object colors but does penalize sources with smaller rendered color gamut areas. The scale of the CQS is converted to span 0-100, and the uniform object color space and chromatic adaptation transform used in the calculations are updated. Supplementary scales have also been developed for expert users.},
-annote = {http://dx.doi.org/10.1117/1.3360335},
+annote = {https://doi.org/10.1117/1.3360335},
 author = {Davis, Wendy and Ohno, Yoshiro},
 doi = {10.1117/1.3360335},
 isbn = {0091-3286},
@@ -1376,7 +1376,7 @@ title = {{Private Discussion with Shaw, N.}},
 year = {2016}
 }
 @article{Nayatani1995a,
-annote = {http://dx.doi.org/10.1002/col.5080200305},
+annote = {https://doi.org/10.1002/col.5080200305},
 author = {Nayatani, Yoshinobu and Sobagaki, Hiroaki and Yano, Kenjiro Hashimoto Tadashi},
 doi = {10.1002/col.5080200305},
 issn = {03612317},
@@ -1407,7 +1407,7 @@ volume = {33},
 year = {1943}
 }
 @article{Ohno2014a,
-annote = {http://dx.doi.org/10.1080/15502724.2014.839020},
+annote = {https://doi.org/10.1080/15502724.2014.839020},
 author = {Ohno, Yoshiro},
 doi = {10.1080/15502724.2014.839020},
 file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Ohno - 2014 - Practical Use and Calculation of CCT and Duv.pdf:pdf},
@@ -1634,7 +1634,7 @@ url = {http://www.invisiblelightimages.com/},
 year = {2015}
 }
 @article{Stearns1988a,
-annote = {http://dx.doi.org/10.1002/col.5080130410},
+annote = {https://doi.org/10.1002/col.5080130410},
 author = {Stearns, E. I. and Stearns, R. E.},
 doi = {10.1002/col.5080130410},
 issn = {03612317},

--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ Colour Science for Python
     :target: https://pypi.python.org/pypi/colour-science
     :alt: Package Version
 .. |zenodo| image:: https://img.shields.io/badge/DOI-10.5281/zenodo.1175177-blue.svg?style=flat-square
-    :target: http://dx.doi.org/10.5281/zenodo.1175177
+    :target: https://doi.org/10.5281/zenodo.1175177
     :alt: DOI
 
 .. end-badges


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Accordingly, this PR updates all DOI links.

Cheers!