### PR TITLE
PR: Fix the various "DeprecationWarning" with Python 3.8.

### DIFF
--- a/colour/colorimetry/spectrum.py
+++ b/colour/colorimetry/spectrum.py
@@ -469,8 +469,9 @@ class SpectralShape(object):
 
         if self._range is None:
             samples = as_int(
-                round((self._interval + self._end - self._start) /
-                      self._interval))
+                int(
+                    round((self._interval + self._end - self._start) /
+                          self._interval)))
             range_, current_interval = np.linspace(
                 self._start, self._end, samples, retstep=True, dtype=dtype)
 

--- a/colour/io/luts/lut.py
+++ b/colour/io/luts/lut.py
@@ -17,7 +17,10 @@ from __future__ import division, unicode_literals
 import numpy as np
 import re
 from abc import ABCMeta, abstractmethod
-from collections import MutableSequence
+try:
+    from collections import MutableSequence
+except ImportError:
+    from collections.abc import MutableSequence
 from copy import deepcopy
 # pylint: disable=W0622
 from operator import add, mul, pow, sub, iadd, imul, ipow, isub


### PR DESCRIPTION
**Numpy 1.18 compatibility fix**
Regarding Issue #543 

I came across this, as the Numpy conversion error causes some of my own unit tests to fail. For me, it actually resulted in an ``TypeError: object of type <class 'numpy.float64'> cannot be safely interpreted as an integer`` unlike the ``DeprecationWarning`` mentioned in #543 .

Numpy's ``TypeError`` fix:
The missing conversion to int is fixed and compatibility to numpy 1.18 restored.
As far as I can tell, there is only one occurence of this issue throughout the colour package.

The ``DeprecationWarning`` regarding abc imports:
To keep backwards compatibility, modules are imported with a try-except clause. Therefore, all code is also compatible with Python>=3.9. I have added one missing try-except clause, but would keep the rest as is to ensure backwards compatibility. Yes, the ``DeprecationWarning``'s are a little annoying, but compatibility is more important, I would say.