### PR TITLE
Deprecated 'colour.models.XYZ_to_colourspace_model'

### DIFF
--- a/colour/models/__init__.py
+++ b/colour/models/__init__.py
@@ -90,6 +90,9 @@ class models(ModuleAPI):
 
 # v0.3.14
 API_CHANGES = {
+    'FutureRemove': [
+        'colour.models.XYZ_to_colourspace_model',
+    ],
     'Renamed': [
         [
             'colour.models.oetf_ST2084',


### PR DESCRIPTION
Not sure if this is all that is needed but deprecated as according to issue #508 