### PR TITLE
PR: Expose "Daylight Locus" function.

### DIFF
--- a/BIBLIOGRAPHY.bib
+++ b/BIBLIOGRAPHY.bib
@@ -1,7 +1,13 @@
+@misc{AdobeSystems2013,
+author = {{Adobe Systems}},
+title = {{Adobe DNG Software Development Kit (SDK) - 1.3.0.0 - dng{\_}sdk{\_}1{\_}3/dng{\_}sdk/source/dng{\_}temperature.cpp::dng{\_}temperature::Set{\_}xy{\_}coord}},
+url = {https://www.adobe.com/support/downloads/dng/dng{\_}sdk.html},
+year = {2013}
+}
 @misc{AdobeSystems2013a,
 author = {{Adobe Systems}},
-title = {{Adobe DNG Software Development Kit (SDK) - 1.3.0.0 - dng_sdk_1_3/dng_sdk/source/dng_temperature.cpp::dng_temperature::xy_coord}},
-url = {https://www.adobe.com/support/downloads/dng/dng_sdk.html},
+title = {{Adobe DNG Software Development Kit (SDK) - 1.3.0.0 - dng{\_}sdk{\_}1{\_}3/dng{\_}sdk/source/dng{\_}temperature.cpp::dng{\_}temperature::xy{\_}coord}},
+url = {https://www.adobe.com/support/downloads/dng/dng{\_}sdk.html},
 year = {2013}
 }
 @misc{AdobeSystems2013b,
@@ -9,7 +15,7 @@ author = {{Adobe Systems}},
 file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Adobe Systems - 2013 - Cube LUT Specification.pdf:pdf},
 keywords = {Iridas,look-up table,specification},
 title = {{Cube LUT Specification}},
-url = {https://drive.google.com/open?id=143Eh08ZYncCAMwJ1q4gWxVOqR_OSWYvs},
+url = {https://drive.google.com/open?id=143Eh08ZYncCAMwJ1q4gWxVOqR{\_}OSWYvs},
 year = {2013}
 }
 @misc{AdobeSystems2005a,
@@ -20,12 +26,6 @@ title = {{Adobe RGB (1998) Color Image Encoding}},
 url = {http://www.adobe.com/digitalimag/pdfs/AdobeRGB1998.pdf},
 volume = {2704},
 year = {2005}
-}
-@misc{AdobeSystems2013,
-author = {{Adobe Systems}},
-title = {{Adobe DNG Software Development Kit (SDK) - 1.3.0.0 - dng_sdk_1_3/dng_sdk/source/dng_temperature.cpp::dng_temperature::Set_xy_coord}},
-url = {https://www.adobe.com/support/downloads/dng/dng_sdk.html},
-year = {2013}
 }
 @misc{ANSI2003a,
 author = {ANSI},
@@ -41,14 +41,14 @@ file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/ARRI - 2012 - A
 number = {June},
 pages = {1--12},
 title = {{ALEXA - Log C Curve - Usage in VFX}},
-url = {http://www.arri.com/?eID=registration&file_uid=8026},
+url = {http://www.arri.com/?eID=registration{\&}file{\_}uid=8026},
 year = {2012}
 }
 @misc{AssociationofRadioIndustriesandBusinesses2015a,
 author = {{Association of Radio Industries and Businesses}},
 file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Association of Radio Industries and Businesses - 2015 - Essential Parameter Values for the Extended Image Dynamic Range Television (EIDR.pdf:pdf},
 title = {{Essential Parameter Values for the Extended Image Dynamic Range Television (EIDRTV) System for Programme Production}},
-url = {https://www.arib.or.jp/english/std_tr/broadcasting/desc/std-b67.html},
+url = {https://www.arib.or.jp/english/std{\_}tr/broadcasting/desc/std-b67.html},
 year = {2015}
 }
 @misc{ASTMInternational2011a,
@@ -60,6 +60,12 @@ pages = {1--10},
 title = {{ASTM E2022-11 - Standard Practice for Calculation of Weighting Factors for Tristimulus Integration}},
 year = {2011}
 }
+@misc{ASTMInternational2008a,
+author = {{ASTM International}},
+doi = {10.1520/D1535-08E01},
+title = {{ASTM D1535-08e1 - Standard Practice for Specifying Color by the Munsell System}},
+year = {2008}
+}
 @misc{ASTMInternational1989a,
 annote = {https://law.resource.org/pub/us/cfr/ibr/003/a},
 author = {{ASTM International}},
@@ -69,12 +75,6 @@ pages = {1--29},
 title = {{ASTM D1535-89 - Standard Practice for Specifying Color by the Munsell System}},
 url = {http://www.astm.org/DATABASE.CART/HISTORICAL/D1535-89.htm},
 year = {1989}
-}
-@misc{ASTMInternational2008a,
-author = {{ASTM International}},
-doi = {10.1520/D1535-08E01},
-title = {{ASTM D1535-08e1 - Standard Practice for Specifying Color by the Munsell System}},
-year = {2008}
 }
 @misc{ASTMInternational2007,
 author = {{ASTM International}},
@@ -95,7 +95,7 @@ year = {2015}
 @misc{BabelColor2012b,
 author = {BabelColor},
 title = {{The ColorChecker (since 1976!)}},
-url = {http://www.babelcolor.com/main_level/ColorChecker.htm},
+url = {http://www.babelcolor.com/main{\_}level/ColorChecker.htm},
 urldate = {2014-09-26},
 year = {2012}
 }
@@ -103,16 +103,47 @@ year = {2012}
 author = {BabelColor},
 file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/BabelColor - 2012 - ColorChecker RGB and spectra.xls:xls},
 title = {{ColorChecker RGB and spectra}},
-url = {http://www.babelcolor.com/download/ColorChecker_RGB_and_spectra.xls},
+url = {http://www.babelcolor.com/download/ColorChecker{\_}RGB{\_}and{\_}spectra.xls},
 year = {2012}
 }
+@book{Barten1999,
+abstract = {PURPOSE: Age-related changes in tongue function may contribute to dysphagia in elderly people. The authors' purpose was to investigate whether aged rats that have undergone tongue exercise would manifest increased protrusive tongue forces and increased genioglossus (GG) muscle fiber cross-sectional areas. METHOD: Forty-eight young adult, middle-aged, and old Fischer 344/Brown Norway rats received 8 weeks of tongue exercise. Protrusive tongue forces were measured before and after exercise. GG muscle fiber cross-sectional area was measured in exercised rats and was compared with cross-sectional areas in a no-exercise control group. RESULTS: A significant increase in maximum tongue force was found following exercise in all age groups. In addition, a trend for increased GG muscle fiber cross-sectional area and a significant increase in variability of GG muscle fiber cross-sectional area was identified postexercise. CONCLUSION: The findings of this study have implications for treatment of elderly persons with dysphagia using tongue exercise programs. Specifically, increases in tongue force that occur following 8 weeks of progressive resistance tongue exercise may be accompanied by alterations in tongue muscle fiber morphology. These changes may provide greater strength and endurance for goal-oriented actions associated with the oropharyngeal swallow and should be investigated in future research.},
+author = {Barten, Peter G.},
+doi = {10.1117/3.353254},
+file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Barten - 1999 - Contrast Sensitivity of the Human Eye and Its Effects on Image Quality.pdf:pdf},
+isbn = {9780819478498},
+issn = {10924388},
+month = {dec},
+number = {1999},
+pmid = {18723593},
+publisher = {SPIE},
+title = {{Contrast Sensitivity of the Human Eye and Its Effects on Image Quality}},
+url = {http://ebooks.spiedigitallibrary.org/book.aspx?doi=10.1117/3.353254 https://spiedigitallibrary.org/ebooks/PM/Contrast-Sensitivity-of-the-Human-Eye-and-Its-Effects-on/eISBN-9780819478498/10.1117/3.353254},
+year = {1999}
+}
+@inproceedings{Barten2003,
+abstract = {The contrast sensitivity of the human eye and its dependence on luminance and display size is described on the basis of internal noise in the visual system. With the addition of a global description of the optical MTF of the eye, a complete physical model is presented for the spatial contrast sensitivity function. Calculation results obtained with this model are compared with measurements published in literature.},
+author = {Barten, Peter G. J.},
+booktitle = {Proceedings of SPIE},
+doi = {10.1117/12.537476},
+editor = {Miyake, Yoichi and Rasmussen, D. Rene},
+isbn = {0819434965},
+issn = {0277786X},
+keywords = {contrast sensitivity,csf,human eye,orientation angle,standard observer,surround luminance},
+month = {dec},
+pages = {231--238},
+title = {{Formula for the contrast sensitivity of the human eye}},
+url = {http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?db=pubmed{\&}cmd=Retrieve{\&}dopt=AbstractPlus{\&}list{\_}uids=15798324032973700240related:kPzpPwHsPtsJ http://proceedings.spiedigitallibrary.org/proceeding.aspx?doi=10.1117/12.135956 http://proceedings.spiedigitallibrary},
+volume = {5294},
+year = {2003}
+}
 @article{Bianco2010a,
-annote = {http://web.stanford.edu/$\sim$sujason/ColorBalancing/Papers/Two New von Kries Based Chromatic Adaptation.pdf},
+annote = {http://web.stanford.edu/{\~{}}sujason/ColorBalancing/Papers/Two New von Kries Based Chromatic Adaptation.pdf},
 author = {Bianco, S. and Schettini, R.},
 doi = {10.1002/col.20573},
 file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Bianco, Schettini - 2010 - Two new von Kries based chromatic adaptation transforms found by numerical optimization.pdf:pdf},
 issn = {03612317},
-journal = {Color Research & Application},
+journal = {Color Research {\&} Application},
 month = {jun},
 number = {3},
 pages = {184--192},
@@ -132,7 +163,7 @@ month = {nov},
 number = {11},
 pages = {1854--1861},
 title = {{On Rayleigh Optical Depth Calculations}},
-url = {http://journals.ametsoc.org/doi/abs/10.1175/1520-0426%281999%29016%3C1854%3AORODC%3E2.0.CO%3B2},
+url = {http://journals.ametsoc.org/doi/abs/10.1175/1520-0426{\%}281999{\%}29016{\%}3C1854{\%}3AORODC{\%}3E2.0.CO{\%}3B2},
 volume = {16},
 year = {1999}
 }
@@ -157,7 +188,7 @@ urldate = {2016-01-15}
 abstract = {While each of his or her two eyes was independently adapted to a different illuminant in viewing a complex visual field, each of a number of observers matched a series of test colors seen by one eye with a juxtaposed variable stimulus seen by the other eye. The 2 degrees test and matching stimuli were located centrally in the complex adapting field, which subtended an angle of 31 degrees X 24 degrees. In making the matches, the observer viewed the test and matching stimuli for a series of brief intervals (approximately 1 sec) while viewing the complex adapting field with normal eye movements. Nine experiments were performed with different pairs of illuminants and different illuminances ranging from that of an average living room to that of a scene illuminated with hazy sunlight. In three other experiments each of the observer's two eyes was adapted to a different illuminance of D55. The amount of adaptation was more nearly complete at high levels of illuminance than at low levels, and the proportional amount of adaptation was less for the "blue" receptors. When adaptation coefficients were determined from the actual adaptation differences (e.g., from corresponding tristimulus values for matching neutrals) rather than from the adapting illuminants, a linear von Kries transformation based on experimentally determined visual primaries gave corresponding chromaticities that were in good agreement with the results obtained in each of the chromatic-adaptation experiments, except at the lowest illuminances. The results of the experiments in which each eye was adapted to different levels of the same illuminant indicated again that adaptation to the different levels was incomplete, the proportional amount of adaptation being less at low illuminances and for the "blue" receptors. This caused a change in chromatic adaptation with the level of illuminance even when the chromaticities of the adapting lights were equal. The results of these experiments also indicated that higher purities are needed in order to produce the same absolute color appearances at low levels of illuminance.},
 author = {Breneman, Edwin J.},
 doi = {10.1364/JOSAA.4.001115},
-file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Breneman - 1987 - Corresponding chromaticities for different states of adaptation to complex visual fields.pdf:pdf;:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Breneman - 1987 - Corresponding chromaticities for different states of adaptation to complex visual fields(2).pdf:pdf},
+file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop//Breneman - 1987 - Corresponding chromaticities for different states of adaptation to complex visual fields.pdf:pdf;:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop//Breneman - 1987 - Corresponding chromaticities for different states of adaptation to complex visual fields.pdf:pdf},
 issn = {1084-7529},
 journal = {Journal of the Optical Society of America A},
 month = {jun},
@@ -165,7 +196,7 @@ number = {6},
 pages = {1115},
 pmid = {3598755},
 title = {{Corresponding chromaticities for different states of adaptation to complex visual fields}},
-url = {https://www.osapublishing.org/abstract.cfm?URI=josaa-4-6-1115 http://www.opticsinfobase.org/josaa/fulltext.cfm?uri=josaa-4-6-1115&id=2783},
+url = {https://www.osapublishing.org/abstract.cfm?URI=josaa-4-6-1115 http://www.opticsinfobase.org/josaa/fulltext.cfm?uri=josaa-4-6-1115{\&}id=2783},
 volume = {4},
 year = {1987}
 }
@@ -174,7 +205,7 @@ abstract = {The color-appearance model CIECAM02 has several problems. which can 
 author = {Brill, Michael H. and Susstrunk, Sabine},
 doi = {10.1002/col.20432},
 issn = {03612317},
-journal = {Color Research & Application},
+journal = {Color Research {\&} Application},
 keywords = {CIECAM02,Chromatic adaptation,Color appearance,Gamut,Model,Primary},
 month = {oct},
 number = {5},
@@ -185,13 +216,13 @@ volume = {33},
 year = {2008}
 }
 @misc{Broadbent2009a,
-abstract = {This paper describes all the steps in the calculations of the CIE 1931 RGB spectral chromaticity co-ordinates and color matching functions starting from the initial experimental data of W. D. Wright and J. Guild. Sufficient information is given to allow the reader to reproduce and verify the results obtained at each stage of the calculations and to critically analyze the procedures used. In some instances, the available literature only provides limited descriptions of the actual steps in the calculations and, in others, important data were not published. Nevertheless, it has been possible to more or less reproduce the entire sequence of calculations. All the tables of numerical data are given in the accompanying computer worksheet file CIE1931_RGB.xls.},
+abstract = {This paper describes all the steps in the calculations of the CIE 1931 RGB spectral chromaticity co-ordinates and color matching functions starting from the initial experimental data of W. D. Wright and J. Guild. Sufficient information is given to allow the reader to reproduce and verify the results obtained at each stage of the calculations and to critically analyze the procedures used. In some instances, the available literature only provides limited descriptions of the actual steps in the calculations and, in others, important data were not published. Nevertheless, it has been possible to more or less reproduce the entire sequence of calculations. All the tables of numerical data are given in the accompanying computer worksheet file CIE1931{\_}RGB.xls.},
 author = {Broadbent, A. D.},
 booktitle = {Qu{\'{e}}bec, Canada: D{\'{e}}partement de g{\'{e}}nie chimique, {\ldots}},
-file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop//Broadbent - 2009 - Calculation from the Original Experimental Data of the Cie 1931 RGB Standard Observer Spectral Chromaticity Co-Ordina.pdf:pdf},
+file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Broadbent - 2009 - Calculation from the Original Experimental Data of the Cie 1931 RGB Standard Observer Spectral Chromaticity Co-Ordina.pdf:pdf},
 pages = {1--17},
 title = {{Calculation from the Original Experimental Data of the Cie 1931 RGB Standard Observer Spectral Chromaticity Co-Ordinates and Color Matching Functions.}},
-url = {http://www.cis.rit.edu/research/mcsl2/research/broadbent/CIE1931_RGB.pdf http://www.cis.rit.edu/mcsl/research/1931.php},
+url = {http://www.cis.rit.edu/research/mcsl2/research/broadbent/CIE1931{\_}RGB.pdf http://www.cis.rit.edu/mcsl/research/1931.php},
 urldate = {2014-06-12},
 year = {2009}
 }
@@ -217,14 +248,15 @@ year = {2014}
 author = {Canon},
 title = {{EOS C300 Mark II - EOS C300 Mark II Input Transform Version 2.0 (for Cinema Gamut / BT.2020)}},
 url = {https://www.usa.canon.com/internet/portal/us/home/support/details/cameras/cinema-eos/eos-c300-mark-ii},
-urldate = {2016-08-23}
+urldate = {2016-08-23},
+year = {2016}
 }
 @article{Cao2013,
 abstract = {The Optical Society of America's Uniform Color Scales (OSA-UCS) is one of the color spaces that most closely approximate a "true" uniform color space. Different techniques have been used to convert OSA-UCS-based color specification parameters, L, j, and g, to the CIE tristimulus values, X, Y, and Z. However, none of these methods provides a direct method of inverting OSA-UCS to CIEXYZ values. Thus, numerical algorithms, such as the Newton-Raphson method, have been employed to obtain the transformations. The relative low accuracy and long computation time of this method makes it undesirable for practical applications. An artificial neural network (ANN) was employed to convert OSA-UCS to CIEXYZ. Its performance was compared with that of numerical methods. After optimization, ANN gave a better performance with a mean error (DeltaEXYZ) of 1.0x10(-4) and a conversion time of less than 1 s for 1891 samples.},
 author = {Cao, Renbo and Trussell, H Joel and Shamey, Renzo},
 doi = {10.1364/JOSAA.30.001508},
 file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Cao, Trussell, Shamey - 2013 - Comparison of the performance of inverse transformation methods from OSA-UCS to CIEXYZ.pdf:pdf},
-isbn = {1520-8532 (Electronic)\r1084-7529 (Linking)},
+isbn = {1520-8532 (Electronic)$\backslash$r1084-7529 (Linking)},
 issn = {1084-7529},
 journal = {Journal of the Optical Society of America A},
 month = {aug},
@@ -239,78 +271,8 @@ year = {2013}
 @misc{Castro2014a,
 author = {Castro, Saullo},
 title = {{Numpy: Fastest way of computing diagonal for each row of a 2d array}},
-url = {http://stackoverflow.com/questions/26511401/numpy-fastest-way-of-computing-diagonal-for-each-row-of-a-2d-array/26517247#26517247},
+url = {http://stackoverflow.com/questions/26511401/numpy-fastest-way-of-computing-diagonal-for-each-row-of-a-2d-array/26517247{\#}26517247},
 urldate = {2014-08-22},
-year = {2014}
-}
-@misc{Centore2014m,
-annote = {http://www.99main.com/$\sim$centore/MunsellAndKubelkaMunkToolbox/MunsellAndKubelkaMunkToolbox.html},
-author = {Centore, Paul},
-title = {{MunsellAndKubelkaMunkToolboxApr2014 - MunsellRenotationRoutines/MunsellToxyY.m}},
-url = {https://github.com/colour-science/MunsellAndKubelkaMunkToolbox},
-year = {2014}
-}
-@misc{Centore2014o,
-annote = {http://www.99main.com/$\sim$centore/MunsellAndKubelkaMunkToolbox/MunsellAndKubelkaMunkToolbox.html},
-author = {Centore, Paul},
-title = {{MunsellAndKubelkaMunkToolboxApr2014 - MunsellSystemRoutines/BoundingRenotationHues.m}},
-url = {https://github.com/colour-science/MunsellAndKubelkaMunkToolbox},
-year = {2014}
-}
-@misc{Centore2014l,
-annote = {http://www.99main.com/$\sim$centore/MunsellAndKubelkaMunkToolbox/MunsellAndKubelkaMunkToolbox.html},
-author = {Centore, Paul},
-title = {{MunsellAndKubelkaMunkToolboxApr2014 - MunsellSystemRoutines/LinearVsRadialInterpOnRenotationOvoid.m}},
-url = {https://github.com/colour-science/MunsellAndKubelkaMunkToolbox},
-year = {2014}
-}
-@misc{Centore2014t,
-annote = {http://www.99main.com/$\sim$centore/MunsellAndKubelkaMunkToolbox/MunsellAndKubelkaMunkToolbox.html},
-author = {Centore, Paul},
-title = {{MunsellAndKubelkaMunkToolboxApr2014 - MunsellRenotationRoutines/ChromDiagHueAngleToMunsellHue.m}},
-url = {https://github.com/colour-science/MunsellAndKubelkaMunkToolbox},
-year = {2014}
-}
-@misc{Centore2014n,
-annote = {http://www.99main.com/$\sim$centore/MunsellAndKubelkaMunkToolbox/MunsellAndKubelkaMunkToolbox.html},
-author = {Centore, Paul},
-title = {{MunsellAndKubelkaMunkToolboxApr2014 - MunsellRenotationRoutines/FindHueOnRenotationOvoid.m}},
-url = {https://github.com/colour-science/MunsellAndKubelkaMunkToolbox},
-year = {2014}
-}
-@misc{Centore2014r,
-annote = {http://www.99main.com/$\sim$centore/MunsellAndKubelkaMunkToolbox/MunsellAndKubelkaMunkToolbox.html},
-author = {Centore, Paul},
-title = {{MunsellAndKubelkaMunkToolboxApr2014 - MunsellRenotationRoutines/MaxChromaForExtrapolatedRenotation.m}},
-url = {https://github.com/colour-science/MunsellAndKubelkaMunkToolbox},
-year = {2014}
-}
-@misc{Centore2014s,
-annote = {http://www.99main.com/$\sim$centore/MunsellAndKubelkaMunkToolbox/MunsellAndKubelkaMunkToolbox.html},
-author = {Centore, Paul},
-title = {{MunsellAndKubelkaMunkToolboxApr2014 - MunsellRenotationRoutines/MunsellHueToChromDiagHueAngle.m}},
-url = {https://github.com/colour-science/MunsellAndKubelkaMunkToolbox},
-year = {2014}
-}
-@misc{Centore2014u,
-annote = {http://www.99main.com/$\sim$centore/MunsellAndKubelkaMunkToolbox/MunsellAndKubelkaMunkToolbox.html},
-author = {Centore, Paul},
-title = {{MunsellAndKubelkaMunkToolboxApr2014 - GeneralRoutines/CIELABtoApproxMunsellSpec.m}},
-url = {https://github.com/colour-science/MunsellAndKubelkaMunkToolbox},
-year = {2014}
-}
-@misc{Centore2014p,
-annote = {http://www.99main.com/$\sim$centore/MunsellAndKubelkaMunkToolbox/MunsellAndKubelkaMunkToolbox.html},
-author = {Centore, Paul},
-title = {{MunsellAndKubelkaMunkToolboxApr2014 - MunsellRenotationRoutines/xyYtoMunsell.m}},
-url = {https://github.com/colour-science/MunsellAndKubelkaMunkToolbox},
-year = {2014}
-}
-@misc{Centore2014k,
-annote = {http://www.99main.com/$\sim$centore/MunsellAndKubelkaMunkToolbox/MunsellAndKubelkaMunkToolbox.html},
-author = {Centore, Paul},
-title = {{MunsellAndKubelkaMunkToolboxApr2014 - MunsellRenotationRoutines/MunsellHueToASTMHue.m}},
-url = {https://github.com/colour-science/MunsellAndKubelkaMunkToolbox},
 year = {2014}
 }
 @article{Centore2012a,
@@ -318,7 +280,7 @@ author = {Centore, Paul},
 doi = {10.1002/col.20715},
 file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Centore - 2012 - An open-source inversion algorithm for the Munsell renotation.pdf:pdf},
 issn = {03612317},
-journal = {Color Research & Application},
+journal = {Color Research {\&} Application},
 keywords = {algorithm,inverse renotation,munsell,open source,renotation},
 month = {dec},
 number = {6},
@@ -328,23 +290,93 @@ url = {http://doi.wiley.com/10.1002/col.20715},
 volume = {37},
 year = {2012}
 }
-@misc{Centore2014q,
-annote = {http://www.99main.com/$\sim$centore/MunsellAndKubelkaMunkToolbox/MunsellAndKubelkaMunkToolbox.html},
-author = {Centore, Paul},
-title = {{MunsellAndKubelkaMunkToolboxApr2014 - MunsellRenotationRoutines/MunsellToxyForIntegerMunsellValue.m}},
-url = {https://github.com/colour-science/MunsellAndKubelkaMunkToolbox},
-year = {2014}
-}
 @misc{Centorea,
 author = {Centore, Paul},
 title = {{The Munsell and Kubelka-Munk Toolbox}},
 url = {http://www.munsellcolourscienceforpainters.com/MunsellAndKubelkaMunkToolbox/MunsellAndKubelkaMunkToolbox.html},
 urldate = {2018-01-23}
 }
+@misc{Centore2014o,
+annote = {http://www.99main.com/{\~{}}centore/MunsellAndKubelkaMunkToolbox/MunsellAndKubelkaMunkToolbox.html},
+author = {Centore, Paul},
+title = {{MunsellAndKubelkaMunkToolboxApr2014 - MunsellSystemRoutines/BoundingRenotationHues.m}},
+url = {https://github.com/colour-science/MunsellAndKubelkaMunkToolbox},
+year = {2014}
+}
+@misc{Centore2014l,
+annote = {http://www.99main.com/{\~{}}centore/MunsellAndKubelkaMunkToolbox/MunsellAndKubelkaMunkToolbox.html},
+author = {Centore, Paul},
+title = {{MunsellAndKubelkaMunkToolboxApr2014 - MunsellSystemRoutines/LinearVsRadialInterpOnRenotationOvoid.m}},
+url = {https://github.com/colour-science/MunsellAndKubelkaMunkToolbox},
+year = {2014}
+}
+@misc{Centore2014n,
+annote = {http://www.99main.com/{\~{}}centore/MunsellAndKubelkaMunkToolbox/MunsellAndKubelkaMunkToolbox.html},
+author = {Centore, Paul},
+title = {{MunsellAndKubelkaMunkToolboxApr2014 - MunsellRenotationRoutines/FindHueOnRenotationOvoid.m}},
+url = {https://github.com/colour-science/MunsellAndKubelkaMunkToolbox},
+year = {2014}
+}
+@misc{Centore2014r,
+annote = {http://www.99main.com/{\~{}}centore/MunsellAndKubelkaMunkToolbox/MunsellAndKubelkaMunkToolbox.html},
+author = {Centore, Paul},
+title = {{MunsellAndKubelkaMunkToolboxApr2014 - MunsellRenotationRoutines/MaxChromaForExtrapolatedRenotation.m}},
+url = {https://github.com/colour-science/MunsellAndKubelkaMunkToolbox},
+year = {2014}
+}
+@misc{Centore2014q,
+annote = {http://www.99main.com/{\~{}}centore/MunsellAndKubelkaMunkToolbox/MunsellAndKubelkaMunkToolbox.html},
+author = {Centore, Paul},
+title = {{MunsellAndKubelkaMunkToolboxApr2014 - MunsellRenotationRoutines/MunsellToxyForIntegerMunsellValue.m}},
+url = {https://github.com/colour-science/MunsellAndKubelkaMunkToolbox},
+year = {2014}
+}
+@misc{Centore2014k,
+annote = {http://www.99main.com/{\~{}}centore/MunsellAndKubelkaMunkToolbox/MunsellAndKubelkaMunkToolbox.html},
+author = {Centore, Paul},
+title = {{MunsellAndKubelkaMunkToolboxApr2014 - MunsellRenotationRoutines/MunsellHueToASTMHue.m}},
+url = {https://github.com/colour-science/MunsellAndKubelkaMunkToolbox},
+year = {2014}
+}
+@misc{Centore2014t,
+annote = {http://www.99main.com/{\~{}}centore/MunsellAndKubelkaMunkToolbox/MunsellAndKubelkaMunkToolbox.html},
+author = {Centore, Paul},
+title = {{MunsellAndKubelkaMunkToolboxApr2014 - MunsellRenotationRoutines/ChromDiagHueAngleToMunsellHue.m}},
+url = {https://github.com/colour-science/MunsellAndKubelkaMunkToolbox},
+year = {2014}
+}
+@misc{Centore2014s,
+annote = {http://www.99main.com/{\~{}}centore/MunsellAndKubelkaMunkToolbox/MunsellAndKubelkaMunkToolbox.html},
+author = {Centore, Paul},
+title = {{MunsellAndKubelkaMunkToolboxApr2014 - MunsellRenotationRoutines/MunsellHueToChromDiagHueAngle.m}},
+url = {https://github.com/colour-science/MunsellAndKubelkaMunkToolbox},
+year = {2014}
+}
+@misc{Centore2014m,
+annote = {http://www.99main.com/{\~{}}centore/MunsellAndKubelkaMunkToolbox/MunsellAndKubelkaMunkToolbox.html},
+author = {Centore, Paul},
+title = {{MunsellAndKubelkaMunkToolboxApr2014 - MunsellRenotationRoutines/MunsellToxyY.m}},
+url = {https://github.com/colour-science/MunsellAndKubelkaMunkToolbox},
+year = {2014}
+}
+@misc{Centore2014u,
+annote = {http://www.99main.com/{\~{}}centore/MunsellAndKubelkaMunkToolbox/MunsellAndKubelkaMunkToolbox.html},
+author = {Centore, Paul},
+title = {{MunsellAndKubelkaMunkToolboxApr2014 - GeneralRoutines/CIELABtoApproxMunsellSpec.m}},
+url = {https://github.com/colour-science/MunsellAndKubelkaMunkToolbox},
+year = {2014}
+}
+@misc{Centore2014p,
+annote = {http://www.99main.com/{\~{}}centore/MunsellAndKubelkaMunkToolbox/MunsellAndKubelkaMunkToolbox.html},
+author = {Centore, Paul},
+title = {{MunsellAndKubelkaMunkToolboxApr2014 - MunsellRenotationRoutines/xyYtoMunsell.m}},
+url = {https://github.com/colour-science/MunsellAndKubelkaMunkToolbox},
+year = {2014}
+}
 @misc{Chamberlain2015,
 author = {Chamberlain, Peter},
 title = {{LUT documentation (to create from another program)}},
-url = {https://forum.blackmagicdesign.com/viewtopic.php?f=21&t=40284#p232952},
+url = {https://forum.blackmagicdesign.com/viewtopic.php?f=21{\&}t=40284{\#}p232952},
 urldate = {2018-08-23},
 year = {2015}
 }
@@ -380,7 +412,7 @@ file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/CIE TC 1-32 - 1
 isbn = {978-3-900734-51-0},
 pages = {1--18},
 title = {{CIE 109-1994 A Method of Predicting Corresponding Colours under Different Chromatic and Illuminance Adaptations}},
-url = {http://div1.cie.co.at/?i_ca_id=551&pubid=34},
+url = {http://div1.cie.co.at/?i{\_}ca{\_}id=551{\&}pubid=34},
 year = {1994}
 }
 @misc{CIETC1-362006a,
@@ -389,18 +421,8 @@ file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/CIE TC 1-36 - 2
 isbn = {978-3-901-90646-6},
 pages = {1--56},
 title = {{CIE 170-1:2006 Fundamental Chromaticity Diagram with Physiological Axes - Part 1}},
-url = {http://div1.cie.co.at/?i_ca_id=551&pubid=48},
+url = {http://div1.cie.co.at/?i{\_}ca{\_}id=551{\&}pubid=48},
 year = {2006}
-}
-@incollection{CIETC1-382005h,
-author = {{CIE TC 1-38}},
-booktitle = {CIE 167:2005 Recommended Practice for Tabulating Spectral Data for Use in Colour Computations},
-chapter = {Table V},
-isbn = {978-3-901-90641-1},
-pages = {19},
-title = {{Table V. Values of the c-coefficients of Equ.s 6 and 7.}},
-url = {http://div1.cie.co.at/?i_ca_id=551&pubid=47},
-year = {2005}
 }
 @incollection{CIETC1-382005e,
 author = {{CIE TC 1-38}},
@@ -409,17 +431,17 @@ chapter = {9},
 isbn = {978-3-901-90641-1},
 pages = {14--19},
 title = {{9. INTERPOLATION}},
-url = {http://div1.cie.co.at/?i_ca_id=551&pubid=47},
+url = {http://div1.cie.co.at/?i{\_}ca{\_}id=551{\&}pubid=47},
 year = {2005}
 }
-@incollection{CIETC1-382005f,
+@incollection{CIETC1-382005h,
 author = {{CIE TC 1-38}},
 booktitle = {CIE 167:2005 Recommended Practice for Tabulating Spectral Data for Use in Colour Computations},
-chapter = {9.2.4},
+chapter = {Table V},
 isbn = {978-3-901-90641-1},
-pages = {1--27},
-title = {{9.2.4 Method of interpolation for uniformly spaced independent variable}},
-url = {http://div1.cie.co.at/?i_ca_id=551&pubid=47},
+pages = {19},
+title = {{Table V. Values of the c-coefficients of Equ.s 6 and 7.}},
+url = {http://div1.cie.co.at/?i{\_}ca{\_}id=551{\&}pubid=47},
 year = {2005}
 }
 @incollection{CIETC1-382005g,
@@ -429,8 +451,68 @@ chapter = {10},
 isbn = {978-3-901-90641-1},
 pages = {19--20},
 title = {{EXTRAPOLATION}},
-url = {http://div1.cie.co.at/?i_ca_id=551&pubid=47},
+url = {http://div1.cie.co.at/?i{\_}ca{\_}id=551{\&}pubid=47},
 year = {2005}
+}
+@incollection{CIETC1-382005f,
+author = {{CIE TC 1-38}},
+booktitle = {CIE 167:2005 Recommended Practice for Tabulating Spectral Data for Use in Colour Computations},
+chapter = {9.2.4},
+isbn = {978-3-901-90641-1},
+pages = {1--27},
+title = {{9.2.4 Method of interpolation for uniformly spaced independent variable}},
+url = {http://div1.cie.co.at/?i{\_}ca{\_}id=551{\&}pubid=47},
+year = {2005}
+}
+@incollection{CIETC1-482004,
+author = {{CIE TC 1-48}},
+booktitle = {CIE 015:2004 Colorimetry, 3rd Edition},
+isbn = {978-3-901-90633-6},
+pages = {68--68},
+title = {{EXPLANATORY COMMENTS - 5}},
+url = {http://www.cie.co.at/publications/colorimetry-3rd-edition},
+year = {2004}
+}
+@incollection{CIETC1-482004k,
+author = {{CIE TC 1-48}},
+booktitle = {CIE 015:2004 Colorimetry, 3rd Edition},
+chapter = {9.4},
+isbn = {978-3-901-90633-6},
+pages = {24},
+title = {{The evaluation of whiteness}},
+url = {http://www.cie.co.at/publications/colorimetry-3rd-edition},
+year = {2004}
+}
+@incollection{CIETC1-482004o,
+author = {{CIE TC 1-48}},
+booktitle = {CIE 015:2004 Colorimetry, 3rd Edition},
+chapter = {9.1},
+isbn = {978-3-901-90633-6},
+pages = {32--33},
+title = {{9.1 Dominant wavelength and purity}},
+url = {http://www.cie.co.at/publications/colorimetry-3rd-edition},
+year = {2004}
+}
+@incollection{CIETC1-482004i,
+author = {{CIE TC 1-48}},
+booktitle = {CIE 015:2004 Colorimetry, 3rd Edition},
+chapter = {APPENDIX E},
+file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/CIE TC 1-48 - 2004 - APPENDIX E. INFORMATION ON THE USE OF PLANCK'S EQUATION FOR STANDARD AIR.pdf:pdf},
+isbn = {978-3-901-90633-6},
+pages = {77--82},
+title = {{APPENDIX E. INFORMATION ON THE USE OF PLANCK'S EQUATION FOR STANDARD AIR}},
+url = {http://www.cie.co.at/publications/colorimetry-3rd-edition},
+year = {2004}
+}
+@incollection{CIETC1-482004j,
+author = {{CIE TC 1-48}},
+booktitle = {CIE 015:2004 Colorimetry, 3rd Edition},
+chapter = {8.1},
+isbn = {978-3-901-90633-6},
+pages = {24},
+title = {{CIE 1976 uniform chromaticity scale diagram (UCS diagram)}},
+url = {http://www.cie.co.at/publications/colorimetry-3rd-edition},
+year = {2004}
 }
 @incollection{CIETC1-482004n,
 author = {{CIE TC 1-48}},
@@ -439,26 +521,6 @@ chapter = {3.1},
 isbn = {978-3-901-90633-6},
 pages = {12--13},
 title = {{3.1 Recommendations concerning standard physical data of illuminants}},
-url = {http://www.cie.co.at/publications/colorimetry-3rd-edition},
-year = {2004}
-}
-@book{CIETC1-482004h,
-author = {{CIE TC 1-48}},
-booktitle = {CIE 015:2004 Colorimetry, 3rd Edition},
-file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/CIE TC 1-48 - 2004 - CIE 0152004 Colorimetry, 3rd Edition.pdf:pdf},
-isbn = {978-3-901-90633-6},
-pages = {1--82},
-publisher = {Commission internationale de l'{\'{e}}clairage},
-title = {{CIE 015:2004 Colorimetry, 3rd Edition}},
-url = {http://www.cie.co.at/publications/colorimetry-3rd-edition},
-year = {2004}
-}
-@incollection{CIETC1-482004,
-author = {{CIE TC 1-48}},
-booktitle = {CIE 015:2004 Colorimetry, 3rd Edition},
-isbn = {978-3-901-90633-6},
-pages = {68--68},
-title = {{EXPLANATORY COMMENTS - 5}},
 url = {http://www.cie.co.at/publications/colorimetry-3rd-edition},
 year = {2004}
 }
@@ -482,46 +544,22 @@ title = {{Extrapolation}},
 url = {http://www.cie.co.at/publications/colorimetry-3rd-edition},
 year = {2004}
 }
-@incollection{CIETC1-482004j,
+@book{CIETC1-482004h,
 author = {{CIE TC 1-48}},
 booktitle = {CIE 015:2004 Colorimetry, 3rd Edition},
-chapter = {8.1},
+file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/CIE TC 1-48 - 2004 - CIE 0152004 Colorimetry, 3rd Edition.pdf:pdf},
 isbn = {978-3-901-90633-6},
-pages = {24},
-title = {{CIE 1976 uniform chromaticity scale diagram (UCS diagram)}},
+pages = {1--82},
+publisher = {Commission internationale de l'{\'{e}}clairage},
+title = {{CIE 015:2004 Colorimetry, 3rd Edition}},
 url = {http://www.cie.co.at/publications/colorimetry-3rd-edition},
 year = {2004}
 }
-@incollection{CIETC1-482004i,
-author = {{CIE TC 1-48}},
-booktitle = {CIE 015:2004 Colorimetry, 3rd Edition},
-chapter = {APPENDIX E},
-file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/CIE TC 1-48 - 2004 - APPENDIX E. INFORMATION ON THE USE OF PLANCK'S EQUATION FOR STANDARD AIR.pdf:pdf},
-isbn = {978-3-901-90633-6},
-pages = {77--82},
-title = {{APPENDIX E. INFORMATION ON THE USE OF PLANCK'S EQUATION FOR STANDARD AIR}},
-url = {http://www.cie.co.at/publications/colorimetry-3rd-edition},
-year = {2004}
-}
-@incollection{CIETC1-482004o,
-author = {{CIE TC 1-48}},
-booktitle = {CIE 015:2004 Colorimetry, 3rd Edition},
-chapter = {9.1},
-isbn = {978-3-901-90633-6},
-pages = {32--33},
-title = {{9.1 Dominant wavelength and purity}},
-url = {http://www.cie.co.at/publications/colorimetry-3rd-edition},
-year = {2004}
-}
-@incollection{CIETC1-482004k,
-author = {{CIE TC 1-48}},
-booktitle = {CIE 015:2004 Colorimetry, 3rd Edition},
-chapter = {9.4},
-isbn = {978-3-901-90633-6},
-pages = {24},
-title = {{The evaluation of whiteness}},
-url = {http://www.cie.co.at/publications/colorimetry-3rd-edition},
-year = {2004}
+@misc{Colblindora,
+author = {Colblindor},
+title = {{Deuteranopia - Red-Green Color Blindness}},
+url = {http://www.color-blindness.com/deuteranopia-red-green-color-blindness/},
+urldate = {2015-07-04}
 }
 @misc{Colblindorb,
 author = {Colblindor},
@@ -535,23 +573,20 @@ title = {{Tritanopia - Blue-Yellow Color Blindness}},
 url = {http://www.color-blindness.com/tritanopia-blue-yellow-color-blindness/},
 urldate = {2015-07-04}
 }
-@misc{Colblindora,
-author = {Colblindor},
-title = {{Deuteranopia - Red-Green Color Blindness}},
-url = {http://www.color-blindness.com/deuteranopia-red-green-color-blindness/},
-urldate = {2015-07-04}
-}
 @misc{Cottrella,
 annote = {http://www.russellcottrell.com/photo/RussellRGB.htm},
 author = {Cottrell, Russell},
 title = {{The Russell RGB working color space}},
 url = {http://www.russellcottrell.com/photo/downloads/RussellRGB.icc}
 }
-@misc{CVRLw,
-author = {CVRL},
-title = {{Stiles & Burch individual 2-deg colour matching data}},
-url = {http://www.cvrl.org/stilesburch2_ind.htm},
-urldate = {2014-02-24}
+@misc{Cowan2004,
+author = {Cowan, Matthew and Kennel, Glenn and Maier, Thomas and Walker, Brad and Cowan, Matthew},
+file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Cowan et al. - 2004 - Constant Sensitivity Experiment to Determine the Bit Depth for Digital Cinema.pdf:pdf},
+issn = {15450279},
+number = {September},
+title = {{Constant Sensitivity Experiment to Determine the Bit Depth for Digital Cinema}},
+url = {http://car.france3.mars.free.fr/Formation INA HD/HDTV/HDTV  2007 v35/SMPTE normes et confs/Contrastm.pdf},
+year = {2004}
 }
 @misc{CVRLq,
 author = {CVRL},
@@ -559,17 +594,23 @@ title = {{Luminous efficiency}},
 url = {http://www.cvrl.org/lumindex.htm},
 urldate = {2014-04-19}
 }
+@misc{CVRLt,
+author = {CVRL},
+title = {{Stiles {\&} Burch individual 10-deg colour matching data}},
+url = {http://www.cvrl.org/stilesburch10{\_}ind.htm},
+urldate = {2014-02-24}
+}
+@misc{CVRLw,
+author = {CVRL},
+title = {{Stiles {\&} Burch individual 2-deg colour matching data}},
+url = {http://www.cvrl.org/stilesburch2{\_}ind.htm},
+urldate = {2014-02-24}
+}
 @misc{CVRLp,
 author = {CVRL},
 title = {{CIE (2012) 10-deg XYZ "physiologically-relevant" colour matching functions}},
 url = {http://www.cvrl.org/database/text/cienewxyz/cie2012xyz10.htm},
 urldate = {2014-06-25}
-}
-@misc{CVRLt,
-author = {CVRL},
-title = {{Stiles & Burch individual 10-deg colour matching data}},
-url = {http://www.cvrl.org/stilesburch10_ind.htm},
-urldate = {2014-02-24}
 }
 @misc{CVRLv,
 author = {CVRL},
@@ -577,16 +618,16 @@ title = {{CIE (2012) 2-deg XYZ "physiologically-relevant" colour matching functi
 url = {http://www.cvrl.org/database/text/cienewxyz/cie2012xyz2.htm},
 urldate = {2014-06-25}
 }
-@misc{CVRLr,
-author = {CVRL},
-title = {{New CIE XYZ functions transformed from the CIE (2006) LMS functions}},
-url = {http://cvrl.ioo.ucl.ac.uk/ciexyzpr.htm},
-urldate = {2014-02-24}
-}
 @misc{CVRLs,
 author = {CVRL},
 title = {{Older CIE Standards}},
 url = {http://cvrl.ioo.ucl.ac.uk/cie.htm},
+urldate = {2014-02-24}
+}
+@misc{CVRLr,
+author = {CVRL},
+title = {{New CIE XYZ functions transformed from the CIE (2006) LMS functions}},
+url = {http://cvrl.ioo.ucl.ac.uk/ciexyzpr.htm},
 urldate = {2014-02-24}
 }
 @article{Darrodi2015a,
@@ -623,7 +664,7 @@ year = {2010}
 author = {{Digital Cinema Initiatives}},
 file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Digital Cinema Initiatives - 2007 - Digital Cinema System Specification - Version 1.1.pdf:pdf},
 title = {{Digital Cinema System Specification - Version 1.1}},
-url = {http://www.dcimovies.com/archives/spec_v1_1/DCI_DCinema_System_Spec_v1_1.pdf},
+url = {http://www.dcimovies.com/archives/spec{\_}v1{\_}1/DCI{\_}DCinema{\_}System{\_}Spec{\_}v1{\_}1.pdf},
 year = {2007}
 }
 @misc{DJI2017,
@@ -631,7 +672,7 @@ author = {Dji},
 file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Dji - 2017 - White Paper on D-Log and D-Gamut of DJI Cinema Color System.pdf:pdf},
 pages = {1--5},
 title = {{White Paper on D-Log and D-Gamut of DJI Cinema Color System}},
-url = {https://dl.djicdn.com/downloads/zenmuse+x7/20171010/D-Log_D-Gamut_Whitepaper.pdf},
+url = {https://dl.djicdn.com/downloads/zenmuse+x7/20171010/D-Log{\_}D-Gamut{\_}Whitepaper.pdf},
 year = {2017}
 }
 @misc{Dolby2016a,
@@ -641,52 +682,52 @@ title = {{WHAT IS ICTCP? - INTRODUCTION}},
 url = {https://www.dolby.com/us/en/technologies/dolby-vision/ICtCp-white-paper.pdf},
 year = {2016}
 }
-@misc{EasyRGBn,
-author = {EasyRGB},
-title = {{HSV —> RGB}},
-url = {http://www.easyrgb.com/index.php?X=MATH&H=21#text21},
-urldate = {2014-05-18}
-}
-@misc{EasyRGBl,
-author = {EasyRGB},
-title = {{RGB —> HSL}},
-url = {http://www.easyrgb.com/index.php?X=MATH&H=18#text18},
-urldate = {2014-05-18}
-}
-@misc{EasyRGBk,
-author = {EasyRGB},
-title = {{HSL —> RGB}},
-url = {http://www.easyrgb.com/index.php?X=MATH&H=19#text19},
-urldate = {2014-05-18}
-}
-@misc{EasyRGBh,
-author = {EasyRGB},
-title = {{RGB —> CMY}},
-url = {http://www.easyrgb.com/index.php?X=MATH&H=11#text11},
-urldate = {2014-05-18}
-}
 @misc{EasyRGBi,
 author = {EasyRGB},
-title = {{CMY —> RGB}},
-url = {http://www.easyrgb.com/index.php?X=MATH&H=12#text12},
-urldate = {2014-05-18}
-}
-@misc{EasyRGBo,
-author = {EasyRGB},
-title = {{CMY —> CMYK}},
-url = {http://www.easyrgb.com/index.php?X=MATH&H=13#text13},
+title = {{CMY —{\textgreater} RGB}},
+url = {http://www.easyrgb.com/index.php?X=MATH{\&}H=12{\#}text12},
 urldate = {2014-05-18}
 }
 @misc{EasyRGBj,
 author = {EasyRGB},
-title = {{RGB —> HSV}},
-url = {http://www.easyrgb.com/index.php?X=MATH&H=20#text20},
+title = {{RGB —{\textgreater} HSV}},
+url = {http://www.easyrgb.com/index.php?X=MATH{\&}H=20{\#}text20},
+urldate = {2014-05-18}
+}
+@misc{EasyRGBh,
+author = {EasyRGB},
+title = {{RGB —{\textgreater} CMY}},
+url = {http://www.easyrgb.com/index.php?X=MATH{\&}H=11{\#}text11},
+urldate = {2014-05-18}
+}
+@misc{EasyRGBo,
+author = {EasyRGB},
+title = {{CMY —{\textgreater} CMYK}},
+url = {http://www.easyrgb.com/index.php?X=MATH{\&}H=13{\#}text13},
 urldate = {2014-05-18}
 }
 @misc{EasyRGBm,
 author = {EasyRGB},
-title = {{CMYK —> CMY}},
-url = {http://www.easyrgb.com/index.php?X=MATH&H=14#text14},
+title = {{CMYK —{\textgreater} CMY}},
+url = {http://www.easyrgb.com/index.php?X=MATH{\&}H=14{\#}text14},
+urldate = {2014-05-18}
+}
+@misc{EasyRGBk,
+author = {EasyRGB},
+title = {{HSL —{\textgreater} RGB}},
+url = {http://www.easyrgb.com/index.php?X=MATH{\&}H=19{\#}text19},
+urldate = {2014-05-18}
+}
+@misc{EasyRGBn,
+author = {EasyRGB},
+title = {{HSV —{\textgreater} RGB}},
+url = {http://www.easyrgb.com/index.php?X=MATH{\&}H=21{\#}text21},
+urldate = {2014-05-18}
+}
+@misc{EasyRGBl,
+author = {EasyRGB},
+title = {{RGB —{\textgreater} HSL}},
+url = {http://www.easyrgb.com/index.php?X=MATH{\&}H=18{\#}text18},
 urldate = {2014-05-18}
 }
 @misc{Erdema,
@@ -701,13 +742,13 @@ author = {Erdogan, Turan},
 file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Erdogan - Unknown - How to Calculate Luminosity, Dominant Wavelength, and Excitation Purity.pdf:pdf},
 pages = {7},
 title = {{How to Calculate Luminosity, Dominant Wavelength, and Excitation Purity}},
-url = {http://www.semrock.com/Data/Sites/1/semrockpdfs/whitepaper_howtocalculateluminositywavelengthandpurity.pdf}
+url = {http://www.semrock.com/Data/Sites/1/semrockpdfs/whitepaper{\_}howtocalculateluminositywavelengthandpurity.pdf}
 }
 @misc{EuropeanColorInitiative2002a,
 annote = {http://www.eci.org/en/colourstandards/workingcolorspaces},
 author = {{European Color Initiative}},
 title = {{ECI RGB v2}},
-url = {http://www.eci.org/_media/downloads/icc_profiles_from_eci/ecirgbv20.zip},
+url = {http://www.eci.org/{\_}media/downloads/icc{\_}profiles{\_}from{\_}eci/ecirgbv20.zip},
 year = {2002}
 }
 @misc{Fairchild1998b,
@@ -716,7 +757,7 @@ author = {Fairchild, M. and Wyble, D.},
 file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Fairchild, Wyble - 1998 - Colorimetric Characterization of The Apple Studio Display (flat panel LCD).pdf:pdf},
 pages = {22},
 title = {{Colorimetric Characterization of The Apple Studio Display (flat panel LCD)}},
-url = {http://scholarworks.rit.edu/cgi/viewcontent.cgi?article=1922&context=article},
+url = {http://scholarworks.rit.edu/cgi/viewcontent.cgi?article=1922{\&}context=article},
 year = {1998}
 }
 @inproceedings{Fairchild2011,
@@ -732,73 +773,17 @@ title = {{Brightness, lightness, and specifying color in high-dynamic-range scen
 url = {http://proceedings.spiedigitallibrary.org/proceeding.aspx?doi=10.1117/12.872075},
 year = {2011}
 }
-@incollection{Fairchild2013t,
+@incollection{Fairchild2013y,
 author = {Fairchild, Mark D.},
 booktitle = {Color Appearance Models},
-chapter = {11},
+chapter = {20.3},
 edition = {3},
 isbn = {B00DAYO8E2},
-pages = {4179--4252},
+pages = {6197--6223},
 publisher = {Wiley},
-series = {The Wiley-IS&T Series in Imaging Science and Technology},
-title = {{Chromatic Adaptation Models}},
+series = {The Wiley-IS{\&}T Series in Imaging Science and Technology},
+title = {{IPT Colourspace}},
 year = {2013}
-}
-@article{Fairchild1991a,
-abstract = {A mathematical model of chromatic adaptation for calculating corresponding colors across changes of illumination based on the Hunt color appearance model is formulated and tested. This model consists of a modified von Kries transform that accounts for incomplete levels of adaptation. The model predicts that adaptation will be less complete as the saturation of the adapting stimulus increases and more complete as the luminance of the adapting stimulus increases. An experiment is described in which achromatic appearance is measured for various adapting conditions. The model is tested with these experimental results as well as results from another study and found to be significantly better at predicting corresponding colors than other proposed models.},
-author = {Fairchild, Mark D.},
-doi = {10.1002/col.5080160406},
-file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Fairchild - 1991 - Formulation and testing of an incomplete-chromatic-adaptation model.pdf:pdf},
-issn = {03612317},
-journal = {Color Research & Application},
-month = {aug},
-number = {4},
-pages = {243--250},
-title = {{Formulation and testing of an incomplete-chromatic-adaptation model}},
-url = {http://doi.wiley.com/10.1002/col.5080160406},
-volume = {16},
-year = {1991}
-}
-@incollection{Fairchild2013w,
-author = {Fairchild, Mark D.},
-booktitle = {Color Appearance Models},
-chapter = {13},
-edition = {3},
-isbn = {B00DAYO8E2},
-pages = {5563--5824},
-publisher = {Wiley},
-series = {The Wiley-IS&T Series in Imaging Science and Technology},
-title = {{The RLAB Model}},
-year = {2013}
-}
-@incollection{Fairchild2013u,
-author = {Fairchild, Mark D.},
-booktitle = {Color Appearance Models},
-chapter = {12},
-edition = {3},
-isbn = {B00DAYO8E2},
-pages = {5094--5556},
-publisher = {Wiley},
-series = {The Wiley-IS&T Series in Imaging Science and Technology},
-title = {{The Hunt Model}},
-year = {2013}
-}
-@article{Fairchild1996a,
-abstract = {The prediction of color appearance using the RLAB color space has been tested for a variety of viewing conditions and stimulus types. These tests have shown that RLAB performs well for complex stimuli and not-so-well for simple stimuli. This article reviews the various psychophysical results, interprets their differences, and describes evolutionary enhancements to the RLAB model that simplify it and improve its performance. (C) 1996 John Wiley & Sons, Inc.},
-annote = {https://ritdml.rit.edu/bitstream/handle/1850/7857/MFairchildArticle12-06-1998.pdf},
-author = {Fairchild, Mark D.},
-doi = {10.1002/(SICI)1520-6378(199610)21:5<338::AID-COL3>3.0.CO;2-Z},
-file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Fairchild - 1996 - Refinement of the RLAB color space.pdf:pdf},
-issn = {0361-2317},
-journal = {Color Research & Application},
-keywords = {color appearance,color spaces,color-appearance models},
-month = {oct},
-number = {5},
-pages = {338--346},
-title = {{Refinement of the RLAB color space}},
-url = {http://doi.wiley.com/10.1002/%28SICI%291520-6378%28199610%2921%3A5%3C338%3A%3AAID-COL3%3E3.0.CO%3B2-Z},
-volume = {21},
-year = {1996}
 }
 @incollection{Fairchild2013x,
 author = {Fairchild, Mark D.},
@@ -808,20 +793,20 @@ edition = {3},
 isbn = {B00DAYO8E2},
 pages = {6025--6178},
 publisher = {Wiley},
-series = {The Wiley-IS&T Series in Imaging Science and Technology},
+series = {The Wiley-IS{\&}T Series in Imaging Science and Technology},
 title = {{LLAB Model}},
 year = {2013}
 }
-@incollection{Fairchild2013s,
+@incollection{Fairchild2013w,
 author = {Fairchild, Mark D.},
 booktitle = {Color Appearance Models},
-chapter = {11},
+chapter = {13},
 edition = {3},
 isbn = {B00DAYO8E2},
-pages = {4418--4495},
+pages = {5563--5824},
 publisher = {Wiley},
-series = {The Wiley-IS&T Series in Imaging Science and Technology},
-title = {{FAIRCHILD'S 1990 MODEL}},
+series = {The Wiley-IS{\&}T Series in Imaging Science and Technology},
+title = {{The RLAB Model}},
 year = {2013}
 }
 @incollection{Fairchild2013ba,
@@ -832,14 +817,94 @@ edition = {3},
 isbn = {B00DAYO8E2},
 pages = {4810--5085},
 publisher = {Wiley},
-series = {The Wiley-IS&T Series in Imaging Science and Technology},
+series = {The Wiley-IS{\&}T Series in Imaging Science and Technology},
 title = {{The Nayatani et al. Model}},
 year = {2013}
+}
+@incollection{Fairchild2013t,
+author = {Fairchild, Mark D.},
+booktitle = {Color Appearance Models},
+chapter = {11},
+edition = {3},
+isbn = {B00DAYO8E2},
+pages = {4179--4252},
+publisher = {Wiley},
+series = {The Wiley-IS{\&}T Series in Imaging Science and Technology},
+title = {{Chromatic Adaptation Models}},
+year = {2013}
+}
+@incollection{Fairchild2013u,
+author = {Fairchild, Mark D.},
+booktitle = {Color Appearance Models},
+chapter = {12},
+edition = {3},
+isbn = {B00DAYO8E2},
+pages = {5094--5556},
+publisher = {Wiley},
+series = {The Wiley-IS{\&}T Series in Imaging Science and Technology},
+title = {{The Hunt Model}},
+year = {2013}
+}
+@article{Fairchild1991a,
+abstract = {A mathematical model of chromatic adaptation for calculating corresponding colors across changes of illumination based on the Hunt color appearance model is formulated and tested. This model consists of a modified von Kries transform that accounts for incomplete levels of adaptation. The model predicts that adaptation will be less complete as the saturation of the adapting stimulus increases and more complete as the luminance of the adapting stimulus increases. An experiment is described in which achromatic appearance is measured for various adapting conditions. The model is tested with these experimental results as well as results from another study and found to be significantly better at predicting corresponding colors than other proposed models.},
+author = {Fairchild, Mark D.},
+doi = {10.1002/col.5080160406},
+file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Fairchild - 1991 - Formulation and testing of an incomplete-chromatic-adaptation model.pdf:pdf},
+issn = {03612317},
+journal = {Color Research {\&} Application},
+month = {aug},
+number = {4},
+pages = {243--250},
+title = {{Formulation and testing of an incomplete-chromatic-adaptation model}},
+url = {http://doi.wiley.com/10.1002/col.5080160406},
+volume = {16},
+year = {1991}
+}
+@incollection{Fairchild2013s,
+author = {Fairchild, Mark D.},
+booktitle = {Color Appearance Models},
+chapter = {11},
+edition = {3},
+isbn = {B00DAYO8E2},
+pages = {4418--4495},
+publisher = {Wiley},
+series = {The Wiley-IS{\&}T Series in Imaging Science and Technology},
+title = {{FAIRCHILD'S 1990 MODEL}},
+year = {2013}
+}
+@article{Fairchild1996a,
+abstract = {The prediction of color appearance using the RLAB color space has been tested for a variety of viewing conditions and stimulus types. These tests have shown that RLAB performs well for complex stimuli and not-so-well for simple stimuli. This article reviews the various psychophysical results, interprets their differences, and describes evolutionary enhancements to the RLAB model that simplify it and improve its performance. (C) 1996 John Wiley {\&} Sons, Inc.},
+annote = {https://ritdml.rit.edu/bitstream/handle/1850/7857/MFairchildArticle12-06-1998.pdf},
+author = {Fairchild, Mark D.},
+doi = {10.1002/(SICI)1520-6378(199610)21:5<338::AID-COL3>3.0.CO;2-Z},
+file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Fairchild - 1996 - Refinement of the RLAB color space.pdf:pdf},
+issn = {0361-2317},
+journal = {Color Research {\&} Application},
+keywords = {color appearance,color spaces,color-appearance models},
+month = {oct},
+number = {5},
+pages = {338--346},
+title = {{Refinement of the RLAB color space}},
+url = {http://doi.wiley.com/10.1002/{\%}28SICI{\%}291520-6378{\%}28199610{\%}2921{\%}3A5{\%}3C338{\%}3A{\%}3AAID-COL3{\%}3E3.0.CO{\%}3B2-Z},
+volume = {21},
+year = {1996}
 }
 @misc{Fairchildb,
 author = {Fairchild, Mark D.},
 title = {{Fairchild YSh}},
 url = {http://rit-mcsl.org/fairchild//files/FairchildYSh.zip}
+}
+@incollection{Fairchild2013v,
+author = {Fairchild, Mark D.},
+booktitle = {Color Appearance Models},
+chapter = {14.2},
+edition = {3},
+isbn = {B00DAYO8E2},
+pages = {5852--5991},
+publisher = {Wiley},
+series = {The Wiley-IS{\&}T Series in Imaging Science and Technology},
+title = {{ATD Model}},
+year = {2013}
 }
 @incollection{Fairchild2004c,
 author = {Fairchild, Mark D.},
@@ -850,33 +915,9 @@ file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Fairchild - 200
 isbn = {978-0470012161},
 pages = {289--301},
 publisher = {Wiley},
-series = {The Wiley-IS&T Series in Imaging Science and Technology},
+series = {The Wiley-IS{\&}T Series in Imaging Science and Technology},
 title = {{CIECAM02}},
 year = {2004}
-}
-@incollection{Fairchild2013y,
-author = {Fairchild, Mark D.},
-booktitle = {Color Appearance Models},
-chapter = {20.3},
-edition = {3},
-isbn = {B00DAYO8E2},
-pages = {6197--6223},
-publisher = {Wiley},
-series = {The Wiley-IS&T Series in Imaging Science and Technology},
-title = {{IPT Colourspace}},
-year = {2013}
-}
-@incollection{Fairchild2013v,
-author = {Fairchild, Mark D.},
-booktitle = {Color Appearance Models},
-chapter = {14.2},
-edition = {3},
-isbn = {B00DAYO8E2},
-pages = {5852--5991},
-publisher = {Wiley},
-series = {The Wiley-IS&T Series in Imaging Science and Technology},
-title = {{ATD Model}},
-year = {2013}
 }
 @inproceedings{Fairchild2010,
 author = {Fairchild, Mark D. and Wyble, David R.},
@@ -895,7 +936,7 @@ author = {Fairman, Hugh S.},
 doi = {10.1002/col.5080100407},
 file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Fairman - 1985 - The calculation of weight factors for tristimulus integration.pdf:pdf},
 issn = {03612317},
-journal = {Color Research & Application},
+journal = {Color Research {\&} Application},
 number = {4},
 pages = {199--203},
 title = {{The calculation of weight factors for tristimulus integration}},
@@ -910,13 +951,13 @@ author = {Fairman, Hugh S. and Brill, Michael H. and Hemmendinger, Henry},
 doi = {10.1002/(SICI)1520-6378(199702)22:1<11::AID-COL4>3.0.CO;2-7},
 file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Fairman, Brill, Hemmendinger - 1997 - How the CIE 1931 color-matching functions were derived from Wright-Guild data.pdf:pdf},
 issn = {0361-2317},
-journal = {Color Research & Application},
+journal = {Color Research {\&} Application},
 keywords = {alychne,chromaticity diagram,cie,cie 1931 system,color-matching,colorimetry,cus,guild data,mation,primary colors,spectrum lo-,transfor-,wright},
 month = {feb},
 number = {1},
 pages = {11--23},
 title = {{How the CIE 1931 color-matching functions were derived from Wright-Guild data}},
-url = {http://doi.wiley.com/10.1002/%28SICI%291520-6378%28199702%2922%3A1%3C11%3A%3AAID-COL4%3E3.0.CO%3B2-7},
+url = {http://doi.wiley.com/10.1002/{\%}28SICI{\%}291520-6378{\%}28199702{\%}2922{\%}3A1{\%}3C11{\%}3A{\%}3AAID-COL4{\%}3E3.0.CO{\%}3B2-7},
 volume = {22},
 year = {1997}
 }
@@ -955,11 +996,11 @@ author = {Gaggioni, Hugo and Dhanendra, Patel and Yamashita, Jin and Kawada, N. 
 file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Gaggioni et al. - Unknown - S-Log A new LUT for digital production mastering and interchange applications.pdf:pdf},
 pages = {1--13},
 title = {{S-Log: A new LUT for digital production mastering and interchange applications}},
-url = {http://pro.sony.com/bbsccms/assets/files/mkt/cinema/solutions/slog_manual.pdf},
+url = {http://pro.sony.com/bbsccms/assets/files/mkt/cinema/solutions/slog{\_}manual.pdf},
 volume = {709}
 }
 @article{Glasser1958a,
-abstract = {A visually uniform color coordinate system, based upon simple mathematical formulas, is described. This system resembles the Adams chromatic-value system but replaces the quintic-parabola function with a cube-root function. For colors having reflectances greater than 0.5% the color spacing obtained agrees with Munsell spacing as closely as the modified Adams system. At lower reflectances an expanded color spacing over that of the Munsell system is provided. The cube-root equations can be solved directly for color coordinate differences in terms of simple functions of the difference in colorimeter readings or tristimulus values. The computation of color coordinates in this system is simpler and requires less computational precision than other visually uniform color coordinate systems. A simple slide rule for computing color differences in cube-root color coordinates is described. A modification of the cube-root color coordinate system which provides nearly perfect representation of the spacing of Munsell colors is described, and the appropriateness of the assumptions required to obtain this behavior is discussed.},
+abstract = {A visually uniform color coordinate system, based upon simple mathematical formulas, is described. This system resembles the Adams chromatic-value system but replaces the quintic-parabola function with a cube-root function. For colors having reflectances greater than 0.5{\%} the color spacing obtained agrees with Munsell spacing as closely as the modified Adams system. At lower reflectances an expanded color spacing over that of the Munsell system is provided. The cube-root equations can be solved directly for color coordinate differences in terms of simple functions of the difference in colorimeter readings or tristimulus values. The computation of color coordinates in this system is simpler and requires less computational precision than other visually uniform color coordinate systems. A simple slide rule for computing color differences in cube-root color coordinates is described. A modification of the cube-root color coordinate system which provides nearly perfect representation of the spacing of Munsell colors is described, and the appropriateness of the assumptions required to obtain this behavior is discussed.},
 author = {Glasser, L. G. and McKinney, A. H. and Reilly, C. D. and Schnelle, P. D.},
 doi = {10.1364/JOSA.48.000736},
 file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Glasser et al. - 1958 - Cube-Root Color Coordinate System.pdf:pdf},
@@ -977,12 +1018,12 @@ year = {1958}
 @misc{GoPro2016a,
 author = {GoPro and Duiker, Haarm-Pieter and Mansencal, Thomas},
 title = {gopro.py},
-url = {https://github.com/hpd/OpenColorIO-Configs/blob/master/aces_1.0.3/python/aces_ocio/colorspaces/gopro.py},
+url = {https://github.com/hpd/OpenColorIO-Configs/blob/master/aces{\_}1.0.3/python/aces{\_}ocio/colorspaces/gopro.py},
 urldate = {2017-04-12},
 year = {2016}
 }
 @inproceedings{Guth1995a,
-abstract = {Previous and recent revisions of the ATD model for color perception\nand visual adaption are incorporated into the version that is fully\ndescribed in this paper.},
+abstract = {Previous and recent revisions of the ATD model for color perception$\backslash$nand visual adaption are incorporated into the version that is fully$\backslash$ndescribed in this paper.},
 author = {Guth, S. Lee},
 booktitle = {Proc. SPIE 2414, Device-Independent Color Imaging II},
 doi = {10.1117/12.206546},
@@ -1032,7 +1073,7 @@ year = {2009}
 annote = {http://www.josephholmes.com/profiles.html},
 author = {Holmes, Joseph},
 title = {{Ekta Space PS 5}},
-url = {https://www.josephholmes.com/userfiles/Ekta_Space_PS5_JHolmes.zip}
+url = {https://www.josephholmes.com/userfiles/Ekta{\_}Space{\_}PS5{\_}JHolmes.zip}
 }
 @misc{Houston2015a,
 author = {Houston, Jim},
@@ -1044,13 +1085,13 @@ address = {Chichester, UK},
 author = {Hunt, R.W.G.},
 doi = {10.1002/0470024275},
 edition = {6},
-file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Hunt - 2004 - The Reproduction of Colour.pdf:pdf;:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Hunt - 2004 - The Reproduction of Colour(2).pdf:pdf},
+file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Hunt - 2004 - The Reproduction of Colour.pdf:pdf;:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop//Hunt - 2004 - The Reproduction of Colour.pdf:pdf},
 isbn = {9780470024270},
 keywords = {calanus finmarchicus,egg production,gonad development,norwegian sea,phytoplankton},
 month = {sep},
 pages = {157--182},
-publisher = {John Wiley & Sons, Ltd},
-series = {The Wiley-IS&T Series in Imaging Science and Technology},
+publisher = {John Wiley {\&} Sons, Ltd},
+series = {The Wiley-IS{\&}T Series in Imaging Science and Technology},
 title = {{The Reproduction of Colour}},
 url = {http://doi.wiley.com/10.1002/0470024275},
 year = {2004}
@@ -1072,7 +1113,7 @@ keywords = {ASTM illuminant},
 number = {2},
 pages = {1--6},
 title = {{Illuminant Factors in Universal Software and EasyMatch Coatings}},
-url = {https://support.hunterlab.com/hc/en-us/article_attachments/201437785/an02_02.pdf},
+url = {https://support.hunterlab.com/hc/en-us/article{\_}attachments/201437785/an02{\_}02.pdf},
 volume = {14},
 year = {2008}
 }
@@ -1083,18 +1124,6 @@ keywords = {a rd,b rd,hunter rd,opponent color scale,rd a b,rdab},
 title = {{Hunter Rd,a,b Color Scale – History and Application}},
 url = {https://hunterlabdotcom.files.wordpress.com/2012/07/an-1016-hunter-rd-a-b-color-scale-update-12-07-03.pdf},
 year = {2012}
-}
-@misc{HutchColorf,
-annote = {http://www.hutchcolor.com/profiles.html},
-author = {HutchColor},
-title = {{MaxRGB (4 K)}},
-url = {http://www.hutchcolor.com/profiles/MaxRGB.zip}
-}
-@misc{HutchColore,
-annote = {http://www.hutchcolor.com/profiles.html},
-author = {HutchColor},
-title = {{XtremeRGB (4 K)}},
-url = {http://www.hutchcolor.com/profiles/XtremeRGB.zip}
 }
 @misc{HutchColorg,
 annote = {http://www.hutchcolor.com/profiles.html},
@@ -1107,6 +1136,18 @@ annote = {http://www.hutchcolor.com/profiles.html},
 author = {HutchColor},
 title = {{BestRGB (4 K)}},
 url = {http://www.hutchcolor.com/profiles/BestRGB.zip}
+}
+@misc{HutchColore,
+annote = {http://www.hutchcolor.com/profiles.html},
+author = {HutchColor},
+title = {{XtremeRGB (4 K)}},
+url = {http://www.hutchcolor.com/profiles/XtremeRGB.zip}
+}
+@misc{HutchColorf,
+annote = {http://www.hutchcolor.com/profiles.html},
+author = {HutchColor},
+title = {{MaxRGB (4 K)}},
+url = {http://www.hutchcolor.com/profiles/MaxRGB.zip}
 }
 @misc{IESComputerCommittee2014a,
 author = {{IES Computer Committee} and {TM-27-14 Working Group}},
@@ -1128,36 +1169,15 @@ author = {{International Telecommunication Union}},
 file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/International Telecommunication Union - 2015 - Recommendation ITU-R BT.709-6 - Parameter values for the HDTV standards for production an.pdf:pdf},
 pages = {1--32},
 title = {{Recommendation ITU-R BT.709-6 - Parameter values for the HDTV standards for production and international programme exchange BT Series Broadcasting service}},
-url = {https://www.itu.int/dms_pubrec/itu-r/rec/bt/R-REC-BT.709-6-201506-I!!PDF-E.pdf},
+url = {https://www.itu.int/dms{\_}pubrec/itu-r/rec/bt/R-REC-BT.709-6-201506-I!!PDF-E.pdf},
 year = {2015}
 }
 @misc{InternationalTelecommunicationUnion2016a,
 author = {{International Telecommunication Union}},
 file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/International Telecommunication Union - 2016 - Recommendation ITU-R BT.2100-1 - Image parameter values for high dynamic range television.pdf:pdf},
 title = {{Recommendation ITU-R BT.2100-1 - Image parameter values for high dynamic range television for use in production and international programme exchange}},
-url = {https://www.itu.int/dms_pubrec/itu-r/rec/bt/R-REC-BT.2100-1-201706-I!!PDF-E.pdf},
+url = {https://www.itu.int/dms{\_}pubrec/itu-r/rec/bt/R-REC-BT.2100-1-201706-I!!PDF-E.pdf},
 year = {2016}
-}
-@misc{InternationalTelecommunicationUnion2011e,
-author = {{International Telecommunication Union}},
-file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/International Telecommunication Union - 2011 - Recommendation ITU-T T.871 - Information technology – Digital compression and coding of.pdf:pdf},
-title = {{Recommendation ITU-T T.871 - Information technology – Digital compression and coding of continuous-tone still images: JPEG File Interchange Format (JFIF)}},
-url = {https://www.itu.int/rec/dologin_pub.asp?lang=e&id=T-REC-T.871-201105-I!!PDF-E&type=items},
-year = {2011}
-}
-@misc{InternationalTelecommunicationUnion2011h,
-author = {{International Telecommunication Union}},
-file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/International Telecommunication Union - 2011 - Recommendation ITU-R BT.1886 - Reference electro-optical transfer function for flat panel.pdf:pdf},
-title = {{Recommendation ITU-R BT.1886 - Reference electro-optical transfer function for flat panel displays used in HDTV studio production BT Series Broadcasting service}},
-url = {https://www.itu.int/dms_pubrec/itu-r/rec/bt/R-REC-BT.1886-0-201103-I!!PDF-E.pdf},
-year = {2011}
-}
-@misc{InternationalTelecommunicationUnion2011f,
-author = {{International Telecommunication Union}},
-file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/International Telecommunication Union - 2011 - Recommendation ITU-R BT.601-7 - Studio encoding parameters of digital television for stan.pdf:pdf},
-title = {{Recommendation ITU-R BT.601-7 - Studio encoding parameters of digital television for standard 4:3 and wide-screen 16:9 aspect ratios}},
-url = {http://www.itu.int/dms_pubrec/itu-r/rec/bt/R-REC-BT.601-7-201103-I!!PDF-E.pdf},
-year = {2011}
 }
 @misc{InternationalTelecommunicationUnion2015h,
 abstract = {The role of the Radiocommunication Sector is to ensure the rational, equitable, efficient and economical use of the radio-frequency spectrum by all radiocommunication services, including satellite services, and carry out studies without limit of frequency range on the basis of which Recommendations are adopted. The regulatory and policy functions of the Radiocommunication Sector are performed by World and Regional Radiocommunication Conferences and Radiocommunication Assemblies supported by Study Groups},
@@ -1165,7 +1185,7 @@ author = {{International Telecommunication Union}},
 file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/International Telecommunication Union - 2015 - Recommendation ITU-R BT.2020 - Parameter values for ultra-high definition television syst.pdf:pdf},
 pages = {1--8},
 title = {{Recommendation ITU-R BT.2020 - Parameter values for ultra-high definition television systems for production and international programme exchange}},
-url = {https://www.itu.int/dms_pubrec/itu-r/rec/bt/R-REC-BT.2020-2-201510-I!!PDF-E.pdf},
+url = {https://www.itu.int/dms{\_}pubrec/itu-r/rec/bt/R-REC-BT.2020-2-201510-I!!PDF-E.pdf},
 volume = {1},
 year = {2015}
 }
@@ -1174,8 +1194,37 @@ author = {{International Telecommunication Union}},
 file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/International Telecommunication Union - 1998 - Recommendation ITU-R BT.470-6 - CONVENTIONAL TELEVISION SYSTEMS.pdf:pdf},
 pages = {1--36},
 title = {{Recommendation ITU-R BT.470-6 - CONVENTIONAL TELEVISION SYSTEMS}},
-url = {http://www.itu.int/dms_pubrec/itu-r/rec/bt/R-REC-BT.470-6-199811-S!!PDF-E.pdf},
+url = {http://www.itu.int/dms{\_}pubrec/itu-r/rec/bt/R-REC-BT.470-6-199811-S!!PDF-E.pdf},
 year = {1998}
+}
+@misc{InternationalTelecommunicationUnion2011f,
+author = {{International Telecommunication Union}},
+file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/International Telecommunication Union - 2011 - Recommendation ITU-R BT.601-7 - Studio encoding parameters of digital television for stan.pdf:pdf},
+title = {{Recommendation ITU-R BT.601-7 - Studio encoding parameters of digital television for standard 4:3 and wide-screen 16:9 aspect ratios}},
+url = {http://www.itu.int/dms{\_}pubrec/itu-r/rec/bt/R-REC-BT.601-7-201103-I!!PDF-E.pdf},
+year = {2011}
+}
+@misc{InternationalTelecommunicationUnion2011e,
+author = {{International Telecommunication Union}},
+file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/International Telecommunication Union - 2011 - Recommendation ITU-T T.871 - Information technology – Digital compression and coding of.pdf:pdf},
+title = {{Recommendation ITU-T T.871 - Information technology – Digital compression and coding of continuous-tone still images: JPEG File Interchange Format (JFIF)}},
+url = {https://www.itu.int/rec/dologin{\_}pub.asp?lang=e{\&}id=T-REC-T.871-201105-I!!PDF-E{\&}type=items},
+year = {2011}
+}
+@misc{InternationalTelecommunicationUnion2011h,
+author = {{International Telecommunication Union}},
+file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/International Telecommunication Union - 2011 - Recommendation ITU-R BT.1886 - Reference electro-optical transfer function for flat panel.pdf:pdf},
+title = {{Recommendation ITU-R BT.1886 - Reference electro-optical transfer function for flat panel displays used in HDTV studio production BT Series Broadcasting service}},
+url = {https://www.itu.int/dms{\_}pubrec/itu-r/rec/bt/R-REC-BT.1886-0-201103-I!!PDF-E.pdf},
+year = {2011}
+}
+@misc{InternationalTelecommunicationUnion2015,
+author = {{International Telecommunication Union}},
+file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop//International Telecommunication Union - 2015 - Report ITU-R BT.2246-4 - The present state of ultra-high definition television BT Series.pdf:pdf},
+pages = {1--92},
+title = {{Report ITU-R BT.2246-4 - The present state of ultra-high definition television BT Series Broadcasting service}},
+volume = {5},
+year = {2015}
 }
 @article{Kang2002a,
 annote = {http://icpr.snu.ac.kr/resource/wop.pdf/J01/2002/041/R06/J012002041R060865.pdf},
@@ -1186,14 +1235,14 @@ keywords = {chromaticity,cie-xyz,color temperature,hdtv},
 number = {6},
 pages = {865--871},
 title = {{Design of advanced color: Temperature control system for HDTV applications}},
-url = {http://cat.inist.fr/?aModele=afficheN&cpsidt=14448733},
+url = {http://cat.inist.fr/?aModele=afficheN{\&}cpsidt=14448733},
 volume = {41},
 year = {2002}
 }
 @misc{Kienzle2011a,
 author = {Kienzle, Paul and Patel, Nikunj and Krycka, James},
 title = {{refl1d.numpyerrors - Refl1D v0.6.19 documentation}},
-url = {http://www.reflectometry.org/danse/docs/refl1d/_modules/refl1d/numpyerrors.html},
+url = {http://www.reflectometry.org/danse/docs/refl1d/{\_}modules/refl1d/numpyerrors.html},
 urldate = {2015-01-30},
 year = {2011}
 }
@@ -1211,7 +1260,7 @@ year = {2006}
 author = {Krystek, M},
 doi = {10.1002/col.5080100109},
 issn = {03612317},
-journal = {Color Research & Application},
+journal = {Color Research {\&} Application},
 number = {1},
 pages = {38--40},
 publisher = {Wiley Subscription Services, Inc., A Wiley Company},
@@ -1232,7 +1281,7 @@ author = {Li, Changjun and Li, Zhiqiang and Wang, Zhifeng and Xu, Yang and Luo, 
 doi = {10.1002/col.22131},
 file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Li et al. - 2017 - Comprehensive color solutions CAM16, CAT16, and CAM16-UCS.pdf:pdf},
 issn = {03612317},
-journal = {Color Research & Application},
+journal = {Color Research {\&} Application},
 keywords = {CAM02-UCS,CAT02,LUTCHI color-appearance datasets,chromatic adaptation,color-appearance models,color-difference evaluation CIECAM02,corresponding color datasets},
 month = {dec},
 number = {6},
@@ -1243,13 +1292,13 @@ volume = {42},
 year = {2017}
 }
 @article{Li2002a,
-abstract = {CMCCAT97 is a chromatic adaptation transform included in CIECAM97s, the CIE 1997 colour appearance model, for describing colour appearance under different viewing conditions and is recommended by, the Colour Measurement Committee of the Society, of Dyers and Colourists for predicting the degree of colour inconstancy, of surface colours. Among the many, transforms tested, this transform gave the most accurate predictions to a number of experimental data sets. However, the structure of CMCCAT97 is considered complicated and causes problems when applications require the use of its reverse mode. This article describes a simplified version of CMCCAT97-CMCCAT2000-which not only, is significantly, simpler and eliminates the problems of reversibility, but also gives a more accurate prediction to almost all experimental data sets than does the original transform. (C) 2002 John Wiley & Sons, Inc.},
+abstract = {CMCCAT97 is a chromatic adaptation transform included in CIECAM97s, the CIE 1997 colour appearance model, for describing colour appearance under different viewing conditions and is recommended by, the Colour Measurement Committee of the Society, of Dyers and Colourists for predicting the degree of colour inconstancy, of surface colours. Among the many, transforms tested, this transform gave the most accurate predictions to a number of experimental data sets. However, the structure of CMCCAT97 is considered complicated and causes problems when applications require the use of its reverse mode. This article describes a simplified version of CMCCAT97-CMCCAT2000-which not only, is significantly, simpler and eliminates the problems of reversibility, but also gives a more accurate prediction to almost all experimental data sets than does the original transform. (C) 2002 John Wiley {\&} Sons, Inc.},
 annote = {http://onlinelibrary.wiley.com/doi/10.1002/col.10005/abstract},
 author = {Li, Changjun and Luo, Ming Ronnier and Rigg, Bryan and Hunt, Robert W. G.},
 doi = {10.1002/col.10005},
 file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Li et al. - 2002 - CMC 2000 chromatic adaptation transform CMCCAT2000.pdf:pdf},
 issn = {0361-2317},
-journal = {Color Research & Application},
+journal = {Color Research {\&} Application},
 keywords = {Chromatic adaptation,Color appearance},
 month = {feb},
 number = {1},
@@ -1268,45 +1317,45 @@ title = {{The Problem with CAT02 and Its Correction}},
 url = {https://pdfs.semanticscholar.org/b5a9/0215ad9a1fb6b01f310b3d64305f7c9feb3a.pdf},
 year = {2007}
 }
-@misc{Lindbloom2009g,
+@misc{Lindbloom2009f,
 author = {Lindbloom, Bruce},
-title = {{Chromatic Adaptation}},
-url = {http://brucelindbloom.com/Eqn_ChromAdapt.html},
+title = {{Delta E (CMC)}},
+url = {http://brucelindbloom.com/Eqn{\_}DeltaE{\_}CMC.html},
 urldate = {2014-02-24},
 year = {2009}
 }
 @misc{Lindbloom2003e,
 author = {Lindbloom, Bruce},
 title = {{XYZ to xyY}},
-url = {http://www.brucelindbloom.com/Eqn_XYZ_to_xyY.html},
+url = {http://www.brucelindbloom.com/Eqn{\_}XYZ{\_}to{\_}xyY.html},
 urldate = {2014-02-24},
 year = {2003}
-}
-@misc{Lindbloom2009e,
-author = {Lindbloom, Bruce},
-title = {{Delta E (CIE 2000)}},
-url = {http://brucelindbloom.com/Eqn_DeltaE_CIE2000.html},
-urldate = {2014-02-24},
-year = {2009}
 }
 @misc{Lindbloom2011a,
 author = {Lindbloom, Bruce},
 title = {{Delta E (CIE 1994)}},
-url = {http://brucelindbloom.com/Eqn_DeltaE_CIE94.html},
+url = {http://brucelindbloom.com/Eqn{\_}DeltaE{\_}CIE94.html},
 urldate = {2014-02-24},
 year = {2011}
 }
-@misc{Lindbloom2003c,
+@misc{Lindbloom2009e,
 author = {Lindbloom, Bruce},
-title = {{Delta E (CIE 1976)}},
-url = {http://brucelindbloom.com/Eqn_DeltaE_CIE76.html},
+title = {{Delta E (CIE 2000)}},
+url = {http://brucelindbloom.com/Eqn{\_}DeltaE{\_}CIE2000.html},
 urldate = {2014-02-24},
-year = {2003}
+year = {2009}
 }
-@misc{Lindbloom2009f,
+@misc{Lindbloom2009g,
 author = {Lindbloom, Bruce},
-title = {{Delta E (CMC)}},
-url = {http://brucelindbloom.com/Eqn_DeltaE_CMC.html},
+title = {{Chromatic Adaptation}},
+url = {http://brucelindbloom.com/Eqn{\_}ChromAdapt.html},
+urldate = {2014-02-24},
+year = {2009}
+}
+@misc{Lindbloom2009d,
+author = {Lindbloom, Bruce},
+title = {{xyY to XYZ}},
+url = {http://www.brucelindbloom.com/Eqn{\_}xyY{\_}to{\_}XYZ.html},
 urldate = {2014-02-24},
 year = {2009}
 }
@@ -1317,19 +1366,19 @@ url = {http://www.brucelindbloom.com/LabGamutDisplayHelp.html},
 urldate = {2018-08-20},
 year = {2015}
 }
+@misc{Lindbloom2003c,
+author = {Lindbloom, Bruce},
+title = {{Delta E (CIE 1976)}},
+url = {http://brucelindbloom.com/Eqn{\_}DeltaE{\_}CIE76.html},
+urldate = {2014-02-24},
+year = {2003}
+}
 @misc{Lindbloom2014a,
 author = {Lindbloom, Bruce},
 title = {{RGB Working Space Information}},
 url = {http://www.brucelindbloom.com/WorkingSpaceInfo.html},
 urldate = {2014-04-11},
 year = {2014}
-}
-@misc{Lindbloom2009d,
-author = {Lindbloom, Bruce},
-title = {{xyY to XYZ}},
-url = {http://www.brucelindbloom.com/Eqn_xyY_to_XYZ.html},
-urldate = {2014-02-24},
-year = {2009}
 }
 @article{Lu2016c,
 abstract = {High Dynamic Range (HDR) and Wider Colour Gamut (WCG) content represents a greater range of luminance levels and a more complete reproduction of colours found in real⁃world scenes. The current video distribution environments deliver Standard Dynamic Range (SDR) signal Y′CbCr. For HDR and WCG content, it is desirable to examine if such signal format still works well for compression, and to know if the overall system performance can be further improved by exploring different signal formats. In this paper, ITP (ICTCP) colour space is presented. The paper concentrates on examining the two aspects of ITP colour space: 1) ITP characteristics in terms of signal quantization at a given bit depth; 2) ITP compression performance. The analysis and simulation results show that ITP 10 bit has better properties than Y′CbCr⁃PQ 10bit in colour quantization, constant luminance, hue property and chroma subsampling, and it also has good compression efficiency. Therefore it is desirable to adopt ITP colour space as a new signal format for HDR/WCG video compression.},
@@ -1351,7 +1400,7 @@ doi = {10.1002/col.20227},
 file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Luo, Cui, Li - 2006 - Uniform colour spaces based on CIECAM02 colour appearance model.pdf:pdf},
 isbn = {0361-2317},
 issn = {0361-2317},
-journal = {Color Research & Application},
+journal = {Color Research {\&} Application},
 keywords = {Colour appearance data,Colour appearance model,Colour difference data,Colour difference formula,Uniform colour space},
 month = {aug},
 number = {4},
@@ -1363,7 +1412,7 @@ year = {2006}
 }
 @incollection{Luo2013,
 address = {New York, NY},
-annote = {http://link.springer.com/chapter/10.1007/978-1-4419-6190-7_2},
+annote = {http://link.springer.com/chapter/10.1007/978-1-4419-6190-7{\_}2},
 author = {Luo, Ming Ronnier and Li, Changjun},
 booktitle = {Advanced Color Image Processing and Analysis},
 doi = {10.1007/978-1-4419-6190-7},
@@ -1378,28 +1427,42 @@ url = {http://link.springer.com/10.1007/978-1-4419-6190-7},
 year = {2013}
 }
 @article{Luo1996b,
-abstract = {A new colour model, named LLAB(l:c) is derived. It includes two parts: the BFD chromatic adaptation transform derived by Lam and Rigg, and a modified CIELAB uniform colour space. The model's performance was compared with the other spaces and models using the LUTCHI Colour Appearance Data Set. The results show that LLAB(l:c) model is capable of precisely quantifying the change of colour appearance under a wide range of viewing parameters such as light sources, surrounds/media, achromatic backgrounds, sizes of stimuli, and luminance levels. It had a similar performance as that of the Hunt colour appearance model. The LLAB(l:c) model was also tested using various colour difference datasets. The model gave a similar performance as the state-of-the-art colour difference formulae such as CMC, CIE94, and BFD. This performance is considered to be very satisfactory, and the model, therefore, should be considered for field trials in applications such as colour specification, colour difference evaluation, cross-image reproduction, gamut mapping, prediction of metamerism and colour constancy, and quantification of colour-rendering properties. The model does not give predictions for chroma (as distinct from colourfulness), or for brightness, and it does not include any rod response. {\textcopyright} 1996 John Wiley & Sons, Inc.},
+abstract = {A new colour model, named LLAB(l:c) is derived. It includes two parts: the BFD chromatic adaptation transform derived by Lam and Rigg, and a modified CIELAB uniform colour space. The model's performance was compared with the other spaces and models using the LUTCHI Colour Appearance Data Set. The results show that LLAB(l:c) model is capable of precisely quantifying the change of colour appearance under a wide range of viewing parameters such as light sources, surrounds/media, achromatic backgrounds, sizes of stimuli, and luminance levels. It had a similar performance as that of the Hunt colour appearance model. The LLAB(l:c) model was also tested using various colour difference datasets. The model gave a similar performance as the state-of-the-art colour difference formulae such as CMC, CIE94, and BFD. This performance is considered to be very satisfactory, and the model, therefore, should be considered for field trials in applications such as colour specification, colour difference evaluation, cross-image reproduction, gamut mapping, prediction of metamerism and colour constancy, and quantification of colour-rendering properties. The model does not give predictions for chroma (as distinct from colourfulness), or for brightness, and it does not include any rod response. {\textcopyright} 1996 John Wiley {\&} Sons, Inc.},
 author = {Luo, Ming Ronnier and Lo, Mei-Chun and Kuo, Wen-Guey},
 doi = {10.1002/(SICI)1520-6378(199612)21:6<412::AID-COL4>3.0.CO;2-Z},
 issn = {0361-2317},
-journal = {Color Research & Application},
+journal = {Color Research {\&} Application},
 keywords = {chromatic adaptation transform,colour appearance,colour appearance model,colour difference,colour difference formula,corresponding colours,uniform colour space},
 month = {dec},
 number = {6},
 pages = {412--429},
 publisher = {Wiley Subscription Services, Inc., A Wiley Company},
 title = {{The LLAB (l:c) colour model}},
-url = {http://doi.wiley.com/10.1002/%28SICI%291520-6378%28199612%2921%3A6%3C412%3A%3AAID-COL4%3E3.0.CO%3B2-Z},
+url = {http://doi.wiley.com/10.1002/{\%}28SICI{\%}291520-6378{\%}28199612{\%}2921{\%}3A6{\%}3C412{\%}3A{\%}3AAID-COL4{\%}3E3.0.CO{\%}3B2-Z},
 volume = {21},
 year = {1996}
 }
 @inproceedings{Luo1996c,
 author = {Luo, Ming Ronnier and Morovic, J{\'{a}}n},
-booktitle = {Conference: 5th International Conference on High Technology: Imaging Science and Technology – Evolution & Promise},
+booktitle = {Conference: 5th International Conference on High Technology: Imaging Science and Technology – Evolution {\&} Promise},
 pages = {136--147},
 title = {{Two Unsolved Issues in Colour Management – Colour Appearance and Gamut Mapping}},
-url = {http://www.researchgate.net/publication/236348295_Two_Unsolved_Issues_in_Colour_Management__Colour_Appearance_and_Gamut_Mapping},
+url = {http://www.researchgate.net/publication/236348295{\_}Two{\_}Unsolved{\_}Issues{\_}in{\_}Colour{\_}Management{\_}{\_}Colour{\_}Appearance{\_}and{\_}Gamut{\_}Mapping},
 year = {1996}
+}
+@article{Macadam1942,
+abstract = {An apparatus is described which facilitates the presentation of pairs of variable colors without variation of luminance. With this instrument, various criteria of visual sensitivity to color difference have been investigated. The standard deviation of color matching was finally adopted as the most reproducible criterion. The test field was two degrees in diameter, divided by a vertical biprism edge, and was viewed centrally with a surrounding field of fortytwo degrees diameter uniformly illuminated so as to have a chromaticity similar to that of the I.C.I. Standard Illuminant C (average daylight). The luminance of the test field was maintained constant at 15 millilamberts, and the surrounding field was 7.5 millilamberts. These fields were viewed monocularly through an artificial pupil, 2.6 mm in diameter. Over twenty-five thousand trials at color matching have been recorded for a single observer, and the readings are analyzed in detail and compared with previously available data. The standard deviations of the trials are represented in terms of distance in the standard 1931 I.C.I. chromaticity diagram. These increments of distance are represented as functions of position along straight lines in the chromaticity diagram, and also as functions of direction of departure from points representing certain standard chromaticities. Such representations are simpler than the traditional representations of wavelength thresholds and purity thresholds as functions of wave-length, and the accuracy of the representations is improved by this simplicity. Chromaticity discrimination for non-spectral colors is represented simultaneously and on the same basis as for spectral colors. Small, equally noticeable chromaticity differences are represented for all chromaticities and for all kinds of variations by the lengths of the radii of a family of ellipses drawn on the standard chromaticity diagram. These ellipses cannot be transformed into equal-sized circles by any projective transformation of the standard chromaticity diagram. The consistency of these data with the results of other investigators is exhibited in terms of the noticeabilities of wave-length differences in the spectrum and of the noticeabilities of purity differences from a neutral stimulus, as functions of dominant wave-length.},
+author = {Macadam, David L.},
+doi = {10.1364/JOSA.32.000247},
+file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Macadam - 1942 - Visual Sensitivities to Color Differences in Daylight.pdf:pdf},
+isbn = {0030-3941},
+issn = {0030-3941},
+journal = {Journal of the Optical Society of America},
+number = {5},
+pages = {28},
+title = {{Visual Sensitivities to Color Differences in Daylight}},
+volume = {32},
+year = {1942}
 }
 @article{MacAdam1935a,
 abstract = {Tristimulus values have been computed for hypothetical spectrophotometric curves of the type found to give the maximum visual reflectance factor (or transmission factor) for specified chromaticities. These computations have been based on the I.C.I. 1931 data for the normal observer for colorimetry, and on the I.C.I. Illuminants ``A'' and ``C.'' By plotting the results on the I.C.I. color mixture diagram, the loci of points characterized by equal maximum efficiencies have been established. Tables have been prepared showing the maximum visual efficiency as a function of excitation purity for twenty-four dominant wave-lengths.},
@@ -1415,20 +1478,6 @@ title = {{Maximum Visual Efficiency of Colored Materials}},
 url = {http://www.opticsinfobase.org/abstract.cfm?URI=josa-25-11-361},
 volume = {25},
 year = {1935}
-}
-@article{Macadam1942,
-abstract = {An apparatus is described which facilitates the presentation of pairs of variable colors without variation of luminance. With this instrument, various criteria of visual sensitivity to color difference have been investigated. The standard deviation of color matching was finally adopted as the most reproducible criterion. The test field was two degrees in diameter, divided by a vertical biprism edge, and was viewed centrally with a surrounding field of fortytwo degrees diameter uniformly illuminated so as to have a chromaticity similar to that of the I.C.I. Standard Illuminant C (average daylight). The luminance of the test field was maintained constant at 15 millilamberts, and the surrounding field was 7.5 millilamberts. These fields were viewed monocularly through an artificial pupil, 2.6 mm in diameter. Over twenty-five thousand trials at color matching have been recorded for a single observer, and the readings are analyzed in detail and compared with previously available data. The standard deviations of the trials are represented in terms of distance in the standard 1931 I.C.I. chromaticity diagram. These increments of distance are represented as functions of position along straight lines in the chromaticity diagram, and also as functions of direction of departure from points representing certain standard chromaticities. Such representations are simpler than the traditional representations of wavelength thresholds and purity thresholds as functions of wave-length, and the accuracy of the representations is improved by this simplicity. Chromaticity discrimination for non-spectral colors is represented simultaneously and on the same basis as for spectral colors. Small, equally noticeable chromaticity differences are represented for all chromaticities and for all kinds of variations by the lengths of the radii of a family of ellipses drawn on the standard chromaticity diagram. These ellipses cannot be transformed into equal-sized circles by any projective transformation of the standard chromaticity diagram. The consistency of these data with the results of other investigators is exhibited in terms of the noticeabilities of wave-length differences in the spectrum and of the noticeabilities of purity differences from a neutral stimulus, as functions of dominant wave-length.},
-author = {Macadam, David L.},
-doi = {10.1364/JOSA.32.000247},
-file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Macadam - 1942 - Visual Sensitivities to Color Differences in Daylight.pdf:pdf},
-isbn = {0030-3941},
-issn = {0030-3941},
-journal = {Journal of the Optical Society of America},
-number = {5},
-pages = {28},
-title = {{Visual Sensitivities to Color Differences in Daylight}},
-volume = {32},
-year = {1942}
 }
 @article{Machado2009,
 abstract = {Color vision deficiency (CVD) affects approximately 200 million people worldwide, compromising the ability of these individuals to effectively perform color and visualization-related tasks. This has a significant impact on their private and professional lives. We present a physiologically-based model for simulating color vision. Our model is based on the stage theory of human color vision and is derived from data reported in electrophysiological studies. It is the first model to consistently handle normal color vision, anomalous trichromacy, and dichromacy in a unified way. We have validated the proposed model through an experimental evaluation involving groups of color vision deficient individuals and normal color vision ones. Our model can provide insights and feedback on how to improve visualization experiences for individuals with CVD. It also provides a framework for testing hypotheses about some aspects of the retinal photoreceptors in color vision deficient individuals.},
@@ -1463,13 +1512,13 @@ file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Malvar, Sulliva
 number = {July},
 pages = {22--24},
 title = {{YCoCg-R: A Color Space with RGB Reversibility and Low Dynamic Range}},
-url = {https://www.microsoft.com/en-us/research/wp-content/uploads/2016/06/Malvar_Sullivan_YCoCg-R_JVT-I014r3-2.pdf},
+url = {https://www.microsoft.com/en-us/research/wp-content/uploads/2016/06/Malvar{\_}Sullivan{\_}YCoCg-R{\_}JVT-I014r3-2.pdf},
 year = {2003}
 }
-@misc{Mansencald,
+@misc{Mansencalc,
 author = {Mansencal, Thomas},
-title = {{Structure}},
-url = {https://github.com/KelSolaar/Foundations/blob/develop/foundations/data_structures.py}
+title = {{Lookup}},
+url = {https://github.com/KelSolaar/Foundations/blob/develop/foundations/data{\_}structures.py}
 }
 @misc{Mansencal2018,
 author = {Mansencal, Thomas},
@@ -1478,6 +1527,11 @@ url = {https://stackoverflow.com/a/48396021/931625},
 urldate = {2018-08-19},
 year = {2018}
 }
+@misc{Mansencald,
+author = {Mansencal, Thomas},
+title = {{Structure}},
+url = {https://github.com/KelSolaar/Foundations/blob/develop/foundations/data{\_}structures.py}
+}
 @misc{Mansencal2015d,
 author = {Mansencal, Thomas},
 title = {{RED Colourspaces Derivation}},
@@ -1485,22 +1539,17 @@ url = {http://colour-science.org/posts/red-colourspaces-derivation},
 urldate = {2015-05-20},
 year = {2015}
 }
-@misc{Mansencalc,
-author = {Mansencal, Thomas},
-title = {{Lookup}},
-url = {https://github.com/KelSolaar/Foundations/blob/develop/foundations/data_structures.py}
-}
 @misc{Melgosa2013b,
 author = {Melgosa, Manuel},
 file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Melgosa - 2013 - CIE ISO new standard CIEDE2000.pdf:pdf},
 number = {July},
 title = {{CIE / ISO new standard: CIEDE2000}},
-url = {http://www.color.org/events/colorimetry/Melgosa_CIEDE2000_Workshop-July4.pdf},
+url = {http://www.color.org/events/colorimetry/Melgosa{\_}CIEDE2000{\_}Workshop-July4.pdf},
 volume = {2013},
 year = {2013}
 }
 @article{Meng2015c,
-annote = {http://jo.dreggn.org/home/2015_spectrum.pdf},
+annote = {http://jo.dreggn.org/home/2015{\_}spectrum.pdf},
 author = {Meng, Johannes and Simon, Florian and Hanika, Johannes and Dachsbacher, Carsten},
 doi = {10.1111/cgf.12676},
 file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Meng et al. - 2015 - Physically Meaningful Rendering using Tristimulus Colours.pdf:pdf},
@@ -1543,24 +1592,24 @@ title = {{The CIECAM02 Color Appearance Model}},
 url = {http://www.ingentaconnect.com/content/ist/cic/2002/00002002/00000001/art00006},
 year = {2002}
 }
-@misc{MunsellColorSciencec,
-author = {{Munsell Color Science}},
-title = {{Munsell Colours Data}},
-url = {http://www.cis.rit.edu/research/mcsl2/online/munsell.php},
-urldate = {2014-08-20}
-}
 @misc{MunsellColorScienceb,
 annote = {http://www.cis.rit.edu/research/mcsl2/online/cie.php},
 author = {{Munsell Color Science}},
 title = {{Macbeth Colorchecker}},
 url = {http://www.rit-mcsl.org/UsefulData/MacbethColorChecker.xls}
 }
+@misc{MunsellColorSciencec,
+author = {{Munsell Color Science}},
+title = {{Munsell Colours Data}},
+url = {http://www.cis.rit.edu/research/mcsl2/online/munsell.php},
+urldate = {2014-08-20}
+}
 @misc{NationalElectricalManufacturersAssociation2004b,
 annote = {http://www.ncbi.nlm.nih.gov/pubmed/2188123},
 author = {{National Electrical Manufacturers Association}},
 file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/National Electrical Manufacturers Association - 2004 - Digital Imaging and Communications in Medicine (DICOM) Part 14 Grayscale Standard.pdf:pdf},
 title = {{Digital Imaging and Communications in Medicine (DICOM) Part 14: Grayscale Standard Display Function}},
-url = {http://medical.nema.org/dicom/2004/04_14PU.PDF},
+url = {http://medical.nema.org/dicom/2004/04{\_}14PU.PDF},
 year = {2004}
 }
 @misc{Nattress2016a,
@@ -1573,7 +1622,7 @@ annote = {https://doi.org/10.1002/col.5080200305},
 author = {Nayatani, Yoshinobu and Sobagaki, Hiroaki and Yano, Kenjiro Hashimoto Tadashi},
 doi = {10.1002/col.5080200305},
 issn = {03612317},
-journal = {Color Research & Application},
+journal = {Color Research {\&} Application},
 keywords = {color-vision model,lightness dependency of chroma,nonlinear color-appearance model},
 month = {jun},
 number = {3},
@@ -1648,7 +1697,7 @@ author = {Panasonic},
 file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Panasonic - 2014 - VARICAM V-LogV-Gamut.pdf:pdf},
 pages = {1--7},
 title = {{VARICAM V-Log/V-Gamut}},
-url = {http://pro-av.panasonic.net/en/varicam/common/pdf/VARICAM_V-Log_V-Gamut.pdf},
+url = {http://pro-av.panasonic.net/en/varicam/common/pdf/VARICAM{\_}V-Log{\_}V-Gamut.pdf},
 year = {2014}
 }
 @misc{Pointer1980a,
@@ -1662,7 +1711,7 @@ year = {1980}
 @misc{Reitza,
 author = {Reitz, Kenneth},
 title = {{CaseInsensitiveDict}},
-url = {https://github.com/kennethreitz/requests/blob/v1.2.3/requests/structures.py#L37}
+url = {https://github.com/kennethreitz/requests/blob/v1.2.3/requests/structures.py{\#}L37}
 }
 @misc{RenewableResourceDataCenter2003a,
 author = {{Renewable Resource Data Center}},
@@ -1690,7 +1739,7 @@ annote = {From Duplicate 2 (Perceptually uniform color space for image signals i
 http://www.opticsexpress.org/abstract.cfm?URI=oe-25-13-15131},
 author = {Safdar, Muhammad and Cui, Guihua and Kim, Youn Jin and Luo, Ming Ronnier},
 doi = {10.1364/OE.25.015131},
-file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Safdar et al. - 2017 - Perceptually uniform color space for image signals including high dynamic range and wide gamut(2).pdf:pdf;:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Safdar et al. - 2017 - Perceptually uniform color space for image signals including high dynamic range and wide gamut.pdf:pdf},
+file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop//Safdar et al. - 2017 - Perceptually uniform color space for image signals including high dynamic range and wide gamut.pdf:pdf;:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop//Safdar et al. - 2017 - Perceptually uniform color space for image signals including high dynamic range and wide gamut.pdf:pdf},
 issn = {1094-4087},
 journal = {Optics Express},
 keywords = {Color,Color vision,Colorimetry,Vision,and visual optics,color},
@@ -1709,13 +1758,13 @@ url = {http://stackoverflow.com/a/2745496/931625},
 urldate = {2014-08-08}
 }
 @article{Sharma2005b,
-abstract = {This article and the associated data and programs\nprovided with it are intended to assist color engineers and\nscientists in correctly implementing the recently developed\nCIEDE2000 color-difference formula. We indicate several\npotential implementation errors that are not uncovered in\ntests performed using the original sample data published\nwith the standard. A supplemental set of data is provided for\ncomprehensive testing of implementations. The test data,\nMicrosoft Excel spreadsheets, and MATLAB scripts for\nevaluating the CIEDE2000 color difference are made avail-\nable at the first author's website. Finally, we also point out\nsmall mathematical discontinuities in the formula.},
+abstract = {This article and the associated data and programs$\backslash$nprovided with it are intended to assist color engineers and$\backslash$nscientists in correctly implementing the recently developed$\backslash$nCIEDE2000 color-difference formula. We indicate several$\backslash$npotential implementation errors that are not uncovered in$\backslash$ntests performed using the original sample data published$\backslash$nwith the standard. A supplemental set of data is provided for$\backslash$ncomprehensive testing of implementations. The test data,$\backslash$nMicrosoft Excel spreadsheets, and MATLAB scripts for$\backslash$nevaluating the CIEDE2000 color difference are made avail-$\backslash$nable at the first author's website. Finally, we also point out$\backslash$nsmall mathematical discontinuities in the formula.},
 annote = {http://onlinelibrary.wiley.com/doi/10.1002/col.20070/abstract},
 author = {Sharma, Gaurav and Wu, Wencheng and Dalal, Edul N.},
 doi = {10.1002/col.20070},
 file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Sharma, Wu, Dalal - 2005 - The CIEDE2000 color-difference formula Implementation notes, supplementary test data, and mathematical observ.pdf:pdf},
 issn = {0361-2317},
-journal = {Color Research & Application},
+journal = {Color Research {\&} Application},
 keywords = {CIE,CIE94,CIEDE2000,CIELAB,CMC,Color-difference metrics},
 month = {feb},
 number = {1},
@@ -1756,7 +1805,7 @@ year = {1978}
 }
 @article{Smits1999a,
 abstract = {The desire for accuracy and realism in images requires a physically-based rendering system. Often this can mean using a full spectral representation, as RGB represen- tations have limitations in some situations4. The spectral representation does come at some cost, not ...},
-annote = {http://www.cs.utah.edu/$\sim$bes/papers/color/},
+annote = {http://www.cs.utah.edu/{\~{}}bes/papers/color/},
 author = {Smits, Brian},
 doi = {10.1080/10867651.1999.10487511},
 file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Smits - 1999 - An RGB-to-Spectrum Conversion for Reflectances.pdf:pdf},
@@ -1771,13 +1820,15 @@ url = {http://www.tandfonline.com/doi/abs/10.1080/10867651.1999.10487511},
 volume = {4},
 year = {1999}
 }
-@misc{SocietyofMotionPictureandTelevisionEngineers1999b,
+@misc{SocietyofMotionPictureandTelevisionEngineers2014a,
+abstract = {This standard specifies an EOTF characterizing high-dynamic-range reference displays used primarily for mastering non-broadcast content. This standard also specifies an Inverse-EOTF derived from the EOTF.},
 author = {{Society of Motion Picture and Television Engineers}},
-file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Society of Motion Picture and Television Engineers - 1999 - ANSISMPTE 240M-1995 - Signal Parameters - 1125-Line High-Definition Producti.pdf:pdf},
-pages = {1--7},
-title = {{ANSI/SMPTE 240M-1995 - Signal Parameters - 1125-Line High-Definition Production Systems}},
-url = {http://car.france3.mars.free.fr/HD/INA- 26 jan 06/SMPTE normes et confs/s240m.pdf},
-year = {1999}
+doi = {10.5594/SMPTE.ST2084.2014},
+file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Society of Motion Picture and Television Engineers - 2014 - SMPTE ST 20842014 - Dynamic Range Electro-Optical Transfer Function of Maste.pdf:pdf},
+pages = {1--14},
+title = {{SMPTE ST 2084:2014 - Dynamic Range Electro-Optical Transfer Function of Mastering Reference Displays}},
+url = {http://www.techstreet.com/products/1883436},
+year = {2014}
 }
 @book{SocietyofMotionPictureandTelevisionEngineers1993a,
 abstract = {color white whitepoint matrix Scope This practice is intended to define the numerical procedures for deriving basic color equations for color television and other systems using additive display devices. These equations are first, the normalized reference primary matrix which defines the relationship between RGB signals and CIE tristimulus values XYZ; then, the system luminance equation; and finally, the color primary transformation matrix for transforming signals from one set of reference primaries to another set of reference primaries or to a set of display primaries.},
@@ -1795,16 +1846,6 @@ url = {http://standards.smpte.org/lookup/doi/10.5594/S9781614821915},
 volume = {RP 177:199},
 year = {1993}
 }
-@misc{SocietyofMotionPictureandTelevisionEngineers2014a,
-abstract = {This standard specifies an EOTF characterizing high-dynamic-range reference displays used primarily for mastering non-broadcast content. This standard also specifies an Inverse-EOTF derived from the EOTF.},
-author = {{Society of Motion Picture and Television Engineers}},
-doi = {10.5594/SMPTE.ST2084.2014},
-file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Society of Motion Picture and Television Engineers - 2014 - SMPTE ST 20842014 - Dynamic Range Electro-Optical Transfer Function of Maste.pdf:pdf},
-pages = {1--14},
-title = {{SMPTE ST 2084:2014 - Dynamic Range Electro-Optical Transfer Function of Mastering Reference Displays}},
-url = {http://www.techstreet.com/products/1883436},
-year = {2014}
-}
 @book{SocietyofMotionPictureandTelevisionEngineers2004a,
 abstract = {cie Scope This practice specifies the chromaticity values of the red, green, and blue visible radiation emitted by the primaries and the chromaticity of the white point for professional monitors used in systems based on SMPTE C colorimetry.},
 annote = {http://standards.smpte.org/content/978-1-61482-164-9/rp-145-2004/SEC1.abstract},
@@ -1820,32 +1861,40 @@ url = {http://standards.smpte.org/lookup/doi/10.5594/S9781614821649},
 volume = {RP 145:200},
 year = {2004}
 }
-@misc{SonyCorporation2012a,
-author = {{Sony Corporation}},
-file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Sony Corporation - 2012 - S-Log2 Technical Paper.pdf:pdf},
-pages = {1--9},
-title = {{S-Log2 Technical Paper}},
-url = {https://pro.sony.com/bbsccms/assets/files/micro/dmpc/training/S-Log2_Technical_PaperV1_0.pdf},
-year = {2012}
-}
-@misc{SonyCorporatione,
-author = {{Sony Corporation}},
-title = {{S-Gamut3_S-Gamut3Cine_Matrix.xlsx}},
-url = {https://community.sony.com/sony/attachments/sony/large-sensor-camera-F5-F55/12359/3/S-Gamut3_S-Gamut3Cine_Matrix.xlsx}
-}
-@misc{SonyCorporationd,
-author = {{Sony Corporation}},
-file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Sony Corporation - Unknown - Technical Summary for S-Gamut3.CineS-Log3 and S-Gamut3S-Log3.pdf:pdf},
+@misc{SocietyofMotionPictureandTelevisionEngineers1999b,
+author = {{Society of Motion Picture and Television Engineers}},
+file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Society of Motion Picture and Television Engineers - 1999 - ANSISMPTE 240M-1995 - Signal Parameters - 1125-Line High-Definition Producti.pdf:pdf},
 pages = {1--7},
-title = {{Technical Summary for S-Gamut3.Cine/S-Log3 and S-Gamut3/S-Log3}},
-url = {http://community.sony.com/sony/attachments/sony/large-sensor-camera-F5-F55/12359/2/TechnicalSummary_for_S-Gamut3Cine_S-Gamut3_S-Log3_V1_00.pdf}
+title = {{ANSI/SMPTE 240M-1995 - Signal Parameters - 1125-Line High-Definition Production Systems}},
+url = {http://car.france3.mars.free.fr/HD/INA- 26 jan 06/SMPTE normes et confs/s240m.pdf},
+year = {1999}
 }
 @misc{SonyCorporation,
 author = {{Sony Corporation}},
 file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Sony Corporation - Unknown - S-Log Whitepaper.pdf:pdf},
 pages = {1--17},
 title = {{S-Log Whitepaper}},
-url = {http://www.theodoropoulos.info/attachments/076_on S-Log.pdf}
+url = {http://www.theodoropoulos.info/attachments/076{\_}on S-Log.pdf}
+}
+@misc{SonyCorporationd,
+author = {{Sony Corporation}},
+file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Sony Corporation - Unknown - Technical Summary for S-Gamut3.CineS-Log3 and S-Gamut3S-Log3.pdf:pdf},
+pages = {1--7},
+title = {{Technical Summary for S-Gamut3.Cine/S-Log3 and S-Gamut3/S-Log3}},
+url = {http://community.sony.com/sony/attachments/sony/large-sensor-camera-F5-F55/12359/2/TechnicalSummary{\_}for{\_}S-Gamut3Cine{\_}S-Gamut3{\_}S-Log3{\_}V1{\_}00.pdf}
+}
+@misc{SonyCorporation2012a,
+author = {{Sony Corporation}},
+file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Sony Corporation - 2012 - S-Log2 Technical Paper.pdf:pdf},
+pages = {1--9},
+title = {{S-Log2 Technical Paper}},
+url = {https://pro.sony.com/bbsccms/assets/files/micro/dmpc/training/S-Log2{\_}Technical{\_}PaperV1{\_}0.pdf},
+year = {2012}
+}
+@misc{SonyCorporatione,
+author = {{Sony Corporation}},
+title = {{S-Gamut3{\_}S-Gamut3Cine{\_}Matrix.xlsx}},
+url = {https://community.sony.com/sony/attachments/sony/large-sensor-camera-F5-F55/12359/3/S-Gamut3{\_}S-Gamut3Cine{\_}Matrix.xlsx}
 }
 @misc{SonyImageworks2012a,
 author = {{Sony Imageworks}},
@@ -1876,7 +1925,7 @@ annote = {https://doi.org/10.1002/col.5080130410},
 author = {Stearns, E. I. and Stearns, R. E.},
 doi = {10.1002/col.5080130410},
 issn = {03612317},
-journal = {Color Research & Application},
+journal = {Color Research {\&} Application},
 month = {aug},
 number = {4},
 pages = {257--259},
@@ -1910,7 +1959,7 @@ volume = {4300},
 year = {2000}
 }
 @misc{Susstrunk1999a,
-abstract = {This paper describes the specifications and usage of standard RGB color spaces promoted today by standard bodies and/or the imaging industry. As in the past, most of the new standard RGB color spaces were developed for specific imaging workflow and applications. They are used as interchange spaces to communicate color and/or as working spaces in imaging applications. Standard color spaces can facilitate color communication: if an image is in ‘knownRGB,' the user, application, and/or device can unambiguously understand the color of the image, and further color manage from there if necessary. When applied correctly, a standard RGB space can minimize color space conversions in an imaging workflow, improve image reproducibility, and facilitate accountability.\nThe digital image color workflow is examined with emphasis on when an RGB color space is appropriate, and when to apply color management by profile. An RGB space is “standard” because either it is defined in an official standards document (a de jure standard) or it is supported by commonly used tools (a de facto standard). Examples of standard RGB color spaces are ISO RGB, sRGB, ROMM RGB, Adobe RGB 98, Apple RGB, and video RGB spaces (NTSC, EBU, ITU-R BT.709). As there is no one RGB color space that is suitable for all imaging needs, factors to consider when choosing an RGB color space are discussed.},
+abstract = {This paper describes the specifications and usage of standard RGB color spaces promoted today by standard bodies and/or the imaging industry. As in the past, most of the new standard RGB color spaces were developed for specific imaging workflow and applications. They are used as interchange spaces to communicate color and/or as working spaces in imaging applications. Standard color spaces can facilitate color communication: if an image is in ‘knownRGB,' the user, application, and/or device can unambiguously understand the color of the image, and further color manage from there if necessary. When applied correctly, a standard RGB space can minimize color space conversions in an imaging workflow, improve image reproducibility, and facilitate accountability.$\backslash$nThe digital image color workflow is examined with emphasis on when an RGB color space is appropriate, and when to apply color management by profile. An RGB space is “standard” because either it is defined in an official standards document (a de jure standard) or it is supported by commonly used tools (a de facto standard). Examples of standard RGB color spaces are ISO RGB, sRGB, ROMM RGB, Adobe RGB 98, Apple RGB, and video RGB spaces (NTSC, EBU, ITU-R BT.709). As there is no one RGB color space that is suitable for all imaging needs, factors to consider when choosing an RGB color space are discussed.},
 author = {Susstrunk, Sabine and Buckley, Robert and Swen, Steve},
 file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Susstrunk, Buckley, Swen - 1999 - Standard RGB Color Spaces.pdf:pdf},
 isbn = {2166-9635},
@@ -1925,36 +1974,6 @@ title = {{Specification S-2016-001 - ACEScct, A Quasi-Logarithmic Encoding of AC
 url = {https://github.com/ampas/aces-dev/tree/v1.0.3/documents},
 urldate = {2016-10-10},
 year = {2016}
-}
-@misc{TheAcademyofMotionPictureArtsandSciencese,
-author = {{The Academy of Motion Picture Arts and Sciences} and {Science and Technology Council} and {Academy Color Encoding System (ACES) Project Subcommittee}},
-title = {{Academy Color Encoding System}},
-url = {http://www.oscars.org/science-technology/council/projects/aces.html},
-urldate = {2014-02-24}
-}
-@misc{TheAcademyofMotionPictureArtsandSciences2014r,
-author = {{The Academy of Motion Picture Arts and Sciences} and {Science and Technology Council} and {Academy Color Encoding System (ACES) Project Subcommittee}},
-file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/The Academy of Motion Picture Arts and Sciences, Science and Technology Council, Academy Color Encoding System (ACES) Project Subcom(12).pdf:pdf},
-pages = {1--8},
-title = {{Technical Bulletin TB-2014-012 - Academy Color Encoding System Version 1.0 Component Names}},
-url = {https://github.com/ampas/aces-dev/tree/master/documents},
-year = {2014}
-}
-@misc{TheAcademyofMotionPictureArtsandSciences2014q,
-author = {{The Academy of Motion Picture Arts and Sciences} and {Science and Technology Council} and {Academy Color Encoding System (ACES) Project Subcommittee}},
-file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/The Academy of Motion Picture Arts and Sciences, Science and Technology Council, Academy Color Encoding System (ACES) Project Subcommi.pdf:pdf},
-pages = {1--40},
-title = {{Technical Bulletin TB-2014-004 - Informative Notes on SMPTE ST 2065-1 – Academy Color Encoding Specification (ACES)}},
-url = {https://github.com/ampas/aces-dev/tree/master/documents},
-year = {2014}
-}
-@misc{TheAcademyofMotionPictureArtsandSciences2014s,
-author = {{The Academy of Motion Picture Arts and Sciences} and {Science and Technology Council} and {Academy Color Encoding System (ACES) Project Subcommittee}},
-file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/The Academy of Motion Picture Arts and Sciences, Science and Technology Council, Academy Color Encoding System (ACES) Project Subcomm(5).pdf:pdf},
-pages = {1--16},
-title = {{Specification S-2013-001 - ACESproxy, an Integer Log Encoding of ACES Image Data}},
-url = {https://github.com/ampas/aces-dev/tree/master/documents},
-year = {2014}
 }
 @misc{TheAcademyofMotionPictureArtsandSciences2015b,
 author = {{The Academy of Motion Picture Arts and Sciences} and {Science and Technology Council} and {Academy Color Encoding System (ACES) Project Subcommittee}},
@@ -1972,11 +1991,41 @@ title = {{Specification S-2014-003 - ACEScc, A Logarithmic Encoding of ACES Data
 url = {https://github.com/ampas/aces-dev/tree/master/documents},
 year = {2014}
 }
+@misc{TheAcademyofMotionPictureArtsandSciencese,
+author = {{The Academy of Motion Picture Arts and Sciences} and {Science and Technology Council} and {Academy Color Encoding System (ACES) Project Subcommittee}},
+title = {{Academy Color Encoding System}},
+url = {http://www.oscars.org/science-technology/council/projects/aces.html},
+urldate = {2014-02-24}
+}
+@misc{TheAcademyofMotionPictureArtsandSciences2014s,
+author = {{The Academy of Motion Picture Arts and Sciences} and {Science and Technology Council} and {Academy Color Encoding System (ACES) Project Subcommittee}},
+file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/The Academy of Motion Picture Arts and Sciences, Science and Technology Council, Academy Color Encoding System (ACES) Project Subcomm(5).pdf:pdf},
+pages = {1--16},
+title = {{Specification S-2013-001 - ACESproxy, an Integer Log Encoding of ACES Image Data}},
+url = {https://github.com/ampas/aces-dev/tree/master/documents},
+year = {2014}
+}
+@misc{TheAcademyofMotionPictureArtsandSciences2014r,
+author = {{The Academy of Motion Picture Arts and Sciences} and {Science and Technology Council} and {Academy Color Encoding System (ACES) Project Subcommittee}},
+file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/The Academy of Motion Picture Arts and Sciences, Science and Technology Council, Academy Color Encoding System (ACES) Project Subcom(12).pdf:pdf},
+pages = {1--8},
+title = {{Technical Bulletin TB-2014-012 - Academy Color Encoding System Version 1.0 Component Names}},
+url = {https://github.com/ampas/aces-dev/tree/master/documents},
+year = {2014}
+}
+@misc{TheAcademyofMotionPictureArtsandSciences2014q,
+author = {{The Academy of Motion Picture Arts and Sciences} and {Science and Technology Council} and {Academy Color Encoding System (ACES) Project Subcommittee}},
+file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/The Academy of Motion Picture Arts and Sciences, Science and Technology Council, Academy Color Encoding System (ACES) Project Subcommi.pdf:pdf},
+pages = {1--40},
+title = {{Technical Bulletin TB-2014-004 - Informative Notes on SMPTE ST 2065-1 – Academy Color Encoding Specification (ACES)}},
+url = {https://github.com/ampas/aces-dev/tree/master/documents},
+year = {2014}
+}
 @misc{Thorpe2012a,
 author = {Thorpe, Larry},
 file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Thorpe - 2012 - CANON-LOG TRANSFER CHARACTERISTIC.pdf:pdf},
 title = {{CANON-LOG TRANSFER CHARACTERISTIC}},
-url = {http://downloads.canon.com/CDLC/Canon-Log_Transfer_Characteristic_6-20-2012.pdf},
+url = {http://downloads.canon.com/CDLC/Canon-Log{\_}Transfer{\_}Characteristic{\_}6-20-2012.pdf},
 year = {2012}
 }
 @misc{Trieu2015a,
@@ -1998,7 +2047,7 @@ journal = {Eurographics workshop on Rendering},
 pages = {117--124},
 publisher = {Eurographics Association},
 title = {{Picture Perfect RGB Rendering Using Spectral Prefiltering and Sharp Color Primaries}},
-url = {http://portal.acm.org/citation.cfm?id=581896.581913%5Cnpapers2://publication/uuid/72F077CB-2366-40E4-901E-5FE35B85BAD6 http://dl.acm.org/citation.cfm?id=581913},
+url = {http://portal.acm.org/citation.cfm?id=581896.581913{\%}5Cnpapers2://publication/uuid/72F077CB-2366-40E4-901E-5FE35B85BAD6 http://dl.acm.org/citation.cfm?id=581913},
 year = {2002}
 }
 @incollection{Westland2004,
@@ -2011,30 +2060,10 @@ file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/Westland, Ripam
 isbn = {9780470845622},
 month = {mar},
 pages = {137},
-publisher = {John Wiley & Sons, Ltd},
+publisher = {John Wiley {\&} Sons, Ltd},
 title = {{Table 8.2}},
 url = {http://doi.wiley.com/10.1002/0470020326},
 year = {2004}
-}
-@incollection{Westland2012g,
-author = {Westland, Stephen and Ripamonti, Caterina and Cheung, Vien},
-booktitle = {Computational Colour Science Using MATLAB},
-chapter = {6.2.2},
-edition = {2},
-isbn = {978-0-470-66569-5},
-pages = {80},
-title = {{CMCCAT97}},
-year = {2012}
-}
-@incollection{Westland2012k,
-author = {Westland, Stephen and Ripamonti, Caterina and Cheung, Vien},
-booktitle = {Computational Colour Science Using MATLAB},
-chapter = {6.2.3},
-edition = {2},
-isbn = {978-0-470-66569-5},
-pages = {83--86},
-title = {{CMCCAT2000}},
-year = {2012}
 }
 @incollection{Westland2012i,
 author = {Westland, Stephen and Ripamonti, Caterina and Cheung, Vien},
@@ -2044,6 +2073,16 @@ edition = {2},
 isbn = {978-0-470-66569-5},
 pages = {38},
 title = {{Extrapolation Methods}},
+year = {2012}
+}
+@incollection{Westland2012g,
+author = {Westland, Stephen and Ripamonti, Caterina and Cheung, Vien},
+booktitle = {Computational Colour Science Using MATLAB},
+chapter = {6.2.2},
+edition = {2},
+isbn = {978-0-470-66569-5},
+pages = {80},
+title = {{CMCCAT97}},
 year = {2012}
 }
 @incollection{Westland2012f,
@@ -2056,6 +2095,16 @@ pages = {38},
 title = {{Correction for Spectral Bandpass}},
 year = {2012}
 }
+@incollection{Westland2012k,
+author = {Westland, Stephen and Ripamonti, Caterina and Cheung, Vien},
+booktitle = {Computational Colour Science Using MATLAB},
+chapter = {6.2.3},
+edition = {2},
+isbn = {978-0-470-66569-5},
+pages = {83--86},
+title = {{CMCCAT2000}},
+year = {2012}
+}
 @incollection{Westland2012h,
 author = {Westland, Stephen and Ripamonti, Caterina and Cheung, Vien},
 booktitle = {Computational Colour Science Using MATLAB},
@@ -2066,102 +2115,11 @@ pages = {29--37},
 title = {{Interpolation Methods}},
 year = {2012}
 }
-@misc{Wikipedia2001c,
+@misc{Wikipedia2007c,
 author = {Wikipedia},
-title = {{Rayleigh scattering}},
-url = {http://en.wikipedia.org/wiki/Rayleigh_scattering},
-urldate = {2014-09-23},
-year = {2001}
-}
-@misc{Wikipedia2005b,
-author = {Wikipedia},
-title = {{Lanczos resampling}},
-url = {https://en.wikipedia.org/wiki/Lanczos_resampling},
-urldate = {2017-10-14},
-year = {2005}
-}
-@misc{Wikipedia2008b,
-author = {Wikipedia},
-title = {{Color difference}},
-url = {http://en.wikipedia.org/wiki/Color_difference},
-urldate = {2014-08-29},
-year = {2008}
-}
-@misc{Wikipedia2001,
-author = {Wikipedia},
-title = {{Approximation}},
-url = {http://en.wikipedia.org/wiki/Color_temperature#Approximation},
-urldate = {2014-06-28},
-year = {2001}
-}
-@misc{Wikipedia2003c,
-author = {Wikipedia},
-title = {{Mean squared error}},
-url = {https://en.wikipedia.org/wiki/Mean_squared_error},
-urldate = {2018-03-05},
-year = {2003}
-}
-@misc{Wikipedia2005d,
-author = {Wikipedia},
-title = {{Mesopic weighting function}},
-url = {http://en.wikipedia.org/wiki/Mesopic_vision#Mesopic_weighting_function},
-urldate = {2014-06-20},
-year = {2005}
-}
-@misc{Wikipedia2005,
-author = {Wikipedia},
-title = {{CIE 1931 color space}},
-url = {http://en.wikipedia.org/wiki/CIE_1931_color_space},
-urldate = {2014-02-24},
-year = {2005}
-}
-@misc{Wikipedia2004a,
-author = {Wikipedia},
-title = {{Surfaces}},
-url = {http://en.wikipedia.org/wiki/Gamut#Surfaces},
-urldate = {2014-09-10},
-year = {2004}
-}
-@misc{Wikipedia2003b,
-author = {Wikipedia},
-title = {{Luminosity function}},
-url = {https://en.wikipedia.org/wiki/Luminosity_function#Details},
-urldate = {2014-10-20},
-year = {2003}
-}
-@misc{Wikipedia2008,
-author = {Wikipedia},
-title = {{CIE 1960 color space}},
-url = {http://en.wikipedia.org/wiki/CIE_1960_color_space},
-urldate = {2014-02-24},
-year = {2008}
-}
-@misc{Wikipedia2007,
-author = {Wikipedia},
-title = {{CAT02}},
-url = {http://en.wikipedia.org/wiki/CIECAM02#CAT02},
-urldate = {2014-02-24},
-year = {2007}
-}
-@misc{Wikipedia2008c,
-author = {Wikipedia},
-title = {{Relation to CIE XYZ}},
-url = {http://en.wikipedia.org/wiki/CIE_1960_color_space#Relation_to_CIE_XYZ},
-urldate = {2014-02-24},
-year = {2008}
-}
-@misc{Wikipedia2003e,
-author = {Wikipedia},
-title = {{Vandermonde matrix}},
-url = {https://en.wikipedia.org/wiki/Vandermonde_matrix},
-urldate = {2018-05-02},
-year = {2003}
-}
-@misc{Wikipedia2007b,
-author = {Wikipedia},
-title = {{CIELUV}},
-url = {http://en.wikipedia.org/wiki/CIELUV},
-urldate = {2014-02-24},
+title = {{Lightness}},
+url = {http://en.wikipedia.org/wiki/Lightness},
+urldate = {2014-04-13},
 year = {2007}
 }
 @misc{Wikipedia2001b,
@@ -2171,45 +2129,52 @@ url = {https://en.wikipedia.org/wiki/Luminance},
 urldate = {2018-02-10},
 year = {2001}
 }
+@misc{Wikipedia2005a,
+author = {Wikipedia},
+title = {{ISO 31-11}},
+url = {https://en.wikipedia.org/wiki/ISO{\_}31-11},
+urldate = {2016-07-31},
+year = {2005}
+}
 @misc{Wikipedia2006,
 author = {Wikipedia},
 title = {{List of common coordinate transformations}},
-url = {http://en.wikipedia.org/wiki/List_of_common_coordinate_transformations},
+url = {http://en.wikipedia.org/wiki/List{\_}of{\_}common{\_}coordinate{\_}transformations},
 urldate = {2014-07-18},
 year = {2006}
 }
-@misc{Wikipedia2003d,
+@misc{Wikipedia2003,
 author = {Wikipedia},
-title = {{Michaelis–Menten kinetics}},
-url = {https://en.wikipedia.org/wiki/Michaelis–Menten_kinetics},
-urldate = {2017-04-29},
+title = {{HSL and HSV}},
+url = {http://en.wikipedia.org/wiki/HSL{\_}and{\_}HSV},
+urldate = {2014-09-10},
 year = {2003}
 }
-@misc{Wikipedia2004d,
+@misc{Wikipedia2004a,
 author = {Wikipedia},
-title = {{YCbCr}},
-url = {https://en.wikipedia.org/wiki/YCbCr},
-urldate = {2016-02-29},
+title = {{Surfaces}},
+url = {http://en.wikipedia.org/wiki/Gamut{\#}Surfaces},
+urldate = {2014-09-10},
 year = {2004}
 }
-@misc{Wikipedia2008a,
+@misc{Wikipedia2007d,
 author = {Wikipedia},
-title = {{CIE 1964 color space}},
-url = {http://en.wikipedia.org/wiki/CIE_1964_color_space},
-urldate = {2014-06-10},
-year = {2008}
-}
-@misc{Wikipedia2006a,
-author = {Wikipedia},
-title = {{White points of standard illuminants}},
-url = {http://en.wikipedia.org/wiki/Standard_illuminant#White_points_of_standard_illuminants},
+title = {{The reverse transformation}},
+url = {http://en.wikipedia.org/wiki/CIELUV{\#}The{\_}reverse{\_}transformation},
 urldate = {2014-02-24},
-year = {2006}
+year = {2007}
+}
+@misc{Wikipedia2007b,
+author = {Wikipedia},
+title = {{CIELUV}},
+url = {http://en.wikipedia.org/wiki/CIELUV},
+urldate = {2014-02-24},
+year = {2007}
 }
 @misc{Wikipedia2003a,
 author = {Wikipedia},
 title = {{Lagrange polynomial - Definition}},
-url = {https://en.wikipedia.org/wiki/Lagrange_polynomial#Definition},
+url = {https://en.wikipedia.org/wiki/Lagrange{\_}polynomial{\#}Definition},
 urldate = {2016-01-20},
 year = {2003}
 }
@@ -2220,47 +2185,26 @@ url = {http://en.wikipedia.org/wiki/CIECAM02},
 urldate = {2014-08-14},
 year = {2007}
 }
-@misc{Wikipedia2005c,
+@misc{Wikipedia2008b,
 author = {Wikipedia},
-title = {{Luminous Efficacy}},
-url = {https://en.wikipedia.org/wiki/Luminous_efficacy},
-urldate = {2016-04-03},
+title = {{Color difference}},
+url = {http://en.wikipedia.org/wiki/Color{\_}difference},
+urldate = {2014-08-29},
+year = {2008}
+}
+@misc{Wikipedia2003b,
+author = {Wikipedia},
+title = {{Luminosity function}},
+url = {https://en.wikipedia.org/wiki/Luminosity{\_}function{\#}Details},
+urldate = {2014-10-20},
+year = {2003}
+}
+@misc{Wikipedia2005d,
+author = {Wikipedia},
+title = {{Mesopic weighting function}},
+url = {http://en.wikipedia.org/wiki/Mesopic{\_}vision{\#}Mesopic{\_}weighting{\_}function},
+urldate = {2014-06-20},
 year = {2005}
-}
-@misc{Wikipedia2005a,
-author = {Wikipedia},
-title = {{ISO 31-11}},
-url = {https://en.wikipedia.org/wiki/ISO_31-11},
-urldate = {2016-07-31},
-year = {2005}
-}
-@misc{Wikipedia2001a,
-author = {Wikipedia},
-title = {{Color temperature}},
-url = {http://en.wikipedia.org/wiki/Color_temperature},
-urldate = {2014-06-28},
-year = {2001}
-}
-@misc{Wikipedia2004c,
-author = {Wikipedia},
-title = {{Wide-gamut RGB color space}},
-url = {http://en.wikipedia.org/wiki/Wide-gamut_RGB_color_space},
-urldate = {2014-04-13},
-year = {2004}
-}
-@misc{Wikipedia2007d,
-author = {Wikipedia},
-title = {{The reverse transformation}},
-url = {http://en.wikipedia.org/wiki/CIELUV#The_reverse_transformation},
-urldate = {2014-02-24},
-year = {2007}
-}
-@misc{Wikipedia2007c,
-author = {Wikipedia},
-title = {{Lightness}},
-url = {http://en.wikipedia.org/wiki/Lightness},
-urldate = {2014-04-13},
-year = {2007}
 }
 @misc{Wikipedia2004b,
 author = {Wikipedia},
@@ -2269,17 +2213,122 @@ url = {http://en.wikipedia.org/wiki/Whiteness},
 urldate = {2014-09-17},
 year = {2004}
 }
-@misc{Wikipedia2003,
+@misc{Wikipedia2005c,
 author = {Wikipedia},
-title = {{HSL and HSV}},
-url = {http://en.wikipedia.org/wiki/HSL_and_HSV},
-urldate = {2014-09-10},
+title = {{Luminous Efficacy}},
+url = {https://en.wikipedia.org/wiki/Luminous{\_}efficacy},
+urldate = {2016-04-03},
+year = {2005}
+}
+@misc{Wikipedia2006a,
+author = {Wikipedia},
+title = {{White points of standard illuminants}},
+url = {http://en.wikipedia.org/wiki/Standard{\_}illuminant{\#}White{\_}points{\_}of{\_}standard{\_}illuminants},
+urldate = {2014-02-24},
+year = {2006}
+}
+@misc{Wikipedia2005b,
+author = {Wikipedia},
+title = {{Lanczos resampling}},
+url = {https://en.wikipedia.org/wiki/Lanczos{\_}resampling},
+urldate = {2017-10-14},
+year = {2005}
+}
+@misc{Wikipedia2003d,
+author = {Wikipedia},
+title = {{Michaelis–Menten kinetics}},
+url = {https://en.wikipedia.org/wiki/Michaelis–Menten{\_}kinetics},
+urldate = {2017-04-29},
 year = {2003}
+}
+@misc{Wikipedia2001a,
+author = {Wikipedia},
+title = {{Color temperature}},
+url = {http://en.wikipedia.org/wiki/Color{\_}temperature},
+urldate = {2014-06-28},
+year = {2001}
+}
+@misc{Wikipedia2003e,
+author = {Wikipedia},
+title = {{Vandermonde matrix}},
+url = {https://en.wikipedia.org/wiki/Vandermonde{\_}matrix},
+urldate = {2018-05-02},
+year = {2003}
+}
+@misc{Wikipedia2003c,
+author = {Wikipedia},
+title = {{Mean squared error}},
+url = {https://en.wikipedia.org/wiki/Mean{\_}squared{\_}error},
+urldate = {2018-03-05},
+year = {2003}
+}
+@misc{Wikipedia2007,
+author = {Wikipedia},
+title = {{CAT02}},
+url = {http://en.wikipedia.org/wiki/CIECAM02{\#}CAT02},
+urldate = {2014-02-24},
+year = {2007}
+}
+@misc{Wikipedia2005,
+author = {Wikipedia},
+title = {{CIE 1931 color space}},
+url = {http://en.wikipedia.org/wiki/CIE{\_}1931{\_}color{\_}space},
+urldate = {2014-02-24},
+year = {2005}
+}
+@misc{Wikipedia2008,
+author = {Wikipedia},
+title = {{CIE 1960 color space}},
+url = {http://en.wikipedia.org/wiki/CIE{\_}1960{\_}color{\_}space},
+urldate = {2014-02-24},
+year = {2008}
+}
+@misc{Wikipedia2004d,
+author = {Wikipedia},
+title = {{YCbCr}},
+url = {https://en.wikipedia.org/wiki/YCbCr},
+urldate = {2016-02-29},
+year = {2004}
+}
+@misc{Wikipedia2001,
+author = {Wikipedia},
+title = {{Approximation}},
+url = {http://en.wikipedia.org/wiki/Color{\_}temperature{\#}Approximation},
+urldate = {2014-06-28},
+year = {2001}
+}
+@misc{Wikipedia2001c,
+author = {Wikipedia},
+title = {{Rayleigh scattering}},
+url = {http://en.wikipedia.org/wiki/Rayleigh{\_}scattering},
+urldate = {2014-09-23},
+year = {2001}
+}
+@misc{Wikipedia2008a,
+author = {Wikipedia},
+title = {{CIE 1964 color space}},
+url = {http://en.wikipedia.org/wiki/CIE{\_}1964{\_}color{\_}space},
+urldate = {2014-06-10},
+year = {2008}
+}
+@misc{Wikipedia2004c,
+author = {Wikipedia},
+title = {{Wide-gamut RGB color space}},
+url = {http://en.wikipedia.org/wiki/Wide-gamut{\_}RGB{\_}color{\_}space},
+urldate = {2014-04-13},
+year = {2004}
+}
+@misc{Wikipedia2008c,
+author = {Wikipedia},
+title = {{Relation to CIE XYZ}},
+url = {http://en.wikipedia.org/wiki/CIE{\_}1960{\_}color{\_}space{\#}Relation{\_}to{\_}CIE{\_}XYZ},
+urldate = {2014-02-24},
+year = {2008}
 }
 @misc{Wikipedia2004,
 author = {Wikipedia},
 title = {{Peak signal-to-noise ratio}},
-url = {https://en.wikipedia.org/wiki/Peak_signal-to-noise_ratio},
+url = {https://en.wikipedia.org/wiki/Peak{\_}signal-to-noise{\_}ratio},
 urldate = {2018-03-05},
 year = {2004}
 }
@@ -2314,6 +2363,78 @@ publisher = {Wiley},
 title = {{Table 2(5.4.1) MacAdam Ellipses (Observer PGN) Observed and Calculated on the Basis of a Normal Distribution of Color Matches about a Color Center (Silberstein and MacAdam, 1945)}},
 year = {2000}
 }
+@incollection{Wyszecki2000a,
+author = {Wyszecki, G{\"{u}}nther and Stiles, W S},
+booktitle = {Color Science: Concepts and Methods, Quantitative Data and Formulae},
+isbn = {978-0471399186},
+pages = {8},
+publisher = {Wiley},
+title = {{Equation I(1.2.1)}},
+year = {2000}
+}
+@incollection{Wyszecki2000ba,
+author = {Wyszecki, G{\"{u}}nther and Stiles, W. S.},
+booktitle = {Color Science: Concepts and Methods, Quantitative Data and Formulae},
+isbn = {978-0471399186},
+pages = {837--839},
+publisher = {Wiley},
+title = {{Table I(6.5.3) Whiteness Formulae (Whiteness Measure Denoted by W)}},
+year = {2000}
+}
+@incollection{Wyszecki2000bf,
+author = {Wyszecki, G{\"{u}}nther and Stiles, W. S.},
+booktitle = {Color Science: Concepts and Methods, Quantitative Data and Formulae},
+isbn = {978-0471399186},
+pages = {158--163},
+publisher = {Wiley},
+title = {{Integration Replaced by Summation}},
+year = {2000}
+}
+@incollection{Wyszecki2000y,
+author = {Wyszecki, G{\"{u}}nther and Stiles, W. S.},
+booktitle = {Color Science: Concepts and Methods, Quantitative Data and Formulae},
+isbn = {978-0471399186},
+pages = {224--229},
+publisher = {Wiley},
+title = {{DISTRIBUTION TEMPERATURE, COLOR TEMPERATURE, AND CORRELATED COLOR TEMPERATURE}},
+year = {2000}
+}
+@incollection{Wyszecki2000be,
+author = {Wyszecki, G{\"{u}}nther and Stiles, W. S.},
+booktitle = {Color Science: Concepts and Methods, Quantitative Data and Formulae},
+isbn = {978-0471399186},
+pages = {141},
+publisher = {Wiley},
+title = {{The CIE 1964 Standard Observer}},
+year = {2000}
+}
+@incollection{Wyszecki2000s,
+author = {Wyszecki, G{\"{u}}nther and Stiles, W. S.},
+booktitle = {Color Science: Concepts and Methods, Quantitative Data and Formulae},
+isbn = {978-0471399186},
+pages = {256--259,395},
+publisher = {Wiley},
+title = {{Standard Photometric Observers}},
+year = {2000}
+}
+@incollection{Wyszecki2000x,
+author = {Wyszecki, G{\"{u}}nther and Stiles, W. S.},
+booktitle = {Color Science: Concepts and Methods, Quantitative Data and Formulae},
+isbn = {978-0471399186},
+pages = {228},
+publisher = {Wiley},
+title = {{Table 1(3.11) Isotemperature Lines}},
+year = {2000}
+}
+@incollection{Wyszecki2000bh,
+author = {Wyszecki, G{\"{u}}nther and Stiles, W. S.},
+booktitle = {Color Science: Concepts and Methods, Quantitative Data and Formulae},
+isbn = {978-0471399186},
+pages = {778--779},
+publisher = {Wiley},
+title = {{Table II(3.7)}},
+year = {2000}
+}
 @incollection{Wyszecki2000bd,
 author = {Wyszecki, G{\"{u}}nther and Stiles, W. S.},
 booktitle = {Color Science: Concepts and Methods, Quantitative Data and Formulae},
@@ -2330,60 +2451,6 @@ isbn = {978-0471399186},
 pages = {145--146},
 publisher = {Wiley},
 title = {{CIE Method of Calculating D-Illuminants}},
-year = {2000}
-}
-@incollection{Wyszecki2000y,
-author = {Wyszecki, G{\"{u}}nther and Stiles, W. S.},
-booktitle = {Color Science: Concepts and Methods, Quantitative Data and Formulae},
-isbn = {978-0471399186},
-pages = {224--229},
-publisher = {Wiley},
-title = {{DISTRIBUTION TEMPERATURE, COLOR TEMPERATURE, AND CORRELATED COLOR TEMPERATURE}},
-year = {2000}
-}
-@incollection{Wyszecki2000x,
-author = {Wyszecki, G{\"{u}}nther and Stiles, W. S.},
-booktitle = {Color Science: Concepts and Methods, Quantitative Data and Formulae},
-isbn = {978-0471399186},
-pages = {228},
-publisher = {Wiley},
-title = {{Table 1(3.11) Isotemperature Lines}},
-year = {2000}
-}
-@incollection{Wyszecki2000bf,
-author = {Wyszecki, G{\"{u}}nther and Stiles, W. S.},
-booktitle = {Color Science: Concepts and Methods, Quantitative Data and Formulae},
-isbn = {978-0471399186},
-pages = {158--163},
-publisher = {Wiley},
-title = {{Integration Replaced by Summation}},
-year = {2000}
-}
-@incollection{Wyszecki2000ba,
-author = {Wyszecki, G{\"{u}}nther and Stiles, W. S.},
-booktitle = {Color Science: Concepts and Methods, Quantitative Data and Formulae},
-isbn = {978-0471399186},
-pages = {837--839},
-publisher = {Wiley},
-title = {{Table I(6.5.3) Whiteness Formulae (Whiteness Measure Denoted by W)}},
-year = {2000}
-}
-@incollection{Wyszecki2000bh,
-author = {Wyszecki, G{\"{u}}nther and Stiles, W. S.},
-booktitle = {Color Science: Concepts and Methods, Quantitative Data and Formulae},
-isbn = {978-0471399186},
-pages = {778--779},
-publisher = {Wiley},
-title = {{Table II(3.7)}},
-year = {2000}
-}
-@incollection{Wyszecki2000be,
-author = {Wyszecki, G{\"{u}}nther and Stiles, W. S.},
-booktitle = {Color Science: Concepts and Methods, Quantitative Data and Formulae},
-isbn = {978-0471399186},
-pages = {141},
-publisher = {Wiley},
-title = {{The CIE 1964 Standard Observer}},
 year = {2000}
 }
 @incollection{Wyszecki2000bg,
@@ -2404,19 +2471,10 @@ publisher = {Wiley},
 title = {{Table I(3.7)}},
 year = {2000}
 }
-@incollection{Wyszecki2000s,
-author = {Wyszecki, G{\"{u}}nther and Stiles, W. S.},
-booktitle = {Color Science: Concepts and Methods, Quantitative Data and Formulae},
-isbn = {978-0471399186},
-pages = {256--259,395},
-publisher = {Wiley},
-title = {{Standard Photometric Observers}},
-year = {2000}
-}
 @misc{X-Rite2015,
 author = {X-Rite},
 title = {{New color specifications for ColorChecker SG and Classic Charts}},
-url = {http://xritephoto.com/ph_product_overview.aspx?ID=938&Action=Support&SupportID=5884#},
+url = {http://xritephoto.com/ph{\_}product{\_}overview.aspx?ID=938{\&}Action=Support{\&}SupportID=5884{\#}},
 urldate = {2018-10-29},
 year = {2015}
 }
@@ -2426,7 +2484,7 @@ file = {:Users/kelsolaar/Google Drive/Documents/Mendeley Desktop/X-Rite, Pantone
 number = {July},
 pages = {1--31},
 title = {{Color iQC and Color iMatch Color Calculations Guide}},
-url = {https://www.xrite.com/-/media/xrite/files/apps_engineering_techdocuments/c/09_color_calculations_en.pdf},
+url = {https://www.xrite.com/-/media/xrite/files/apps{\_}engineering{\_}techdocuments/c/09{\_}color{\_}calculations{\_}en.pdf},
 year = {2012}
 }
 @misc{Yorke2014a,

--- a/colour/colorimetry/__init__.py
+++ b/colour/colorimetry/__init__.py
@@ -33,7 +33,7 @@ from .correction import BANDPASS_CORRECTION_METHODS
 from .correction import bandpass_correction
 from .correction import bandpass_correction_Stearns1988
 from .illuminants import (sd_CIE_standard_illuminant_A,
-                          sd_CIE_illuminant_D_series)
+                          sd_CIE_illuminant_D_series, daylight_locus_function)
 from .lefs import (sd_mesopic_luminous_efficiency_function,
                    mesopic_weighting_function)
 from .lightness import LIGHTNESS_METHODS
@@ -95,8 +95,8 @@ __all__ += ['BANDPASS_CORRECTION_METHODS']
 __all__ += ['bandpass_correction']
 __all__ += ['bandpass_correction_Stearns1988']
 __all__ += [
-    'sd_CIE_standard_illuminant_A',
-    'sd_CIE_illuminant_D_series',
+    'sd_CIE_standard_illuminant_A', 'sd_CIE_illuminant_D_series',
+    'daylight_locus_function'
 ]
 __all__ += [
     'sd_mesopic_luminous_efficiency_function', 'mesopic_weighting_function'

--- a/colour/colorimetry/illuminants.py
+++ b/colour/colorimetry/illuminants.py
@@ -7,6 +7,7 @@ Defines *CIE* illuminants computation related objects:
 
 -   :func:`colour.sd_CIE_standard_illuminant_A`
 -   :func:`colour.sd_CIE_illuminant_D_series`
+-   :func:`colour.daylight_locus_function`
 
 See Also
 --------
@@ -21,6 +22,9 @@ References
 -   :cite:`CIETC1-482004n` : CIE TC 1-48. (2004). 3.1 Recommendations
     concerning standard physical data of illuminants. In CIE 015:2004
     Colorimetry, 3rd Edition (pp. 12-13). ISBN:978-3-901-90633-6
+-   :cite:`Wyszecki2000a` : Wyszecki, G., & Stiles, W. S. (2000). Equation
+    I(1.2.1). In Color Science: Concepts and Methods, Quantitative Data and
+    Formulae (p. 8). Wiley. ISBN:978-0471399186
 -   :cite:`Wyszecki2000z` : Wyszecki, G., & Stiles, W. S. (2000). CIE Method of
     Calculating D-Illuminants. In Color Science: Concepts and Methods,
     Quantitative Data and Formulae (pp. 145-146). Wiley. ISBN:978-0471399186
@@ -32,7 +36,7 @@ import numpy as np
 
 from colour.colorimetry import (DEFAULT_SPECTRAL_SHAPE, D_ILLUMINANTS_S_SDS,
                                 SpectralDistribution)
-from colour.utilities import tsplit
+from colour.utilities import as_float_array, as_numeric, tsplit
 
 __author__ = 'Colour Developers'
 __copyright__ = 'Copyright (C) 2013-2018 - Colour Developers'
@@ -41,7 +45,10 @@ __maintainer__ = 'Colour Developers'
 __email__ = 'colour-science@googlegroups.com'
 __status__ = 'Production'
 
-__all__ = ['sd_CIE_standard_illuminant_A', 'sd_CIE_illuminant_D_series']
+__all__ = [
+    'sd_CIE_standard_illuminant_A', 'sd_CIE_illuminant_D_series',
+    'daylight_locus_function'
+]
 
 
 def sd_CIE_standard_illuminant_A(shape=DEFAULT_SPECTRAL_SHAPE):
@@ -290,3 +297,34 @@ def sd_CIE_illuminant_D_series(xy, M1_M2_rounding=True):
 
     return SpectralDistribution(
         distribution, S0.wavelengths, name='CIE Illuminant D Series')
+
+
+def daylight_locus_function(x_D):
+    """
+    Returns the daylight locus as *xy* chromaticity coordinates.
+
+    Parameters
+    ----------
+    x_D : numeric or array_like
+        *x* chromaticity coordinates
+
+    Returns
+    -------
+    numeric or array_like
+        Daylight locus as *xy* chromaticity coordinates.
+
+    References
+    ----------
+    :cite:`Wyszecki2000a`
+
+    Examples
+    --------
+    >>> daylight_locus_function(0.31270)  # doctest: +ELLIPSIS
+    0.3291051...
+    """
+
+    x_D = as_float_array(x_D)
+
+    y_D = -3.000 * x_D ** 2 + 2.870 * x_D - 0.275
+
+    return as_numeric(y_D)

--- a/colour/colorimetry/tests/test_illuminants.py
+++ b/colour/colorimetry/tests/test_illuminants.py
@@ -8,10 +8,11 @@ from __future__ import division, unicode_literals
 import numpy as np
 import unittest
 
-from colour.colorimetry import (ILLUMINANTS_SDS, SpectralShape,
-                                sd_CIE_standard_illuminant_A,
-                                sd_CIE_illuminant_D_series)
+from colour.colorimetry import (
+    ILLUMINANTS_SDS, SpectralShape, sd_CIE_standard_illuminant_A,
+    sd_CIE_illuminant_D_series, daylight_locus_function)
 from colour.temperature import CCT_to_xy_CIE_D
+from colour.utilities import ignore_numpy_errors
 
 __author__ = 'Colour Developers'
 __copyright__ = 'Copyright (C) 2013-2018 - Colour Developers'
@@ -21,7 +22,8 @@ __email__ = 'colour-science@googlegroups.com'
 __status__ = 'Production'
 
 __all__ = [
-    'A_DATA', 'TestSdCIEStandardIlluminantA', 'TestSd_CIEIlluminantDSeries'
+    'A_DATA', 'TestSdCIEStandardIlluminantA', 'TestSd_CIEIlluminantDSeries',
+    'TestDaylightLocusFunction'
 ]
 
 A_DATA = np.array([
@@ -169,6 +171,60 @@ sd_CIE_illuminant_D_series` definition.
                 sd_t[sd_r.wavelengths],
                 rtol=tolerance,
                 atol=tolerance)
+
+
+class TestDaylightLocusFunction(unittest.TestCase):
+    """
+    Defines :func:`colour.colorimetry.illuminants.daylight_locus_function`
+    definition unit tests methods.
+    """
+
+    def test_daylight_locus_function(self):
+        """
+        Tests :func:`colour.colorimetry.illuminants.daylight_locus_function`
+        definition.
+        """
+
+        self.assertAlmostEqual(
+            daylight_locus_function(0.31270), 0.329105129999999, places=7)
+
+        self.assertAlmostEqual(
+            daylight_locus_function(0.34570), 0.358633529999999, places=7)
+
+        self.assertAlmostEqual(
+            daylight_locus_function(0.44758), 0.408571030799999, places=7)
+
+    def test_n_dimensional_daylight_locus_function(self):
+        """
+        Tests :func:`colour.colorimetry.illuminants.daylight_locus_function`
+        definition n-dimensions support.
+        """
+
+        x_D = np.array([0.31270])
+        y_D = np.array([0.329105129999999])
+        np.testing.assert_almost_equal(
+            daylight_locus_function(x_D), y_D, decimal=7)
+
+        x_D = np.tile(x_D, (6, 1))
+        y_D = np.tile(y_D, (6, 1))
+        np.testing.assert_almost_equal(
+            daylight_locus_function(x_D), y_D, decimal=7)
+
+        x_D = np.reshape(x_D, (2, 3, 1))
+        y_D = np.reshape(y_D, (2, 3, 1))
+        np.testing.assert_almost_equal(
+            daylight_locus_function(x_D), y_D, decimal=7)
+
+    @ignore_numpy_errors
+    def test_nan_daylight_locus_function(self):
+        """
+        Tests :func:`colour.colorimetry.illuminants.daylight_locus_function`
+        definition nan support.
+        """
+
+        cases = [-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan]
+        for case in cases:
+            daylight_locus_function(case)
 
 
 if __name__ == '__main__':

--- a/colour/temperature/cct.py
+++ b/colour/temperature/cct.py
@@ -89,9 +89,9 @@ from __future__ import division, unicode_literals
 import numpy as np
 from collections import namedtuple
 
-from colour.colorimetry import (ASTME30815_PRACTISE_SHAPE,
-                                STANDARD_OBSERVERS_CMFS, sd_blackbody,
-                                sd_to_XYZ)
+from colour.colorimetry import (
+    ASTME30815_PRACTISE_SHAPE, STANDARD_OBSERVERS_CMFS,
+    daylight_locus_function, sd_blackbody, sd_to_XYZ)
 from colour.models import UCS_to_uv, XYZ_to_UCS
 from colour.utilities import (CaseInsensitiveMapping, as_float_array, as_float,
                               filter_kwargs, runtime_warning, tsplit, tstack,
@@ -980,7 +980,7 @@ def CCT_to_xy_CIE_D(CCT):
         0.24748 * 10 ** 3 / CCT + 0.23704,
     )
 
-    y = -3 * x ** 2 + 2.87 * x - 0.275
+    y = daylight_locus_function(x)
 
     xy = tstack([x, y])
 

--- a/docs/colour.colorimetry.rst
+++ b/docs/colour.colorimetry.rst
@@ -50,6 +50,7 @@ Spectral Data Generation
     :toctree: generated/
 
     blackbody_spectral_radiance
+    daylight_locus_function
     planck_law
     sd_gaussian_normal
     sd_gaussian_fwhm

--- a/docs/generated/colour.colorimetry.daylight_locus_function.rst
+++ b/docs/generated/colour.colorimetry.daylight_locus_function.rst
@@ -1,0 +1,6 @@
+colour.colorimetry.daylight\_locus\_function
+============================================
+
+.. currentmodule:: colour.colorimetry
+
+.. autofunction:: daylight_locus_function


### PR DESCRIPTION
We are computing the *Daylight Locus* implicitly here: https://github.com/colour-science/colour/blob/cd891c2abed839d350423b02e30c9f78e01a8071/colour/temperature/cct.py#L983 but this PR exposes it as a proper function so that it can be specified from a chromaticity coordinate `x_D` as given in Wyszecki and Styles (2000).