### PR TITLE
PR: Fix "from collections import Mapping, MutableMapping" with Python 3.8.

### DIFF
--- a/colour/utilities/data_structures.py
+++ b/colour/utilities/data_structures.py
@@ -27,7 +27,7 @@ structures.py#L37
 
 from __future__ import division, unicode_literals
 
-from collections import Mapping, MutableMapping
+from collections.abc import Mapping, MutableMapping
 
 __author__ = 'Colour Developers'
 __copyright__ = 'Copyright (C) 2013-2019 - Colour Developers'


### PR DESCRIPTION
In Python 3.8 from collections import Mutable no longer works, instead
from collections.abc import Mutable must be used