### PR TITLE
PR: Replace generator based tests.

### DIFF
--- a/colour/appearance/tests/common.py
+++ b/colour/appearance/tests/common.py
@@ -165,8 +165,9 @@ class ColourAppearanceModelTest(object):
         """
 
         for data_attr, specification_attr in sorted(output_attributes.items()):
-            yield (self.check_specification_attribute, data.get('Case'), data,
-                   specification_attr, data[data_attr])
+            self.check_specification_attribute(
+                data.get('Case'), data, specification_attr, data[data_attr]
+            )
 
     def fixtures(self):
         """
@@ -190,9 +191,7 @@ class ColourAppearanceModelTest(object):
         """
 
         for data in self.fixtures():
-            for test in self.check_model_consistency(data,
-                                                     self.OUTPUT_ATTRIBUTES):
-                yield test
+            self.check_model_consistency(data, self.OUTPUT_ATTRIBUTES)
 
     def test_n_dimensional_examples(self):
         """
@@ -212,5 +211,4 @@ class ColourAppearanceModelTest(object):
         for key in data:
             data[key] = np.array(data[key])
 
-        for test in self.check_model_consistency(data, self.OUTPUT_ATTRIBUTES):
-            yield test
+        self.check_model_consistency(data, self.OUTPUT_ATTRIBUTES)

--- a/colour/appearance/tests/test_llab.py
+++ b/colour/appearance/tests/test_llab.py
@@ -92,9 +92,7 @@ class TestLLABColourAppearanceModel(ColourAppearanceModelTest):
                 'colour.appearance.llab.LLAB_RGB_TO_XYZ_MATRIX',
                 np.around(
                     np.linalg.inv(llab.LLAB_XYZ_TO_RGB_MATRIX), decimals=4)):
-            for test in super(TestLLABColourAppearanceModel,
-                              self).test_examples():
-                yield test
+            super(TestLLABColourAppearanceModel, self).test_examples()
 
     def test_n_dimensional_examples(self):
         """
@@ -116,9 +114,8 @@ class TestLLABColourAppearanceModel(ColourAppearanceModelTest):
                 'colour.appearance.llab.LLAB_RGB_TO_XYZ_MATRIX',
                 np.around(
                     np.linalg.inv(llab.LLAB_XYZ_TO_RGB_MATRIX), decimals=4)):
-            for test in super(TestLLABColourAppearanceModel,
-                              self).test_n_dimensional_examples():
-                yield test
+            super(TestLLABColourAppearanceModel, self)\
+                .test_n_dimensional_examples()
 
     def test_colourspace_conversion_matrices_precision(self):
         """


### PR DESCRIPTION
References #518 .

This is probably the minimum possible change that avoids the generator based tests.

Instead of yielding tests, each check is executed, resulting in a single test that checks the whole dataset for each CAM.

A fancier version could use [pytest's parametrized test fixtures](http://doc.pytest.org/en/latest/parametrize.html) to re-create the one test per case behaviour we had before. But I'm not sure we actually need that.