### PR TITLE
PR: Fix incorrect spelling of HLG inverse OETF

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -808,7 +808,7 @@ OETFs Inverse
 
     >>> sorted(colour.OETF_INVERSES.keys())
     ['ARIB STD-B67',
-     'ITU-R BT.2100 HLD',
+     'ITU-R BT.2100 HLG',
      'ITU-R BT.2100 PQ',
      'ITU-R BT.601',
      'ITU-R BT.709']

--- a/colour/models/rgb/transfer_functions/__init__.py
+++ b/colour/models/rgb/transfer_functions/__init__.py
@@ -484,7 +484,7 @@ def oetf(value, function='ITU-R BT.709', **kwargs):
 
 OETF_INVERSES = CaseInsensitiveMapping({
     'ARIB STD-B67': oetf_inverse_ARIBSTDB67,
-    'ITU-R BT.2100 HLD': oetf_inverse_HLG_BT2100,
+    'ITU-R BT.2100 HLG': oetf_inverse_HLG_BT2100,
     'ITU-R BT.2100 PQ': oetf_inverse_PQ_BT2100,
     'ITU-R BT.601': oetf_inverse_BT601,
     'ITU-R BT.709': oetf_inverse_BT709,
@@ -493,7 +493,7 @@ OETF_INVERSES.__doc__ = """
 Supported inverse opto-electrical transfer functions (OETFs / OECFs).
 
 OETF_INVERSES : CaseInsensitiveMapping
-    **{'ARIB STD-B67', 'ITU-R BT.2100 HLD', 'ITU-R BT.2100 PQ',
+    **{'ARIB STD-B67', 'ITU-R BT.2100 HLG', 'ITU-R BT.2100 PQ',
     'ITU-R BT.601', 'ITU-R BT.709'}**
 """
 
@@ -509,7 +509,7 @@ def oetf_inverse(value, function='ITU-R BT.709', **kwargs):
     value : numeric or array_like
         Value.
     function : unicode, optional
-        **{'ITU-R BT.709', 'ARIB STD-B67', 'ITU-R BT.2100 HLD',
+        **{'ITU-R BT.709', 'ARIB STD-B67', 'ITU-R BT.2100 HLG',
         'ITU-R BT.2100 PQ', 'ITU-R BT.601', }**,
         Inverse opto-electronic transfer function (OETF / OECF).
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -742,7 +742,7 @@ OETFs Inverse
 
     >>> sorted(colour.OETF_INVERSES.keys())
     ['ARIB STD-B67',
-     'ITU-R BT.2100 HLD',
+     'ITU-R BT.2100 HLG',
      'ITU-R BT.2100 PQ',
      'ITU-R BT.601',
      'ITU-R BT.709']


### PR DESCRIPTION
`'ITU-R BT.2100 HLG'` was incorrectly written as `'ITU-R BT.2100 HLD'` See also #571 .