### PR TITLE
Add Colorio to "See Also" section of README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1079,8 +1079,9 @@ Here is a list of notable colour science packages sorted by languages:
 **Python**
 
 - `ColorPy <http://markkness.net/colorpy/ColorPy.html>`_ by Kness, M.
-- `Colorspacious <http://colorspacious.readthedocs.io/>`_ by Smith, N. J., et al.
 - `python-colormath <http://python-colormath.readthedocs.io/>`_ by Taylor, G., et al.
+- `Colorio <https://github.com/nschloe/colorio/>`_  by Schlömer, N.
+- `Colorspacious <http://colorspacious.readthedocs.io/>`_ by Smith, N. J., et al.
 
 **.NET**
 


### PR DESCRIPTION
The Colorspacious Python library is good but it doesn't include more recent models than CAM02-UCS such as CAM-16, Jzazbz, ICtCp etc. Colorio supports these.

The Colorspacious author clearly states inability to update the library:
https://github.com/njsmith/colorspacious/issues/10
https://github.com/njsmith/colorspacious/issues/13

So definitely Colorio should be mentioned above Colorspacious as it is better than the letter.