### PR TITLE
Move third party notices from LICENSE to THIRD_PARTY

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -22,16 +22,3 @@ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
 ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-Copyright for portions of project Adobe DNG Software Development Kit (SDK) are
-held by Adobe Systems, 2013 as part of project Adobe DNG SDK and are distributed
-under the DNG SDK License Agreement.
-
-Copyright for portions of project The Munsell and Kubelka-Munk Toolbox are
-held by Paul Centore, 2010-2018 as part of project The Munsell and Kubelka-Munk
-Toolbox and are distributed under the New BSD License by explicit permission
-of the author.
-
-Copyright for portions of project The ColorChecker (since 1976!) are
-held by Danny Pascale, 2004-2012 as part of project The ColorChecker
-(since 1976!) and are used by explicit permission of the author.

--- a/THIRD_PARTY
+++ b/THIRD_PARTY
@@ -1,0 +1,12 @@
+Copyright for portions of project Adobe DNG Software Development Kit (SDK) are
+held by Adobe Systems, 2013 as part of project Adobe DNG SDK and are distributed
+under the DNG SDK License Agreement.
+
+Copyright for portions of project The Munsell and Kubelka-Munk Toolbox are
+held by Paul Centore, 2010-2018 as part of project The Munsell and Kubelka-Munk
+Toolbox and are distributed under the New BSD License by explicit permission
+of the author.
+
+Copyright for portions of project The ColorChecker (since 1976!) are
+held by Danny Pascale, 2004-2012 as part of project The ColorChecker
+(since 1976!) and are used by explicit permission of the author.


### PR DESCRIPTION
Just a recommendation - this makes the GitHub automatic license identifier properly tag this project as BSD-3-Clause versus Unknown ( which also helps the ASWF Landscape identify the license as well ).