### PR TITLE
PR: Micro-optimizations for the "colour.models" sub-package.

### DIFF
--- a/colour/models/cie_luv.py
+++ b/colour/models/cie_luv.py
@@ -110,10 +110,11 @@ def XYZ_to_Luv(
     with domain_range_scale('100'):
         L = lightness_CIE1976(Y, Y_r)
 
-    u = (13 * L * ((4 * X / (X + 15 * Y + 3 * Z)) -
-                   (4 * X_r / (X_r + 15 * Y_r + 3 * Z_r))))
-    v = (13 * L * ((9 * Y / (X + 15 * Y + 3 * Z)) -
-                   (9 * Y_r / (X_r + 15 * Y_r + 3 * Z_r))))
+    X_Y_Z = X + 15 * Y + 3 * Z
+    X_r_Y_r_Z_r = X_r + 15 * Y_r + 3 * Z_r
+
+    u = (13 * L * ((4 * X / X_Y_Z) - (4 * X_r / X_r_Y_r_Z_r)))
+    v = (13 * L * ((9 * Y / X_Y_Z) - (9 * Y_r / X_r_Y_r_Z_r)))
 
     Luv = tstack([L, u, v])
 
@@ -246,7 +247,9 @@ def Luv_to_uv(
 
     X, Y, Z = tsplit(Luv_to_XYZ(Luv, illuminant))
 
-    uv = tstack([4 * X / (X + 15 * Y + 3 * Z), 9 * Y / (X + 15 * Y + 3 * Z)])
+    X_Y_Z = X + 15 * Y + 3 * Z
+
+    uv = tstack([4 * X / X_Y_Z, 9 * Y / X_Y_Z])
 
     return uv
 

--- a/colour/models/cie_ucs.py
+++ b/colour/models/cie_ucs.py
@@ -172,7 +172,9 @@ def UCS_to_uv(UVW):
 
     U, V, W = tsplit(to_domain_1(UVW))
 
-    uv = tstack([U / (U + V + W), V / (U + V + W)])
+    U_V_W = U + V + W
+
+    uv = tstack([U / U_V_W, V / U_V_W])
 
     return uv
 

--- a/colour/models/rgb/cmyk.py
+++ b/colour/models/rgb/cmyk.py
@@ -26,7 +26,7 @@ from __future__ import division, unicode_literals
 
 import numpy as np
 
-from colour.utilities import (as_float_array, from_range_1, ones, to_domain_1,
+from colour.utilities import (as_float_array, from_range_1, to_domain_1,
                               tsplit, tstack)
 
 __author__ = 'Colour Developers'
@@ -171,8 +171,7 @@ def CMY_to_CMYK(CMY):
 
     C, M, Y = tsplit(to_domain_1(CMY))
 
-    K = ones(C.shape)
-    K = np.where(C < K, C, K)
+    K = np.where(C < 1, C, 1)
     K = np.where(M < K, M, K)
     K = np.where(Y < K, Y, K)
 

--- a/colour/models/rgb/cylindrical.py
+++ b/colour/models/rgb/cylindrical.py
@@ -37,7 +37,7 @@ from __future__ import division, unicode_literals
 
 import numpy as np
 
-from colour.utilities import (as_float_array, from_range_1, full, to_domain_1,
+from colour.utilities import (as_float_array, from_range_1, to_domain_1,
                               tsplit, tstack)
 
 __author__ = 'Colour Developers'
@@ -309,12 +309,10 @@ def HSL_to_RGB(HSL):
         vH[np.asarray(vH < 0)] += 1
         vH[np.asarray(vH > 1)] -= 1
 
-        v = full(vi.shape, np.nan)
-
         v = np.where(
-            np.logical_and(6 * vH < 1, np.isnan(v)),
+            6 * vH < 1,
             vi + (vj - vi) * 6 * vH,
-            v,
+            np.nan,
         )
         v = np.where(np.logical_and(2 * vH < 1, np.isnan(v)), vj, v)
         v = np.where(

--- a/colour/models/rgb/transfer_functions/aces.py
+++ b/colour/models/rgb/transfer_functions/aces.py
@@ -182,8 +182,8 @@ def log_encoding_ACESproxy(lin_AP1,
 
     constants = constants[bit_depth]
 
-    CV_min = np.resize(constants.CV_min, lin_AP1.shape)
-    CV_max = np.resize(constants.CV_max, lin_AP1.shape)
+    CV_min = constants.CV_min
+    CV_max = constants.CV_max
 
     def float_2_cv(x):
         """

--- a/colour/models/rgb/transfer_functions/itur_bt_2100.py
+++ b/colour/models/rgb/transfer_functions/itur_bt_2100.py
@@ -1344,23 +1344,22 @@ def ootf_inverse_HLG_BT2100_1(F_D, L_B=0, L_W=1000, gamma=None):
     if gamma is None:
         gamma = gamma_function_HLG_BT2100(L_W)
 
+    Y_D_beta = (np.abs((Y_D - beta) / alpha) ** ((1 - gamma) / gamma))
+
     R_S = np.where(
         Y_D == beta,
         0.0,
-        (np.abs((Y_D - beta) / alpha) **
-         ((1 - gamma) / gamma)) * (R_D - beta) / alpha,
+        Y_D_beta * (R_D - beta) / alpha,
     )
     G_S = np.where(
         Y_D == beta,
         0.0,
-        (np.abs((Y_D - beta) / alpha) **
-         ((1 - gamma) / gamma)) * (G_D - beta) / alpha,
+        Y_D_beta * (G_D - beta) / alpha,
     )
     B_S = np.where(
         Y_D == beta,
         0.0,
-        (np.abs((Y_D - beta) / alpha) **
-         ((1 - gamma) / gamma)) * (B_D - beta) / alpha,
+        Y_D_beta * (B_D - beta) / alpha,
     )
 
     if F_D.shape[-1] != 3:
@@ -1439,20 +1438,22 @@ def ootf_inverse_HLG_BT2100_2(F_D, L_W=1000, gamma=None):
     if gamma is None:
         gamma = gamma_function_HLG_BT2100(L_W)
 
+    Y_D_alpha = (np.abs(Y_D / alpha) ** ((1 - gamma) / gamma))
+
     R_S = np.where(
         Y_D == 0,
         0.0,
-        (np.abs(Y_D / alpha) ** ((1 - gamma) / gamma)) * R_D / alpha,
+        Y_D_alpha * R_D / alpha,
     )
     G_S = np.where(
         Y_D == 0,
         0.0,
-        (np.abs(Y_D / alpha) ** ((1 - gamma) / gamma)) * G_D / alpha,
+        Y_D_alpha * G_D / alpha,
     )
     B_S = np.where(
         Y_D == 0,
         0.0,
-        (np.abs(Y_D / alpha) ** ((1 - gamma) / gamma)) * B_D / alpha,
+        Y_D_alpha * B_D / alpha,
     )
 
     if F_D.shape[-1] != 3:


### PR DESCRIPTION
Hello, This is a pull request for small microoptimizations. 

The optimizations for the models/rgb are small and get about 5-10% speedup, while the optimizations for the transfer_functions module although small get about 40-50% for the last two and about 90% for the aces function.

As for comments on the previous pull request (sorry my local repository got deleted and so i had to close that one)

The X_Y_Z and X_r_Y_r_Z_r variables don't seem to have a more descriptive name as far as I've searched and the U_V_W would need to be tstacked to divide over the entire variable, losing some performance.