### PR TITLE
PR: Add "ISO" 7589 spectral distributions.

### DIFF
--- a/BIBLIOGRAPHY.bib
+++ b/BIBLIOGRAPHY.bib
@@ -1,3 +1,10 @@
+@misc{AdobeSystems2013b,
+  author       = {{Adobe Systems}},
+  keywords     = {Iridas,look-up table,specification},
+  title        = {{Cube LUT Specification}},
+  url          = {https://drive.google.com/open?id=143Eh08ZYncCAMwJ1q4gWxVOqR{\_}OSWYvs},
+  year         = 2013,
+}
 @misc{AdobeSystems2005a,
   author       = {{Adobe Systems}},
   number       = {May},
@@ -20,13 +27,6 @@
     -
     dng{\_}sdk{\_}1{\_}3/dng{\_}sdk/source/dng{\_}temperature.cpp::dng{\_}temperature::xy{\_}coord}},
   url          = {https://www.adobe.com/support/downloads/dng/dng{\_}sdk.html},
-  year         = 2013,
-}
-@misc{AdobeSystems2013b,
-  author       = {{Adobe Systems}},
-  keywords     = {Iridas,look-up table,specification},
-  title        = {{Cube LUT Specification}},
-  url          = {https://drive.google.com/open?id=143Eh08ZYncCAMwJ1q4gWxVOqR{\_}OSWYvs},
   year         = 2013,
 }
 @misc{ANSI2003a,
@@ -58,6 +58,26 @@
   url          = {https://www.arib.or.jp/english/std{\_}tr/broadcasting/desc/std-b67.html},
   year         = 2015,
 }
+@misc{ASTMInternational2007,
+  author       = {{ASTM International}},
+  pages        = {1--10},
+  title        = {{ASTM D2244-07 - Standard Practice for Calculation
+    of Color Tolerances and Color Differences from Instrumentally
+    Measured Color Coordinates}},
+  volume       = {i},
+  year         = 2007,
+}
+@misc{ASTMInternational1989a,
+  annote       = {https://law.resource.org/pub/us/cfr/ibr/003/a},
+  author       = {{ASTM International}},
+  keywords     = {D1535,Munsell,Munsell color order system,Munsell
+    notation,color},
+  pages        = {1--29},
+  title        = {{ASTM D1535-89 - Standard Practice for Specifying
+    Color by the Munsell System}},
+  url          = {http://www.astm.org/DATABASE.CART/HISTORICAL/D1535-89.htm},
+  year         = 1989,
+}
 @misc{ASTMInternational2011a,
   abstract     = {This standard is issued under the fixed designation
     E2022; the number immediately following the designation indicates
@@ -72,22 +92,6 @@
     of Weighting Factors for Tristimulus Integration}},
   year         = 2011,
 }
-@misc{ASTMInternational2008a,
-  author       = {{ASTM International}},
-  doi          = {10.1520/D1535-08E01},
-  title        = {{ASTM D1535-08e1 - Standard Practice for Specifying
-    Color by the Munsell System}},
-  year         = 2008,
-}
-@misc{ASTMInternational2007,
-  author       = {{ASTM International}},
-  pages        = {1--10},
-  title        = {{ASTM D2244-07 - Standard Practice for Calculation
-    of Color Tolerances and Color Differences from Instrumentally
-    Measured Color Coordinates}},
-  volume       = {i},
-  year         = 2007,
-}
 @misc{ASTMInternational2015b,
   author       = {{ASTM International}},
   doi          = {10.1520/E0308-15},
@@ -96,28 +100,24 @@
     Colors of Objects by Using the CIE System}},
   year         = 2015,
 }
-@misc{ASTMInternational1989a,
-  annote       = {https://law.resource.org/pub/us/cfr/ibr/003/a},
+@misc{ASTMInternational2008a,
   author       = {{ASTM International}},
-  keywords     = {D1535,Munsell,Munsell color order system,Munsell
-    notation,color},
-  pages        = {1--29},
-  title        = {{ASTM D1535-89 - Standard Practice for Specifying
+  doi          = {10.1520/D1535-08E01},
+  title        = {{ASTM D1535-08e1 - Standard Practice for Specifying
     Color by the Munsell System}},
-  url          = {http://www.astm.org/DATABASE.CART/HISTORICAL/D1535-89.htm},
-  year         = 1989,
-}
-@misc{BabelColor2012c,
-  author       = {BabelColor},
-  title        = {{ColorChecker RGB and spectra}},
-  url          = {http://www.babelcolor.com/download/ColorChecker{\_}RGB{\_}and{\_}spectra.xls},
-  year         = 2012,
+  year         = 2008,
 }
 @misc{BabelColor2012b,
   author       = {BabelColor},
   title        = {{The ColorChecker (since 1976!)}},
   url          = {http://www.babelcolor.com/main{\_}level/ColorChecker.htm},
   urldate      = {2014-09-26},
+  year         = 2012,
+}
+@misc{BabelColor2012c,
+  author       = {BabelColor},
+  title        = {{ColorChecker RGB and spectra}},
+  url          = {http://www.babelcolor.com/download/ColorChecker{\_}RGB{\_}and{\_}spectra.xls},
   year         = 2012,
 }
 @book{Barten1999,
@@ -342,6 +342,11 @@
   url          = {http://link.springer.com/10.1007/978-1-84800-195-4},
   year         = 2009,
 }
+@misc{Cabello,
+  author       = {Cabello, Ricardo},
+  title        = {{PlaneGeometry.js}},
+  url          = {https://github.com/mrdoob/three.js/blob/dev/src/geometries/PlaneGeometry.js},
+}
 @misc{Cabello2015,
   author       = {Cabello, Ricardo},
   title        = {{PlaneGeometry.js}},
@@ -417,49 +422,27 @@
   urldate      = {2014-08-22},
   year         = 2014,
 }
+@article{Centore2012a,
+  author       = {Centore, Paul},
+  doi          = {10.1002/col.20715},
+  issn         = 03612317,
+  journal      = {Color Research {\&} Application},
+  keywords     = {algorithm,inverse renotation,munsell,open
+    source,renotation},
+  month        = dec,
+  number       = 6,
+  pages        = {455--464},
+  title        = {{An open-source inversion algorithm for the Munsell
+    renotation}},
+  url          = {http://doi.wiley.com/10.1002/col.20715},
+  volume       = 37,
+  year         = 2012,
+}
 @misc{Centore2014u,
   annote       = {http://www.99main.com/{\~{}}centore/MunsellAndKubelkaMunkToolbox/MunsellAndKubelkaMunkToolbox.html},
   author       = {Centore, Paul},
   title        = {{MunsellAndKubelkaMunkToolboxApr2014 -
     GeneralRoutines/CIELABtoApproxMunsellSpec.m}},
-  url          = {https://github.com/colour-science/MunsellAndKubelkaMunkToolbox},
-  year         = 2014,
-}
-@misc{Centore2014r,
-  annote       = {http://www.99main.com/{\~{}}centore/MunsellAndKubelkaMunkToolbox/MunsellAndKubelkaMunkToolbox.html},
-  author       = {Centore, Paul},
-  title        = {{MunsellAndKubelkaMunkToolboxApr2014 -
-    MunsellRenotationRoutines/MaxChromaForExtrapolatedRenotation.m}},
-  url          = {https://github.com/colour-science/MunsellAndKubelkaMunkToolbox},
-  year         = 2014,
-}
-@misc{Centore2014l,
-  annote       = {http://www.99main.com/{\~{}}centore/MunsellAndKubelkaMunkToolbox/MunsellAndKubelkaMunkToolbox.html},
-  author       = {Centore, Paul},
-  title        = {{MunsellAndKubelkaMunkToolboxApr2014 -
-    MunsellSystemRoutines/LinearVsRadialInterpOnRenotationOvoid.m}},
-  url          = {https://github.com/colour-science/MunsellAndKubelkaMunkToolbox},
-  year         = 2014,
-}
-@misc{Centorea,
-  author       = {Centore, Paul},
-  title        = {{The Munsell and Kubelka-Munk Toolbox}},
-  url          = {http://www.munsellcolourscienceforpainters.com/MunsellAndKubelkaMunkToolbox/MunsellAndKubelkaMunkToolbox.html},
-  urldate      = {2018-01-23},
-}
-@misc{Centore2014s,
-  annote       = {http://www.99main.com/{\~{}}centore/MunsellAndKubelkaMunkToolbox/MunsellAndKubelkaMunkToolbox.html},
-  author       = {Centore, Paul},
-  title        = {{MunsellAndKubelkaMunkToolboxApr2014 -
-    MunsellRenotationRoutines/MunsellHueToChromDiagHueAngle.m}},
-  url          = {https://github.com/colour-science/MunsellAndKubelkaMunkToolbox},
-  year         = 2014,
-}
-@misc{Centore2014k,
-  annote       = {http://www.99main.com/{\~{}}centore/MunsellAndKubelkaMunkToolbox/MunsellAndKubelkaMunkToolbox.html},
-  author       = {Centore, Paul},
-  title        = {{MunsellAndKubelkaMunkToolboxApr2014 -
-    MunsellRenotationRoutines/MunsellHueToASTMHue.m}},
   url          = {https://github.com/colour-science/MunsellAndKubelkaMunkToolbox},
   year         = 2014,
 }
@@ -479,27 +462,11 @@
   url          = {https://github.com/colour-science/MunsellAndKubelkaMunkToolbox},
   year         = 2014,
 }
-@misc{Centore2014t,
+@misc{Centore2014r,
   annote       = {http://www.99main.com/{\~{}}centore/MunsellAndKubelkaMunkToolbox/MunsellAndKubelkaMunkToolbox.html},
   author       = {Centore, Paul},
   title        = {{MunsellAndKubelkaMunkToolboxApr2014 -
-    MunsellRenotationRoutines/ChromDiagHueAngleToMunsellHue.m}},
-  url          = {https://github.com/colour-science/MunsellAndKubelkaMunkToolbox},
-  year         = 2014,
-}
-@misc{Centore2014o,
-  annote       = {http://www.99main.com/{\~{}}centore/MunsellAndKubelkaMunkToolbox/MunsellAndKubelkaMunkToolbox.html},
-  author       = {Centore, Paul},
-  title        = {{MunsellAndKubelkaMunkToolboxApr2014 -
-    MunsellSystemRoutines/BoundingRenotationHues.m}},
-  url          = {https://github.com/colour-science/MunsellAndKubelkaMunkToolbox},
-  year         = 2014,
-}
-@misc{Centore2014q,
-  annote       = {http://www.99main.com/{\~{}}centore/MunsellAndKubelkaMunkToolbox/MunsellAndKubelkaMunkToolbox.html},
-  author       = {Centore, Paul},
-  title        = {{MunsellAndKubelkaMunkToolboxApr2014 -
-    MunsellRenotationRoutines/MunsellToxyForIntegerMunsellValue.m}},
+    MunsellRenotationRoutines/MaxChromaForExtrapolatedRenotation.m}},
   url          = {https://github.com/colour-science/MunsellAndKubelkaMunkToolbox},
   year         = 2014,
 }
@@ -511,21 +478,59 @@
   url          = {https://github.com/colour-science/MunsellAndKubelkaMunkToolbox},
   year         = 2014,
 }
-@article{Centore2012a,
+@misc{Centore2014q,
+  annote       = {http://www.99main.com/{\~{}}centore/MunsellAndKubelkaMunkToolbox/MunsellAndKubelkaMunkToolbox.html},
   author       = {Centore, Paul},
-  doi          = {10.1002/col.20715},
-  issn         = 03612317,
-  journal      = {Color Research {\&} Application},
-  keywords     = {algorithm,inverse renotation,munsell,open
-    source,renotation},
-  month        = dec,
-  number       = 6,
-  pages        = {455--464},
-  title        = {{An open-source inversion algorithm for the Munsell
-    renotation}},
-  url          = {http://doi.wiley.com/10.1002/col.20715},
-  volume       = 37,
-  year         = 2012,
+  title        = {{MunsellAndKubelkaMunkToolboxApr2014 -
+    MunsellRenotationRoutines/MunsellToxyForIntegerMunsellValue.m}},
+  url          = {https://github.com/colour-science/MunsellAndKubelkaMunkToolbox},
+  year         = 2014,
+}
+@misc{Centorea,
+  author       = {Centore, Paul},
+  title        = {{The Munsell and Kubelka-Munk Toolbox}},
+  url          = {http://www.munsellcolourscienceforpainters.com/MunsellAndKubelkaMunkToolbox/MunsellAndKubelkaMunkToolbox.html},
+  urldate      = {2018-01-23},
+}
+@misc{Centore2014t,
+  annote       = {http://www.99main.com/{\~{}}centore/MunsellAndKubelkaMunkToolbox/MunsellAndKubelkaMunkToolbox.html},
+  author       = {Centore, Paul},
+  title        = {{MunsellAndKubelkaMunkToolboxApr2014 -
+    MunsellRenotationRoutines/ChromDiagHueAngleToMunsellHue.m}},
+  url          = {https://github.com/colour-science/MunsellAndKubelkaMunkToolbox},
+  year         = 2014,
+}
+@misc{Centore2014s,
+  annote       = {http://www.99main.com/{\~{}}centore/MunsellAndKubelkaMunkToolbox/MunsellAndKubelkaMunkToolbox.html},
+  author       = {Centore, Paul},
+  title        = {{MunsellAndKubelkaMunkToolboxApr2014 -
+    MunsellRenotationRoutines/MunsellHueToChromDiagHueAngle.m}},
+  url          = {https://github.com/colour-science/MunsellAndKubelkaMunkToolbox},
+  year         = 2014,
+}
+@misc{Centore2014o,
+  annote       = {http://www.99main.com/{\~{}}centore/MunsellAndKubelkaMunkToolbox/MunsellAndKubelkaMunkToolbox.html},
+  author       = {Centore, Paul},
+  title        = {{MunsellAndKubelkaMunkToolboxApr2014 -
+    MunsellSystemRoutines/BoundingRenotationHues.m}},
+  url          = {https://github.com/colour-science/MunsellAndKubelkaMunkToolbox},
+  year         = 2014,
+}
+@misc{Centore2014k,
+  annote       = {http://www.99main.com/{\~{}}centore/MunsellAndKubelkaMunkToolbox/MunsellAndKubelkaMunkToolbox.html},
+  author       = {Centore, Paul},
+  title        = {{MunsellAndKubelkaMunkToolboxApr2014 -
+    MunsellRenotationRoutines/MunsellHueToASTMHue.m}},
+  url          = {https://github.com/colour-science/MunsellAndKubelkaMunkToolbox},
+  year         = 2014,
+}
+@misc{Centore2014l,
+  annote       = {http://www.99main.com/{\~{}}centore/MunsellAndKubelkaMunkToolbox/MunsellAndKubelkaMunkToolbox.html},
+  author       = {Centore, Paul},
+  title        = {{MunsellAndKubelkaMunkToolboxApr2014 -
+    MunsellSystemRoutines/LinearVsRadialInterpOnRenotationOvoid.m}},
+  url          = {https://github.com/colour-science/MunsellAndKubelkaMunkToolbox},
+  year         = 2014,
 }
 @misc{Chamberlain2015,
   author       = {Chamberlain, Peter},
@@ -590,6 +595,29 @@
   url          = {http://div1.cie.co.at/?i{\_}ca{\_}id=551{\&}pubid=48},
   year         = 2006,
 }
+@incollection{CIETC1-382005f,
+  author       = {{CIE TC 1-38}},
+  booktitle    = {CIE 167:2005 Recommended Practice for Tabulating
+    Spectral Data for Use in Colour Computations},
+  chapter      = {9.2.4},
+  isbn         = {978-3-901-90641-1},
+  pages        = {1--27},
+  title        = {{9.2.4 Method of interpolation for uniformly spaced
+    independent variable}},
+  url          = {http://div1.cie.co.at/?i{\_}ca{\_}id=551{\&}pubid=47},
+  year         = 2005,
+}
+@incollection{CIETC1-382005e,
+  author       = {{CIE TC 1-38}},
+  booktitle    = {CIE 167:2005 Recommended Practice for Tabulating
+    Spectral Data for Use in Colour Computations},
+  chapter      = 9,
+  isbn         = {978-3-901-90641-1},
+  pages        = {14--19},
+  title        = {{9. INTERPOLATION}},
+  url          = {http://div1.cie.co.at/?i{\_}ca{\_}id=551{\&}pubid=47},
+  year         = 2005,
+}
 @incollection{CIETC1-382005h,
   author       = {{CIE TC 1-38}},
   booktitle    = {CIE 167:2005 Recommended Practice for Tabulating
@@ -613,28 +641,14 @@
   url          = {http://div1.cie.co.at/?i{\_}ca{\_}id=551{\&}pubid=47},
   year         = 2005,
 }
-@incollection{CIETC1-382005e,
-  author       = {{CIE TC 1-38}},
-  booktitle    = {CIE 167:2005 Recommended Practice for Tabulating
-    Spectral Data for Use in Colour Computations},
-  chapter      = 9,
-  isbn         = {978-3-901-90641-1},
-  pages        = {14--19},
-  title        = {{9. INTERPOLATION}},
-  url          = {http://div1.cie.co.at/?i{\_}ca{\_}id=551{\&}pubid=47},
-  year         = 2005,
-}
-@incollection{CIETC1-382005f,
-  author       = {{CIE TC 1-38}},
-  booktitle    = {CIE 167:2005 Recommended Practice for Tabulating
-    Spectral Data for Use in Colour Computations},
-  chapter      = {9.2.4},
-  isbn         = {978-3-901-90641-1},
-  pages        = {1--27},
-  title        = {{9.2.4 Method of interpolation for uniformly spaced
-    independent variable}},
-  url          = {http://div1.cie.co.at/?i{\_}ca{\_}id=551{\&}pubid=47},
-  year         = 2005,
+@incollection{CIETC1-482004,
+  author       = {{CIE TC 1-48}},
+  booktitle    = {CIE 015:2004 Colorimetry, 3rd Edition},
+  isbn         = {978-3-901-90633-6},
+  pages        = {68--68},
+  title        = {{EXPLANATORY COMMENTS - 5}},
+  url          = {http://www.cie.co.at/publications/colorimetry-3rd-edition},
+  year         = 2004,
 }
 @incollection{CIETC1-482004k,
   author       = {{CIE TC 1-48}},
@@ -643,16 +657,6 @@
   isbn         = {978-3-901-90633-6},
   pages        = 24,
   title        = {{The evaluation of whiteness}},
-  url          = {http://www.cie.co.at/publications/colorimetry-3rd-edition},
-  year         = 2004,
-}
-@incollection{CIETC1-482004o,
-  author       = {{CIE TC 1-48}},
-  booktitle    = {CIE 015:2004 Colorimetry, 3rd Edition},
-  chapter      = {9.1},
-  isbn         = {978-3-901-90633-6},
-  pages        = {32--33},
-  title        = {{9.1 Dominant wavelength and purity}},
   url          = {http://www.cie.co.at/publications/colorimetry-3rd-edition},
   year         = 2004,
 }
@@ -667,12 +671,13 @@
   url          = {http://www.cie.co.at/publications/colorimetry-3rd-edition},
   year         = 2004,
 }
-@incollection{CIETC1-482004,
+@incollection{CIETC1-482004o,
   author       = {{CIE TC 1-48}},
   booktitle    = {CIE 015:2004 Colorimetry, 3rd Edition},
+  chapter      = {9.1},
   isbn         = {978-3-901-90633-6},
-  pages        = {68--68},
-  title        = {{EXPLANATORY COMMENTS - 5}},
+  pages        = {32--33},
+  title        = {{9.1 Dominant wavelength and purity}},
   url          = {http://www.cie.co.at/publications/colorimetry-3rd-edition},
   year         = 2004,
 }
@@ -683,27 +688,6 @@
   isbn         = {978-3-901-90633-6},
   pages        = 24,
   title        = {{CIE 1976 uniform colour spaces}},
-  url          = {http://www.cie.co.at/publications/colorimetry-3rd-edition},
-  year         = 2004,
-}
-@incollection{CIETC1-482004n,
-  author       = {{CIE TC 1-48}},
-  booktitle    = {CIE 015:2004 Colorimetry, 3rd Edition},
-  chapter      = {3.1},
-  isbn         = {978-3-901-90633-6},
-  pages        = {12--13},
-  title        = {{3.1 Recommendations concerning standard physical
-    data of illuminants}},
-  url          = {http://www.cie.co.at/publications/colorimetry-3rd-edition},
-  year         = 2004,
-}
-@incollection{CIETC1-482004l,
-  author       = {{CIE TC 1-48}},
-  booktitle    = {CIE 015:2004 Colorimetry, 3rd Edition},
-  chapter      = {7.2.2.1},
-  isbn         = {978-3-901-90633-6},
-  pages        = 24,
-  title        = {{Extrapolation}},
   url          = {http://www.cie.co.at/publications/colorimetry-3rd-edition},
   year         = 2004,
 }
@@ -728,6 +712,33 @@
   url          = {http://www.cie.co.at/publications/colorimetry-3rd-edition},
   year         = 2004,
 }
+@incollection{CIETC1-482004n,
+  author       = {{CIE TC 1-48}},
+  booktitle    = {CIE 015:2004 Colorimetry, 3rd Edition},
+  chapter      = {3.1},
+  isbn         = {978-3-901-90633-6},
+  pages        = {12--13},
+  title        = {{3.1 Recommendations concerning standard physical
+    data of illuminants}},
+  url          = {http://www.cie.co.at/publications/colorimetry-3rd-edition},
+  year         = 2004,
+}
+@incollection{CIETC1-482004l,
+  author       = {{CIE TC 1-48}},
+  booktitle    = {CIE 015:2004 Colorimetry, 3rd Edition},
+  chapter      = {7.2.2.1},
+  isbn         = {978-3-901-90633-6},
+  pages        = 24,
+  title        = {{Extrapolation}},
+  url          = {http://www.cie.co.at/publications/colorimetry-3rd-edition},
+  year         = 2004,
+}
+@misc{Colblindora,
+  author       = {Colblindor},
+  title        = {{Deuteranopia - Red-Green Color Blindness}},
+  url          = {http://www.color-blindness.com/deuteranopia-red-green-color-blindness/},
+  urldate      = {2015-07-04},
+}
 @misc{Colblindorc,
   author       = {Colblindor},
   title        = {{Tritanopia - Blue-Yellow Color Blindness}},
@@ -738,12 +749,6 @@
   author       = {Colblindor},
   title        = {{Protanopia - Red-Green Color Blindness}},
   url          = {http://www.color-blindness.com/protanopia-red-green-color-blindness/},
-  urldate      = {2015-07-04},
-}
-@misc{Colblindora,
-  author       = {Colblindor},
-  title        = {{Deuteranopia - Red-Green Color Blindness}},
-  url          = {http://www.color-blindness.com/deuteranopia-red-green-color-blindness/},
   urldate      = {2015-07-04},
 }
 @misc{Cottrella,
@@ -770,18 +775,18 @@
   url          = {http://www.cvrl.org/stilesburch10{\_}ind.htm},
   urldate      = {2014-02-24},
 }
+@misc{CVRLp,
+  author       = {CVRL},
+  title        = {{CIE (2012) 10-deg XYZ "physiologically-relevant"
+    colour matching functions}},
+  url          = {http://www.cvrl.org/database/text/cienewxyz/cie2012xyz10.htm},
+  urldate      = {2014-06-25},
+}
 @misc{CVRLq,
   author       = {CVRL},
   title        = {{Luminous efficiency}},
   url          = {http://www.cvrl.org/lumindex.htm},
   urldate      = {2014-04-19},
-}
-@misc{CVRLw,
-  author       = {CVRL},
-  title        = {{Stiles {\&} Burch individual 2-deg colour matching
-    data}},
-  url          = {http://www.cvrl.org/stilesburch2{\_}ind.htm},
-  urldate      = {2014-02-24},
 }
 @misc{CVRLv,
   author       = {CVRL},
@@ -796,12 +801,12 @@
   url          = {http://cvrl.ioo.ucl.ac.uk/cie.htm},
   urldate      = {2014-02-24},
 }
-@misc{CVRLp,
+@misc{CVRLw,
   author       = {CVRL},
-  title        = {{CIE (2012) 10-deg XYZ "physiologically-relevant"
-    colour matching functions}},
-  url          = {http://www.cvrl.org/database/text/cienewxyz/cie2012xyz10.htm},
-  urldate      = {2014-06-25},
+  title        = {{Stiles {\&} Burch individual 2-deg colour matching
+    data}},
+  url          = {http://www.cvrl.org/stilesburch2{\_}ind.htm},
+  urldate      = {2014-02-24},
 }
 @misc{CVRLr,
   author       = {CVRL},
@@ -880,34 +885,10 @@
   url          = {https://www.dolby.com/us/en/technologies/dolby-vision/ICtCp-white-paper.pdf},
   year         = 2016,
 }
-@misc{EasyRGBj,
-  author       = {EasyRGB},
-  title        = {{RGB —{\textgreater} HSV}},
-  url          = {http://www.easyrgb.com/index.php?X=MATH{\&}H=20{\#}text20},
-  urldate      = {2014-05-18},
-}
 @misc{EasyRGBk,
   author       = {EasyRGB},
   title        = {{HSL —{\textgreater} RGB}},
   url          = {http://www.easyrgb.com/index.php?X=MATH{\&}H=19{\#}text19},
-  urldate      = {2014-05-18},
-}
-@misc{EasyRGBn,
-  author       = {EasyRGB},
-  title        = {{HSV —{\textgreater} RGB}},
-  url          = {http://www.easyrgb.com/index.php?X=MATH{\&}H=21{\#}text21},
-  urldate      = {2014-05-18},
-}
-@misc{EasyRGBh,
-  author       = {EasyRGB},
-  title        = {{RGB —{\textgreater} CMY}},
-  url          = {http://www.easyrgb.com/index.php?X=MATH{\&}H=11{\#}text11},
-  urldate      = {2014-05-18},
-}
-@misc{EasyRGBl,
-  author       = {EasyRGB},
-  title        = {{RGB —{\textgreater} HSL}},
-  url          = {http://www.easyrgb.com/index.php?X=MATH{\&}H=18{\#}text18},
   urldate      = {2014-05-18},
 }
 @misc{EasyRGBo,
@@ -916,16 +897,40 @@
   url          = {http://www.easyrgb.com/index.php?X=MATH{\&}H=13{\#}text13},
   urldate      = {2014-05-18},
 }
-@misc{EasyRGBm,
+@misc{EasyRGBj,
   author       = {EasyRGB},
-  title        = {{CMYK —{\textgreater} CMY}},
-  url          = {http://www.easyrgb.com/index.php?X=MATH{\&}H=14{\#}text14},
+  title        = {{RGB —{\textgreater} HSV}},
+  url          = {http://www.easyrgb.com/index.php?X=MATH{\&}H=20{\#}text20},
+  urldate      = {2014-05-18},
+}
+@misc{EasyRGBl,
+  author       = {EasyRGB},
+  title        = {{RGB —{\textgreater} HSL}},
+  url          = {http://www.easyrgb.com/index.php?X=MATH{\&}H=18{\#}text18},
+  urldate      = {2014-05-18},
+}
+@misc{EasyRGBh,
+  author       = {EasyRGB},
+  title        = {{RGB —{\textgreater} CMY}},
+  url          = {http://www.easyrgb.com/index.php?X=MATH{\&}H=11{\#}text11},
   urldate      = {2014-05-18},
 }
 @misc{EasyRGBi,
   author       = {EasyRGB},
   title        = {{CMY —{\textgreater} RGB}},
   url          = {http://www.easyrgb.com/index.php?X=MATH{\&}H=12{\#}text12},
+  urldate      = {2014-05-18},
+}
+@misc{EasyRGBn,
+  author       = {EasyRGB},
+  title        = {{HSV —{\textgreater} RGB}},
+  url          = {http://www.easyrgb.com/index.php?X=MATH{\&}H=21{\#}text21},
+  urldate      = {2014-05-18},
+}
+@misc{EasyRGBm,
+  author       = {EasyRGB},
+  title        = {{CMYK —{\textgreater} CMY}},
+  url          = {http://www.easyrgb.com/index.php?X=MATH{\&}H=14{\#}text14},
   urldate      = {2014-05-18},
 }
 @inproceedings{Ebner1998,
@@ -1015,17 +1020,17 @@
   title        = {{Fairchild YSh}},
   url          = {http://rit-mcsl.org/fairchild//files/FairchildYSh.zip},
 }
-@incollection{Fairchild2013w,
+@incollection{Fairchild2013ba,
   author       = {Fairchild, Mark D.},
   booktitle    = {Color Appearance Models},
-  chapter      = 13,
+  chapter      = 11,
   edition      = 3,
   isbn         = {B00DAYO8E2},
-  pages        = {5563--5824},
+  pages        = {4810--5085},
   publisher    = {Wiley},
   series       = {The Wiley-IS{\&}T Series in Imaging Science and
     Technology},
-  title        = {{The RLAB Model}},
+  title        = {{The Nayatani et al. Model}},
   year         = 2013,
 }
 @incollection{Fairchild2013y,
@@ -1041,57 +1046,18 @@
   title        = {{IPT Colourspace}},
   year         = 2013,
 }
-@incollection{Fairchild2013ba,
+@incollection{Fairchild2004c,
   author       = {Fairchild, Mark D.},
   booktitle    = {Color Appearance Models},
-  chapter      = 11,
-  edition      = 3,
-  isbn         = {B00DAYO8E2},
-  pages        = {4810--5085},
+  chapter      = {CIECAM02},
+  edition      = 2,
+  isbn         = {978-0470012161},
+  pages        = {289--301},
   publisher    = {Wiley},
   series       = {The Wiley-IS{\&}T Series in Imaging Science and
     Technology},
-  title        = {{The Nayatani et al. Model}},
-  year         = 2013,
-}
-@incollection{Fairchild2013u,
-  author       = {Fairchild, Mark D.},
-  booktitle    = {Color Appearance Models},
-  chapter      = 12,
-  edition      = 3,
-  isbn         = {B00DAYO8E2},
-  pages        = {5094--5556},
-  publisher    = {Wiley},
-  series       = {The Wiley-IS{\&}T Series in Imaging Science and
-    Technology},
-  title        = {{The Hunt Model}},
-  year         = 2013,
-}
-@incollection{Fairchild2013v,
-  author       = {Fairchild, Mark D.},
-  booktitle    = {Color Appearance Models},
-  chapter      = {14.2},
-  edition      = 3,
-  isbn         = {B00DAYO8E2},
-  pages        = {5852--5991},
-  publisher    = {Wiley},
-  series       = {The Wiley-IS{\&}T Series in Imaging Science and
-    Technology},
-  title        = {{ATD Model}},
-  year         = 2013,
-}
-@incollection{Fairchild2013t,
-  author       = {Fairchild, Mark D.},
-  booktitle    = {Color Appearance Models},
-  chapter      = 11,
-  edition      = 3,
-  isbn         = {B00DAYO8E2},
-  pages        = {4179--4252},
-  publisher    = {Wiley},
-  series       = {The Wiley-IS{\&}T Series in Imaging Science and
-    Technology},
-  title        = {{Chromatic Adaptation Models}},
-  year         = 2013,
+  title        = {{CIECAM02}},
+  year         = 2004,
 }
 @incollection{Fairchild2013x,
   author       = {Fairchild, Mark D.},
@@ -1119,18 +1085,57 @@
   title        = {{FAIRCHILD'S 1990 MODEL}},
   year         = 2013,
 }
-@incollection{Fairchild2004c,
+@incollection{Fairchild2013v,
   author       = {Fairchild, Mark D.},
   booktitle    = {Color Appearance Models},
-  chapter      = {CIECAM02},
-  edition      = 2,
-  isbn         = {978-0470012161},
-  pages        = {289--301},
+  chapter      = {14.2},
+  edition      = 3,
+  isbn         = {B00DAYO8E2},
+  pages        = {5852--5991},
   publisher    = {Wiley},
   series       = {The Wiley-IS{\&}T Series in Imaging Science and
     Technology},
-  title        = {{CIECAM02}},
-  year         = 2004,
+  title        = {{ATD Model}},
+  year         = 2013,
+}
+@incollection{Fairchild2013w,
+  author       = {Fairchild, Mark D.},
+  booktitle    = {Color Appearance Models},
+  chapter      = 13,
+  edition      = 3,
+  isbn         = {B00DAYO8E2},
+  pages        = {5563--5824},
+  publisher    = {Wiley},
+  series       = {The Wiley-IS{\&}T Series in Imaging Science and
+    Technology},
+  title        = {{The RLAB Model}},
+  year         = 2013,
+}
+@incollection{Fairchild2013u,
+  author       = {Fairchild, Mark D.},
+  booktitle    = {Color Appearance Models},
+  chapter      = 12,
+  edition      = 3,
+  isbn         = {B00DAYO8E2},
+  pages        = {5094--5556},
+  publisher    = {Wiley},
+  series       = {The Wiley-IS{\&}T Series in Imaging Science and
+    Technology},
+  title        = {{The Hunt Model}},
+  year         = 2013,
+}
+@incollection{Fairchild2013t,
+  author       = {Fairchild, Mark D.},
+  booktitle    = {Color Appearance Models},
+  chapter      = 11,
+  edition      = 3,
+  isbn         = {B00DAYO8E2},
+  pages        = {4179--4252},
+  publisher    = {Wiley},
+  series       = {The Wiley-IS{\&}T Series in Imaging Science and
+    Technology},
+  title        = {{Chromatic Adaptation Models}},
+  year         = 2013,
 }
 @article{Fairchild1991a,
   abstract     = {A mathematical model of chromatic adaptation for
@@ -1460,15 +1465,6 @@
   url          = {https://hunterlabdotcom.files.wordpress.com/2012/07/an-1016-hunter-rd-a-b-color-scale-update-12-07-03.pdf},
   year         = 2012,
 }
-@misc{HunterLab2008b,
-  author       = {HunterLab},
-  number       = 9,
-  pages        = {1--4},
-  title        = {{Hunter L,a,b Color Scale}},
-  url          = {http://www.hunterlab.se/wp-content/uploads/2012/11/Hunter-L-a-b.pdf},
-  volume       = 8,
-  year         = 2008,
-}
 @misc{HunterLab2008c,
   author       = {HunterLab},
   keywords     = {ASTM illuminant},
@@ -1480,17 +1476,20 @@
   volume       = 14,
   year         = 2008,
 }
+@misc{HunterLab2008b,
+  author       = {HunterLab},
+  number       = 9,
+  pages        = {1--4},
+  title        = {{Hunter L,a,b Color Scale}},
+  url          = {http://www.hunterlab.se/wp-content/uploads/2012/11/Hunter-L-a-b.pdf},
+  volume       = 8,
+  year         = 2008,
+}
 @misc{HutchColorf,
   annote       = {http://www.hutchcolor.com/profiles.html},
   author       = {HutchColor},
   title        = {{MaxRGB (4 K)}},
   url          = {http://www.hutchcolor.com/profiles/MaxRGB.zip},
-}
-@misc{HutchColorg,
-  annote       = {http://www.hutchcolor.com/profiles.html},
-  author       = {HutchColor},
-  title        = {{DonRGB4 (4 K)}},
-  url          = {http://www.hutchcolor.com/profiles/DonRGB4.zip},
 }
 @misc{HutchColore,
   annote       = {http://www.hutchcolor.com/profiles.html},
@@ -1504,6 +1503,12 @@
   title        = {{BestRGB (4 K)}},
   url          = {http://www.hutchcolor.com/profiles/BestRGB.zip},
 }
+@misc{HutchColorg,
+  annote       = {http://www.hutchcolor.com/profiles.html},
+  author       = {HutchColor},
+  title        = {{DonRGB4 (4 K)}},
+  url          = {http://www.hutchcolor.com/profiles/DonRGB4.zip},
+}
 @misc{IESComputerCommittee2014a,
   author       = {{IES Computer Committee} and {TM-27-14 Working
     Group}},
@@ -1512,6 +1517,13 @@
   title        = {{IES Standard Format for the Electronic Transfer of
     Spectral Data Electronic Transfer of Spectral Data}},
   year         = 2014,
+}
+@misc{InternationalColorConsortium2010,
+  author       = {{International Color Consortium}},
+  pages        = {1--130},
+  title        = {{Specification ICC.1:2010 (Profile version 4.3.0.0)}},
+  url          = {http://www.color.org/specification/ICC1v43{\_}2010-12.pdf},
+  year         = 2010,
 }
 @misc{InternationalElectrotechnicalCommission1999a,
   author       = {{International Electrotechnical Commission}},
@@ -1530,31 +1542,6 @@
   url          = {https://www.itu.int/dms{\_}pubrec/itu-r/rec/bt/R-REC-BT.2100-2-201807-I!!PDF-E.pdf},
   year         = 2018,
 }
-@misc{InternationalTelecommunicationUnion1998a,
-  author       = {{International Telecommunication Union}},
-  pages        = {1--36},
-  title        = {{Recommendation ITU-R BT.470-6 - CONVENTIONAL
-    TELEVISION SYSTEMS}},
-  url          = {http://www.itu.int/dms{\_}pubrec/itu-r/rec/bt/R-REC-BT.470-6-199811-S!!PDF-E.pdf},
-  year         = 1998,
-}
-@misc{InternationalTelecommunicationUnion2011f,
-  author       = {{International Telecommunication Union}},
-  title        = {{Recommendation ITU-R BT.601-7 - Studio encoding
-    parameters of digital television for standard 4:3 and wide-screen
-    16:9 aspect ratios}},
-  url          = {http://www.itu.int/dms{\_}pubrec/itu-r/rec/bt/R-REC-BT.601-7-201103-I!!PDF-E.pdf},
-  year         = 2011,
-}
-@misc{InternationalTelecommunicationUnion2015i,
-  author       = {{International Telecommunication Union}},
-  pages        = {1--32},
-  title        = {{Recommendation ITU-R BT.709-6 - Parameter values
-    for the HDTV standards for production and international programme
-    exchange BT Series Broadcasting service}},
-  url          = {https://www.itu.int/dms{\_}pubrec/itu-r/rec/bt/R-REC-BT.709-6-201506-I!!PDF-E.pdf},
-  year         = 2015,
-}
 @misc{InternationalTelecommunicationUnion2015,
   author       = {{International Telecommunication Union}},
   pages        = {1--92},
@@ -1563,13 +1550,13 @@
   volume       = 5,
   year         = 2015,
 }
-@misc{InternationalTelecommunicationUnion2011h,
+@misc{InternationalTelecommunicationUnion1998a,
   author       = {{International Telecommunication Union}},
-  title        = {{Recommendation ITU-R BT.1886 - Reference
-    electro-optical transfer function for flat panel displays used in
-    HDTV studio production BT Series Broadcasting service}},
-  url          = {https://www.itu.int/dms{\_}pubrec/itu-r/rec/bt/R-REC-BT.1886-0-201103-I!!PDF-E.pdf},
-  year         = 2011,
+  pages        = {1--36},
+  title        = {{Recommendation ITU-R BT.470-6 - CONVENTIONAL
+    TELEVISION SYSTEMS}},
+  url          = {http://www.itu.int/dms{\_}pubrec/itu-r/rec/bt/R-REC-BT.470-6-199811-S!!PDF-E.pdf},
+  year         = 1998,
 }
 @misc{InternationalTelecommunicationUnion2015h,
   abstract     = {The role of the Radiocommunication Sector is to
@@ -1595,6 +1582,31 @@
     – Digital compression and coding of continuous-tone still images:
     JPEG File Interchange Format (JFIF)}},
   url          = {https://www.itu.int/rec/dologin{\_}pub.asp?lang=e{\&}id=T-REC-T.871-201105-I!!PDF-E{\&}type=items},
+  year         = 2011,
+}
+@misc{InternationalTelecommunicationUnion2011h,
+  author       = {{International Telecommunication Union}},
+  title        = {{Recommendation ITU-R BT.1886 - Reference
+    electro-optical transfer function for flat panel displays used in
+    HDTV studio production BT Series Broadcasting service}},
+  url          = {https://www.itu.int/dms{\_}pubrec/itu-r/rec/bt/R-REC-BT.1886-0-201103-I!!PDF-E.pdf},
+  year         = 2011,
+}
+@misc{InternationalTelecommunicationUnion2015i,
+  author       = {{International Telecommunication Union}},
+  pages        = {1--32},
+  title        = {{Recommendation ITU-R BT.709-6 - Parameter values
+    for the HDTV standards for production and international programme
+    exchange BT Series Broadcasting service}},
+  url          = {https://www.itu.int/dms{\_}pubrec/itu-r/rec/bt/R-REC-BT.709-6-201506-I!!PDF-E.pdf},
+  year         = 2015,
+}
+@misc{InternationalTelecommunicationUnion2011f,
+  author       = {{International Telecommunication Union}},
+  title        = {{Recommendation ITU-R BT.601-7 - Studio encoding
+    parameters of digital television for standard 4:3 and wide-screen
+    16:9 aspect ratios}},
+  url          = {http://www.itu.int/dms{\_}pubrec/itu-r/rec/bt/R-REC-BT.601-7-201103-I!!PDF-E.pdf},
   year         = 2011,
 }
 @misc{InternationalTelecommunicationUnion2017,
@@ -1718,6 +1730,34 @@
   url          = {https://pdfs.semanticscholar.org/b5a9/0215ad9a1fb6b01f310b3d64305f7c9feb3a.pdf},
   year         = 2007,
 }
+@misc{Lindbloom2015,
+  author       = {Lindbloom, Bruce},
+  title        = {{About the Lab Gamut}},
+  url          = {http://www.brucelindbloom.com/LabGamutDisplayHelp.html},
+  urldate      = {2018-08-20},
+  year         = 2015,
+}
+@misc{Lindbloom2009e,
+  author       = {Lindbloom, Bruce},
+  title        = {{Delta E (CIE 2000)}},
+  url          = {http://brucelindbloom.com/Eqn{\_}DeltaE{\_}CIE2000.html},
+  urldate      = {2014-02-24},
+  year         = 2009,
+}
+@misc{Lindbloom2009f,
+  author       = {Lindbloom, Bruce},
+  title        = {{Delta E (CMC)}},
+  url          = {http://brucelindbloom.com/Eqn{\_}DeltaE{\_}CMC.html},
+  urldate      = {2014-02-24},
+  year         = 2009,
+}
+@misc{Lindbloom2009d,
+  author       = {Lindbloom, Bruce},
+  title        = {{xyY to XYZ}},
+  url          = {http://www.brucelindbloom.com/Eqn{\_}xyY{\_}to{\_}XYZ.html},
+  urldate      = {2014-02-24},
+  year         = 2009,
+}
 @misc{Lindbloom2003e,
   author       = {Lindbloom, Bruce},
   title        = {{XYZ to xyY}},
@@ -1732,27 +1772,6 @@
   urldate      = {2014-02-24},
   year         = 2003,
 }
-@misc{Lindbloom2009e,
-  author       = {Lindbloom, Bruce},
-  title        = {{Delta E (CIE 2000)}},
-  url          = {http://brucelindbloom.com/Eqn{\_}DeltaE{\_}CIE2000.html},
-  urldate      = {2014-02-24},
-  year         = 2009,
-}
-@misc{Lindbloom2009d,
-  author       = {Lindbloom, Bruce},
-  title        = {{xyY to XYZ}},
-  url          = {http://www.brucelindbloom.com/Eqn{\_}xyY{\_}to{\_}XYZ.html},
-  urldate      = {2014-02-24},
-  year         = 2009,
-}
-@misc{Lindbloom2015,
-  author       = {Lindbloom, Bruce},
-  title        = {{About the Lab Gamut}},
-  url          = {http://www.brucelindbloom.com/LabGamutDisplayHelp.html},
-  urldate      = {2018-08-20},
-  year         = 2015,
-}
 @misc{Lindbloom2009g,
   author       = {Lindbloom, Bruce},
   title        = {{Chromatic Adaptation}},
@@ -1760,12 +1779,12 @@
   urldate      = {2014-02-24},
   year         = 2009,
 }
-@misc{Lindbloom2009f,
+@misc{Lindbloom2014a,
   author       = {Lindbloom, Bruce},
-  title        = {{Delta E (CMC)}},
-  url          = {http://brucelindbloom.com/Eqn{\_}DeltaE{\_}CMC.html},
-  urldate      = {2014-02-24},
-  year         = 2009,
+  title        = {{RGB Working Space Information}},
+  url          = {http://www.brucelindbloom.com/WorkingSpaceInfo.html},
+  urldate      = {2014-04-11},
+  year         = 2014,
 }
 @misc{Lindbloom2011a,
   author       = {Lindbloom, Bruce},
@@ -1773,13 +1792,6 @@
   url          = {http://brucelindbloom.com/Eqn{\_}DeltaE{\_}CIE94.html},
   urldate      = {2014-02-24},
   year         = 2011,
-}
-@misc{Lindbloom2014a,
-  author       = {Lindbloom, Bruce},
-  title        = {{RGB Working Space Information}},
-  url          = {http://www.brucelindbloom.com/WorkingSpaceInfo.html},
-  urldate      = {2014-04-11},
-  year         = 2014,
 }
 @article{Lu2016c,
   abstract     = {High Dynamic Range (HDR) and Wider Colour Gamut
@@ -1952,6 +1964,30 @@
   url          = {http://www.researchgate.net/publication/236348295{\_}Two{\_}Unsolved{\_}Issues{\_}in{\_}Colour{\_}Management{\_}{\_}Colour{\_}Appearance{\_}and{\_}Gamut{\_}Mapping},
   year         = 1996,
 }
+@article{MacAdam1935a,
+  abstract     = {Tristimulus values have been computed for
+    hypothetical spectrophotometric curves of the type found to give
+    the maximum visual reflectance factor (or transmission factor) for
+    specified chromaticities. These computations have been based on
+    the I.C.I. 1931 data for the normal observer for colorimetry, and
+    on the I.C.I. Illuminants ``A'' and ``C.'' By plotting the results
+    on the I.C.I. color mixture diagram, the loci of points
+    characterized by equal maximum efficiencies have been established.
+    Tables have been prepared showing the maximum visual efficiency as
+    a function of excitation purity for twenty-four dominant
+    wave-lengths.},
+  author       = {MacAdam, David L.},
+  doi          = {10.1364/JOSA.25.000361},
+  journal      = {Journal of the Optical Society of America},
+  month        = nov,
+  number       = 11,
+  pages        = {361--367},
+  publisher    = {OSA},
+  title        = {{Maximum Visual Efficiency of Colored Materials}},
+  url          = {http://www.opticsinfobase.org/abstract.cfm?URI=josa-25-11-361},
+  volume       = 25,
+  year         = 1935,
+}
 @article{Macadam1942,
   abstract     = {An apparatus is described which facilitates the
     presentation of pairs of variable colors without variation of
@@ -2002,30 +2038,6 @@
     Daylight}},
   volume       = 32,
   year         = 1942,
-}
-@article{MacAdam1935a,
-  abstract     = {Tristimulus values have been computed for
-    hypothetical spectrophotometric curves of the type found to give
-    the maximum visual reflectance factor (or transmission factor) for
-    specified chromaticities. These computations have been based on
-    the I.C.I. 1931 data for the normal observer for colorimetry, and
-    on the I.C.I. Illuminants ``A'' and ``C.'' By plotting the results
-    on the I.C.I. color mixture diagram, the loci of points
-    characterized by equal maximum efficiencies have been established.
-    Tables have been prepared showing the maximum visual efficiency as
-    a function of excitation purity for twenty-four dominant
-    wave-lengths.},
-  author       = {MacAdam, David L.},
-  doi          = {10.1364/JOSA.25.000361},
-  journal      = {Journal of the Optical Society of America},
-  month        = nov,
-  number       = 11,
-  pages        = {361--367},
-  publisher    = {OSA},
-  title        = {{Maximum Visual Efficiency of Colored Materials}},
-  url          = {http://www.opticsinfobase.org/abstract.cfm?URI=josa-25-11-361},
-  volume       = 25,
-  year         = 1935,
 }
 @article{Machado2009,
   abstract     = {Color vision deficiency (CVD) affects approximately
@@ -2090,13 +2102,6 @@
   url          = {https://github.com/colour-science/colour-datasets},
   year         = 2019,
 }
-@misc{Mansencal2015d,
-  author       = {Mansencal, Thomas},
-  title        = {{RED Colourspaces Derivation}},
-  url          = {https://www.colour-science.org/posts/red-colourspaces-derivation},
-  urldate      = {2015-05-20},
-  year         = 2015,
-}
 @misc{Mansencal2018,
   author       = {Mansencal, Thomas},
   title        = {{How is the visible gamut bounded?}},
@@ -2104,15 +2109,22 @@
   urldate      = {2018-08-19},
   year         = 2018,
 }
+@misc{Mansencald,
+  author       = {Mansencal, Thomas},
+  title        = {{Structure}},
+  url          = {https://github.com/KelSolaar/Foundations/blob/develop/foundations/data{\_}structures.py},
+}
 @misc{Mansencalc,
   author       = {Mansencal, Thomas},
   title        = {{Lookup}},
   url          = {https://github.com/KelSolaar/Foundations/blob/develop/foundations/data{\_}structures.py},
 }
-@misc{Mansencald,
+@misc{Mansencal2015d,
   author       = {Mansencal, Thomas},
-  title        = {{Structure}},
-  url          = {https://github.com/KelSolaar/Foundations/blob/develop/foundations/data{\_}structures.py},
+  title        = {{RED Colourspaces Derivation}},
+  url          = {https://www.colour-science.org/posts/red-colourspaces-derivation},
+  urldate      = {2015-05-20},
+  year         = 2015,
 }
 @misc{Melgosa2013b,
   author       = {Melgosa, Manuel},
@@ -2316,6 +2328,12 @@
   volume       = 10,
   year         = 2014,
 }
+@misc{Ohno2013,
+  author       = {Ohno, Yoshiro and Davis, Wendy},
+  title        = {{NIST CQS simulation 9.0}},
+  url          = {https://www.researchgate.net/file.PostFileLoader.html?id=5541c498f15bc7cc2c8b4578{\&}assetKey=AS{\%}3A273582771376136{\%}401442238623549},
+  year         = 2013,
+}
 @misc{Ohno2008a,
   annote       = {http://cie2.nist.gov/TC1-69/NIST CQS simulation
     7.4.xls},
@@ -2323,12 +2341,6 @@
   title        = {{NIST CQS simulation 7.4}},
   url          = {https://drive.google.com/file/d/1PsuU6QjUJjCX6tQyCud6ul2Tbs8rYWW9/view?usp=sharing},
   year         = 2008,
-}
-@misc{Ohno2013,
-  author       = {Ohno, Yoshiro and Davis, Wendy},
-  title        = {{NIST CQS simulation 9.0}},
-  url          = {https://www.researchgate.net/file.PostFileLoader.html?id=5541c498f15bc7cc2c8b4578{\&}assetKey=AS{\%}3A273582771376136{\%}401442238623549},
-  year         = 2013,
 }
 @misc{Ohta1997a,
   author       = {Ohta, N.},
@@ -2505,28 +2517,6 @@
   volume       = 4,
   year         = 1999,
 }
-@misc{SocietyofMotionPictureandTelevisionEngineers2014a,
-  abstract     = {This standard specifies an EOTF characterizing
-    high-dynamic-range reference displays used primarily for mastering
-    non-broadcast content. This standard also specifies an
-    Inverse-EOTF derived from the EOTF.},
-  author       = {{Society of Motion Picture and Television Engineers}},
-  doi          = {10.5594/SMPTE.ST2084.2014},
-  pages        = {1--14},
-  title        = {{SMPTE ST 2084:2014 - Dynamic Range Electro-Optical
-    Transfer Function of Mastering Reference Displays}},
-  url          = {http://www.techstreet.com/products/1883436},
-  year         = 2014,
-}
-@misc{SocietyofMotionPictureandTelevisionEngineers1999b,
-  author       = {{Society of Motion Picture and Television Engineers}},
-  pages        = {1--7},
-  title        = {{ANSI/SMPTE 240M-1995 - Signal Parameters -
-    1125-Line High-Definition Production Systems}},
-  url          = {http://car.france3.mars.free.fr/HD/INA- 26 jan
-    06/SMPTE normes et confs/s240m.pdf},
-  year         = 1999,
-}
 @book{SocietyofMotionPictureandTelevisionEngineers2004a,
   abstract     = {cie Scope This practice specifies the chromaticity
     values of the red, green, and blue visible radiation emitted by
@@ -2545,6 +2535,19 @@
   url          = {http://standards.smpte.org/lookup/doi/10.5594/S9781614821649},
   volume       = {RP 145:200},
   year         = 2004,
+}
+@misc{SocietyofMotionPictureandTelevisionEngineers2014a,
+  abstract     = {This standard specifies an EOTF characterizing
+    high-dynamic-range reference displays used primarily for mastering
+    non-broadcast content. This standard also specifies an
+    Inverse-EOTF derived from the EOTF.},
+  author       = {{Society of Motion Picture and Television Engineers}},
+  doi          = {10.5594/SMPTE.ST2084.2014},
+  pages        = {1--14},
+  title        = {{SMPTE ST 2084:2014 - Dynamic Range Electro-Optical
+    Transfer Function of Mastering Reference Displays}},
+  url          = {http://www.techstreet.com/products/1883436},
+  year         = 2014,
 }
 @book{SocietyofMotionPictureandTelevisionEngineers1993a,
   abstract     = {color white whitepoint matrix Scope This practice is
@@ -2573,12 +2576,19 @@
   volume       = {RP 177:199},
   year         = 1993,
 }
-@misc{SonyCorporation,
+@misc{SocietyofMotionPictureandTelevisionEngineers1999b,
+  author       = {{Society of Motion Picture and Television Engineers}},
+  pages        = {1--7},
+  title        = {{ANSI/SMPTE 240M-1995 - Signal Parameters -
+    1125-Line High-Definition Production Systems}},
+  url          = {http://car.france3.mars.free.fr/HD/INA- 26 jan
+    06/SMPTE normes et confs/s240m.pdf},
+  year         = 1999,
+}
+@misc{SonyCorporatione,
   author       = {{Sony Corporation}},
-  pages        = {1--17},
-  title        = {{S-Log Whitepaper}},
-  url          = {http://www.theodoropoulos.info/attachments/076{\_}on
-    S-Log.pdf},
+  title        = {{S-Gamut3{\_}S-Gamut3Cine{\_}Matrix.xlsx}},
+  url          = {https://community.sony.com/sony/attachments/sony/large-sensor-camera-F5-F55/12359/3/S-Gamut3{\_}S-Gamut3Cine{\_}Matrix.xlsx},
 }
 @misc{SonyCorporationd,
   author       = {{Sony Corporation}},
@@ -2587,17 +2597,19 @@
     S-Gamut3/S-Log3}},
   url          = {http://community.sony.com/sony/attachments/sony/large-sensor-camera-F5-F55/12359/2/TechnicalSummary{\_}for{\_}S-Gamut3Cine{\_}S-Gamut3{\_}S-Log3{\_}V1{\_}00.pdf},
 }
+@misc{SonyCorporation,
+  author       = {{Sony Corporation}},
+  pages        = {1--17},
+  title        = {{S-Log Whitepaper}},
+  url          = {http://www.theodoropoulos.info/attachments/076{\_}on
+    S-Log.pdf},
+}
 @misc{SonyCorporation2012a,
   author       = {{Sony Corporation}},
   pages        = {1--9},
   title        = {{S-Log2 Technical Paper}},
   url          = {https://pro.sony.com/bbsccms/assets/files/micro/dmpc/training/S-Log2{\_}Technical{\_}PaperV1{\_}0.pdf},
   year         = 2012,
-}
-@misc{SonyCorporatione,
-  author       = {{Sony Corporation}},
-  title        = {{S-Gamut3{\_}S-Gamut3Cine{\_}Matrix.xlsx}},
-  url          = {https://community.sony.com/sony/attachments/sony/large-sensor-camera-F5-F55/12359/3/S-Gamut3{\_}S-Gamut3Cine{\_}Matrix.xlsx},
 }
 @misc{SonyImageworks2012a,
   author       = {{Sony Imageworks}},
@@ -2757,6 +2769,24 @@
   urldate      = {2016-10-10},
   year         = 2016,
 }
+@misc{TheAcademyofMotionPictureArtsandSciencese,
+  author       = {{The Academy of Motion Picture Arts and Sciences}
+    and {Science and Technology Council} and {Academy Color Encoding
+    System (ACES) Project Subcommittee}},
+  title        = {{Academy Color Encoding System}},
+  url          = {http://www.oscars.org/science-technology/council/projects/aces.html},
+  urldate      = {2014-02-24},
+}
+@misc{TheAcademyofMotionPictureArtsandSciences2014r,
+  author       = {{The Academy of Motion Picture Arts and Sciences}
+    and {Science and Technology Council} and {Academy Color Encoding
+    System (ACES) Project Subcommittee}},
+  pages        = {1--8},
+  title        = {{Technical Bulletin TB-2014-012 - Academy Color
+    Encoding System Version 1.0 Component Names}},
+  url          = {https://github.com/ampas/aces-dev/tree/master/documents},
+  year         = 2014,
+}
 @misc{TheAcademyofMotionPictureArtsandSciences2014s,
   author       = {{The Academy of Motion Picture Arts and Sciences}
     and {Science and Technology Council} and {Academy Color Encoding
@@ -2767,13 +2797,13 @@
   url          = {https://github.com/ampas/aces-dev/tree/master/documents},
   year         = 2014,
 }
-@misc{TheAcademyofMotionPictureArtsandSciences2014t,
+@misc{TheAcademyofMotionPictureArtsandSciences2014q,
   author       = {{The Academy of Motion Picture Arts and Sciences}
     and {Science and Technology Council} and {Academy Color Encoding
     System (ACES) Project Subcommittee}},
-  pages        = {1--12},
-  title        = {{Specification S-2014-003 - ACEScc, A Logarithmic
-    Encoding of ACES Data for use within Color Grading Systems}},
+  pages        = {1--40},
+  title        = {{Technical Bulletin TB-2014-004 - Informative Notes
+    on SMPTE ST 2065-1 – Academy Color Encoding Specification (ACES)}},
   url          = {https://github.com/ampas/aces-dev/tree/master/documents},
   year         = 2014,
 }
@@ -2787,31 +2817,13 @@
   url          = {https://github.com/ampas/aces-dev/tree/master/documents},
   year         = 2015,
 }
-@misc{TheAcademyofMotionPictureArtsandSciences2014r,
+@misc{TheAcademyofMotionPictureArtsandSciences2014t,
   author       = {{The Academy of Motion Picture Arts and Sciences}
     and {Science and Technology Council} and {Academy Color Encoding
     System (ACES) Project Subcommittee}},
-  pages        = {1--8},
-  title        = {{Technical Bulletin TB-2014-012 - Academy Color
-    Encoding System Version 1.0 Component Names}},
-  url          = {https://github.com/ampas/aces-dev/tree/master/documents},
-  year         = 2014,
-}
-@misc{TheAcademyofMotionPictureArtsandSciencese,
-  author       = {{The Academy of Motion Picture Arts and Sciences}
-    and {Science and Technology Council} and {Academy Color Encoding
-    System (ACES) Project Subcommittee}},
-  title        = {{Academy Color Encoding System}},
-  url          = {http://www.oscars.org/science-technology/council/projects/aces.html},
-  urldate      = {2014-02-24},
-}
-@misc{TheAcademyofMotionPictureArtsandSciences2014q,
-  author       = {{The Academy of Motion Picture Arts and Sciences}
-    and {Science and Technology Council} and {Academy Color Encoding
-    System (ACES) Project Subcommittee}},
-  pages        = {1--40},
-  title        = {{Technical Bulletin TB-2014-004 - Informative Notes
-    on SMPTE ST 2065-1 – Academy Color Encoding Specification (ACES)}},
+  pages        = {1--12},
+  title        = {{Specification S-2014-003 - ACEScc, A Logarithmic
+    Encoding of ACES Data for use within Color Grading Systems}},
   url          = {https://github.com/ampas/aces-dev/tree/master/documents},
   year         = 2014,
 }
@@ -2861,15 +2873,15 @@
   url          = {http://doi.wiley.com/10.1002/0470020326},
   year         = 2004,
 }
-@incollection{Westland2012i,
+@incollection{Westland2012g,
   author       = {Westland, Stephen and Ripamonti, Caterina and
     Cheung, Vien},
   booktitle    = {Computational Colour Science Using MATLAB},
-  chapter      = {4.4},
+  chapter      = {6.2.2},
   edition      = 2,
   isbn         = {978-0-470-66569-5},
-  pages        = 38,
-  title        = {{Extrapolation Methods}},
+  pages        = 80,
+  title        = {{CMCCAT97}},
   year         = 2012,
 }
 @incollection{Westland2012k,
@@ -2883,17 +2895,6 @@
   title        = {{CMCCAT2000}},
   year         = 2012,
 }
-@incollection{Westland2012g,
-  author       = {Westland, Stephen and Ripamonti, Caterina and
-    Cheung, Vien},
-  booktitle    = {Computational Colour Science Using MATLAB},
-  chapter      = {6.2.2},
-  edition      = 2,
-  isbn         = {978-0-470-66569-5},
-  pages        = 80,
-  title        = {{CMCCAT97}},
-  year         = 2012,
-}
 @incollection{Westland2012f,
   author       = {Westland, Stephen and Ripamonti, Caterina and
     Cheung, Vien},
@@ -2903,6 +2904,17 @@
   isbn         = {978-0-470-66569-5},
   pages        = 38,
   title        = {{Correction for Spectral Bandpass}},
+  year         = 2012,
+}
+@incollection{Westland2012i,
+  author       = {Westland, Stephen and Ripamonti, Caterina and
+    Cheung, Vien},
+  booktitle    = {Computational Colour Science Using MATLAB},
+  chapter      = {4.4},
+  edition      = 2,
+  isbn         = {978-0-470-66569-5},
+  pages        = 38,
+  title        = {{Extrapolation Methods}},
   year         = 2012,
 }
 @incollection{Westland2012h,
@@ -2916,12 +2928,32 @@
   title        = {{Interpolation Methods}},
   year         = 2012,
 }
-@misc{Wikipedia2005a,
+@misc{Wikipedia,
   author       = {Wikipedia},
-  title        = {{ISO 31-11}},
-  url          = {https://en.wikipedia.org/wiki/ISO{\_}31-11},
-  urldate      = {2016-07-31},
-  year         = 2005,
+  title        = {{Ellipse}},
+  url          = {https://en.wikipedia.org/wiki/Ellipse},
+  urldate      = {2018-11-24},
+}
+@misc{Wikipedia2003e,
+  author       = {Wikipedia},
+  title        = {{Vandermonde matrix}},
+  url          = {https://en.wikipedia.org/wiki/Vandermonde{\_}matrix},
+  urldate      = {2018-05-02},
+  year         = 2003,
+}
+@misc{Wikipedia2004,
+  author       = {Wikipedia},
+  title        = {{Peak signal-to-noise ratio}},
+  url          = {https://en.wikipedia.org/wiki/Peak{\_}signal-to-noise{\_}ratio},
+  urldate      = {2018-03-05},
+  year         = 2004,
+}
+@misc{Wikipedia2003c,
+  author       = {Wikipedia},
+  title        = {{Mean squared error}},
+  url          = {https://en.wikipedia.org/wiki/Mean{\_}squared{\_}error},
+  urldate      = {2018-03-05},
+  year         = 2003,
 }
 @misc{Wikipedia2001b,
   author       = {Wikipedia},
@@ -2930,12 +2962,33 @@
   urldate      = {2018-02-10},
   year         = 2001,
 }
-@misc{Wikipedia2004a,
+@misc{Wikipedia2007b,
   author       = {Wikipedia},
-  title        = {{Surfaces}},
-  url          = {http://en.wikipedia.org/wiki/Gamut{\#}Surfaces},
+  title        = {{CIELUV}},
+  url          = {http://en.wikipedia.org/wiki/CIELUV},
+  urldate      = {2014-02-24},
+  year         = 2007,
+}
+@misc{Wikipedia2008c,
+  author       = {Wikipedia},
+  title        = {{Relation to CIE XYZ}},
+  url          = {http://en.wikipedia.org/wiki/CIE{\_}1960{\_}color{\_}space{\#}Relation{\_}to{\_}CIE{\_}XYZ},
+  urldate      = {2014-02-24},
+  year         = 2008,
+}
+@misc{Wikipedia2008b,
+  author       = {Wikipedia},
+  title        = {{Color difference}},
+  url          = {http://en.wikipedia.org/wiki/Color{\_}difference},
+  urldate      = {2014-08-29},
+  year         = 2008,
+}
+@misc{Wikipedia2003,
+  author       = {Wikipedia},
+  title        = {{HSL and HSV}},
+  url          = {http://en.wikipedia.org/wiki/HSL{\_}and{\_}HSV},
   urldate      = {2014-09-10},
-  year         = 2004,
+  year         = 2003,
 }
 @misc{Wikipedia2001a,
   author       = {Wikipedia},
@@ -2944,18 +2997,19 @@
   urldate      = {2014-06-28},
   year         = 2001,
 }
-@misc{Wikipedia,
+@misc{Wikipedia2007c,
   author       = {Wikipedia},
-  title        = {{Ellipse}},
-  url          = {https://en.wikipedia.org/wiki/Ellipse},
-  urldate      = {2018-11-24},
-}
-@misc{Wikipedia2007b,
-  author       = {Wikipedia},
-  title        = {{CIELUV}},
-  url          = {http://en.wikipedia.org/wiki/CIELUV},
-  urldate      = {2014-02-24},
+  title        = {{Lightness}},
+  url          = {http://en.wikipedia.org/wiki/Lightness},
+  urldate      = {2014-04-13},
   year         = 2007,
+}
+@misc{Wikipedia2001c,
+  author       = {Wikipedia},
+  title        = {{Rayleigh scattering}},
+  url          = {http://en.wikipedia.org/wiki/Rayleigh{\_}scattering},
+  urldate      = {2014-09-23},
+  year         = 2001,
 }
 @misc{Wikipedia2005d,
   author       = {Wikipedia},
@@ -2971,137 +3025,11 @@
   urldate      = {2014-02-24},
   year         = 2008,
 }
-@misc{Wikipedia2004b,
-  author       = {Wikipedia},
-  title        = {{Whiteness}},
-  url          = {http://en.wikipedia.org/wiki/Whiteness},
-  urldate      = {2014-09-17},
-  year         = 2004,
-}
-@misc{Wikipedia2003e,
-  author       = {Wikipedia},
-  title        = {{Vandermonde matrix}},
-  url          = {https://en.wikipedia.org/wiki/Vandermonde{\_}matrix},
-  urldate      = {2018-05-02},
-  year         = 2003,
-}
-@misc{Wikipedia2004c,
-  author       = {Wikipedia},
-  title        = {{Wide-gamut RGB color space}},
-  url          = {http://en.wikipedia.org/wiki/Wide-gamut{\_}RGB{\_}color{\_}space},
-  urldate      = {2014-04-13},
-  year         = 2004,
-}
-@misc{Wikipedia2001c,
-  author       = {Wikipedia},
-  title        = {{Rayleigh scattering}},
-  url          = {http://en.wikipedia.org/wiki/Rayleigh{\_}scattering},
-  urldate      = {2014-09-23},
-  year         = 2001,
-}
-@misc{Wikipedia2007d,
-  author       = {Wikipedia},
-  title        = {{The reverse transformation}},
-  url          = {http://en.wikipedia.org/wiki/CIELUV{\#}The{\_}reverse{\_}transformation},
-  urldate      = {2014-02-24},
-  year         = 2007,
-}
-@misc{Wikipedia2003b,
-  author       = {Wikipedia},
-  title        = {{Luminosity function}},
-  url          = {https://en.wikipedia.org/wiki/Luminosity{\_}function{\#}Details},
-  urldate      = {2014-10-20},
-  year         = 2003,
-}
-@misc{Wikipedia2007c,
-  author       = {Wikipedia},
-  title        = {{Lightness}},
-  url          = {http://en.wikipedia.org/wiki/Lightness},
-  urldate      = {2014-04-13},
-  year         = 2007,
-}
-@misc{Wikipedia2003d,
-  author       = {Wikipedia},
-  title        = {{Michaelis–Menten kinetics}},
-  url          = {https://en.wikipedia.org/wiki/Michaelis–Menten{\_}kinetics},
-  urldate      = {2017-04-29},
-  year         = 2003,
-}
-@misc{Wikipedia2006,
-  author       = {Wikipedia},
-  title        = {{List of common coordinate transformations}},
-  url          = {http://en.wikipedia.org/wiki/List{\_}of{\_}common{\_}coordinate{\_}transformations},
-  urldate      = {2014-07-18},
-  year         = 2006,
-}
-@misc{Wikipedia2001,
-  author       = {Wikipedia},
-  title        = {{Approximation}},
-  url          = {http://en.wikipedia.org/wiki/Color{\_}temperature{\#}Approximation},
-  urldate      = {2014-06-28},
-  year         = 2001,
-}
-@misc{Wikipedia2005b,
-  author       = {Wikipedia},
-  title        = {{Lanczos resampling}},
-  url          = {https://en.wikipedia.org/wiki/Lanczos{\_}resampling},
-  urldate      = {2017-10-14},
-  year         = 2005,
-}
-@misc{Wikipedia2005c,
-  author       = {Wikipedia},
-  title        = {{Luminous Efficacy}},
-  url          = {https://en.wikipedia.org/wiki/Luminous{\_}efficacy},
-  urldate      = {2016-04-03},
-  year         = 2005,
-}
-@misc{Wikipedia2007,
-  author       = {Wikipedia},
-  title        = {{CAT02}},
-  url          = {http://en.wikipedia.org/wiki/CIECAM02{\#}CAT02},
-  urldate      = {2014-02-24},
-  year         = 2007,
-}
-@misc{Wikipedia2004d,
-  author       = {Wikipedia},
-  title        = {{YCbCr}},
-  url          = {https://en.wikipedia.org/wiki/YCbCr},
-  urldate      = {2016-02-29},
-  year         = 2004,
-}
-@misc{Wikipedia2003a,
-  author       = {Wikipedia},
-  title        = {{Lagrange polynomial - Definition}},
-  url          = {https://en.wikipedia.org/wiki/Lagrange{\_}polynomial{\#}Definition},
-  urldate      = {2016-01-20},
-  year         = 2003,
-}
-@misc{Wikipedia2003c,
-  author       = {Wikipedia},
-  title        = {{Mean squared error}},
-  url          = {https://en.wikipedia.org/wiki/Mean{\_}squared{\_}error},
-  urldate      = {2018-03-05},
-  year         = 2003,
-}
 @misc{Wikipedia2008a,
   author       = {Wikipedia},
   title        = {{CIE 1964 color space}},
   url          = {http://en.wikipedia.org/wiki/CIE{\_}1964{\_}color{\_}space},
   urldate      = {2014-06-10},
-  year         = 2008,
-}
-@misc{Wikipedia2008b,
-  author       = {Wikipedia},
-  title        = {{Color difference}},
-  url          = {http://en.wikipedia.org/wiki/Color{\_}difference},
-  urldate      = {2014-08-29},
-  year         = 2008,
-}
-@misc{Wikipedia2008c,
-  author       = {Wikipedia},
-  title        = {{Relation to CIE XYZ}},
-  url          = {http://en.wikipedia.org/wiki/CIE{\_}1960{\_}color{\_}space{\#}Relation{\_}to{\_}CIE{\_}XYZ},
-  urldate      = {2014-02-24},
   year         = 2008,
 }
 @misc{Wikipedia2006a,
@@ -3111,13 +3039,6 @@
   urldate      = {2014-02-24},
   year         = 2006,
 }
-@misc{Wikipedia2004,
-  author       = {Wikipedia},
-  title        = {{Peak signal-to-noise ratio}},
-  url          = {https://en.wikipedia.org/wiki/Peak{\_}signal-to-noise{\_}ratio},
-  urldate      = {2018-03-05},
-  year         = 2004,
-}
 @misc{Wikipedia2007a,
   author       = {Wikipedia},
   title        = {{CIECAM02}},
@@ -3125,18 +3046,109 @@
   urldate      = {2014-08-14},
   year         = 2007,
 }
-@misc{Wikipedia2003,
-  author       = {Wikipedia},
-  title        = {{HSL and HSV}},
-  url          = {http://en.wikipedia.org/wiki/HSL{\_}and{\_}HSV},
-  urldate      = {2014-09-10},
-  year         = 2003,
-}
 @misc{Wikipedia2005,
   author       = {Wikipedia},
   title        = {{CIE 1931 color space}},
   url          = {http://en.wikipedia.org/wiki/CIE{\_}1931{\_}color{\_}space},
   urldate      = {2014-02-24},
+  year         = 2005,
+}
+@misc{Wikipedia2006,
+  author       = {Wikipedia},
+  title        = {{List of common coordinate transformations}},
+  url          = {http://en.wikipedia.org/wiki/List{\_}of{\_}common{\_}coordinate{\_}transformations},
+  urldate      = {2014-07-18},
+  year         = 2006,
+}
+@misc{Wikipedia2004c,
+  author       = {Wikipedia},
+  title        = {{Wide-gamut RGB color space}},
+  url          = {http://en.wikipedia.org/wiki/Wide-gamut{\_}RGB{\_}color{\_}space},
+  urldate      = {2014-04-13},
+  year         = 2004,
+}
+@misc{Wikipedia2003a,
+  author       = {Wikipedia},
+  title        = {{Lagrange polynomial - Definition}},
+  url          = {https://en.wikipedia.org/wiki/Lagrange{\_}polynomial{\#}Definition},
+  urldate      = {2016-01-20},
+  year         = 2003,
+}
+@misc{Wikipedia2005a,
+  author       = {Wikipedia},
+  title        = {{ISO 31-11}},
+  url          = {https://en.wikipedia.org/wiki/ISO{\_}31-11},
+  urldate      = {2016-07-31},
+  year         = 2005,
+}
+@misc{Wikipedia2004d,
+  author       = {Wikipedia},
+  title        = {{YCbCr}},
+  url          = {https://en.wikipedia.org/wiki/YCbCr},
+  urldate      = {2016-02-29},
+  year         = 2004,
+}
+@misc{Wikipedia2005c,
+  author       = {Wikipedia},
+  title        = {{Luminous Efficacy}},
+  url          = {https://en.wikipedia.org/wiki/Luminous{\_}efficacy},
+  urldate      = {2016-04-03},
+  year         = 2005,
+}
+@misc{Wikipedia2007d,
+  author       = {Wikipedia},
+  title        = {{The reverse transformation}},
+  url          = {http://en.wikipedia.org/wiki/CIELUV{\#}The{\_}reverse{\_}transformation},
+  urldate      = {2014-02-24},
+  year         = 2007,
+}
+@misc{Wikipedia2003d,
+  author       = {Wikipedia},
+  title        = {{Michaelis–Menten kinetics}},
+  url          = {https://en.wikipedia.org/wiki/Michaelis–Menten{\_}kinetics},
+  urldate      = {2017-04-29},
+  year         = 2003,
+}
+@misc{Wikipedia2004b,
+  author       = {Wikipedia},
+  title        = {{Whiteness}},
+  url          = {http://en.wikipedia.org/wiki/Whiteness},
+  urldate      = {2014-09-17},
+  year         = 2004,
+}
+@misc{Wikipedia2003b,
+  author       = {Wikipedia},
+  title        = {{Luminosity function}},
+  url          = {https://en.wikipedia.org/wiki/Luminosity{\_}function{\#}Details},
+  urldate      = {2014-10-20},
+  year         = 2003,
+}
+@misc{Wikipedia2001,
+  author       = {Wikipedia},
+  title        = {{Approximation}},
+  url          = {http://en.wikipedia.org/wiki/Color{\_}temperature{\#}Approximation},
+  urldate      = {2014-06-28},
+  year         = 2001,
+}
+@misc{Wikipedia2004a,
+  author       = {Wikipedia},
+  title        = {{Surfaces}},
+  url          = {http://en.wikipedia.org/wiki/Gamut{\#}Surfaces},
+  urldate      = {2014-09-10},
+  year         = 2004,
+}
+@misc{Wikipedia2007,
+  author       = {Wikipedia},
+  title        = {{CAT02}},
+  url          = {http://en.wikipedia.org/wiki/CIECAM02{\#}CAT02},
+  urldate      = {2014-02-24},
+  year         = 2007,
+}
+@misc{Wikipedia2005b,
+  author       = {Wikipedia},
+  title        = {{Lanczos resampling}},
+  url          = {https://en.wikipedia.org/wiki/Lanczos{\_}resampling},
+  urldate      = {2017-10-14},
   year         = 2005,
 }
 @article{Wyszecki1963b,
@@ -3154,6 +3166,16 @@
   volume       = 53,
   year         = 1963,
 }
+@incollection{Wyszecki2000a,
+  author       = {Wyszecki, G{\"{u}}nther and Stiles, W S},
+  booktitle    = {Color Science: Concepts and Methods, Quantitative
+    Data and Formulae},
+  isbn         = {978-0471399186},
+  pages        = 8,
+  publisher    = {Wiley},
+  title        = {{Equation I(1.2.1)}},
+  year         = 2000,
+}
 @incollection{Wyszecki2000,
   author       = {Wyszecki, G{\"{u}}nther and Stiles, W S},
   booktitle    = {Color Science: Concepts and Methods, Quantitative
@@ -3167,56 +3189,6 @@
     1945)}},
   year         = 2000,
 }
-@incollection{Wyszecki2000a,
-  author       = {Wyszecki, G{\"{u}}nther and Stiles, W S},
-  booktitle    = {Color Science: Concepts and Methods, Quantitative
-    Data and Formulae},
-  isbn         = {978-0471399186},
-  pages        = 8,
-  publisher    = {Wiley},
-  title        = {{Equation I(1.2.1)}},
-  year         = 2000,
-}
-@incollection{Wyszecki2000bh,
-  author       = {Wyszecki, G{\"{u}}nther and Stiles, W. S.},
-  booktitle    = {Color Science: Concepts and Methods, Quantitative
-    Data and Formulae},
-  isbn         = {978-0471399186},
-  pages        = {778--779},
-  publisher    = {Wiley},
-  title        = {{Table II(3.7)}},
-  year         = 2000,
-}
-@incollection{Wyszecki2000bg,
-  author       = {Wyszecki, G{\"{u}}nther and Stiles, W. S.},
-  booktitle    = {Color Science: Concepts and Methods, Quantitative
-    Data and Formulae},
-  isbn         = {978-0471399186},
-  pages        = {138--139},
-  publisher    = {Wiley},
-  title        = {{Table 1(3.3.3)}},
-  year         = 2000,
-}
-@incollection{Wyszecki2000bf,
-  author       = {Wyszecki, G{\"{u}}nther and Stiles, W. S.},
-  booktitle    = {Color Science: Concepts and Methods, Quantitative
-    Data and Formulae},
-  isbn         = {978-0471399186},
-  pages        = {158--163},
-  publisher    = {Wiley},
-  title        = {{Integration Replaced by Summation}},
-  year         = 2000,
-}
-@incollection{Wyszecki2000s,
-  author       = {Wyszecki, G{\"{u}}nther and Stiles, W. S.},
-  booktitle    = {Color Science: Concepts and Methods, Quantitative
-    Data and Formulae},
-  isbn         = {978-0471399186},
-  pages        = {256--259,395},
-  publisher    = {Wiley},
-  title        = {{Standard Photometric Observers}},
-  year         = 2000,
-}
 @incollection{Wyszecki2000bb,
   author       = {Wyszecki, G{\"{u}}nther and Stiles, W. S.},
   booktitle    = {Color Science: Concepts and Methods, Quantitative
@@ -3227,15 +3199,14 @@
   title        = {{Table I(3.7)}},
   year         = 2000,
 }
-@incollection{Wyszecki2000ba,
+@incollection{Wyszecki2000bf,
   author       = {Wyszecki, G{\"{u}}nther and Stiles, W. S.},
   booktitle    = {Color Science: Concepts and Methods, Quantitative
     Data and Formulae},
   isbn         = {978-0471399186},
-  pages        = {837--839},
+  pages        = {158--163},
   publisher    = {Wiley},
-  title        = {{Table I(6.5.3) Whiteness Formulae (Whiteness
-    Measure Denoted by W)}},
+  title        = {{Integration Replaced by Summation}},
   year         = 2000,
 }
 @incollection{Wyszecki2000be,
@@ -3258,17 +3229,6 @@
   title        = {{CIE Method of Calculating D-Illuminants}},
   year         = 2000,
 }
-@incollection{Wyszecki2000y,
-  author       = {Wyszecki, G{\"{u}}nther and Stiles, W. S.},
-  booktitle    = {Color Science: Concepts and Methods, Quantitative
-    Data and Formulae},
-  isbn         = {978-0471399186},
-  pages        = {224--229},
-  publisher    = {Wiley},
-  title        = {{DISTRIBUTION TEMPERATURE, COLOR TEMPERATURE, AND
-    CORRELATED COLOR TEMPERATURE}},
-  year         = 2000,
-}
 @incollection{Wyszecki2000x,
   author       = {Wyszecki, G{\"{u}}nther and Stiles, W. S.},
   booktitle    = {Color Science: Concepts and Methods, Quantitative
@@ -3277,6 +3237,37 @@
   pages        = 228,
   publisher    = {Wiley},
   title        = {{Table 1(3.11) Isotemperature Lines}},
+  year         = 2000,
+}
+@incollection{Wyszecki2000ba,
+  author       = {Wyszecki, G{\"{u}}nther and Stiles, W. S.},
+  booktitle    = {Color Science: Concepts and Methods, Quantitative
+    Data and Formulae},
+  isbn         = {978-0471399186},
+  pages        = {837--839},
+  publisher    = {Wiley},
+  title        = {{Table I(6.5.3) Whiteness Formulae (Whiteness
+    Measure Denoted by W)}},
+  year         = 2000,
+}
+@incollection{Wyszecki2000bh,
+  author       = {Wyszecki, G{\"{u}}nther and Stiles, W. S.},
+  booktitle    = {Color Science: Concepts and Methods, Quantitative
+    Data and Formulae},
+  isbn         = {978-0471399186},
+  pages        = {778--779},
+  publisher    = {Wiley},
+  title        = {{Table II(3.7)}},
+  year         = 2000,
+}
+@incollection{Wyszecki2000bg,
+  author       = {Wyszecki, G{\"{u}}nther and Stiles, W. S.},
+  booktitle    = {Color Science: Concepts and Methods, Quantitative
+    Data and Formulae},
+  isbn         = {978-0471399186},
+  pages        = {138--139},
+  publisher    = {Wiley},
+  title        = {{Table 1(3.3.3)}},
   year         = 2000,
 }
 @incollection{Wyszecki2000bd,
@@ -3288,6 +3279,27 @@
   publisher    = {Wiley},
   title        = {{CIE 1976 (L*u*v*)-Space and Color-Difference
     Formula}},
+  year         = 2000,
+}
+@incollection{Wyszecki2000s,
+  author       = {Wyszecki, G{\"{u}}nther and Stiles, W. S.},
+  booktitle    = {Color Science: Concepts and Methods, Quantitative
+    Data and Formulae},
+  isbn         = {978-0471399186},
+  pages        = {256--259,395},
+  publisher    = {Wiley},
+  title        = {{Standard Photometric Observers}},
+  year         = 2000,
+}
+@incollection{Wyszecki2000y,
+  author       = {Wyszecki, G{\"{u}}nther and Stiles, W. S.},
+  booktitle    = {Color Science: Concepts and Methods, Quantitative
+    Data and Formulae},
+  isbn         = {978-0471399186},
+  pages        = {224--229},
+  publisher    = {Wiley},
+  title        = {{DISTRIBUTION TEMPERATURE, COLOR TEMPERATURE, AND
+    CORRELATED COLOR TEMPERATURE}},
   year         = 2000,
 }
 @misc{X-Rite2015,

--- a/BIBLIOGRAPHY.bib
+++ b/BIBLIOGRAPHY.bib
@@ -1617,6 +1617,13 @@
   url          = {https://www.itu.int/dms{\_}pubrec/itu-r/rec/bt/R-REC-BT.2100-1-201706-I!!PDF-E.pdf},
   year         = 2017,
 }
+@misc{ISO2002,
+  author       = {ISO},
+  title        = {{INTERNATIONAL STANDARD 7589-2002 - Photography -
+    Illuminants for sensitometry - Specifications for daylight,
+    incandescent tungsten and printer}},
+  year         = 2002,
+}
 @article{Kang2002a,
   annote       = {http://icpr.snu.ac.kr/resource/wop.pdf/J01/2002/041/R06/J012002041R060865.pdf},
   author       = {Kang, Bongsoon and Moon, Ohak and Hong, Changhee and

--- a/colour/__init__.py
+++ b/colour/__init__.py
@@ -90,9 +90,9 @@ from .appearance import (
 from .difference import DELTA_E_METHODS, delta_E
 from .characterisation import (
     CAMERA_RGB_SPECTRAL_SENSITIVITIES, COLOURCHECKERS, COLOURCHECKER_SDS,
-    DISPLAY_RGB_PRIMARIES, POLYNOMIAL_EXPANSION_METHODS, polynomial_expansion,
-    COLOUR_CORRECTION_MATRIX_METHODS, colour_correction_matrix,
-    COLOUR_CORRECTION_METHODS, colour_correction)
+    DISPLAY_RGB_PRIMARIES, LENS_SDS, POLYNOMIAL_EXPANSION_METHODS,
+    polynomial_expansion, COLOUR_CORRECTION_MATRIX_METHODS,
+    colour_correction_matrix, COLOUR_CORRECTION_METHODS, colour_correction)
 from .geometry import (PRIMITIVE_METHODS, primitive,
                        PRIMITIVE_VERTICES_METHODS, primitive_vertices)
 from .io import (LUT1D, LUT3x1D, LUT3D, LUTSequence, READ_IMAGE_METHODS,
@@ -221,7 +221,7 @@ __all__ += [
 __all__ += ['DELTA_E_METHODS', 'delta_E']
 __all__ += [
     'CAMERA_RGB_SPECTRAL_SENSITIVITIES', 'COLOURCHECKERS', 'COLOURCHECKER_SDS',
-    'DISPLAY_RGB_PRIMARIES', 'POLYNOMIAL_EXPANSION_METHODS',
+    'DISPLAY_RGB_PRIMARIES', 'LENS_SDS', 'POLYNOMIAL_EXPANSION_METHODS',
     'polynomial_expansion', 'COLOUR_CORRECTION_MATRIX_METHODS',
     'colour_correction_matrix', 'COLOUR_CORRECTION_METHODS',
     'colour_correction'

--- a/colour/__init__.py
+++ b/colour/__init__.py
@@ -90,7 +90,7 @@ from .appearance import (
 from .difference import DELTA_E_METHODS, delta_E
 from .characterisation import (
     CAMERA_RGB_SPECTRAL_SENSITIVITIES, COLOURCHECKERS, COLOURCHECKER_SDS,
-    DISPLAY_RGB_PRIMARIES, LENS_SDS, POLYNOMIAL_EXPANSION_METHODS,
+    DISPLAY_RGB_PRIMARIES, FILTER_SDS, LENS_SDS, POLYNOMIAL_EXPANSION_METHODS,
     polynomial_expansion, COLOUR_CORRECTION_MATRIX_METHODS,
     colour_correction_matrix, COLOUR_CORRECTION_METHODS, colour_correction)
 from .geometry import (PRIMITIVE_METHODS, primitive,
@@ -221,10 +221,10 @@ __all__ += [
 __all__ += ['DELTA_E_METHODS', 'delta_E']
 __all__ += [
     'CAMERA_RGB_SPECTRAL_SENSITIVITIES', 'COLOURCHECKERS', 'COLOURCHECKER_SDS',
-    'DISPLAY_RGB_PRIMARIES', 'LENS_SDS', 'POLYNOMIAL_EXPANSION_METHODS',
-    'polynomial_expansion', 'COLOUR_CORRECTION_MATRIX_METHODS',
-    'colour_correction_matrix', 'COLOUR_CORRECTION_METHODS',
-    'colour_correction'
+    'DISPLAY_RGB_PRIMARIES', 'FILTER_SDS', 'LENS_SDS',
+    'POLYNOMIAL_EXPANSION_METHODS', 'polynomial_expansion',
+    'COLOUR_CORRECTION_MATRIX_METHODS', 'colour_correction_matrix',
+    'COLOUR_CORRECTION_METHODS', 'colour_correction'
 ]
 __all__ += [
     'PRIMITIVE_METHODS', 'primitive', 'PRIMITIVE_VERTICES_METHODS',

--- a/colour/characterisation/datasets/__init__.py
+++ b/colour/characterisation/datasets/__init__.py
@@ -5,8 +5,10 @@ from __future__ import absolute_import
 from .cameras import CAMERA_RGB_SPECTRAL_SENSITIVITIES
 from .colour_checkers import COLOURCHECKERS, ColourChecker, COLOURCHECKER_SDS
 from .displays import DISPLAY_RGB_PRIMARIES
+from .lenses import LENS_SDS
 
 __all__ = []
 __all__ += ['CAMERA_RGB_SPECTRAL_SENSITIVITIES']
 __all__ += ['COLOURCHECKERS', 'ColourChecker', 'COLOURCHECKER_SDS']
 __all__ += ['DISPLAY_RGB_PRIMARIES']
+__all__ += ['LENS_SDS']

--- a/colour/characterisation/datasets/__init__.py
+++ b/colour/characterisation/datasets/__init__.py
@@ -5,10 +5,12 @@ from __future__ import absolute_import
 from .cameras import CAMERA_RGB_SPECTRAL_SENSITIVITIES
 from .colour_checkers import COLOURCHECKERS, ColourChecker, COLOURCHECKER_SDS
 from .displays import DISPLAY_RGB_PRIMARIES
+from .filters import FILTER_SDS
 from .lenses import LENS_SDS
 
 __all__ = []
 __all__ += ['CAMERA_RGB_SPECTRAL_SENSITIVITIES']
 __all__ += ['COLOURCHECKERS', 'ColourChecker', 'COLOURCHECKER_SDS']
 __all__ += ['DISPLAY_RGB_PRIMARIES']
+__all__ += ['FILTER_SDS']
 __all__ += ['LENS_SDS']

--- a/colour/characterisation/datasets/filters/__init__.py
+++ b/colour/characterisation/datasets/filters/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+
+from .sds import FILTER_SDS
+
+__all__ = ['FILTER_SDS']

--- a/colour/characterisation/datasets/filters/sds.py
+++ b/colour/characterisation/datasets/filters/sds.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+"""
+Filter Spectral Distributions
+=============================
+
+Defines *filter* spectral distributions.
+
+Each *filter* data is in the form of :class:`OrderedDict`
+class instance of :class:`colour.SpectralDistribution` classes as
+follows::
+
+    {'name': SpectralDistribution, ..., 'name': SpectralDistribution}
+
+The following *filters* are available:
+
+-   ISO 7589 Diffuser
+
+References
+----------
+-   :cite:`ISO2002` : ISO. (2002). INTERNATIONAL STANDARD 7589-2002 -
+    Photography - Illuminants for sensitometry - Specifications for daylight,
+    incandescent tungsten and printer.
+"""
+
+from __future__ import division, unicode_literals
+
+from colour.colorimetry import SpectralDistribution
+from colour.utilities import CaseInsensitiveMapping
+
+__author__ = 'Colour Developers'
+__copyright__ = 'Copyright (C) 2013-2020 - Colour Developers'
+__license__ = 'New BSD License - https://opensource.org/licenses/BSD-3-Clause'
+__maintainer__ = 'Colour Developers'
+__email__ = 'colour-developers@colour-science.org'
+__status__ = 'Production'
+
+__all__ = ['FILTER_ISO_SDS_DATA', 'FILTER_ISO_SDS', 'FILTER_SDS']
+
+FILTER_ISO_SDS_DATA = {
+    'ISO 7589 Diffuser': {
+        350: 0.00,
+        360: 0.00,
+        370: 0.00,
+        380: 0.10,
+        390: 0.43,
+        400: 0.69,
+        410: 0.78,
+        420: 0.83,
+        430: 0.86,
+        440: 0.88,
+        450: 0.90,
+        460: 0.91,
+        470: 0.93,
+        480: 0.94,
+        490: 0.95,
+        500: 0.96,
+        510: 0.97,
+        520: 0.98,
+        530: 0.99,
+        540: 0.99,
+        550: 1.00,
+        560: 1.00,
+    }
+}
+
+FILTER_ISO_SDS = CaseInsensitiveMapping({
+    'ISO 7589 Diffuser':
+        SpectralDistribution(
+            FILTER_ISO_SDS_DATA['ISO 7589 Diffuser'],
+            name='ISO 7589 Diffuser'),
+})
+FILTER_ISO_SDS.__doc__ = """
+*ISO* filter spectral distributions.
+
+References
+----------
+:cite:`ISO2002`
+
+FILTER_ISO_SDS : CaseInsensitiveMapping
+"""
+
+FILTER_SDS = CaseInsensitiveMapping(FILTER_ISO_SDS)
+FILTER_SDS.__doc__ = """
+Aggregated filter spectral distributions.
+
+References
+----------
+:cite:`ISO2002`
+
+FILTER_SDS : CaseInsensitiveMapping
+"""

--- a/colour/characterisation/datasets/lenses/__init__.py
+++ b/colour/characterisation/datasets/lenses/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+
+from .sds import LENS_SDS
+
+__all__ = ['LENS_SDS']

--- a/colour/characterisation/datasets/lenses/sds.py
+++ b/colour/characterisation/datasets/lenses/sds.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+"""
+Lens Spectral Distributions
+===========================
+
+Defines *lens* spectral distributions.
+
+Each *lens* data is in the form of :class:`OrderedDict`
+class instance of :class:`colour.SpectralDistribution` classes as
+follows::
+
+    {'name': SpectralDistribution, ..., 'name': SpectralDistribution}
+
+The following *lenses* are available:
+
+-   ISO Standard Lens
+
+References
+----------
+-   :cite:`ISO2002` : ISO. (2002). INTERNATIONAL STANDARD 7589-2002 -
+    Photography - Illuminants for sensitometry - Specifications for daylight,
+    incandescent tungsten and printer.
+"""
+
+from __future__ import division, unicode_literals
+
+from colour.colorimetry import SpectralDistribution
+from colour.utilities import CaseInsensitiveMapping
+
+__author__ = 'Colour Developers'
+__copyright__ = 'Copyright (C) 2013-2020 - Colour Developers'
+__license__ = 'New BSD License - https://opensource.org/licenses/BSD-3-Clause'
+__maintainer__ = 'Colour Developers'
+__email__ = 'colour-developers@colour-science.org'
+__status__ = 'Production'
+
+__all__ = ['LENS_ISO_SDS_DATA', 'LENS_ISO_SDS', 'LENS_SDS']
+
+LENS_ISO_SDS_DATA = {
+    'ISO Standard Lens': {
+        350: 0.00,
+        360: 0.07,
+        370: 0.23,
+        380: 0.42,
+        390: 0.60,
+        400: 0.74,
+        410: 0.83,
+        420: 0.88,
+        430: 0.91,
+        440: 0.94,
+        450: 0.95,
+        460: 0.97,
+        470: 0.98,
+        480: 0.98,
+        490: 0.99,
+        500: 0.99,
+        510: 1.00,
+        520: 1.00,
+        530: 1.00,
+        540: 1.00,
+        550: 1.00,
+        560: 1.00,
+        570: 1.00,
+        580: 1.00,
+        590: 0.99,
+        600: 0.99,
+        610: 0.99,
+        620: 0.98,
+        630: 0.98,
+        640: 0.97,
+        650: 0.97,
+        660: 0.96,
+        670: 0.95,
+        680: 0.94,
+        690: 0.94,
+    }
+}
+
+LENS_ISO_SDS = CaseInsensitiveMapping({
+    'ISO Standard Lens':
+        SpectralDistribution(
+            LENS_ISO_SDS_DATA['ISO Standard Lens'], name='ISO Standard Lens'),
+})
+LENS_ISO_SDS.__doc__ = """
+*ISO* lens spectral distributions.
+
+References
+----------
+:cite:`ISO2002`
+
+LENS_ISO_SDS : CaseInsensitiveMapping
+"""
+
+LENS_SDS = CaseInsensitiveMapping(LENS_ISO_SDS)
+LENS_SDS.__doc__ = """
+Aggregated lens spectral distributions.
+
+References
+----------
+:cite:`ISO2002`
+
+LENS_SDS : CaseInsensitiveMapping
+"""

--- a/colour/colorimetry/datasets/illuminants/chromaticity_coordinates.py
+++ b/colour/colorimetry/datasets/illuminants/chromaticity_coordinates.py
@@ -44,6 +44,9 @@ References
     Digital Cinema System Specification - Version 1.1. Retrieved from
     http://www.dcimovies.com/archives/spec_v1_1/\
 DCI_DCinema_System_Spec_v1_1.pdf
+-   :cite:`InternationalColorConsortium2010` : International Color Consortium.
+    (2010). Specification ICC.1:2010 (Profile version 4.3.0.0) (pp. 1-130).
+    http://www.color.org/specification/ICC1v43_2010-12.pdf
 -   :cite:`TheAcademyofMotionPictureArtsandSciences2014q` : The Academy of
     Motion Picture Arts and Sciences, Science and Technology Council, & Academy
     Color Encoding System (ACES) Project Subcommittee. (2014). Technical
@@ -176,6 +179,10 @@ ILLUMINANTS_ICC_CIE_1931_2_DEGREE_STANDARD_OBSERVER = CaseInsensitiveMapping({
 *ICC* illuminant chromaticity coordinates for the
 *CIE 1931 2 Degree Standard Observer*.
 
+References
+----------
+:cite:`InternationalColorConsortium2010`
+
 ILLUMINANTS_ICC_CIE_1931_2_DEGREE_STANDARD_OBSERVER : CaseInsensitiveMapping
 """
 
@@ -293,6 +300,7 @@ computed as follows::
 References
 ----------
 :cite:`CIETC1-482004h`, :cite:`DigitalCinemaInitiatives2007b`,
+:cite:`InternationalColorConsortium2010`,
 :cite:`TheAcademyofMotionPictureArtsandSciences2014q`, :cite:`Wikipedia2006a`
 
 ILLUMINANTS : CaseInsensitiveMapping

--- a/colour/colorimetry/datasets/illuminants/chromaticity_coordinates.py
+++ b/colour/colorimetry/datasets/illuminants/chromaticity_coordinates.py
@@ -22,6 +22,16 @@ The following *CIE* illuminants are available:
     LED-RGB1, LED-V1, LED-V2)
 -   Recommended indoor illuminants ID65 and ID50.
 
+The following *ISO* illuminants are available:
+
+-   ISO 7589 Photographic Daylight
+-   ISO 7589 Sensitometric Daylight
+-   ISO 7589 Studio Tungsten
+-   ISO 7589 Sensitometric Studio Tungsten
+-   ISO 7589 Photoflood
+-   ISO 7589 Sensitometric Photoflood
+-   ISO 7589 Sensitometric Printer
+
 The following other illuminants are available for the
 *CIE 1931 2 Degree Standard Observer* only:
 
@@ -47,6 +57,9 @@ DCI_DCinema_System_Spec_v1_1.pdf
 -   :cite:`InternationalColorConsortium2010` : International Color Consortium.
     (2010). Specification ICC.1:2010 (Profile version 4.3.0.0) (pp. 1-130).
     http://www.color.org/specification/ICC1v43_2010-12.pdf
+-   :cite:`ISO2002` : ISO. (2002). INTERNATIONAL STANDARD 7589-2002 -
+    Photography - Illuminants for sensitometry - Specifications for daylight,
+    incandescent tungsten and printer.
 -   :cite:`TheAcademyofMotionPictureArtsandSciences2014q` : The Academy of
     Motion Picture Arts and Sciences, Science and Technology Council, & Academy
     Color Encoding System (ACES) Project Subcommittee. (2014). Technical
@@ -76,7 +89,9 @@ __all__ = [
     'ILLUMINANTS_ACES_CIE_1931_2_DEGREE_STANDARD_OBSERVER',
     'ILLUMINANTS_DCI_CIE_1931_2_DEGREE_STANDARD_OBSERVER',
     'ILLUMINANTS_ICC_CIE_1931_2_DEGREE_STANDARD_OBSERVER',
-    'ILLUMINANTS_CIE_CIE_1964_10_DEGREE_STANDARD_OBSERVER', 'ILLUMINANTS'
+    'ILLUMINANTS_ISO_CIE_1931_2_DEGREE_STANDARD_OBSERVER',
+    'ILLUMINANTS_CIE_CIE_1964_10_DEGREE_STANDARD_OBSERVER',
+    'ILLUMINANTS_ISO_CIE_1964_10_DEGREE_STANDARD_OBSERVER', 'ILLUMINANTS'
 ]
 
 ILLUMINANTS_CIE_CIE_1931_2_DEGREE_STANDARD_OBSERVER = CaseInsensitiveMapping({
@@ -186,6 +201,33 @@ References
 ILLUMINANTS_ICC_CIE_1931_2_DEGREE_STANDARD_OBSERVER : CaseInsensitiveMapping
 """
 
+ILLUMINANTS_ISO_CIE_1931_2_DEGREE_STANDARD_OBSERVER = CaseInsensitiveMapping({
+    'ISO 7589 Photographic Daylight':
+        np.array([0.332039098470978, 0.347263885596614]),
+    'ISO 7589 Sensitometric Daylight':
+        np.array([0.333818313227557, 0.353436231513603]),
+    'ISO 7589 Studio Tungsten':
+        np.array([0.430944089109761, 0.403585442674295]),
+    'ISO 7589 Sensitometric Studio Tungsten':
+        np.array([0.431418223648390, 0.407471441950342]),
+    'ISO 7589 Photoflood':
+        np.array([0.411146015714843, 0.393719378241161]),
+    'ISO 7589 Sensitometric Photoflood':
+        np.array([0.412024776908998, 0.398177410548532]),
+    'ISO 7589 Sensitometric Printer':
+        np.array([0.412087967973680, 0.421104984758526]),
+})
+"""
+*ISO* illuminant chromaticity coordinates for the
+*CIE 1931 2 Degree Standard Observer*.
+
+References
+----------
+:cite:`ISO2002`
+
+ILLUMINANTS_ISO_CIE_1931_2_DEGREE_STANDARD_OBSERVER : CaseInsensitiveMapping
+"""
+
 ILLUMINANTS_CIE_CIE_1964_10_DEGREE_STANDARD_OBSERVER = CaseInsensitiveMapping({
     'A': np.array([0.45117, 0.40594]),
     'B': np.array([0.34980, 0.35270]),
@@ -251,6 +293,33 @@ References
 ILLUMINANTS_CIE_CIE_1964_10_DEGREE_STANDARD_OBSERVER : CaseInsensitiveMapping
 """
 
+ILLUMINANTS_ISO_CIE_1964_10_DEGREE_STANDARD_OBSERVER = CaseInsensitiveMapping({
+    'ISO 7589 Photographic Daylight':
+        np.array([0.333716908394534, 0.348592494683065]),
+    'ISO 7589 Sensitometric Daylight':
+        np.array([0.336125906007630, 0.354997062476417]),
+    'ISO 7589 Studio Tungsten':
+        np.array([0.434575926493196, 0.402219691745325]),
+    'ISO 7589 Sensitometric Studio Tungsten':
+        np.array([0.435607674215215, 0.406129244796761]),
+    'ISO 7589 Photoflood':
+        np.array([0.414144647169611, 0.392458587686395]),
+    'ISO 7589 Sensitometric Photoflood':
+        np.array([0.415625819190627, 0.397002292994179]),
+    'ISO 7589 Sensitometric Printer':
+        np.array([0.418841052206998, 0.418695130974955]),
+})
+"""
+*ISO* illuminant chromaticity coordinates for the
+*CIE 1964 10 Degree Standard Observer*.
+
+References
+----------
+:cite:`ISO2002`
+
+ILLUMINANTS_ISO_CIE_1964_10_DEGREE_STANDARD_OBSERVER : CaseInsensitiveMapping
+"""
+
 ILLUMINANTS = CaseInsensitiveMapping({
     'CIE 1931 2 Degree Standard Observer':
         CaseInsensitiveMapping(
@@ -299,7 +368,7 @@ computed as follows::
 
 References
 ----------
-:cite:`CIETC1-482004h`, :cite:`DigitalCinemaInitiatives2007b`,
+:cite:`CIETC1-482004h`, :cite:`DigitalCinemaInitiatives2007b`, :cite:`ISO2002`,
 :cite:`InternationalColorConsortium2010`,
 :cite:`TheAcademyofMotionPictureArtsandSciences2014q`, :cite:`Wikipedia2006a`
 
@@ -325,3 +394,9 @@ ILLUMINANTS['CIE 1931 2 Degree Standard Observer'].update(
 
 ILLUMINANTS['CIE 1931 2 Degree Standard Observer'].update(
     ILLUMINANTS_ICC_CIE_1931_2_DEGREE_STANDARD_OBSERVER)
+
+ILLUMINANTS['CIE 1931 2 Degree Standard Observer'].update(
+    ILLUMINANTS_ISO_CIE_1931_2_DEGREE_STANDARD_OBSERVER)
+
+ILLUMINANTS['CIE 1964 10 Degree Standard Observer'].update(
+    ILLUMINANTS_ISO_CIE_1964_10_DEGREE_STANDARD_OBSERVER)

--- a/colour/colorimetry/datasets/illuminants/chromaticity_coordinates.py
+++ b/colour/colorimetry/datasets/illuminants/chromaticity_coordinates.py
@@ -69,11 +69,14 @@ __email__ = 'colour-developers@colour-science.org'
 __status__ = 'Production'
 
 __all__ = [
-    'ILLUMINANTS_CIE_1931_2_DEGREE_STANDARD_OBSERVER',
-    'ILLUMINANTS_CIE_1964_10_DEGREE_STANDARD_OBSERVER', 'ILLUMINANTS'
+    'ILLUMINANTS_CIE_CIE_1931_2_DEGREE_STANDARD_OBSERVER',
+    'ILLUMINANTS_ACES_CIE_1931_2_DEGREE_STANDARD_OBSERVER',
+    'ILLUMINANTS_DCI_CIE_1931_2_DEGREE_STANDARD_OBSERVER',
+    'ILLUMINANTS_ICC_CIE_1931_2_DEGREE_STANDARD_OBSERVER',
+    'ILLUMINANTS_CIE_CIE_1964_10_DEGREE_STANDARD_OBSERVER', 'ILLUMINANTS'
 ]
 
-ILLUMINANTS_CIE_1931_2_DEGREE_STANDARD_OBSERVER = CaseInsensitiveMapping({
+ILLUMINANTS_CIE_CIE_1931_2_DEGREE_STANDARD_OBSERVER = CaseInsensitiveMapping({
     'A': np.array([0.44758, 0.40745]),
     'B': np.array([0.34842, 0.35161]),
     'C': np.array([0.31006, 0.31616]),
@@ -94,22 +97,7 @@ ILLUMINANTS_CIE_1931_2_DEGREE_STANDARD_OBSERVER = CaseInsensitiveMapping({
     'FL9': np.array([0.37410, 0.37270]),
     'FL10': np.array([0.34580, 0.35880]),
     'FL11': np.array([0.38050, 0.37690]),
-    'FL12': np.array([0.43700, 0.40420])
-})
-"""
-*CIE* illuminant chromaticity coordinates for the
-*CIE 1931 2 Degree Standard Observer*.
-
-ILLUMINANTS_CIE_1931_2_DEGREE_STANDARD_OBSERVER : CaseInsensitiveMapping
-"""
-
-ILLUMINANTS_CIE_1931_2_DEGREE_STANDARD_OBSERVER.update({
-    'ACES': np.array([0.32168, 0.33767]),
-    'DCI-P3': np.array([0.31400, 0.35100]),
-    'ICC D50': np.array([0.345702914918791, 0.358538596679933])
-})
-
-ILLUMINANTS_CIE_1931_2_DEGREE_STANDARD_OBSERVER.update({
+    'FL12': np.array([0.43700, 0.40420]),
     'FL3.1': np.array([0.44070, 0.40330]),
     'FL3.2': np.array([0.38080, 0.37340]),
     'FL3.3': np.array([0.31530, 0.34390]),
@@ -142,8 +130,56 @@ ILLUMINANTS_CIE_1931_2_DEGREE_STANDARD_OBSERVER.update({
     'ID65': np.array([0.310656625403120, 0.330663091836953]),
     'ID50': np.array([0.343211370103531, 0.360207541805137])
 })
+"""
+*CIE* illuminant chromaticity coordinates for the
+*CIE 1931 2 Degree Standard Observer*.
 
-ILLUMINANTS_CIE_1964_10_DEGREE_STANDARD_OBSERVER = CaseInsensitiveMapping({
+References
+----------
+:cite:`CIETC1-482004h`, :cite:`Wikipedia2006a`
+
+ILLUMINANTS_CIE_CIE_1931_2_DEGREE_STANDARD_OBSERVER : CaseInsensitiveMapping
+"""
+
+ILLUMINANTS_ACES_CIE_1931_2_DEGREE_STANDARD_OBSERVER = CaseInsensitiveMapping({
+    'ACES': np.array([0.32168, 0.33767]),
+})
+"""
+*Academy Color Encoding System* (ACES) illuminant chromaticity coordinates for
+the *CIE 1931 2 Degree Standard Observer*.
+
+References
+----------
+:cite:`TheAcademyofMotionPictureArtsandSciences2014q`
+
+ILLUMINANTS_ICC_CIE_1931_2_DEGREE_STANDARD_OBSERVER : CaseInsensitiveMapping
+"""
+
+ILLUMINANTS_DCI_CIE_1931_2_DEGREE_STANDARD_OBSERVER = CaseInsensitiveMapping({
+    'DCI-P3': np.array([0.31400, 0.35100]),
+})
+"""
+*DCI* illuminant chromaticity coordinates for the
+*CIE 1931 2 Degree Standard Observer*.
+
+References
+----------
+:cite:`DigitalCinemaInitiatives2007b`
+
+ILLUMINANTS_DCI_CIE_1931_2_DEGREE_STANDARD_OBSERVER : CaseInsensitiveMapping
+"""
+
+ILLUMINANTS_ICC_CIE_1931_2_DEGREE_STANDARD_OBSERVER = CaseInsensitiveMapping({
+    'ICC D50': np.array([0.345702914918791, 0.358538596679933])
+})
+"""
+*ICC* illuminant chromaticity coordinates for the
+*CIE 1931 2 Degree Standard Observer*.
+
+ILLUMINANTS_ICC_CIE_1931_2_DEGREE_STANDARD_OBSERVER : CaseInsensitiveMapping
+"""
+
+ILLUMINANTS_CIE_CIE_1964_10_DEGREE_STANDARD_OBSERVER = CaseInsensitiveMapping({
     'A': np.array([0.45117, 0.40594]),
     'B': np.array([0.34980, 0.35270]),
     'C': np.array([0.31039, 0.31905]),
@@ -164,16 +200,7 @@ ILLUMINANTS_CIE_1964_10_DEGREE_STANDARD_OBSERVER = CaseInsensitiveMapping({
     'FL9': np.array([0.37829, 0.37045]),
     'FL10': np.array([0.35090, 0.35444]),
     'FL11': np.array([0.38541, 0.37123]),
-    'FL12': np.array([0.44256, 0.39717])
-})
-"""
-*CIE* illuminant chromaticity coordinates for the
-*CIE 1964 10 Degree Standard Observer*.
-
-ILLUMINANTS_CIE_1964_10_DEGREE_STANDARD_OBSERVER : CaseInsensitiveMapping
-"""
-
-ILLUMINANTS_CIE_1964_10_DEGREE_STANDARD_OBSERVER.update({
+    'FL12': np.array([0.44256, 0.39717]),
     'FL3.1': np.array([0.449830684010003, 0.390231404321266]),
     'FL3.2': np.array([0.386924116672933, 0.365756034732821]),
     'FL3.3': np.array([0.321176986855865, 0.340501092654981]),
@@ -206,15 +233,27 @@ ILLUMINANTS_CIE_1964_10_DEGREE_STANDARD_OBSERVER.update({
     'ID65': np.array([0.312074043269908, 0.332660121024630]),
     'ID50': np.array([0.345621427535976, 0.361228962209198])
 })
+"""
+*CIE* illuminant chromaticity coordinates for the
+*CIE 1964 10 Degree Standard Observer*.
+
+References
+----------
+:cite:`CIETC1-482004h`, :cite:`Wikipedia2006a`
+
+ILLUMINANTS_CIE_CIE_1964_10_DEGREE_STANDARD_OBSERVER : CaseInsensitiveMapping
+"""
 
 ILLUMINANTS = CaseInsensitiveMapping({
     'CIE 1931 2 Degree Standard Observer':
-        ILLUMINANTS_CIE_1931_2_DEGREE_STANDARD_OBSERVER,
+        CaseInsensitiveMapping(
+            ILLUMINANTS_CIE_CIE_1931_2_DEGREE_STANDARD_OBSERVER),
     'CIE 1964 10 Degree Standard Observer':
-        ILLUMINANTS_CIE_1964_10_DEGREE_STANDARD_OBSERVER
+        CaseInsensitiveMapping(
+            ILLUMINANTS_CIE_CIE_1964_10_DEGREE_STANDARD_OBSERVER)
 })
 ILLUMINANTS.__doc__ = """
-Aggregated *CIE* illuminant chromaticity coordinates.
+Aggregated illuminant chromaticity coordinates.
 
 Warning
 -------
@@ -269,3 +308,12 @@ ILLUMINANTS['cie_2_1931'] = (
     ILLUMINANTS['CIE 1931 2 Degree Standard Observer'])
 ILLUMINANTS['cie_10_1964'] = (
     ILLUMINANTS['CIE 1964 10 Degree Standard Observer'])
+
+ILLUMINANTS['CIE 1931 2 Degree Standard Observer'].update(
+    ILLUMINANTS_ACES_CIE_1931_2_DEGREE_STANDARD_OBSERVER)
+
+ILLUMINANTS['CIE 1931 2 Degree Standard Observer'].update(
+    ILLUMINANTS_DCI_CIE_1931_2_DEGREE_STANDARD_OBSERVER)
+
+ILLUMINANTS['CIE 1931 2 Degree Standard Observer'].update(
+    ILLUMINANTS_ICC_CIE_1931_2_DEGREE_STANDARD_OBSERVER)

--- a/colour/colorimetry/datasets/illuminants/sds.py
+++ b/colour/colorimetry/datasets/illuminants/sds.py
@@ -25,12 +25,21 @@ The following *CIE* illuminants are available:
     LED-RGB1, LED-V1, LED-V2)
 -   Recommended indoor illuminants ID65 and ID50.
 
+The following *ISO* illuminants are available:
+
+-   ISO 7589 Photographic Daylight
+-   ISO 7589 Sensitometric Daylight
+-   ISO 7589 Studio Tungsten
+-   ISO 7589 Sensitometric Studio Tungsten
+-   ISO 7589 Photoflood
+-   ISO 7589 Sensitometric Photoflood
+-   ISO 7589 Sensitometric Printer
+
 Notes
 -----
--   The spectral distributions are provided at 5 nm interval.
--   *CIE Illuminant D Series* *D60* spectral
-    distribution is calculated using :func:`colour.sd_CIE_illuminant_D_series`
-    definition.
+-   The spectral distributions are typically provided at 5nm or 10nm interval.
+-   *CIE Illuminant D Series* *D60* spectral distribution is calculated using
+    :func:`colour.sd_CIE_illuminant_D_series` definition.
 
 References
 ----------
@@ -41,6 +50,9 @@ References
     https://law.resource.org/pub/us/cfr/ibr/003/cie.15.2004.tables.xls
 -   :cite:`CIEcf` : CIE. (n.d.). CIE Spectral Data. Retrieved from
     http://files.cie.co.at/204.xls
+-   :cite:`ISO2002` : ISO. (2002). INTERNATIONAL STANDARD 7589-2002 -
+    Photography - Illuminants for sensitometry - Specifications for daylight,
+    incandescent tungsten and printer.
 """
 
 from __future__ import division, unicode_literals
@@ -56,7 +68,10 @@ __maintainer__ = 'Colour Developers'
 __email__ = 'colour-developers@colour-science.org'
 __status__ = 'Production'
 
-__all__ = ['ILLUMINANT_CIE_SDS_DATA', 'ILLUMINANT_CIE_SDS', 'ILLUMINANT_SDS']
+__all__ = [
+    'ILLUMINANT_CIE_SDS_DATA', 'ILLUMINANT_CIE_SDS', 'ILLUMINANT_ISO_SDS_DATA',
+    'ILLUMINANT_ISO_SDS', 'ILLUMINANT_SDS'
+]
 
 ILLUMINANT_CIE_SDS_DATA = {
     'A': {
@@ -4688,16 +4703,324 @@ References
 ILLUMINANT_CIE_SDS : CaseInsensitiveMapping
 """
 
+ILLUMINANT_ISO_SDS_DATA = {
+    'ISO 7589 Photographic Daylight': {
+        350: 28,
+        360: 31,
+        370: 34,
+        380: 33,
+        390: 38,
+        400: 61,
+        410: 69,
+        420: 72,
+        430: 68,
+        440: 86,
+        450: 98,
+        460: 100,
+        470: 100,
+        480: 103,
+        490: 98,
+        500: 101,
+        510: 101,
+        520: 100,
+        530: 104,
+        540: 102,
+        550: 103,
+        560: 100,
+        570: 97,
+        580: 98,
+        590: 91,
+        600: 94,
+        610: 95,
+        620: 94,
+        630: 90,
+        640: 92,
+        650: 89,
+        660: 90,
+        670: 94,
+        680: 90,
+        690: 80,
+    },
+    'ISO 7589 Sensitometric Daylight': {
+        350: 0.00,
+        360: 2.17,
+        370: 7.82,
+        380: 13.86,
+        390: 22.80,
+        400: 45.14,
+        410: 57.27,
+        420: 63.36,
+        430: 61.88,
+        440: 80.84,
+        450: 93.10,
+        460: 97.00,
+        470: 98.00,
+        480: 100.94,
+        490: 97.02,
+        500: 99.99,
+        510: 101.00,
+        520: 100.00,
+        530: 104.00,
+        540: 102.00,
+        550: 103.00,
+        560: 100.00,
+        570: 97.00,
+        580: 98.00,
+        590: 90.09,
+        600: 93.06,
+        610: 94.05,
+        620: 92.12,
+        630: 88.20,
+        640: 89.24,
+        650: 86.33,
+        660: 86.40,
+        670: 89.30,
+        680: 84.60,
+        690: 75.20,
+    },
+    'ISO 7589 Studio Tungsten': {
+        350: 1,
+        360: 3,
+        370: 5,
+        380: 8,
+        390: 12,
+        400: 16,
+        410: 20,
+        420: 24,
+        430: 29,
+        440: 34,
+        450: 38,
+        460: 43,
+        470: 48,
+        480: 53,
+        490: 59,
+        500: 64,
+        510: 70,
+        520: 76,
+        530: 81,
+        540: 88,
+        550: 94,
+        560: 100,
+        570: 105,
+        580: 111,
+        590: 116,
+        600: 122,
+        610: 127,
+        620: 132,
+        630: 138,
+        640: 143,
+        650: 148,
+        660: 153,
+        670: 157,
+        680: 162,
+        690: 167,
+    },
+    'ISO 7589 Sensitometric Studio Tungsten': {
+        350: 0.00,
+        360: 0.21,
+        370: 1.15,
+        380: 3.36,
+        390: 7.20,
+        400: 11.84,
+        410: 16.60,
+        420: 21.12,
+        430: 26.39,
+        440: 31.96,
+        450: 36.10,
+        460: 41.71,
+        470: 47.04,
+        480: 51.94,
+        490: 58.41,
+        500: 63.36,
+        510: 70.00,
+        520: 76.00,
+        530: 81.00,
+        540: 88.00,
+        550: 94.00,
+        560: 100.00,
+        570: 105.00,
+        580: 111.00,
+        590: 114.84,
+        600: 120.78,
+        610: 125.73,
+        620: 129.36,
+        630: 135.24,
+        640: 138.71,
+        650: 143.56,
+        660: 146.88,
+        670: 149.15,
+        680: 152.28,
+        690: 156.98,
+    },
+    'ISO 7589 Photoflood': {
+        350: 11,
+        360: 14,
+        370: 16,
+        380: 19,
+        390: 23,
+        400: 26,
+        410: 30,
+        420: 34,
+        430: 38,
+        440: 42,
+        450: 47,
+        460: 52,
+        470: 56,
+        480: 61,
+        490: 66,
+        500: 71,
+        510: 76,
+        520: 81,
+        530: 86,
+        540: 91,
+        550: 95,
+        560: 100,
+        570: 104,
+        580: 109,
+        590: 113,
+        600: 117,
+        610: 121,
+        620: 125,
+        630: 129,
+        640: 132,
+        650: 135,
+        660: 138,
+        670: 141,
+        680: 144,
+        690: 146,
+    },
+    'ISO 7589 Sensitometric Photoflood': {
+        350: 0.00,
+        360: 0.98,
+        370: 3.68,
+        380: 7.98,
+        390: 13.80,
+        400: 19.24,
+        410: 24.90,
+        420: 29.92,
+        430: 34.58,
+        440: 39.48,
+        450: 44.65,
+        460: 50.44,
+        470: 54.88,
+        480: 59.78,
+        490: 65.34,
+        500: 70.29,
+        510: 76.00,
+        520: 81.00,
+        530: 86.00,
+        540: 91.00,
+        550: 95.00,
+        560: 100.00,
+        570: 104.00,
+        580: 109.00,
+        590: 111.87,
+        600: 115.83,
+        610: 119.79,
+        620: 122.50,
+        630: 126.42,
+        640: 128.04,
+        650: 130.95,
+        660: 132.48,
+        670: 133.95,
+        680: 135.36,
+        690: 137.24,
+    },
+    'ISO 7589 Sensitometric Printer': {
+        350: 0.00,
+        360: 0.00,
+        370: 0.00,
+        380: 0.34,
+        390: 3.10,
+        400: 8.17,
+        410: 12.95,
+        420: 17.53,
+        430: 22.70,
+        440: 28.12,
+        450: 32.49,
+        460: 37.96,
+        470: 43.75,
+        480: 48.82,
+        490: 55.49,
+        500: 60.83,
+        510: 67.90,
+        520: 74.48,
+        530: 80.19,
+        540: 87.12,
+        550: 94.00,
+        560: 100.00,
+    }
+}
+
+ILLUMINANT_ISO_SDS = CaseInsensitiveMapping({
+    'ISO 7589 Photographic Daylight':
+        SpectralDistribution(
+            ILLUMINANT_ISO_SDS_DATA['ISO 7589 Photographic Daylight'],
+            name='ISO 7589 Photographic Daylight'),
+    'ISO 7589 Sensitometric Daylight':
+        SpectralDistribution(
+            ILLUMINANT_ISO_SDS_DATA['ISO 7589 Sensitometric Daylight'],
+            name='ISO 7589 Sensitometric Daylight'),
+    'ISO 7589 Studio Tungsten':
+        SpectralDistribution(
+            ILLUMINANT_ISO_SDS_DATA['ISO 7589 Studio Tungsten'],
+            name='ISO 7589 Studio Tungsten'),
+    'ISO 7589 Sensitometric Studio Tungsten':
+        SpectralDistribution(
+            ILLUMINANT_ISO_SDS_DATA['ISO 7589 Sensitometric Studio Tungsten'],
+            name='ISO 7589 Sensitometric Studio Tungsten'),
+    'ISO 7589 Photoflood':
+        SpectralDistribution(
+            ILLUMINANT_ISO_SDS_DATA['ISO 7589 Photoflood'],
+            name='ISO 7589 Photoflood'),
+    'ISO 7589 Sensitometric Photoflood':
+        SpectralDistribution(
+            ILLUMINANT_ISO_SDS_DATA['ISO 7589 Sensitometric Photoflood'],
+            name='ISO 7589 Sensitometric Photoflood'),
+    'ISO 7589 Sensitometric Printer':
+        SpectralDistribution(
+            ILLUMINANT_ISO_SDS_DATA['ISO 7589 Sensitometric Printer'],
+            name='ISO 7589 Sensitometric Printer'),
+})
+ILLUMINANT_ISO_SDS.__doc__ = """
+*ISO* illuminant spectral distributions.
+
+Notes
+-----
+-   All the *ISO 7589 Sensitometric* spectral distributions are transmitted by
+    the *ISO Standard Lens* given in :attr:`colour.LENS_SDS` attribute except
+    for the *ISO 7589 Sensitometric Printer* spectral distribution which is
+    modulated by both the *ISO Standard Lens* and the *ISO 7589 Diffuser* given
+    in :attr:`colour.FILTERS_SDS` attribute:
+
+    -   *ISO 7589 Sensitometric Daylight* = \
+ISO 7589 Photographic Daylight * ISO Standard Lens
+    -   *ISO 7589 Sensitometric Studio Tungsten* = \
+ISO 7589 Studio Tungsten * ISO Standard Lens
+    -   *ISO 7589 Sensitometric Photoflood* = \
+ISO 7589 Photoflood * ISO Standard Lens
+    -   *ISO 7589 Sensitometric Printer* = \
+ISO 7589 Studio Tungsten * ISO Standard Lens * ISO 7589 Diffuser
+
+References
+----------
+:cite:`ISO2002`
+
+ILLUMINANT_ISO_SDS : CaseInsensitiveMapping
+"""
+
 ILLUMINANT_SDS = CaseInsensitiveMapping(ILLUMINANT_CIE_SDS)
 ILLUMINANT_SDS.__doc__ = """
 Aggregated illuminant spectral distributions.
 
 References
 ----------
-:cite:`Carter2018`, :cite:`CIEce`, :cite:`CIEcf`
+:cite:`Carter2018`, :cite:`CIEce`, :cite:`CIEcf`, :cite:`ISO2002`
 
 ILLUMINANT_SDS : CaseInsensitiveMapping
 """
+
+ILLUMINANT_SDS.update(ILLUMINANT_ISO_SDS)
 
 # *CIE 15:2004* recommends using linear interpolation for
 # *CIE Standard Illuminant D Series*, for consistency all the illuminants are

--- a/colour/colorimetry/datasets/illuminants/sds.py
+++ b/colour/colorimetry/datasets/illuminants/sds.py
@@ -3,9 +3,9 @@
 Illuminant Spectral Distributions
 =================================
 
-Defines the *CIE* illuminant spectral distributions.
+Defines the illuminant spectral distributions.
 
-The *CIE* illuminants data is in the form of a *dict* of
+The illuminants data is in the form of a *dict* of
 :class:`colour.SpectralDistribution` classes as follows::
 
     {'name': SpectralDistribution, ..., 'name': SpectralDistribution}
@@ -56,9 +56,9 @@ __maintainer__ = 'Colour Developers'
 __email__ = 'colour-developers@colour-science.org'
 __status__ = 'Production'
 
-__all__ = ['ILLUMINANT_SDS_DATA', 'ILLUMINANT_SDS']
+__all__ = ['ILLUMINANT_CIE_SDS_DATA', 'ILLUMINANT_CIE_SDS', 'ILLUMINANT_SDS']
 
-ILLUMINANT_SDS_DATA = {
+ILLUMINANT_CIE_SDS_DATA = {
     'A': {
         300: 0.930483,
         305: 1.128210,
@@ -4559,114 +4559,116 @@ ILLUMINANT_SDS_DATA = {
     }
 }
 
-ILLUMINANT_SDS = CaseInsensitiveMapping({
+ILLUMINANT_CIE_SDS = CaseInsensitiveMapping({
     'A':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['A'], name='A'),
+        SpectralDistribution(ILLUMINANT_CIE_SDS_DATA['A'], name='A'),
     'B':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['B'], name='B'),
+        SpectralDistribution(ILLUMINANT_CIE_SDS_DATA['B'], name='B'),
     'C':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['C'], name='C'),
+        SpectralDistribution(ILLUMINANT_CIE_SDS_DATA['C'], name='C'),
     'D50':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['D50'], name='D50'),
+        SpectralDistribution(ILLUMINANT_CIE_SDS_DATA['D50'], name='D50'),
     'D55':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['D55'], name='D55'),
+        SpectralDistribution(ILLUMINANT_CIE_SDS_DATA['D55'], name='D55'),
     'D60':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['D60'], name='D60'),
+        SpectralDistribution(ILLUMINANT_CIE_SDS_DATA['D60'], name='D60'),
     'D65':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['D65'], name='D65'),
+        SpectralDistribution(ILLUMINANT_CIE_SDS_DATA['D65'], name='D65'),
     'D75':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['D75'], name='D75'),
+        SpectralDistribution(ILLUMINANT_CIE_SDS_DATA['D75'], name='D75'),
     'E':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['E'], name='E'),
+        SpectralDistribution(ILLUMINANT_CIE_SDS_DATA['E'], name='E'),
     'FL1':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['FL1'], name='FL1'),
+        SpectralDistribution(ILLUMINANT_CIE_SDS_DATA['FL1'], name='FL1'),
     'FL2':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['FL2'], name='FL2'),
+        SpectralDistribution(ILLUMINANT_CIE_SDS_DATA['FL2'], name='FL2'),
     'FL3':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['FL3'], name='FL3'),
+        SpectralDistribution(ILLUMINANT_CIE_SDS_DATA['FL3'], name='FL3'),
     'FL4':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['FL4'], name='FL4'),
+        SpectralDistribution(ILLUMINANT_CIE_SDS_DATA['FL4'], name='FL4'),
     'FL5':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['FL5'], name='FL5'),
+        SpectralDistribution(ILLUMINANT_CIE_SDS_DATA['FL5'], name='FL5'),
     'FL6':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['FL6'], name='FL6'),
+        SpectralDistribution(ILLUMINANT_CIE_SDS_DATA['FL6'], name='FL6'),
     'FL7':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['FL7'], name='FL7'),
+        SpectralDistribution(ILLUMINANT_CIE_SDS_DATA['FL7'], name='FL7'),
     'FL8':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['FL8'], name='FL8'),
+        SpectralDistribution(ILLUMINANT_CIE_SDS_DATA['FL8'], name='FL8'),
     'FL9':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['FL9'], name='FL9'),
+        SpectralDistribution(ILLUMINANT_CIE_SDS_DATA['FL9'], name='FL9'),
     'FL10':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['FL10'], name='FL10'),
+        SpectralDistribution(ILLUMINANT_CIE_SDS_DATA['FL10'], name='FL10'),
     'FL11':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['FL11'], name='FL11'),
+        SpectralDistribution(ILLUMINANT_CIE_SDS_DATA['FL11'], name='FL11'),
     'FL12':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['FL12'], name='FL12'),
+        SpectralDistribution(ILLUMINANT_CIE_SDS_DATA['FL12'], name='FL12'),
     'FL3.1':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['FL3.1'], name='FL3.1'),
+        SpectralDistribution(ILLUMINANT_CIE_SDS_DATA['FL3.1'], name='FL3.1'),
     'FL3.2':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['FL3.2'], name='FL3.2'),
+        SpectralDistribution(ILLUMINANT_CIE_SDS_DATA['FL3.2'], name='FL3.2'),
     'FL3.3':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['FL3.3'], name='FL3.3'),
+        SpectralDistribution(ILLUMINANT_CIE_SDS_DATA['FL3.3'], name='FL3.3'),
     'FL3.4':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['FL3.4'], name='FL3.4'),
+        SpectralDistribution(ILLUMINANT_CIE_SDS_DATA['FL3.4'], name='FL3.4'),
     'FL3.5':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['FL3.5'], name='FL3.5'),
+        SpectralDistribution(ILLUMINANT_CIE_SDS_DATA['FL3.5'], name='FL3.5'),
     'FL3.6':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['FL3.6'], name='FL3.6'),
+        SpectralDistribution(ILLUMINANT_CIE_SDS_DATA['FL3.6'], name='FL3.6'),
     'FL3.7':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['FL3.7'], name='FL3.7'),
+        SpectralDistribution(ILLUMINANT_CIE_SDS_DATA['FL3.7'], name='FL3.7'),
     'FL3.8':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['FL3.8'], name='FL3.8'),
+        SpectralDistribution(ILLUMINANT_CIE_SDS_DATA['FL3.8'], name='FL3.8'),
     'FL3.9':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['FL3.9'], name='FL3.9'),
+        SpectralDistribution(ILLUMINANT_CIE_SDS_DATA['FL3.9'], name='FL3.9'),
     'FL3.10':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['FL3.10'], name='FL3.10'),
+        SpectralDistribution(ILLUMINANT_CIE_SDS_DATA['FL3.10'], name='FL3.10'),
     'FL3.11':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['FL3.11'], name='FL3.11'),
+        SpectralDistribution(ILLUMINANT_CIE_SDS_DATA['FL3.11'], name='FL3.11'),
     'FL3.12':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['FL3.12'], name='FL3.12'),
+        SpectralDistribution(ILLUMINANT_CIE_SDS_DATA['FL3.12'], name='FL3.12'),
     'FL3.13':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['FL3.13'], name='FL3.13'),
+        SpectralDistribution(ILLUMINANT_CIE_SDS_DATA['FL3.13'], name='FL3.13'),
     'FL3.14':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['FL3.14'], name='FL3.14'),
+        SpectralDistribution(ILLUMINANT_CIE_SDS_DATA['FL3.14'], name='FL3.14'),
     'FL3.15':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['FL3.15'], name='FL3.15'),
+        SpectralDistribution(ILLUMINANT_CIE_SDS_DATA['FL3.15'], name='FL3.15'),
     'HP1':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['HP1'], name='HP1'),
+        SpectralDistribution(ILLUMINANT_CIE_SDS_DATA['HP1'], name='HP1'),
     'HP2':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['HP2'], name='HP2'),
+        SpectralDistribution(ILLUMINANT_CIE_SDS_DATA['HP2'], name='HP2'),
     'HP3':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['HP3'], name='HP3'),
+        SpectralDistribution(ILLUMINANT_CIE_SDS_DATA['HP3'], name='HP3'),
     'HP4':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['HP4'], name='HP4'),
+        SpectralDistribution(ILLUMINANT_CIE_SDS_DATA['HP4'], name='HP4'),
     'HP5':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['HP5'], name='HP5'),
+        SpectralDistribution(ILLUMINANT_CIE_SDS_DATA['HP5'], name='HP5'),
     'LED-B1':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['LED-B1'], name='LED-B1'),
+        SpectralDistribution(ILLUMINANT_CIE_SDS_DATA['LED-B1'], name='LED-B1'),
     'LED-B2':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['LED-B2'], name='LED-B2'),
+        SpectralDistribution(ILLUMINANT_CIE_SDS_DATA['LED-B2'], name='LED-B2'),
     'LED-B3':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['LED-B3'], name='LED-B3'),
+        SpectralDistribution(ILLUMINANT_CIE_SDS_DATA['LED-B3'], name='LED-B3'),
     'LED-B4':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['LED-B4'], name='LED-B4'),
+        SpectralDistribution(ILLUMINANT_CIE_SDS_DATA['LED-B4'], name='LED-B4'),
     'LED-B5':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['LED-B5'], name='LED-B5'),
+        SpectralDistribution(ILLUMINANT_CIE_SDS_DATA['LED-B5'], name='LED-B5'),
     'LED-BH1':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['LED-BH1'], name='LED-BH1'),
+        SpectralDistribution(
+            ILLUMINANT_CIE_SDS_DATA['LED-BH1'], name='LED-BH1'),
     'LED-RGB1':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['LED-RGB1'], name='LED-RGB1'),
+        SpectralDistribution(
+            ILLUMINANT_CIE_SDS_DATA['LED-RGB1'], name='LED-RGB1'),
     'LED-V1':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['LED-V1'], name='LED-V1'),
+        SpectralDistribution(ILLUMINANT_CIE_SDS_DATA['LED-V1'], name='LED-V1'),
     'LED-V2':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['LED-V2'], name='LED-V2'),
+        SpectralDistribution(ILLUMINANT_CIE_SDS_DATA['LED-V2'], name='LED-V2'),
     'ID65':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['ID65'], name='ID65'),
+        SpectralDistribution(ILLUMINANT_CIE_SDS_DATA['ID65'], name='ID65'),
     'ID50':
-        SpectralDistribution(ILLUMINANT_SDS_DATA['ID50'], name='ID50'),
+        SpectralDistribution(ILLUMINANT_CIE_SDS_DATA['ID50'], name='ID50'),
 })
-ILLUMINANT_SDS.__doc__ = """
-*CIE* illuminants spectral distributions.
+ILLUMINANT_CIE_SDS.__doc__ = """
+*CIE* illuminant spectral distributions.
 
 Notes
 -----
@@ -4678,6 +4680,17 @@ computed as follows::
     xy = colour.temperature.CCT_to_xy_CIE_D(CCT)
 
     sd = colour.sd_CIE_illuminant_D_series(xy)
+
+References
+----------
+:cite:`Carter2018`, :cite:`CIEce`, :cite:`CIEcf`
+
+ILLUMINANT_CIE_SDS : CaseInsensitiveMapping
+"""
+
+ILLUMINANT_SDS = CaseInsensitiveMapping(ILLUMINANT_CIE_SDS)
+ILLUMINANT_SDS.__doc__ = """
+Aggregated illuminant spectral distributions.
 
 References
 ----------

--- a/colour/colorimetry/datasets/light_sources/sds.py
+++ b/colour/colorimetry/datasets/light_sources/sds.py
@@ -5154,6 +5154,10 @@ LIGHT_SOURCE_SDS = CaseInsensitiveMapping(LIGHT_SOURCE_RIT_SDS)
 LIGHT_SOURCE_SDS.__doc__ = """
 Aggregated light sources spectral distributions.
 
+References
+----------
+:cite:`Houston2015a`, :cite:`Ohno2008a`, :cite:`Pointer1980a`
+
 LIGHT_SOURCE_SDS : CaseInsensitiveMapping
 """
 

--- a/docs/colour.characterisation.rst
+++ b/docs/colour.characterisation.rst
@@ -112,3 +112,17 @@ Displays
     :toctree: generated/
 
     DISPLAY_RGB_PRIMARIES
+
+Lenses
+------
+
+**Dataset**
+
+``colour``
+
+.. currentmodule:: colour
+
+.. autosummary::
+    :toctree: generated/
+
+    LENS_SDS

--- a/docs/colour.characterisation.rst
+++ b/docs/colour.characterisation.rst
@@ -113,6 +113,20 @@ Displays
 
     DISPLAY_RGB_PRIMARIES
 
+Filters
+-------
+
+**Dataset**
+
+``colour``
+
+.. currentmodule:: colour
+
+.. autosummary::
+    :toctree: generated/
+
+    FILTER_SDS
+
 Lenses
 ------
 


### PR DESCRIPTION
This PR adds the spectral distributions of *ISO* 7589 illuminants and the related lens and diffuser:

The following new spectral distributions are available:

-   ISO 7589 Photographic Daylight
-   ISO 7589 Sensitometric Daylight
-   ISO 7589 Studio Tungsten
-   ISO 7589 Sensitometric Studio Tungsten
-   ISO 7589 Photoflood
-   ISO 7589 Sensitometric Photoflood
-   ISO 7589 Sensitometric Printer

Along with:

- ISO 6728 Standard Lens
- ISO 7589 Diffuser

Colour has also now the following new attributes:

- `colour.LENS_SDS` that contains *ISO 6728 Standard Lens*
- `colour.FILTER_SDS` that contains *ISO 7589 Diffuser*