### PR TITLE
PR: Deprecate "colour.models.XYZ_to_colourspace_model" definition.

### DIFF
--- a/colour/models/__init__.py
+++ b/colour/models/__init__.py
@@ -90,6 +90,9 @@ class models(ModuleAPI):
 
 # v0.3.14
 API_CHANGES = {
+    'FutureRemove': [
+        'colour.models.XYZ_to_colourspace_model',
+    ],
     'Renamed': [
         [
             'colour.models.oetf_ST2084',


### PR DESCRIPTION
Deprecated 'models.XYZ_to_colourspace_model' in reference to issue #508 