### PR TITLE
Fix default values in docstring

### DIFF
--- a/colour/models/rgb/ycbcr.py
+++ b/colour/models/rgb/ycbcr.py
@@ -346,9 +346,9 @@ def YCbCr_to_RGB(YCbCr,
     in_bits : int, optional
         Bit depth for integer input, or used in the calculation of the
         denominator for legal range float values, i.e. 8-bit means the float
-        value for legal white is *235 / 255*. Default is *10*.
+        value for legal white is *235 / 255*. Default is *8*.
     in_legal : bool, optional
-        Whether to treat the input values as legal range. Default is *False*.
+        Whether to treat the input values as legal range. Default is *True*.
     in_int : bool, optional
         Whether to treat the input values as ``in_bits`` integer code values.
         Default is *False*.
@@ -356,9 +356,9 @@ def YCbCr_to_RGB(YCbCr,
         Bit depth for integer output, or used in the calculation of the
         denominator for legal range float values, i.e. 8-bit means the float
         value for legal white is *235 / 255*. Ignored if ``out_legal`` and
-        ``out_int`` are both *False*. Default is *8*.
+        ``out_int`` are both *False*. Default is *10*.
     out_legal : bool, optional
-        Whether to return legal range values. Default is *True*.
+        Whether to return legal range values. Default is *False*.
     out_int : bool, optional
         Whether to return values as ``out_bits`` integer code values. Default
         is *False*.


### PR DESCRIPTION
Fixes default values in `colour.models.rgb.ycbcr.YCbCr_to_RGB`s docstring maybe coming from copy-pasting the docstring from `colour.models.rgb.ycbcr.RGB_to_YCbCr`.