### PR TITLE
PR: Implement support for n-dimensional arrays and multiprocessing to various definitions.

### DIFF
--- a/colour/examples/temperature/examples_cct.py
+++ b/colour/examples/temperature/examples_cct.py
@@ -34,25 +34,26 @@ print(colour.temperature.uv_to_CCT_Robertson1968(uv))
 
 print('\n')
 
-CCT, D_uv = 6503.49254150, 0.00320598
+CCT_D_uv = [6503.49254150, 0.00320598]
 message_box(('Converting to "CIE UCS" colourspace "uv" chromaticity '
              'coordinates from given "CCT" and "D_uv" using '
              '"Ohno (2013)" method:\n'
-             '\n\t({0}, {1})'.format(CCT, D_uv)))
-print(colour.CCT_to_uv(CCT, D_uv=D_uv, cmfs=cmfs))
-print(colour.temperature.CCT_to_uv_Ohno2013(CCT, D_uv, cmfs=cmfs))
+             '\n\t{0}'.format(CCT_D_uv)))
+print(colour.CCT_to_uv(CCT_D_uv, cmfs=cmfs))
+print(colour.temperature.CCT_to_uv_Ohno2013(CCT_D_uv, cmfs=cmfs))
 
 print('\n')
 
 message_box(('Converting to "CIE UCS" colourspace "uv" chromaticity '
              'coordinates from given "CCT" and "D_uv" using '
              '"Robertson (1968)" method:\n'
-             '\n\t({0}, {1})'.format(CCT, D_uv)))
-print(colour.CCT_to_uv(CCT, D_uv=D_uv, method='Robertson 1968'))
-print(colour.temperature.CCT_to_uv_Robertson1968(CCT, D_uv))
+             '\n\t{0}'.format(CCT_D_uv)))
+print(colour.CCT_to_uv(CCT_D_uv, method='Robertson 1968'))
+print(colour.temperature.CCT_to_uv_Robertson1968(CCT_D_uv))
 
 print('\n')
 
+CCT = 6503.49254150
 message_box(('Converting to "CIE UCS" colourspace "uv" chromaticity '
              'coordinates from given "CCT" using "Krystek (1985)" method:\n'
              '\n\t({0})'.format(CCT)))

--- a/colour/notation/munsell.py
+++ b/colour/notation/munsell.py
@@ -123,7 +123,6 @@ from __future__ import division, unicode_literals
 import numpy as np
 import re
 from collections import OrderedDict
-from functools import partial
 
 from colour.algebra import (Extrapolator, LinearInterpolator,
                             cartesian_to_cylindrical, euclidean_distance,
@@ -137,8 +136,8 @@ from colour.notation import MUNSELL_COLOURS_ALL
 from colour.utilities import (
     CaseInsensitiveMapping, Lookup, as_float_array, as_float, as_int,
     as_numeric, domain_range_scale, from_range_1, from_range_10,
-    get_domain_range_scale, multiprocessing_pool, to_domain_1, to_domain_10,
-    to_domain_100, is_integer, is_numeric, tsplit, usage_warning)
+    get_domain_range_scale, to_domain_1, to_domain_10, to_domain_100,
+    is_integer, is_numeric, tsplit, usage_warning)
 
 __author__ = 'Colour Developers, Paul Centore'
 __copyright__ = 'Copyright (C) 2013-2019 - Colour Developers'
@@ -843,9 +842,10 @@ def munsell_specification_to_xyY(specification):
     specification = as_float_array(specification)
     shape = list(specification.shape)
 
-    with multiprocessing_pool() as pool:
-        xyY = pool.map(_munsell_specification_to_xyY,
-                       specification.reshape([-1, 4]))
+    xyY = [
+        _munsell_specification_to_xyY(a)
+        for a in specification.reshape([-1, 4])
+    ]
 
     shape[-1] = 3
 
@@ -890,11 +890,10 @@ def munsell_colour_to_xyY(munsell_colour):
     munsell_colour = np.array(munsell_colour)
     shape = list(munsell_colour.shape)
 
-    with multiprocessing_pool() as pool:
-        specification = np.array([
-            pool.map(munsell_colour_to_munsell_specification,
-                     np.ravel(munsell_colour))
-        ])
+    specification = np.array([
+        munsell_colour_to_munsell_specification(a)
+        for a in np.ravel(munsell_colour)
+    ])
 
     return munsell_specification_to_xyY(specification.reshape(shape + [4]))
 
@@ -1190,9 +1189,9 @@ def xyY_to_munsell_specification(xyY):
     xyY = as_float_array(xyY)
     shape = list(xyY.shape)
 
-    with multiprocessing_pool() as pool:
-        specification = pool.map(_xyY_to_munsell_specification,
-                                 xyY.reshape([-1, 3]))
+    specification = [
+        _xyY_to_munsell_specification(a) for a in xyY.reshape([-1, 3])
+    ]
 
     shape[-1] = 4
 
@@ -1246,15 +1245,11 @@ def xyY_to_munsell_colour(xyY,
     specification = xyY_to_munsell_specification(xyY)
     shape = list(specification.shape)
 
-    with multiprocessing_pool() as pool:
-        munsell_colour = pool.map(
-            partial(
-                munsell_specification_to_munsell_colour,
-                hue_decimals=hue_decimals,
-                value_decimals=value_decimals,
-                chroma_decimals=chroma_decimals),
-            specification.reshape([-1, 4]))
-
+    munsell_colour = [
+        munsell_specification_to_munsell_colour(
+            a, hue_decimals, value_decimals, chroma_decimals)
+        for a in specification.reshape([-1, 4])
+    ]
     munsell_colour = np.array(munsell_colour).reshape(shape[:-1])
     munsell_colour = str(munsell_colour) if shape == [4] else munsell_colour
 

--- a/colour/notation/tests/test_munsell.py
+++ b/colour/notation/tests/test_munsell.py
@@ -35,8 +35,8 @@ from colour.notation import (munsell_value_Priest1920,
                              munsell_value_Saunderson1944,
                              munsell_value_Ladd1955, munsell_value_McCamy1987,
                              munsell_value_ASTMD153508)
-from colour.utilities import (as_float_array, disable_multiprocessing,
-                              domain_range_scale, ignore_numpy_errors, tstack)
+from colour.utilities import (as_float_array, domain_range_scale,
+                              ignore_numpy_errors, tstack)
 
 __author__ = 'Colour Developers'
 __copyright__ = 'Copyright (C) 2013-2019 - Colour Developers'
@@ -1357,7 +1357,6 @@ class TestMunsellSpecification_to_xyY(unittest.TestCase):
         np.testing.assert_almost_equal(
             munsell_specification_to_xyY(specification), xyY, decimal=7)
 
-    @disable_multiprocessing()
     def test_domain_range_scale_munsell_specification_to_xyY(self):
         """
         Tests :func:`colour.notation.munsell.munsell_specification_to_xyY`
@@ -1381,7 +1380,6 @@ class TestMunsellSpecification_to_xyY(unittest.TestCase):
                     decimal=7)
 
     @ignore_numpy_errors
-    @disable_multiprocessing()
     def test_nan_munsell_specification_to_xyY(self):
         """
         Tests :func:`colour.notation.munsell.munsell_specification_to_xyY`
@@ -1475,7 +1473,6 @@ class TestxyY_to_munsell_specification(unittest.TestCase):
             rtol=0.00001,
             atol=0.00001)
 
-    @disable_multiprocessing()
     def test_n_dimensional_xyY_to_munsell_specification(self):
         """
         Tests :func:`colour.notation.munsell.xyY_to_munsell_specification`
@@ -1518,7 +1515,6 @@ class TestxyY_to_munsell_specification(unittest.TestCase):
                     atol=0.00001)
 
     @ignore_numpy_errors
-    @disable_multiprocessing()
     def test_nan_xyY_to_munsell_specification(self):
         """
         Tests :func:`colour.notation.munsell.xyY_to_munsell_specification`

--- a/colour/notation/tests/test_munsell.py
+++ b/colour/notation/tests/test_munsell.py
@@ -35,7 +35,8 @@ from colour.notation import (munsell_value_Priest1920,
                              munsell_value_Saunderson1944,
                              munsell_value_Ladd1955, munsell_value_McCamy1987,
                              munsell_value_ASTMD153508)
-from colour.utilities import domain_range_scale, ignore_numpy_errors
+from colour.utilities import (as_float_array, disable_multiprocessing,
+                              domain_range_scale, ignore_numpy_errors, tstack)
 
 __author__ = 'Colour Developers'
 __copyright__ = 'Copyright (C) 2013-2019 - Colour Developers'
@@ -1304,16 +1305,24 @@ class TestMunsellSpecification_to_xyY(unittest.TestCase):
         definition.
         """
 
-        for specification, xyY in MUNSELL_SPECIFICATIONS:
-            np.testing.assert_almost_equal(
-                munsell_specification_to_xyY(specification), xyY, decimal=7)
+        specification, xyY = (
+            as_float_array(list(MUNSELL_SPECIFICATIONS[..., 0])),
+            as_float_array(list(MUNSELL_SPECIFICATIONS[..., 1])),
+        )
+        np.testing.assert_almost_equal(
+            munsell_specification_to_xyY(specification), xyY, decimal=7)
 
-        for specification, xyY in MUNSELL_GREYS_SPECIFICATIONS:
-            np.testing.assert_almost_equal(
-                munsell_specification_to_xyY(
-                    np.array([np.nan, specification[0], np.nan, np.nan])),
-                xyY,
-                decimal=7)
+        specification, xyY = (
+            as_float_array(list(MUNSELL_GREYS_SPECIFICATIONS[..., 0])),
+            as_float_array(list(MUNSELL_GREYS_SPECIFICATIONS[..., 1])),
+        )
+        specification = np.squeeze(specification)
+        nan_array = np.full(specification.shape, np.nan)
+        specification = tstack(
+            [nan_array, specification, nan_array, nan_array])
+
+        np.testing.assert_almost_equal(
+            munsell_specification_to_xyY(specification), xyY, decimal=7)
 
     def test_n_dimensional_munsell_specification_to_xyY(self):
         """
@@ -1348,6 +1357,7 @@ class TestMunsellSpecification_to_xyY(unittest.TestCase):
         np.testing.assert_almost_equal(
             munsell_specification_to_xyY(specification), xyY, decimal=7)
 
+    @disable_multiprocessing()
     def test_domain_range_scale_munsell_specification_to_xyY(self):
         """
         Tests :func:`colour.notation.munsell.munsell_specification_to_xyY`
@@ -1371,6 +1381,7 @@ class TestMunsellSpecification_to_xyY(unittest.TestCase):
                     decimal=7)
 
     @ignore_numpy_errors
+    @disable_multiprocessing()
     def test_nan_munsell_specification_to_xyY(self):
         """
         Tests :func:`colour.notation.munsell.munsell_specification_to_xyY`
@@ -1392,16 +1403,6 @@ class TestMunsellColour_to_xyY(unittest.TestCase):
     Defines :func:`colour.notation.munsell.munsell_colour_to_xyY` definition
     unit tests methods.
     """
-
-    def test_munsell_colour_to_xyY(self):
-        """
-        Tests :func:`colour.notation.munsell.munsell_colour_to_xyY` definition.
-        """
-
-        # TODO: This test is covered by the previous class,
-        # do we need a dedicated one?
-
-        pass
 
     def test_n_dimensional_munsell_colour_to_xyY(self):
         """
@@ -1448,20 +1449,33 @@ class TestxyY_to_munsell_specification(unittest.TestCase):
         definition.
         """
 
-        for specification, xyY in MUNSELL_SPECIFICATIONS:
-            np.testing.assert_allclose(
-                xyY_to_munsell_specification(xyY),
-                specification,
-                rtol=0.00001,
-                atol=0.00001)
+        specification, xyY = (
+            as_float_array(list(MUNSELL_SPECIFICATIONS[..., 0])),
+            as_float_array(list(MUNSELL_SPECIFICATIONS[..., 1])),
+        )
 
-        for specification, xyY in MUNSELL_GREYS_SPECIFICATIONS:
-            np.testing.assert_allclose(
-                xyY_to_munsell_specification(xyY),
-                np.array([np.nan, specification[0], np.nan, np.nan]),
-                rtol=0.00001,
-                atol=0.00001)
+        np.testing.assert_allclose(
+            xyY_to_munsell_specification(xyY),
+            specification,
+            rtol=0.00001,
+            atol=0.00001)
 
+        specification, xyY = (
+            as_float_array(list(MUNSELL_GREYS_SPECIFICATIONS[..., 0])),
+            as_float_array(list(MUNSELL_GREYS_SPECIFICATIONS[..., 1])),
+        )
+        specification = np.squeeze(specification)
+        nan_array = np.full(specification.shape, np.nan)
+        specification = tstack(
+            [nan_array, specification, nan_array, nan_array])
+
+        np.testing.assert_allclose(
+            xyY_to_munsell_specification(xyY),
+            specification,
+            rtol=0.00001,
+            atol=0.00001)
+
+    @disable_multiprocessing()
     def test_n_dimensional_xyY_to_munsell_specification(self):
         """
         Tests :func:`colour.notation.munsell.xyY_to_munsell_specification`
@@ -1504,6 +1518,7 @@ class TestxyY_to_munsell_specification(unittest.TestCase):
                     atol=0.00001)
 
     @ignore_numpy_errors
+    @disable_multiprocessing()
     def test_nan_xyY_to_munsell_specification(self):
         """
         Tests :func:`colour.notation.munsell.xyY_to_munsell_specification`
@@ -1525,16 +1540,6 @@ class TestxyY_to_munsell_colour(unittest.TestCase):
     Defines :func:`colour.notation.munsell.xyY_to_munsell_colour` definition
     unit tests methods.
     """
-
-    def test_xyY_to_munsell_colour(self):
-        """
-        Tests :func:`colour.notation.munsell.xyY_to_munsell_colour` definition.
-        """
-
-        # TODO: This test is covered by the previous class,
-        # do we need a dedicated one?
-
-        pass
 
     def test_n_dimensional_xyY_to_munsell_colour(self):
         """

--- a/colour/temperature/cct.py
+++ b/colour/temperature/cct.py
@@ -112,15 +112,13 @@ from __future__ import division, unicode_literals
 
 import numpy as np
 from collections import namedtuple
-from functools import partial
 
 from colour.colorimetry import (
     ASTME30815_PRACTISE_SHAPE, STANDARD_OBSERVERS_CMFS,
     daylight_locus_function, sd_blackbody, sd_to_XYZ)
 from colour.models import UCS_to_uv, XYZ_to_UCS
 from colour.utilities import (CaseInsensitiveMapping, as_float_array, as_float,
-                              filter_kwargs, multiprocessing_pool,
-                              runtime_warning, tsplit, tstack,
+                              filter_kwargs, runtime_warning, tsplit, tstack,
                               usage_warning)
 
 __author__ = 'Colour Developers'
@@ -457,11 +455,10 @@ def uv_to_CCT_Ohno2013(
 
     uv = as_float_array(uv)
 
-    with multiprocessing_pool() as pool:
-        CCT_D_uv = pool.map(
-            partial(_uv_to_CCT_Ohno2013, cmfs=cmfs, start=start, end=end,
-                    count=count, iterations=iterations),
-            np.reshape(uv, (-1, 2)))
+    CCT_D_uv = [
+        _uv_to_CCT_Ohno2013(a, cmfs, start, end, count, iterations)
+        for a in np.reshape(uv, (-1, 2))
+    ]
 
     return as_float_array(CCT_D_uv).reshape(uv.shape)
 
@@ -554,10 +551,7 @@ def CCT_to_uv_Ohno2013(
 
     CCT_D_uv = as_float_array(CCT_D_uv)
 
-    with multiprocessing_pool() as pool:
-        uv = pool.map(
-            partial(_CCT_to_uv_Ohno2013, cmfs=cmfs),
-            np.reshape(CCT_D_uv, (-1, 2)))
+    uv = [_CCT_to_uv_Ohno2013(a, cmfs) for a in np.reshape(CCT_D_uv, (-1, 2))]
 
     return as_float_array(uv).reshape(CCT_D_uv.shape)
 
@@ -661,9 +655,7 @@ def uv_to_CCT_Robertson1968(uv):
 
     uv = as_float_array(uv)
 
-    with multiprocessing_pool() as pool:
-        CCT_D_uv = pool.map(_uv_to_CCT_Robertson1968,
-                            np.reshape(uv, (-1, 2)))
+    CCT_D_uv = [_uv_to_CCT_Robertson1968(a) for a in np.reshape(uv, (-1, 2))]
 
     return as_float_array(CCT_D_uv).reshape(uv.shape)
 
@@ -754,9 +746,7 @@ def CCT_to_uv_Robertson1968(CCT_D_uv):
 
     CCT_D_uv = as_float_array(CCT_D_uv)
 
-    with multiprocessing_pool() as pool:
-        uv = pool.map(_CCT_to_uv_Robertson1968,
-                      np.reshape(CCT_D_uv, (-1, 2)))
+    uv = [_CCT_to_uv_Robertson1968(a) for a in np.reshape(CCT_D_uv, (-1, 2))]
 
     return as_float_array(uv).reshape(CCT_D_uv.shape)
 

--- a/colour/temperature/cct.py
+++ b/colour/temperature/cct.py
@@ -310,7 +310,7 @@ def planckian_table_minimal_distance_index(planckian_table_):
     return distances.index(min(distances))
 
 
-def uv_to_CCT_Ohno2013(
+def _uv_to_CCT_Ohno2013(
         uv,
         cmfs=STANDARD_OBSERVERS_CMFS['CIE 1931 2 Degree Standard Observer'],
         start=CCT_MINIMAL,
@@ -346,18 +346,6 @@ def uv_to_CCT_Ohno2013(
     -------
     ndarray
         Correlated colour temperature :math:`T_{cp}`, :math:`\\Delta_{uv}`.
-
-    References
-    ----------
-    :cite:`Ohno2014a`
-
-    Examples
-    --------
-    >>> from colour import STANDARD_OBSERVERS_CMFS
-    >>> cmfs = STANDARD_OBSERVERS_CMFS['CIE 1931 2 Degree Standard Observer']
-    >>> uv = np.array([0.1978, 0.3122])
-    >>> uv_to_CCT_Ohno2013(uv, cmfs)  # doctest: +ELLIPSIS
-    array([  6.5074738...e+03,   3.2233461...e-03])
     """
 
     # Ensuring we do at least one iteration to initialise variables.
@@ -414,28 +402,42 @@ def uv_to_CCT_Ohno2013(
     return np.array([T, D_uv])
 
 
-def CCT_to_uv_Ohno2013(
-        CCT,
-        D_uv=0,
-        cmfs=STANDARD_OBSERVERS_CMFS['CIE 1931 2 Degree Standard Observer']):
+def uv_to_CCT_Ohno2013(
+        uv,
+        cmfs=STANDARD_OBSERVERS_CMFS['CIE 1931 2 Degree Standard Observer'],
+        start=CCT_MINIMAL,
+        end=CCT_MAXIMAL,
+        count=CCT_SAMPLES,
+        iterations=CCT_CALCULATION_ITERATIONS):
     """
-    Returns the *CIE UCS* colourspace *uv* chromaticity coordinates from given
-    correlated colour temperature :math:`T_{cp}`, :math:`\\Delta_{uv}` and
-    colour matching functions using *Ohno (2013)* method.
+    Returns the correlated colour temperature :math:`T_{cp}` and
+    :math:`\\Delta_{uv}` from given *CIE UCS* colourspace *uv* chromaticity
+    coordinates, colour matching functions and temperature range using
+    *Ohno (2013)* method.
+
+    The iterations parameter defines the calculations precision: The higher its
+    value, the more planckian tables will be generated through cascade
+    expansion in order to converge to the exact solution.
 
     Parameters
     ----------
-    CCT : numeric
-        Correlated colour temperature :math:`T_{cp}`.
-    D_uv : numeric, optional
-        :math:`\\Delta_{uv}`.
+    uv : array_like
+        *CIE UCS* colourspace *uv* chromaticity coordinates.
     cmfs : XYZ_ColourMatchingFunctions, optional
         Standard observer colour matching functions.
+    start : numeric, optional
+        Temperature range start in kelvins.
+    end : numeric, optional
+        Temperature range end in kelvins.
+    count : int, optional
+        Temperatures count in the planckian tables.
+    iterations : int, optional
+        Number of planckian tables to generate.
 
     Returns
     -------
     ndarray
-        *CIE UCS* colourspace *uv* chromaticity coordinates.
+        Correlated colour temperature :math:`T_{cp}`, :math:`\\Delta_{uv}`.
 
     References
     ----------
@@ -445,11 +447,43 @@ def CCT_to_uv_Ohno2013(
     --------
     >>> from colour import STANDARD_OBSERVERS_CMFS
     >>> cmfs = STANDARD_OBSERVERS_CMFS['CIE 1931 2 Degree Standard Observer']
-    >>> CCT = 6507.4342201047066
-    >>> D_uv = 0.003223690901513
-    >>> CCT_to_uv_Ohno2013(CCT, D_uv, cmfs)  # doctest: +ELLIPSIS
-    array([ 0.1977999...,  0.3122004...])
+    >>> uv = np.array([0.1978, 0.3122])
+    >>> uv_to_CCT_Ohno2013(uv, cmfs)  # doctest: +ELLIPSIS
+    array([  6.5074738...e+03,   3.2233461...e-03])
     """
+
+    uv = as_float_array(uv)
+
+    CCT_D_uv = [
+        _uv_to_CCT_Ohno2013(a, cmfs, start, end, count, iterations)
+        for a in np.reshape(uv, (-1, 2))
+    ]
+
+    return as_float_array(CCT_D_uv).reshape(uv.shape)
+
+
+def _CCT_to_uv_Ohno2013(
+        CCT_D_uv,
+        cmfs=STANDARD_OBSERVERS_CMFS['CIE 1931 2 Degree Standard Observer']):
+    """
+    Returns the *CIE UCS* colourspace *uv* chromaticity coordinates from given
+    correlated colour temperature :math:`T_{cp}`, :math:`\\Delta_{uv}` and
+    colour matching functions using *Ohno (2013)* method.
+
+    Parameters
+    ----------
+    CCT_D_uv : ndarray
+        Correlated colour temperature :math:`T_{cp}`, :math:`\\Delta_{uv}`.
+    cmfs : XYZ_ColourMatchingFunctions, optional
+        Standard observer colour matching functions.
+
+    Returns
+    -------
+    ndarray
+        *CIE UCS* colourspace *uv* chromaticity coordinates.
+    """
+
+    CCT, D_uv = tsplit(CCT_D_uv)
 
     cmfs = cmfs.copy().trim(ASTME30815_PRACTISE_SHAPE)
 
@@ -481,7 +515,47 @@ def CCT_to_uv_Ohno2013(
         return np.array([u, v])
 
 
-def uv_to_CCT_Robertson1968(uv):
+def CCT_to_uv_Ohno2013(
+        CCT_D_uv,
+        cmfs=STANDARD_OBSERVERS_CMFS['CIE 1931 2 Degree Standard Observer']):
+    """
+    Returns the *CIE UCS* colourspace *uv* chromaticity coordinates from given
+    correlated colour temperature :math:`T_{cp}`, :math:`\\Delta_{uv}` and
+    colour matching functions using *Ohno (2013)* method.
+
+    Parameters
+    ----------
+    CCT_D_uv : ndarray
+        Correlated colour temperature :math:`T_{cp}`, :math:`\\Delta_{uv}`.
+    cmfs : XYZ_ColourMatchingFunctions, optional
+        Standard observer colour matching functions.
+
+    Returns
+    -------
+    ndarray
+        *CIE UCS* colourspace *uv* chromaticity coordinates.
+
+    References
+    ----------
+    :cite:`Ohno2014a`
+
+    Examples
+    --------
+    >>> from colour import STANDARD_OBSERVERS_CMFS
+    >>> cmfs = STANDARD_OBSERVERS_CMFS['CIE 1931 2 Degree Standard Observer']
+    >>> CCT_D_uv = np.array([6507.4342201047066, 0.003223690901513])
+    >>> CCT_to_uv_Ohno2013(CCT_D_uv, cmfs)  # doctest: +ELLIPSIS
+    array([ 0.1977999...,  0.3122004...])
+    """
+
+    CCT_D_uv = as_float_array(CCT_D_uv)
+
+    uv = [_CCT_to_uv_Ohno2013(a, cmfs) for a in np.reshape(CCT_D_uv, (-1, 2))]
+
+    return as_float_array(uv).reshape(CCT_D_uv.shape)
+
+
+def _uv_to_CCT_Robertson1968(uv):
     """
     Returns the correlated colour temperature :math:`T_{cp}` and
     :math:`\\Delta_{uv}` from given *CIE UCS* colourspace *uv* chromaticity
@@ -496,16 +570,6 @@ def uv_to_CCT_Robertson1968(uv):
     -------
     ndarray
         Correlated colour temperature :math:`T_{cp}`, :math:`\\Delta_{uv}`.
-
-    References
-    ----------
-    :cite:`AdobeSystems2013`, :cite:`Wyszecki2000y`
-
-    Examples
-    --------
-    >>> uv = np.array([0.193741375998230, 0.315221043940594])
-    >>> uv_to_CCT_Robertson1968(uv)  # doctest: +ELLIPSIS
-    array([  6.5000162...e+03,   8.3333289...e-03])
     """
 
     u, v = uv
@@ -561,7 +625,41 @@ def uv_to_CCT_Robertson1968(uv):
     return np.array([T, -D_uv])
 
 
-def CCT_to_uv_Robertson1968(CCT, D_uv=0):
+def uv_to_CCT_Robertson1968(uv):
+    """
+    Returns the correlated colour temperature :math:`T_{cp}` and
+    :math:`\\Delta_{uv}` from given *CIE UCS* colourspace *uv* chromaticity
+    coordinates using *Roberston (1968)* method.
+
+    Parameters
+    ----------
+    uv : array_like
+        *CIE UCS* colourspace *uv* chromaticity coordinates.
+
+    Returns
+    -------
+    ndarray
+        Correlated colour temperature :math:`T_{cp}`, :math:`\\Delta_{uv}`.
+
+    References
+    ----------
+    :cite:`AdobeSystems2013`, :cite:`Wyszecki2000y`
+
+    Examples
+    --------
+    >>> uv = np.array([0.193741375998230, 0.315221043940594])
+    >>> uv_to_CCT_Robertson1968(uv)  # doctest: +ELLIPSIS
+    array([  6.5000162...e+03,   8.3333289...e-03])
+    """
+
+    uv = as_float_array(uv)
+
+    CCT_D_uv = [_uv_to_CCT_Robertson1968(a) for a in np.reshape(uv, (-1, 2))]
+
+    return as_float_array(CCT_D_uv).reshape(uv.shape)
+
+
+def _CCT_to_uv_Robertson1968(CCT_D_uv):
     """
     Returns the *CIE UCS* colourspace *uv* chromaticity coordinates from given
     correlated colour temperature :math:`T_{cp}` and :math:`\\Delta_{uv}` using
@@ -569,27 +667,16 @@ def CCT_to_uv_Robertson1968(CCT, D_uv=0):
 
     Parameters
     ----------
-    CCT : numeric
-        Correlated colour temperature :math:`T_{cp}`.
-    D_uv : numeric
-        :math:`\\Delta_{uv}`.
+    CCT_D_uv : ndarray
+        Correlated colour temperature :math:`T_{cp}`, :math:`\\Delta_{uv}`.
 
     Returns
     -------
     ndarray
         *CIE UCS* colourspace *uv* chromaticity coordinates.
-
-    References
-    ----------
-    :cite:`AdobeSystems2013a`, :cite:`Wyszecki2000y`
-
-    Examples
-    --------
-    >>> CCT = 6500.0081378199056
-    >>> D_uv = 0.008333331244225
-    >>> CCT_to_uv_Robertson1968(CCT, D_uv)  # doctest: +ELLIPSIS
-    array([ 0.1937413...,  0.3152210...])
     """
+
+    CCT, D_uv = tsplit(CCT_D_uv)
 
     r = 1.0e6 / CCT
 
@@ -627,6 +714,40 @@ def CCT_to_uv_Robertson1968(CCT, D_uv=0):
             v += vv3 * -D_uv
 
             return np.array([u, v])
+
+
+def CCT_to_uv_Robertson1968(CCT_D_uv):
+    """
+    Returns the *CIE UCS* colourspace *uv* chromaticity coordinates from given
+    correlated colour temperature :math:`T_{cp}` and :math:`\\Delta_{uv}` using
+    *Roberston (1968)* method.
+
+    Parameters
+    ----------
+    CCT_D_uv : ndarray
+        Correlated colour temperature :math:`T_{cp}`, :math:`\\Delta_{uv}`.
+
+    Returns
+    -------
+    ndarray
+        *CIE UCS* colourspace *uv* chromaticity coordinates.
+
+    References
+    ----------
+    :cite:`AdobeSystems2013a`, :cite:`Wyszecki2000y`
+
+    Examples
+    --------
+    >>> CCT_D_uv = np.array([6500.0081378199056, 0.008333331244225])
+    >>> CCT_to_uv_Robertson1968(CCT_D_uv)  # doctest: +ELLIPSIS
+    array([ 0.1937413...,  0.3152210...])
+    """
+
+    CCT_D_uv = as_float_array(CCT_D_uv)
+
+    uv = [_CCT_to_uv_Robertson1968(a) for a in np.reshape(CCT_D_uv, (-1, 2))]
+
+    return as_float_array(uv).reshape(CCT_D_uv.shape)
 
 
 def CCT_to_uv_Krystek1985(CCT):
@@ -776,24 +897,21 @@ CCT_TO_UV_METHODS['ohno2013'] = CCT_TO_UV_METHODS['Ohno 2013']
 CCT_TO_UV_METHODS['robertson1968'] = CCT_TO_UV_METHODS['Robertson 1968']
 
 
-def CCT_to_uv(CCT, method='Ohno 2013', **kwargs):
+def CCT_to_uv(CCT_D_uv, method='Ohno 2013', **kwargs):
     """
     Returns the *CIE UCS* colourspace *uv* chromaticity coordinates from given
     correlated colour temperature :math:`T_{cp}` using given method.
 
     Parameters
     ----------
-    CCT : numeric
-        Correlated colour temperature :math:`T_{cp}`.
+    CCT_D_uv : ndarray
+        Correlated colour temperature :math:`T_{cp}`, :math:`\\Delta_{uv}`.
     method : unicode, optional
         **{'Ohno 2013', 'Robertson 1968', 'Krystek 1985}**,
         Computation method.
 
     Other Parameters
     ----------------
-    D_uv : numeric
-       {:func:`CCT_to_uv_Ohno2013, CCT_to_uv_Robertson1968`},
-       :math:`\\Delta_{uv}`.
     cmfs : XYZ_ColourMatchingFunctions, optional
         {:func:`colour.temperature.CCT_to_uv_Ohno2013`},
         Standard observer colour matching functions.
@@ -812,15 +930,14 @@ def CCT_to_uv(CCT, method='Ohno 2013', **kwargs):
     --------
     >>> from colour import STANDARD_OBSERVERS_CMFS
     >>> cmfs = STANDARD_OBSERVERS_CMFS['CIE 1931 2 Degree Standard Observer']
-    >>> CCT = 6507.47380460
-    >>> D_uv = 0.00322335
-    >>> CCT_to_uv(CCT, D_uv=D_uv, cmfs=cmfs)  # doctest: +ELLIPSIS
+    >>> CCT_D_uv = np.array([6507.47380460, 0.00322335])
+    >>> CCT_to_uv(CCT_D_uv, cmfs=cmfs)  # doctest: +ELLIPSIS
     array([ 0.1977999...,  0.3121999...])
     """
 
     function = CCT_TO_UV_METHODS[method]
 
-    return function(CCT, **filter_kwargs(function, **kwargs))
+    return function(CCT_D_uv, **filter_kwargs(function, **kwargs))
 
 
 def xy_to_CCT_McCamy1992(xy):

--- a/colour/temperature/cct.py
+++ b/colour/temperature/cct.py
@@ -112,13 +112,15 @@ from __future__ import division, unicode_literals
 
 import numpy as np
 from collections import namedtuple
+from functools import partial
 
 from colour.colorimetry import (
     ASTME30815_PRACTISE_SHAPE, STANDARD_OBSERVERS_CMFS,
     daylight_locus_function, sd_blackbody, sd_to_XYZ)
 from colour.models import UCS_to_uv, XYZ_to_UCS
 from colour.utilities import (CaseInsensitiveMapping, as_float_array, as_float,
-                              filter_kwargs, runtime_warning, tsplit, tstack,
+                              filter_kwargs, multiprocessing_pool,
+                              runtime_warning, tsplit, tstack,
                               usage_warning)
 
 __author__ = 'Colour Developers'
@@ -392,8 +394,9 @@ def _uv_to_CCT_Ohno2013(
         b = (-(Tip ** 2 * (din - di) + Ti ** 2 * (dip - din) + Tin ** 2 *
                (di - dip)) * X ** -1)
         c = (
-            -(dip * (Tin - Ti) * Ti * Tin + di *
-              (Tip - Tin) * Tip * Tin + din * (Ti - Tip) * Tip * Ti) * X ** -1)
+                -(dip * (Tin - Ti) * Ti * Tin + di *
+                  (Tip - Tin) * Tip * Tin + din * (
+                          Ti - Tip) * Tip * Ti) * X ** -1)
 
         T = -b / (2 * a)
 
@@ -454,10 +457,11 @@ def uv_to_CCT_Ohno2013(
 
     uv = as_float_array(uv)
 
-    CCT_D_uv = [
-        _uv_to_CCT_Ohno2013(a, cmfs, start, end, count, iterations)
-        for a in np.reshape(uv, (-1, 2))
-    ]
+    with multiprocessing_pool() as pool:
+        CCT_D_uv = pool.map(
+            partial(_uv_to_CCT_Ohno2013, cmfs=cmfs, start=start, end=end,
+                    count=count, iterations=iterations),
+            np.reshape(uv, (-1, 2)))
 
     return as_float_array(CCT_D_uv).reshape(uv.shape)
 
@@ -550,7 +554,10 @@ def CCT_to_uv_Ohno2013(
 
     CCT_D_uv = as_float_array(CCT_D_uv)
 
-    uv = [_CCT_to_uv_Ohno2013(a, cmfs) for a in np.reshape(CCT_D_uv, (-1, 2))]
+    with multiprocessing_pool() as pool:
+        uv = pool.map(
+            partial(_CCT_to_uv_Ohno2013, cmfs=cmfs),
+            np.reshape(CCT_D_uv, (-1, 2)))
 
     return as_float_array(uv).reshape(CCT_D_uv.shape)
 
@@ -654,7 +661,9 @@ def uv_to_CCT_Robertson1968(uv):
 
     uv = as_float_array(uv)
 
-    CCT_D_uv = [_uv_to_CCT_Robertson1968(a) for a in np.reshape(uv, (-1, 2))]
+    with multiprocessing_pool() as pool:
+        CCT_D_uv = pool.map(_uv_to_CCT_Robertson1968,
+                            np.reshape(uv, (-1, 2)))
 
     return as_float_array(CCT_D_uv).reshape(uv.shape)
 
@@ -745,7 +754,9 @@ def CCT_to_uv_Robertson1968(CCT_D_uv):
 
     CCT_D_uv = as_float_array(CCT_D_uv)
 
-    uv = [_CCT_to_uv_Robertson1968(a) for a in np.reshape(CCT_D_uv, (-1, 2))]
+    with multiprocessing_pool() as pool:
+        uv = pool.map(_CCT_to_uv_Robertson1968,
+                      np.reshape(CCT_D_uv, (-1, 2)))
 
     return as_float_array(uv).reshape(CCT_D_uv.shape)
 

--- a/colour/temperature/tests/test_cct.py
+++ b/colour/temperature/tests/test_cct.py
@@ -16,7 +16,7 @@ from colour.temperature import (
     CCT_to_xy_CIE_D, xy_to_CCT_McCamy1992, xy_to_CCT_Hernandez1999)
 from colour.temperature.cct import (planckian_table,
                                     planckian_table_minimal_distance_index)
-from colour.utilities import ignore_numpy_errors
+from colour.utilities import disable_multiprocessing, ignore_numpy_errors
 
 __author__ = 'Colour Developers'
 __copyright__ = 'Copyright (C) 2013-2019 - Colour Developers'
@@ -236,6 +236,7 @@ class Testuv_to_CCT_Ohno2013(unittest.TestCase):
             uv_to_CCT_Ohno2013(uv), CCT_D_uv, decimal=7)
 
     @ignore_numpy_errors
+    @disable_multiprocessing()
     def test_nan_uv_to_CCT_Ohno2013(self):
         """
         Tests :func:`colour.temperature.cct.uv_to_CCT_Ohno2013` definition nan
@@ -297,6 +298,7 @@ class TestCCT_to_uv_Ohno2013(unittest.TestCase):
             CCT_to_uv_Ohno2013(CCT_D_uv, cmfs), uv, decimal=7)
 
     @ignore_numpy_errors
+    @disable_multiprocessing()
     def test_nan_CCT_to_uv_Ohno2013(self):
         """
         Tests :func:`colour.temperature.cct.CCT_to_uv_Ohno2013` definition nan
@@ -346,6 +348,7 @@ class Testuv_to_CCT_Robertson1968(unittest.TestCase):
             uv_to_CCT_Robertson1968(uv), CCT_D_uv, decimal=7)
 
     @ignore_numpy_errors
+    @disable_multiprocessing()
     def test_nan_uv_to_CCT_Robertson1968(self):
         """
         Tests :func:`colour.temperature.cct.uv_to_CCT_Robertson1968` definition
@@ -395,6 +398,7 @@ class TestCCT_to_uv_Robertson1968(unittest.TestCase):
             CCT_to_uv_Robertson1968(CCT_D_uv), uv, decimal=7)
 
     @ignore_numpy_errors
+    @disable_multiprocessing()
     def test_nan_CCT_to_uv_Robertson1968(self):
         """
         Tests :func:`colour.temperature.cct.CCT_to_uv_Robertson1968` definition

--- a/colour/temperature/tests/test_cct.py
+++ b/colour/temperature/tests/test_cct.py
@@ -216,6 +216,38 @@ class Testuv_to_CCT_Ohno2013(unittest.TestCase):
             np.array([2452.15316417, -0.08437064]),
             decimal=7)
 
+    def test_n_dimensional_uv_to_CCT_Ohno2013(self):
+        """
+        Tests :func:`colour.temperature.cct.uv_to_CCT_Ohno2013` definition
+        n-dimensional arrays support.
+        """
+
+        uv = np.array([0.1978, 0.3122])
+        CCT_D_uv = uv_to_CCT_Ohno2013(uv)
+
+        uv = np.tile(uv, (6, 1))
+        CCT_D_uv = np.tile(CCT_D_uv, (6, 1))
+        np.testing.assert_almost_equal(
+            uv_to_CCT_Ohno2013(uv), CCT_D_uv, decimal=7)
+
+        uv = np.reshape(uv, (2, 3, 2))
+        CCT_D_uv = np.reshape(CCT_D_uv, (2, 3, 2))
+        np.testing.assert_almost_equal(
+            uv_to_CCT_Ohno2013(uv), CCT_D_uv, decimal=7)
+
+    @ignore_numpy_errors
+    def test_nan_uv_to_CCT_Ohno2013(self):
+        """
+        Tests :func:`colour.temperature.cct.uv_to_CCT_Ohno2013` definition nan
+        support.
+        """
+
+        cases = [-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan]
+        cases = set(permutations(cases * 3, r=2))
+        for case in cases:
+            uv = np.array(case)
+            uv_to_CCT_Ohno2013(uv)
+
 
 class TestCCT_to_uv_Ohno2013(unittest.TestCase):
     """
@@ -230,19 +262,52 @@ class TestCCT_to_uv_Ohno2013(unittest.TestCase):
 
         cmfs = STANDARD_OBSERVERS_CMFS['CIE 1931 2 Degree Standard Observer']
         np.testing.assert_almost_equal(
-            CCT_to_uv_Ohno2013(6507.47380460, 0.00322335, cmfs),
+            CCT_to_uv_Ohno2013(np.array([6507.47380460, 0.00322335]), cmfs),
             np.array([0.19779997, 0.31219997]),
             decimal=7)
 
         np.testing.assert_almost_equal(
-            CCT_to_uv_Ohno2013(1041.68315360, -0.06737802, cmfs),
+            CCT_to_uv_Ohno2013(np.array([1041.68315360, -0.06737802]), cmfs),
             np.array([0.43279885, 0.28830013]),
             decimal=7)
 
         np.testing.assert_almost_equal(
-            CCT_to_uv_Ohno2013(2452.15316417, -0.08437064, cmfs),
+            CCT_to_uv_Ohno2013(np.array([2452.15316417, -0.08437064]), cmfs),
             np.array([0.29247364, 0.27215157]),
             decimal=7)
+
+    def test_n_dimensional_CCT_to_uv_Ohno2013(self):
+        """
+        Tests :func:`colour.temperature.cct.CCT_to_uv_Ohno2013` definition
+        n-dimensional arrays support.
+        """
+
+        cmfs = STANDARD_OBSERVERS_CMFS['CIE 1931 2 Degree Standard Observer']
+        CCT_D_uv = np.array([6507.47380460, 0.00322335])
+        uv = CCT_to_uv_Ohno2013(CCT_D_uv, cmfs)
+
+        CCT_D_uv = np.tile(CCT_D_uv, (6, 1))
+        uv = np.tile(uv, (6, 1))
+        np.testing.assert_almost_equal(
+            CCT_to_uv_Ohno2013(CCT_D_uv, cmfs), uv, decimal=7)
+
+        CCT_D_uv = np.reshape(CCT_D_uv, (2, 3, 2))
+        uv = np.reshape(uv, (2, 3, 2))
+        np.testing.assert_almost_equal(
+            CCT_to_uv_Ohno2013(CCT_D_uv, cmfs), uv, decimal=7)
+
+    @ignore_numpy_errors
+    def test_nan_CCT_to_uv_Ohno2013(self):
+        """
+        Tests :func:`colour.temperature.cct.CCT_to_uv_Ohno2013` definition nan
+        support.
+        """
+
+        cases = [-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan]
+        cases = set(permutations(cases * 3, r=2))
+        for case in cases:
+            CCT_D_uv = np.array(case)
+            CCT_to_uv_Ohno2013(CCT_D_uv)
 
 
 class Testuv_to_CCT_Robertson1968(unittest.TestCase):
@@ -261,6 +326,38 @@ class Testuv_to_CCT_Robertson1968(unittest.TestCase):
             np.testing.assert_allclose(
                 uv_to_CCT_Robertson1968(value), key, atol=0.25)
 
+    def test_n_dimensional_uv_to_CCT_Robertson1968(self):
+        """
+        Tests :func:`colour.temperature.cct.uv_to_CCT_Robertson1968` definition
+        n-dimensional arrays support.
+        """
+
+        uv = np.array([0.1978, 0.3122])
+        CCT_D_uv = uv_to_CCT_Robertson1968(uv)
+
+        uv = np.tile(uv, (6, 1))
+        CCT_D_uv = np.tile(CCT_D_uv, (6, 1))
+        np.testing.assert_almost_equal(
+            uv_to_CCT_Robertson1968(uv), CCT_D_uv, decimal=7)
+
+        uv = np.reshape(uv, (2, 3, 2))
+        CCT_D_uv = np.reshape(CCT_D_uv, (2, 3, 2))
+        np.testing.assert_almost_equal(
+            uv_to_CCT_Robertson1968(uv), CCT_D_uv, decimal=7)
+
+    @ignore_numpy_errors
+    def test_nan_uv_to_CCT_Robertson1968(self):
+        """
+        Tests :func:`colour.temperature.cct.uv_to_CCT_Robertson1968` definition
+        nan support.
+        """
+
+        cases = [-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan]
+        cases = set(permutations(cases * 3, r=2))
+        for case in cases:
+            uv = np.array(case)
+            uv_to_CCT_Robertson1968(uv)
+
 
 class TestCCT_to_uv_Robertson1968(unittest.TestCase):
     """
@@ -276,7 +373,39 @@ class TestCCT_to_uv_Robertson1968(unittest.TestCase):
 
         for key, value in TEMPERATURE_DUV_TO_UV.items():
             np.testing.assert_almost_equal(
-                CCT_to_uv_Robertson1968(*key), value, decimal=7)
+                CCT_to_uv_Robertson1968(key), value, decimal=7)
+
+    def test_n_dimensional_CCT_to_uv_Robertson1968(self):
+        """
+        Tests :func:`colour.temperature.cct.CCT_to_uv_Robertson1968` definition
+        n-dimensional arrays support.
+        """
+
+        CCT_D_uv = np.array([4500, 0.0250])
+        uv = CCT_to_uv_Robertson1968(CCT_D_uv)
+
+        CCT_D_uv = np.tile(CCT_D_uv, (6, 1))
+        uv = np.tile(uv, (6, 1))
+        np.testing.assert_almost_equal(
+            CCT_to_uv_Robertson1968(CCT_D_uv), uv, decimal=7)
+
+        CCT_D_uv = np.reshape(CCT_D_uv, (2, 3, 2))
+        uv = np.reshape(uv, (2, 3, 2))
+        np.testing.assert_almost_equal(
+            CCT_to_uv_Robertson1968(CCT_D_uv), uv, decimal=7)
+
+    @ignore_numpy_errors
+    def test_nan_CCT_to_uv_Robertson1968(self):
+        """
+        Tests :func:`colour.temperature.cct.CCT_to_uv_Robertson1968` definition
+        nan support.
+        """
+
+        cases = [-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan]
+        cases = set(permutations(cases * 3, r=2))
+        for case in cases:
+            CCT_D_uv = np.array(case)
+            CCT_to_uv_Robertson1968(CCT_D_uv)
 
 
 class TestCCT_to_uv_Krystek1985(unittest.TestCase):

--- a/colour/utilities/__init__.py
+++ b/colour/utilities/__init__.py
@@ -6,6 +6,7 @@ from .data_structures import Lookup, Structure, CaseInsensitiveMapping
 from .common import (
     handle_numpy_errors, ignore_numpy_errors, raise_numpy_errors,
     print_numpy_errors, warn_numpy_errors, ignore_python_warnings, batch,
+    multiprocessing_pool,
     is_openimageio_installed, is_pandas_installed, is_iterable, is_string,
     is_numeric, is_integer, is_sibling, filter_kwargs, filter_mapping,
     first_item, get_domain_range_scale, set_domain_range_scale,
@@ -29,7 +30,8 @@ __all__ = ['Lookup', 'Structure', 'CaseInsensitiveMapping']
 __all__ += [
     'handle_numpy_errors', 'ignore_numpy_errors', 'raise_numpy_errors',
     'print_numpy_errors', 'warn_numpy_errors', 'ignore_python_warnings',
-    'batch', 'is_openimageio_installed', 'is_pandas_installed', 'is_iterable',
+    'batch', 'multiprocessing_pool', 'is_openimageio_installed',
+    'is_pandas_installed', 'is_iterable',
     'is_string', 'is_numeric', 'is_integer', 'is_sibling', 'filter_kwargs',
     'filter_mapping', 'first_item', 'get_domain_range_scale',
     'set_domain_range_scale', 'domain_range_scale', 'to_domain_1',

--- a/colour/utilities/__init__.py
+++ b/colour/utilities/__init__.py
@@ -6,13 +6,13 @@ from .data_structures import Lookup, Structure, CaseInsensitiveMapping
 from .common import (
     handle_numpy_errors, ignore_numpy_errors, raise_numpy_errors,
     print_numpy_errors, warn_numpy_errors, ignore_python_warnings, batch,
-    multiprocessing_pool,
-    is_openimageio_installed, is_pandas_installed, is_iterable, is_string,
-    is_numeric, is_integer, is_sibling, filter_kwargs, filter_mapping,
-    first_item, get_domain_range_scale, set_domain_range_scale,
-    domain_range_scale, to_domain_1, to_domain_10, to_domain_100,
-    to_domain_degrees, to_domain_int, from_range_1, from_range_10,
-    from_range_100, from_range_degrees, from_range_int)
+    disable_multiprocessing, multiprocessing_pool, is_openimageio_installed,
+    is_pandas_installed, is_iterable, is_string, is_numeric, is_integer,
+    is_sibling, filter_kwargs, filter_mapping, first_item,
+    get_domain_range_scale, set_domain_range_scale, domain_range_scale,
+    to_domain_1, to_domain_10, to_domain_100, to_domain_degrees, to_domain_int,
+    from_range_1, from_range_10, from_range_100, from_range_degrees,
+    from_range_int)
 from .array import (as_array, as_int_array, as_float_array, as_numeric, as_int,
                     as_float, as_namedtuple, closest_indexes, closest,
                     normalise_maximum, interval, is_uniform, in_array, tstack,
@@ -30,8 +30,8 @@ __all__ = ['Lookup', 'Structure', 'CaseInsensitiveMapping']
 __all__ += [
     'handle_numpy_errors', 'ignore_numpy_errors', 'raise_numpy_errors',
     'print_numpy_errors', 'warn_numpy_errors', 'ignore_python_warnings',
-    'batch', 'multiprocessing_pool', 'is_openimageio_installed',
-    'is_pandas_installed', 'is_iterable',
+    'batch', 'disable_multiprocessing', 'multiprocessing_pool',
+    'is_openimageio_installed', 'is_pandas_installed', 'is_iterable',
     'is_string', 'is_numeric', 'is_integer', 'is_sibling', 'filter_kwargs',
     'filter_mapping', 'first_item', 'get_domain_range_scale',
     'set_domain_range_scale', 'domain_range_scale', 'to_domain_1',

--- a/colour/utilities/common.py
+++ b/colour/utilities/common.py
@@ -16,10 +16,12 @@ refl1d/numpyerrors.html
 from __future__ import division, unicode_literals
 
 import inspect
+import multiprocessing
 import functools
 import numpy as np
 import re
 import warnings
+from contextlib import contextmanager
 from collections import OrderedDict
 from copy import deepcopy
 from six import integer_types, string_types
@@ -37,7 +39,8 @@ __status__ = 'Production'
 __all__ = [
     'handle_numpy_errors', 'ignore_numpy_errors', 'raise_numpy_errors',
     'print_numpy_errors', 'warn_numpy_errors', 'ignore_python_warnings',
-    'batch', 'is_openimageio_installed', 'is_pandas_installed', 'is_iterable',
+    'batch', 'multiprocessing_pool', 'is_openimageio_installed',
+    'is_pandas_installed', 'is_iterable',
     'is_string', 'is_numeric', 'is_integer', 'is_sibling', 'filter_kwargs',
     'filter_mapping', 'first_item', 'get_domain_range_scale',
     'set_domain_range_scale', 'domain_range_scale', 'to_domain_1',
@@ -159,6 +162,37 @@ def batch(iterable, k=3):
 
     for i in range(0, len(iterable), k):
         yield iterable[i:i + k]
+
+
+@contextmanager
+def multiprocessing_pool(*args, **kwargs):
+    """
+    A context manager providing a multiprocessing pool.
+
+    Other Parameters
+    ----------------
+    \\*args : list, optional
+        Arguments.
+    \\**kwargs : dict, optional
+        Keywords arguments.
+
+    Examples
+    --------
+    >>> from functools import partial
+    >>> def _add(a, b):
+    ...     return a + b
+    >>> with multiprocessing_pool() as pool:
+    ...     pool.map(partial(_add, b=2), range(10))
+    ... # doctest: +SKIP
+    [2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+    """
+
+    # TODO: Replace with "multiprocessing.Pool.starmap".
+    pool = multiprocessing.Pool(*args, **kwargs)
+
+    yield pool
+
+    pool.terminate()
 
 
 def is_openimageio_installed(raise_exception=False):

--- a/colour/utilities/tests/test_common.py
+++ b/colour/utilities/tests/test_common.py
@@ -8,13 +8,15 @@ from __future__ import division, unicode_literals
 import numpy as np
 import unittest
 from collections import OrderedDict
+from functools import partial
 
 from colour.utilities import (
-    batch, is_iterable, is_string, is_numeric, is_integer, is_sibling,
-    filter_kwargs, filter_mapping, first_item, get_domain_range_scale,
-    set_domain_range_scale, domain_range_scale, to_domain_1, to_domain_10,
-    to_domain_100, to_domain_int, to_domain_degrees, from_range_1,
-    from_range_10, from_range_100, from_range_int, from_range_degrees)
+    batch, multiprocessing_pool, is_iterable, is_string, is_numeric,
+    is_integer, is_sibling, filter_kwargs, filter_mapping, first_item,
+    get_domain_range_scale, set_domain_range_scale, domain_range_scale,
+    to_domain_1, to_domain_10, to_domain_100, to_domain_int, to_domain_degrees,
+    from_range_1, from_range_10, from_range_100, from_range_int,
+    from_range_degrees)
 
 __author__ = 'Colour Developers'
 __copyright__ = 'Copyright (C) 2013-2019 - Colour Developers'
@@ -24,12 +26,12 @@ __email__ = 'colour-science@googlegroups.com'
 __status__ = 'Production'
 
 __all__ = [
-    'TestBatch', 'TestIsIterable', 'TestIsString', 'TestIsNumeric',
-    'TestIsInteger', 'TestIsSibling', 'TestFilterKwargs', 'TestFilterMapping',
-    'TestFirstItem', 'TestGetDomainRangeScale', 'TestSetDomainRangeScale',
-    'TestDomainRangeScale', 'TestToDomain1', 'TestToDomain10',
-    'TestToDomain100', 'TestToDomainDegrees', 'TestToDomainInt',
-    'TestFromRange1', 'TestFromRange10', 'TestFromRange100',
+    'TestBatch', 'TestMultiprocessingPool', 'TestIsIterable', 'TestIsString',
+    'TestIsNumeric', 'TestIsInteger', 'TestIsSibling', 'TestFilterKwargs',
+    'TestFilterMapping', 'TestFirstItem', 'TestGetDomainRangeScale',
+    'TestSetDomainRangeScale', 'TestDomainRangeScale', 'TestToDomain1',
+    'TestToDomain10', 'TestToDomain100', 'TestToDomainDegrees',
+    'TestToDomainInt', 'TestFromRange1', 'TestFromRange10', 'TestFromRange100',
     'TestFromRangeDegrees', 'TestFromRangeInt'
 ]
 
@@ -57,6 +59,43 @@ class TestBatch(unittest.TestCase):
             list(batch(tuple(range(10)), 1)),
             [(0,), (1,), (2,), (3,), (4,),
              (5,), (6,), (7,), (8,), (9,)])  # yapf: disable
+
+
+def _add(a, b):
+    """
+    Function to map with a multiprocessing pool.
+
+    Parameters
+    ----------
+    a : numeric
+        Variable :math:`a`.
+    b : numeric
+        Variable :math:`b`.
+
+    Returns
+    -------
+    numeric
+        Addition result.
+    """
+
+    return a + b
+
+
+class TestMultiprocessingPool(unittest.TestCase):
+    """
+    Defines :func:`colour.utilities.common.multiprocessing_pool` definition
+    units tests methods.
+    """
+
+    def test_multiprocessing_pool(self):
+        """
+        Tests :func:`colour.utilities.common.multiprocessing_pool` definition.
+        """
+
+        with multiprocessing_pool() as pool:
+            self.assertListEqual(
+                pool.map(partial(_add, b=2), range(10)),
+                [2, 3, 4, 5, 6, 7, 8, 9, 10, 11])
 
 
 class TestIsIterable(unittest.TestCase):
@@ -132,7 +171,7 @@ class TestIsNumeric(unittest.TestCase):
 
         self.assertTrue(is_numeric(complex(1)))
 
-        self.assertFalse(is_numeric((1, )))
+        self.assertFalse(is_numeric((1,)))
 
         self.assertFalse(is_numeric([1]))
 
@@ -363,8 +402,8 @@ class TestSetDomainRangeScale(unittest.TestCase):
             set_domain_range_scale('Reference')
             self.assertEqual(get_domain_range_scale(), 'reference')
 
-        self.assertRaises(AssertionError,
-                          lambda: set_domain_range_scale('Invalid'))
+        self.assertRaises(
+            AssertionError, lambda: set_domain_range_scale('Invalid'))
 
 
 class TestDomainRangeScale(unittest.TestCase):

--- a/colour/volume/rgb.py
+++ b/colour/volume/rgb.py
@@ -29,7 +29,7 @@ from colour.colorimetry import ILLUMINANTS
 from colour.constants import DEFAULT_INT_DTYPE
 from colour.models import (Lab_to_XYZ, RGB_to_XYZ, XYZ_to_Lab, XYZ_to_RGB)
 from colour.volume import is_within_pointer_gamut, is_within_visible_spectrum
-from colour.utilities import as_float_array
+from colour.utilities import as_float_array, multiprocessing_pool
 
 __author__ = 'Colour Developers'
 __copyright__ = 'Copyright (C) 2013-2019 - Colour Developers'
@@ -47,7 +47,7 @@ __all__ = [
 ]
 
 
-def _wrapper_RGB_colourspace_volume_MonteCarlo(args):
+def _wrapper_RGB_colourspace_volume_MonteCarlo(arguments):
     """
     Convenient wrapper to be able to call
     :func:`colour.volume.rgb.sample_RGB_colourspace_volume_MonteCarlo`:
@@ -55,7 +55,7 @@ def _wrapper_RGB_colourspace_volume_MonteCarlo(args):
 
     Parameters
     ----------
-    args : array_like, optional
+    arguments : array_like, optional
         Arguments.
 
     Returns
@@ -64,15 +64,15 @@ def _wrapper_RGB_colourspace_volume_MonteCarlo(args):
         Inside *RGB* colourspace volume samples count.
     """
 
-    return sample_RGB_colourspace_volume_MonteCarlo(*args)
+    return sample_RGB_colourspace_volume_MonteCarlo(*arguments)
 
 
 def sample_RGB_colourspace_volume_MonteCarlo(
         colourspace,
         samples=10e6,
         limits=np.array([[0, 100], [-150, 150], [-150, 150]]),
-        illuminant_Lab=ILLUMINANTS['CIE 1931 2 Degree Standard Observer'][
-            'D65'],
+        illuminant_Lab=ILLUMINANTS['CIE 1931 2 Degree Standard Observer']
+        ['D65'],
         chromatic_adaptation_method='CAT02',
         random_generator=random_triplet_generator,
         random_state=None):
@@ -189,8 +189,8 @@ def RGB_colourspace_volume_MonteCarlo(
         colourspace,
         samples=10e6,
         limits=np.array([[0, 100], [-150, 150], [-150, 150]], dtype=np.float),
-        illuminant_Lab=ILLUMINANTS['CIE 1931 2 Degree Standard Observer'][
-            'D65'],
+        illuminant_Lab=ILLUMINANTS['CIE 1931 2 Degree Standard Observer']
+        ['D65'],
         chromatic_adaptation_method='CAT02',
         random_generator=random_triplet_generator,
         random_state=None,
@@ -251,20 +251,19 @@ reproducibility-of-python-pseudo-random-numbers-across-systems-and-versions
     816...
     """
 
-    cpu_count = processes if processes else multiprocessing.cpu_count()
-    pool = multiprocessing.Pool(processes=cpu_count)
-
-    process_samples = DEFAULT_INT_DTYPE(np.round(samples / cpu_count))
+    processes = processes if processes else multiprocessing.cpu_count()
+    process_samples = DEFAULT_INT_DTYPE(np.round(samples / processes))
 
     arguments = (colourspace, process_samples, limits, illuminant_Lab,
                  chromatic_adaptation_method, random_generator, random_state)
 
-    results = pool.map(_wrapper_RGB_colourspace_volume_MonteCarlo,
-                       [arguments for _ in range(cpu_count)])
+    with multiprocessing_pool(processes=processes) as pool:
+        results = pool.map(_wrapper_RGB_colourspace_volume_MonteCarlo,
+                           [arguments for _ in range(processes)])
 
     Lab_volume = np.product([np.sum(np.abs(x)) for x in limits])
 
-    return Lab_volume * np.sum(results) / (process_samples * cpu_count)
+    return Lab_volume * np.sum(results) / (process_samples * processes)
 
 
 def RGB_colourspace_volume_coverage_MonteCarlo(

--- a/colour/volume/rgb.py
+++ b/colour/volume/rgb.py
@@ -193,8 +193,7 @@ def RGB_colourspace_volume_MonteCarlo(
         ['D65'],
         chromatic_adaptation_method='CAT02',
         random_generator=random_triplet_generator,
-        random_state=None,
-        processes=None):
+        random_state=None):
     """
     Performs given *RGB* colourspace volume computation using *Monte Carlo*
     method and multiprocessing.
@@ -220,9 +219,6 @@ def RGB_colourspace_volume_MonteCarlo(
     random_state : RandomState, optional
         Mersenne Twister pseudo-random number generator to use in the random
         number generator.
-    processes : integer, optional
-        Processes count, default to :func:`multiprocessing.cpu_count`
-        definition.
 
     Returns
     -------
@@ -243,21 +239,21 @@ reproducibility-of-python-pseudo-random-numbers-across-systems-and-versions
     Examples
     --------
     >>> from colour.models import sRGB_COLOURSPACE as sRGB
+    >>> from colour.utilities import disable_multiprocessing
     >>> prng = np.random.RandomState(2)
-    >>> processes = 1
-    >>> RGB_colourspace_volume_MonteCarlo(sRGB, 10e3, random_state=prng,
-    ...                                   processes=processes)
+    >>> with disable_multiprocessing():
+    ...     RGB_colourspace_volume_MonteCarlo(sRGB, 10e3, random_state=prng)
     ... # doctest: +ELLIPSIS
-    816...
+    8...
     """
 
-    processes = processes if processes else multiprocessing.cpu_count()
+    processes = multiprocessing.cpu_count()
     process_samples = DEFAULT_INT_DTYPE(np.round(samples / processes))
 
     arguments = (colourspace, process_samples, limits, illuminant_Lab,
                  chromatic_adaptation_method, random_generator, random_state)
 
-    with multiprocessing_pool(processes=processes) as pool:
+    with multiprocessing_pool() as pool:
         results = pool.map(_wrapper_RGB_colourspace_volume_MonteCarlo,
                            [arguments for _ in range(processes)])
 

--- a/colour/volume/tests/test_rgb.py
+++ b/colour/volume/tests/test_rgb.py
@@ -31,6 +31,7 @@ from colour.volume import (
     RGB_colourspace_pointer_gamut_coverage_MonteCarlo,
     RGB_colourspace_visible_spectrum_coverage_MonteCarlo,
     is_within_pointer_gamut)
+from colour.utilities import disable_multiprocessing
 
 __author__ = 'Colour Developers'
 __copyright__ = 'Copyright (C) 2013-2019 - Colour Developers'
@@ -96,18 +97,19 @@ class TestRGB_colourspaceVolumeMonteCarlo(unittest.TestCase):
     :cite:`Laurent2012a`
     """
 
+    @disable_multiprocessing()
     def test_RGB_colourspace_volume_MonteCarlo(self):
         """
         Tests :func:`colour.volume.rgb.RGB_colourspace_volume_MonteCarlo`
         definition.
         """
 
-        self.assertEquals(
+        self.assertAlmostEqual(
             RGB_colourspace_volume_MonteCarlo(
                 BT709_COLOURSPACE,
                 10e3,
-                random_state=np.random.RandomState(2),
-                processes=1), 816300.0)
+                random_state=np.random.RandomState(2)) * 1e-6, 821700.0 * 1e-6,
+            places=1)
 
 
 class TestRGB_colourspace_volume_coverage_MonteCarlo(unittest.TestCase):

--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -114,8 +114,7 @@ Domain-Range Scales
     This section has important information.
 
 
-`Colour <https://github.com/colour-science/Colour/>`__ adopts 4 main
-input domains and output ranges:
+**Colour** adopts 4 main input domains and output ranges:
 
 -   *Scalars* usually in domain-range `[0, 1]` (or `[0, 10]` for
     *Munsell Value*).
@@ -144,9 +143,8 @@ available domain-range scales.
 Scale - Reference
 ~~~~~~~~~~~~~~~~~
 
-**'Reference'** is the default domain-range scale of
-`Colour <https://github.com/colour-science/Colour/>`__, objects adopt the
-implemented reference, i.e. paper, publication, etc.., domain-range scale.
+**'Reference'** is the default domain-range scale of **Colour**, objects adopt
+the implemented reference, i.e. paper, publication, etc.., domain-range scale.
 
 The **'Reference'** domain-range scale is inconsistent, e.g. colour appearance
 models, spectral conversions are typically in domain-range `[0, 100]` while RGB
@@ -158,8 +156,7 @@ Scale - 1
 ~~~~~~~~~
 
 **'1'** is a domain-range scale converting all the relevant objects from
-`Colour <https://github.com/colour-science/Colour/>`__ public API to
-domain-range `[0, 1]`:
+**Colour** public API to domain-range `[0, 1]`:
 
 -   *Scalars* in domain-range `[0, 10]`, e.g *Munsell Value* are
     scaled by *10*.
@@ -289,8 +286,8 @@ return value ``XYZ_2`` is converted from range `[0, 100]` to range `[0, 1]` by
 
 A convenient alternative to the :func:`colour.set_domain_range_scale`
 definition is the :class:`colour.domain_range_scale` context manager and
-decorator. It temporarily overrides `Colour <https://github.com/colour-science/Colour/>`__
-domain-range scale with given scale value:
+decorator. It temporarily overrides **Colour** domain-range scale with given
+scale value:
 
 .. code:: python
 
@@ -301,3 +298,20 @@ domain-range scale with given scale value:
 .. code-block:: text
 
     [ 0.24033795  0.21156212  0.17643012]
+
+Multiprocessing on Windows with Domain-Range Scales
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Windows does not have a `fork <https://linux.die.net/man/2/fork>`_ system call,
+a consequence is that child processes do not necessarily
+`inherit from changes made to global variables <https://docs.python.org/2/library/multiprocessing.html#windows>`_.
+
+It has crucial `consequences <https://stackoverflow.com/q/55742917/931625>`_
+as **Colour** stores the current domain-range scale into a global variable.
+
+The solution is to define an initialisation definition that defines the
+scale upon child processes spawning.
+
+The :class:`colour.utilities.multiprocessing_pool` context manager conveniently
+performs the required initialisation so that the domain-range scale is
+propagated appropriately to child processes.

--- a/docs/colour.utilities.rst
+++ b/docs/colour.utilities.rst
@@ -32,6 +32,8 @@ Common
     warn_numpy_errors
     ignore_python_warnings
     batch
+    disable_multiprocessing
+    multiprocessing_pool
     is_openimageio_installed
     is_pandas_installed
     is_iterable

--- a/docs/generated/colour.utilities.disable_multiprocessing.rst
+++ b/docs/generated/colour.utilities.disable_multiprocessing.rst
@@ -1,0 +1,16 @@
+colour.utilities.disable\_multiprocessing
+=========================================
+
+.. currentmodule:: colour.utilities
+
+.. autoclass:: disable_multiprocessing
+
+   
+   .. automethod:: __init__
+
+   
+   
+
+   
+   
+   

--- a/docs/generated/colour.utilities.multiprocessing_pool.rst
+++ b/docs/generated/colour.utilities.multiprocessing_pool.rst
@@ -1,0 +1,6 @@
+colour.utilities.multiprocessing\_pool
+======================================
+
+.. currentmodule:: colour.utilities
+
+.. autofunction:: multiprocessing_pool


### PR DESCRIPTION
The following definitions have received a bit of love, i.e. n-dimensional arrays support ~and multiprocessing~:

- `colour.notation.munsell_specification_to_xyY`
- `colour.notation.xyY_to_munsell_specification`
- `colour.munsell_colour_to_xyY`
- `colour.xyY_to_munsell_colour`
- `colour.cct.uv_to_CCT_Ohno2013`
- `colour.cct.CCT_to_uv_Ohno2013`
- `colour.cct.uv_to_CCT_Robertson1968`
- `colour.cct.CCT_to_uv_Robertson1968`
- `colour.CCT_to_uv`
- `colour.uv_to_CCT`

I added two new context manager: the `colour.utilities.multiprocessing_pool` context manager that provides a multiprocessing pool and the `colour.utilities.disable_multiprocessing` that disable multiprocessing if used.