### PR TITLE
PR: Add "colour.models.rgb.transfer_functions.log" module.

### DIFF
--- a/colour/models/rgb/transfer_functions/__init__.py
+++ b/colour/models/rgb/transfer_functions/__init__.py
@@ -58,6 +58,7 @@ from .sony_slog import (log_encoding_SLog, log_decoding_SLog,
                         log_encoding_SLog3, log_decoding_SLog3)
 from .srgb import eotf_inverse_sRGB, eotf_sRGB
 from .viper_log import log_encoding_ViperLog, log_decoding_ViperLog
+from .log import log_encoding_Log2, log_decoding_Log2
 
 __all__ = ['CV_range', 'legal_to_full', 'full_to_legal']
 __all__ += ['gamma_function']
@@ -116,6 +117,7 @@ __all__ += [
 ]
 __all__ += ['eotf_inverse_sRGB', 'eotf_sRGB']
 __all__ += ['log_encoding_ViperLog', 'log_decoding_ViperLog']
+__all__ += ['log_encoding_Log2', 'log_decoding_Log2']
 
 LOG_ENCODINGS = CaseInsensitiveMapping({
     'ACEScc': log_encoding_ACEScc,
@@ -142,7 +144,8 @@ LOG_ENCODINGS = CaseInsensitiveMapping({
     'S-Log3': log_encoding_SLog3,
     'T-Log': log_encoding_FilmLightTLog,
     'V-Log': log_encoding_VLog,
-    'ViperLog': log_encoding_ViperLog
+    'ViperLog': log_encoding_ViperLog,
+    'Log2': log_encoding_Log2
 })
 LOG_ENCODINGS.__doc__ = """
 Supported *log* encoding functions.
@@ -152,7 +155,7 @@ LOG_ENCODINGS : CaseInsensitiveMapping
     'Canon Log 3', 'Canon Log', 'Cineon', 'D-Log', 'ERIMM RGB', 'F-Log',
     'Filmic Pro 6', 'Log3G10', 'Log3G12', 'Panalog', 'PLog', 'Protune',
     'REDLog', 'REDLogFilm', 'S-Log', 'S-Log2', 'S-Log3', 'T-Log', 'V-Log',
-    'ViperLog'}**
+    'ViperLog', 'Log2'}**
 """
 
 
@@ -170,7 +173,7 @@ def log_encoding(value, function='Cineon', **kwargs):
         'Canon Log 3', 'Canon Log', 'Cineon', 'D-Log', 'ERIMM RGB', 'F-Log',
         'Filmic Pro 6', 'Log3G10', 'Log3G12', 'Panalog', 'PLog', 'Protune',
         'REDLog', 'REDLogFilm', 'S-Log', 'S-Log2', 'S-Log3', 'T-Log',
-        'V-Log', 'ViperLog'}**,
+        'V-Log', 'ViperLog', 'Log2'}**,
         Computation function.
 
     Other Parameters
@@ -286,7 +289,8 @@ LOG_DECODINGS = CaseInsensitiveMapping({
     'S-Log3': log_decoding_SLog3,
     'T-Log': log_decoding_FilmLightTLog,
     'V-Log': log_decoding_VLog,
-    'ViperLog': log_decoding_ViperLog
+    'ViperLog': log_decoding_ViperLog,
+    'Log2': log_decoding_Log2
 })
 LOG_DECODINGS.__doc__ = """
 Supported *log* decoding functions.
@@ -296,7 +300,7 @@ LOG_DECODINGS : CaseInsensitiveMapping
     'Canon Log 3', 'Canon Log', 'Cineon', 'D-Log', 'ERIMM RGB', 'F-Log',
     'Filmic Pro 6', 'Log3G10', 'Log3G12', 'Panalog', 'PLog', 'Protune',
     'REDLog', 'REDLogFilm', 'S-Log', 'S-Log2', 'S-Log3', 'T-Log', 'V-Log',
-    'ViperLog'}**
+    'ViperLog', 'Log2'}**
 """
 
 
@@ -314,7 +318,7 @@ def log_decoding(value, function='Cineon', **kwargs):
         'Canon Log 3', 'Canon Log', 'Cineon', 'D-Log', 'ERIMM RGB', 'F-Log',
         'Filmic Pro 6', 'Log3G10', 'Log3G12', 'Panalog', 'PLog', 'Protune',
         'REDLog', 'REDLogFilm', 'S-Log', 'S-Log2', 'S-Log3', 'T-Log',
-        'V-Log', 'ViperLog'}**,
+        'V-Log', 'ViperLog', 'Log2'}**,
         Computation function.
 
     Other Parameters

--- a/colour/models/rgb/transfer_functions/__init__.py
+++ b/colour/models/rgb/transfer_functions/__init__.py
@@ -39,6 +39,7 @@ from .itur_bt_2100 import (
     BT2100_HLG_OOTF_METHODS, ootf_HLG_BT2100, BT2100_HLG_OOTF_INVERSE_METHODS,
     ootf_inverse_HLG_BT2100)
 from .linear import linear_function
+from .log import log_encoding_Log2, log_decoding_Log2
 from .panalog import log_encoding_Panalog, log_decoding_Panalog
 from .panasonic_vlog import log_encoding_VLog, log_decoding_VLog
 from .fujifilm_flog import log_encoding_FLog, log_decoding_FLog
@@ -58,7 +59,6 @@ from .sony_slog import (log_encoding_SLog, log_decoding_SLog,
                         log_encoding_SLog3, log_decoding_SLog3)
 from .srgb import eotf_inverse_sRGB, eotf_sRGB
 from .viper_log import log_encoding_ViperLog, log_decoding_ViperLog
-from .log import log_encoding_Log2, log_decoding_Log2
 
 __all__ = ['CV_range', 'legal_to_full', 'full_to_legal']
 __all__ += ['gamma_function']
@@ -94,6 +94,7 @@ __all__ += [
     'BT2100_HLG_OOTF_INVERSE_METHODS', 'ootf_inverse_HLG_BT2100'
 ]
 __all__ += ['linear_function']
+__all__ += ['log_encoding_Log2', 'log_decoding_Log2']
 __all__ += ['log_encoding_Panalog', 'log_decoding_Panalog']
 __all__ += ['log_encoding_VLog', 'log_decoding_VLog']
 __all__ += ['log_encoding_FLog', 'log_decoding_FLog']
@@ -117,7 +118,6 @@ __all__ += [
 ]
 __all__ += ['eotf_inverse_sRGB', 'eotf_sRGB']
 __all__ += ['log_encoding_ViperLog', 'log_decoding_ViperLog']
-__all__ += ['log_encoding_Log2', 'log_decoding_Log2']
 
 LOG_ENCODINGS = CaseInsensitiveMapping({
     'ACEScc': log_encoding_ACEScc,
@@ -132,6 +132,7 @@ LOG_ENCODINGS = CaseInsensitiveMapping({
     'ERIMM RGB': log_encoding_ERIMMRGB,
     'F-Log': log_encoding_FLog,
     'Filmic Pro 6': log_encoding_FilmicPro6,
+    'Log2': log_encoding_Log2,
     'Log3G10': log_encoding_Log3G10,
     'Log3G12': log_encoding_Log3G12,
     'Panalog': log_encoding_Panalog,
@@ -144,8 +145,7 @@ LOG_ENCODINGS = CaseInsensitiveMapping({
     'S-Log3': log_encoding_SLog3,
     'T-Log': log_encoding_FilmLightTLog,
     'V-Log': log_encoding_VLog,
-    'ViperLog': log_encoding_ViperLog,
-    'Log2': log_encoding_Log2
+    'ViperLog': log_encoding_ViperLog
 })
 LOG_ENCODINGS.__doc__ = """
 Supported *log* encoding functions.
@@ -153,9 +153,9 @@ Supported *log* encoding functions.
 LOG_ENCODINGS : CaseInsensitiveMapping
     **{'ACEScc', 'ACEScct', 'ACESproxy', 'ALEXA Log C', 'Canon Log 2',
     'Canon Log 3', 'Canon Log', 'Cineon', 'D-Log', 'ERIMM RGB', 'F-Log',
-    'Filmic Pro 6', 'Log3G10', 'Log3G12', 'Panalog', 'PLog', 'Protune',
-    'REDLog', 'REDLogFilm', 'S-Log', 'S-Log2', 'S-Log3', 'T-Log', 'V-Log',
-    'ViperLog', 'Log2'}**
+    'Filmic Pro 6', 'Log2', 'Log3G10', 'Log3G12', 'Panalog', 'PLog',
+    'Protune', 'REDLog', 'REDLogFilm', 'S-Log', 'S-Log2', 'S-Log3',
+    'T-Log', 'V-Log', 'ViperLog'}**
 """
 
 
@@ -171,9 +171,9 @@ def log_encoding(value, function='Cineon', **kwargs):
     function : unicode, optional
         **{'ACEScc', 'ACEScct', 'ACESproxy', 'ALEXA Log C', 'Canon Log 2',
         'Canon Log 3', 'Canon Log', 'Cineon', 'D-Log', 'ERIMM RGB', 'F-Log',
-        'Filmic Pro 6', 'Log3G10', 'Log3G12', 'Panalog', 'PLog', 'Protune',
-        'REDLog', 'REDLogFilm', 'S-Log', 'S-Log2', 'S-Log3', 'T-Log',
-        'V-Log', 'ViperLog', 'Log2'}**,
+        'Filmic Pro 6', 'Log2', 'Log3G10', 'Log3G12', 'Panalog', 'PLog',
+        'Protune', 'REDLog', 'REDLogFilm', 'S-Log', 'S-Log2', 'S-Log3',
+        'T-Log', 'V-Log', 'ViperLog'}**,
         Computation function.
 
     Other Parameters
@@ -277,6 +277,7 @@ LOG_DECODINGS = CaseInsensitiveMapping({
     'ERIMM RGB': log_decoding_ERIMMRGB,
     'F-Log': log_decoding_FLog,
     'Filmic Pro 6': log_decoding_FilmicPro6,
+    'Log2': log_decoding_Log2,
     'Log3G10': log_decoding_Log3G10,
     'Log3G12': log_decoding_Log3G12,
     'Panalog': log_decoding_Panalog,
@@ -289,8 +290,7 @@ LOG_DECODINGS = CaseInsensitiveMapping({
     'S-Log3': log_decoding_SLog3,
     'T-Log': log_decoding_FilmLightTLog,
     'V-Log': log_decoding_VLog,
-    'ViperLog': log_decoding_ViperLog,
-    'Log2': log_decoding_Log2
+    'ViperLog': log_decoding_ViperLog
 })
 LOG_DECODINGS.__doc__ = """
 Supported *log* decoding functions.
@@ -298,9 +298,9 @@ Supported *log* decoding functions.
 LOG_DECODINGS : CaseInsensitiveMapping
     **{'ACEScc', 'ACEScct', 'ACESproxy', 'ALEXA Log C', 'Canon Log 2',
     'Canon Log 3', 'Canon Log', 'Cineon', 'D-Log', 'ERIMM RGB', 'F-Log',
-    'Filmic Pro 6', 'Log3G10', 'Log3G12', 'Panalog', 'PLog', 'Protune',
-    'REDLog', 'REDLogFilm', 'S-Log', 'S-Log2', 'S-Log3', 'T-Log', 'V-Log',
-    'ViperLog', 'Log2'}**
+    'Filmic Pro 6', 'Log2', 'Log3G10', 'Log3G12', 'Panalog', 'PLog',
+    'Protune', 'REDLog', 'REDLogFilm', 'S-Log', 'S-Log2', 'S-Log3',
+    'T-Log', 'V-Log', 'ViperLog'}**
 """
 
 
@@ -316,9 +316,9 @@ def log_decoding(value, function='Cineon', **kwargs):
     function : unicode, optional
         **{'ACEScc', 'ACEScct', 'ACESproxy', 'ALEXA Log C', 'Canon Log 2',
         'Canon Log 3', 'Canon Log', 'Cineon', 'D-Log', 'ERIMM RGB', 'F-Log',
-        'Filmic Pro 6', 'Log3G10', 'Log3G12', 'Panalog', 'PLog', 'Protune',
-        'REDLog', 'REDLogFilm', 'S-Log', 'S-Log2', 'S-Log3', 'T-Log',
-        'V-Log', 'ViperLog', 'Log2'}**,
+        'Filmic Pro 6', 'Log2', 'Log3G10', 'Log3G12', 'Panalog', 'PLog',
+        'Protune', 'REDLog', 'REDLogFilm', 'S-Log', 'S-Log2', 'S-Log3',
+        'T-Log', 'V-Log', 'ViperLog'}**,
         Computation function.
 
     Other Parameters

--- a/colour/models/rgb/transfer_functions/log.py
+++ b/colour/models/rgb/transfer_functions/log.py
@@ -1,7 +1,7 @@
 #
 """
 Common Log Encodings
-==========================
+====================
 
 Defines the common log encodings:
 
@@ -74,11 +74,11 @@ def log_encoding_Log2(lin,
     A (48-nits OCIO) shaper having values in a linear
     domain, can be encoded to a logarithmic domain:
 
-    +-------------------+------------------+
-    | **Shaper Domain** | **Shaper range** |
-    +===================+==================+
-    | [0.002, 16.291]   | [0, 1]           |
-    +-------------------+------------------+
+    +-------------------+-------------------+
+    | **Shaper Domain** | **Shaper Range**  |
+    +===================+===================+
+    | [0.002, 16.291]   | [0, 1]            |
+    +-------------------+-------------------+
 
     References
     ----------
@@ -138,11 +138,11 @@ def log_decoding_Log2(log_norm,
     The shaper with logarithmic encoded values can be
     decoded back to linear domain:
 
-    +-------------------+------------------+
-    | **Shaper Range** | **Shaper Domain** |
-    +===================+==================+
-    | [0, 1]           | [0.002, 16.291]   |
-    +-------------------+------------------+
+    +-------------------+-------------------+
+    | **Shaper Range**  | **Shaper Domain** |
+    +===================+===================+
+    | [0, 1]            | [0.002, 16.291]   |
+    +-------------------+-------------------+
 
     References
     ----------

--- a/colour/models/rgb/transfer_functions/log.py
+++ b/colour/models/rgb/transfer_functions/log.py
@@ -1,9 +1,9 @@
 #
 """
-Log2 Shaper Implementation
+Common Log Encodings
 ==========================
 
-Defines the *Log2 shaper* log encodings:
+Defines the common log encodings:
 
 -   :func:`colour.models.log_encoding_Log2`
 -   :func:`colour.models.log_decoding_Log2`
@@ -46,38 +46,52 @@ def log_encoding_Log2(lin,
                       min_exposure=0.18 * 2 ** -6.5,
                       max_exposure=0.18 * 2 ** 6.5):
     """
-    Defines the *Log2 shaper* log encoding function.
+    Defines the common *Log2* encoding function.
 
     Parameters
     ----------
     lin : numeric or array_like
           Linear data to undergo encoding.
     middle_grey : numeric, optional
-                  'Middle Grey' exposure value.
+          *Middle Grey* exposure value.
     min_exposure : numeric, optional
-                   Minimum exposure level.
+          Minimum exposure level.
     max_exposure : numeric, optional
-                   Maximum exposure level.
+          Maximum exposure level.
 
     Returns
     -------
     numeric or ndarray
-        Non-linear *Log2 shaper* encoded data
+        Non-linear *Log2* encoded data.
 
     Notes
     -----
 
+    The common *Log2* encoding function can be used
+    to build linear to logarithmic shapers in the
+    ACES OCIO configuration.
+
+    A (48-nits OCIO) shaper having values in a linear
+    domain, can be encoded to a logarithmic domain:
+
+    +-------------------+------------------+
+    | **Shaper Domain** | **Shaper range** |
+    +===================+==================+
+    | [0.002, 16.291]   | [0, 1]           |
+    +-------------------+------------------+
+
     References
     ----------
+    :cite:`TheAcademyofMotionPictureArtsandSciencesa`
 
     Examples
     --------
-    Linear numeric input gets encoded as follows:
+    Linear numeric input is encoded as follows:
 
     >>> log_encoding_Log2(18)
     0.40773288970434662
 
-    Linear array-like input gets encoded as follows:
+    Linear array-like input is encoded as follows:
 
     >>> log_encoding_Log2(np.linspace(1, 2, 3))
     array([ 0.15174832,  0.18765817,  0.21313661])
@@ -96,38 +110,52 @@ def log_decoding_Log2(log_norm,
                       min_exposure=0.18 * 2 ** -6.5,
                       max_exposure=0.18 * 2 ** 6.5):
     """
-    Defines the *Log2 shaper* log decoding function.
+    Defines the common *Log2* decoding function.
 
     Parameters
     ----------
     log_norm : numeric or array_like
                Logarithmic data to undergo decoding.
     middle_grey : numeric, optional
-                  'Middle Grey' exposure value.
+               *Middle Grey* exposure value.
     min_exposure : numeric, optional
-                   Minimum exposure level.
+               Minimum exposure level.
     max_exposure : numeric, optional
-                   Maximum exposure level.
+               Maximum exposure level.
 
     Returns
     -------
     numeric or ndarray
-        Linear *Log2 shaper* decoded data
+        Linear *Log2* decoded data.
 
     Notes
     -----
 
+    The common *Log2* decoding function can be used
+    to build logarithmic to linear shapers in the
+    ACES OCIO configuration.
+
+    The shaper with logarithmic encoded values can be
+    decoded back to linear domain:
+
+    +-------------------+------------------+
+    | **Shaper Range** | **Shaper Domain** |
+    +===================+==================+
+    | [0, 1]           | [0.002, 16.291]   |
+    +-------------------+------------------+
+
     References
     ----------
+    :cite:`TheAcademyofMotionPictureArtsandSciencesb`
 
     Examples
     --------
-    Logarithmic input gets decoded as follows:
+    Logarithmic input is decoded as follows:
 
     >>> log_decoding_Log2(0.40773288970434662)
     17.999999999999993
 
-    Linear array-like input gets encoded as follows:
+    Linear array-like input is encoded as follows:
 
     >>> log_decoding_Log2(np.linspace(0, 1, 4))
     array([  1.80248299e-01,   7.77032379e+00,   3.34970882e+02,

--- a/colour/models/rgb/transfer_functions/log.py
+++ b/colour/models/rgb/transfer_functions/log.py
@@ -1,0 +1,142 @@
+#
+"""
+Log2 Shaper Implementation
+==========================
+
+Defines the *Log2 shaper* log encodings:
+
+-   :func:`colour.models.log_encoding_Log2`
+-   :func:`colour.models.log_decoding_Log2`
+
+References
+----------
+-   :cite:`TheAcademyofMotionPictureArtsandSciencesa` :
+    The Academy of Motion Picture Arts and Sciences,
+    Science and Technology Council,
+    & Academy Color Encoding System (ACES) Project Subcommittee.(n.d.-a).
+    ACESutil.Lin_to_Log2_param.ctl. Retrieved June 14, 2020,
+    from https://github.com/ampas/aces-dev/blob/\
+518c27f577e99cdecfddf2ebcfaa53444b1f9343/transforms/ctl/utilities/ACESutil.Lin_to_Log2_param.ctl
+-   :cite:`TheAcademyofMotionPictureArtsandSciencesb` :
+    The Academy of Motion Picture Arts and Sciences,
+    Science and Technology Council,
+    & Academy Color Encoding System (ACES) Project Subcommittee.(n.d.-b).
+    ACESutil.Log2_to_Lin_param.ctl. Retrieved June 14, 2020,
+    from https://github.com/ampas/aces-dev/blob/\
+518c27f577e99cdecfddf2ebcfaa53444b1f9343/transforms/ctl/utilities/ACESutil.Log2_to_Lin_param.ctl
+"""
+
+from __future__ import division, unicode_literals
+
+import numpy as np
+from colour.utilities import from_range_1, to_domain_1
+
+__author__ = 'Colour Developers'
+__copyright__ = 'Copyright (C) 2013-2020 - Colour Developers'
+__license__ = 'New BSD License - https://opensource.org/licenses/BSD-3-Clause'
+__maintainer__ = 'Colour Developers'
+__email__ = 'colour-developers@colour-science.org'
+__status__ = 'Production'
+
+__all__ = ['log_encoding_Log2', 'log_decoding_Log2']
+
+
+def log_encoding_Log2(lin,
+                      middle_grey=0.18,
+                      min_exposure=0.18 * 2 ** -6.5,
+                      max_exposure=0.18 * 2 ** 6.5):
+    """
+    Defines the *Log2 shaper* log encoding function.
+
+    Parameters
+    ----------
+    lin : numeric or array_like
+          Linear data to undergo encoding.
+    middle_grey : numeric, optional
+                  'Middle Grey' exposure value.
+    min_exposure : numeric, optional
+                   Minimum exposure level.
+    max_exposure : numeric, optional
+                   Maximum exposure level.
+
+    Returns
+    -------
+    numeric or ndarray
+        Non-linear *Log2 shaper* encoded data
+
+    Notes
+    -----
+
+    References
+    ----------
+
+    Examples
+    --------
+    Linear numeric input gets encoded as follows:
+
+    >>> log_encoding_Log2(18)
+    0.40773288970434662
+
+    Linear array-like input gets encoded as follows:
+
+    >>> log_encoding_Log2(np.linspace(1, 2, 3))
+    array([ 0.15174832,  0.18765817,  0.21313661])
+    """
+
+    lin = to_domain_1(lin)
+
+    lg2 = np.log2(lin / middle_grey)
+    log_norm = (lg2 - min_exposure) / (max_exposure - min_exposure)
+
+    return from_range_1(log_norm)
+
+
+def log_decoding_Log2(log_norm,
+                      middle_grey=0.18,
+                      min_exposure=0.18 * 2 ** -6.5,
+                      max_exposure=0.18 * 2 ** 6.5):
+    """
+    Defines the *Log2 shaper* log decoding function.
+
+    Parameters
+    ----------
+    log_norm : numeric or array_like
+               Logarithmic data to undergo decoding.
+    middle_grey : numeric, optional
+                  'Middle Grey' exposure value.
+    min_exposure : numeric, optional
+                   Minimum exposure level.
+    max_exposure : numeric, optional
+                   Maximum exposure level.
+
+    Returns
+    -------
+    numeric or ndarray
+        Linear *Log2 shaper* decoded data
+
+    Notes
+    -----
+
+    References
+    ----------
+
+    Examples
+    --------
+    Logarithmic input gets decoded as follows:
+
+    >>> log_decoding_Log2(0.40773288970434662)
+    17.999999999999993
+
+    Linear array-like input gets encoded as follows:
+
+    >>> log_decoding_Log2(np.linspace(0, 1, 4))
+    array([  1.80248299e-01,   7.77032379e+00,   3.34970882e+02,
+             1.44402595e+04])
+    """
+
+    log_norm = to_domain_1(log_norm)
+
+    lg2 = log_norm * (max_exposure - min_exposure) + min_exposure
+    lin = (2 ** lg2) * middle_grey
+
+    return from_range_1(lin)

--- a/colour/models/rgb/transfer_functions/tests/test_log.py
+++ b/colour/models/rgb/transfer_functions/tests/test_log.py
@@ -1,0 +1,175 @@
+#
+"""
+Defines unit tests for :mod:`colour.models.rgb.transfer_functions.log`
+module.
+"""
+
+from __future__ import division, unicode_literals
+
+import numpy as np
+import unittest
+
+from colour.models.rgb.transfer_functions import (log_encoding_Log2,
+                                                  log_decoding_Log2)
+from colour.utilities import domain_range_scale, ignore_numpy_errors
+
+__author__ = 'Colour Developers'
+__copyright__ = 'Copyright (C) 2013-2020 - Colour Developers'
+__license__ = 'New BSD License - https://opensource.org/licenses/BSD-3-Clause'
+__maintainer__ = 'Colour Developers'
+__email__ = 'colour-developers@colour-science.org'
+__status__ = 'Production'
+
+__all__ = [
+    'TestLogEncoding_Log2',
+    'TestLogDecoding_Log2',
+]
+
+
+class TestLogEncoding_Log2(unittest.TestCase):
+    """
+   Defines :func:`colour.models.rgb.transfer_functions.log.\
+log_encoding_Log2` definition unit tests methods.
+    """
+
+    def test_log_encoding_Log2(self):
+        """
+        Tests :func:`colour.models.rgb.transfer_functions.log.\
+log_encoding_Log2` definition.
+        """
+
+        self.assertAlmostEqual(log_encoding_Log2(18), 0.407732889704, places=7)
+
+        self.assertAlmostEqual(
+            log_encoding_Log2(18, 0.12), 0.443642737727, places=7)
+
+        self.assertAlmostEqual(
+            log_encoding_Log2(18, 0.12, 0.0045), 0.443556955303, places=7)
+
+        self.assertAlmostEqual(
+            log_encoding_Log2(18, 0.12, 0.0045, 15.0),
+            0.481765775766,
+            places=7)
+
+    def test_n_dimensional_log_encoding_Log2(self):
+        """
+        Tests :func:`colour.models.rgb.transfer_functions.log.\
+log_encoding_Log2` definition n-dimensional arrays support.
+        """
+
+        x = 18
+        y = log_encoding_Log2(x)
+
+        x = np.tile(x, 6)
+        y = np.tile(y, 6)
+        np.testing.assert_almost_equal(log_encoding_Log2(x), y, decimal=7)
+
+        x = np.reshape(x, (2, 3))
+        y = np.reshape(y, (2, 3))
+        np.testing.assert_almost_equal(log_encoding_Log2(x), y, decimal=7)
+
+        x = np.reshape(x, (2, 3, 1))
+        y = np.reshape(y, (2, 3, 1))
+        np.testing.assert_almost_equal(log_encoding_Log2(x), y, decimal=7)
+
+    def test_domain_range_scale_log_encoding_Log2(self):
+        """
+        Tests :func:`colour.models.rgb.transfer_functions.log.\
+log_encoding_Log2` definition domain and range scale support.
+        """
+
+        x = 18
+        y = log_encoding_Log2(x)
+
+        d_r = (('reference', 1), (1, 1), (100, 100))
+        for scale, factor in d_r:
+            with domain_range_scale(scale):
+                np.testing.assert_almost_equal(
+                    log_encoding_Log2(x * factor), y * factor, decimal=7)
+
+    @ignore_numpy_errors
+    def test_nan_log_encoding_Log2(self):
+        """
+        Tests :func:`colour.models.rgb.transfer_functions.log.\
+log_encoding_Log2` definition nan support.
+        """
+
+        log_encoding_Log2(np.array([-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan]))
+
+
+class TestLogDecoding_Log2(unittest.TestCase):
+    """
+    Defines :func:`colour.models.rgb.transfer_functions.log.\
+log_decoding_Log2` definition unit tests methods.
+    """
+
+    def test_log_decoding_Log2(self):
+        """
+        Tests :func:`colour.models.rgb.transfer_functions.log.\
+log_decoding_Log2` definition.
+        """
+
+        self.assertAlmostEqual(
+            log_decoding_Log2(0.40773288970434662), 17.9999999991, places=7)
+
+        self.assertAlmostEqual(
+            log_decoding_Log2(0.4077328897, 0.12), 11.9999999994, places=7)
+
+        self.assertAlmostEqual(
+            log_decoding_Log2(0.4077328897, 0.12, 0.0045),
+            12.0123777083,
+            places=7)
+
+        self.assertAlmostEqual(
+            log_decoding_Log2(0.4077328897, 0.12, 0.0045, 15.0),
+            8.33836692466,
+            places=7)
+
+    def test_n_dimensional_log_decoding_Log2(self):
+        """
+        Tests :func:`colour.models.rgb.transfer_functions.log.\
+log_decoding_Log2` definition n-dimensional arrays support.
+        """
+
+        y = 0.384970815928670
+        x = log_decoding_Log2(y)
+
+        y = np.tile(y, 6)
+        x = np.tile(x, 6)
+        np.testing.assert_almost_equal(log_decoding_Log2(y), x, decimal=7)
+
+        y = np.reshape(y, (2, 3))
+        x = np.reshape(x, (2, 3))
+        np.testing.assert_almost_equal(log_decoding_Log2(y), x, decimal=7)
+
+        y = np.reshape(y, (2, 3, 1))
+        x = np.reshape(x, (2, 3, 1))
+        np.testing.assert_almost_equal(log_decoding_Log2(y), x, decimal=7)
+
+    def test_domain_range_scale_log_decoding_Log2(self):
+        """
+        Tests :func:`colour.models.rgb.transfer_functions.log.\
+log_decoding_Log2` definition domain and range scale support.
+        """
+
+        y = 0.384970815928670
+        x = log_decoding_Log2(y)
+
+        d_r = (('reference', 1), (1, 1), (100, 100))
+        for scale, factor in d_r:
+            with domain_range_scale(scale):
+                np.testing.assert_almost_equal(
+                    log_decoding_Log2(y * factor), x * factor, decimal=7)
+
+    @ignore_numpy_errors
+    def test_nan_log_decoding_Log2(self):
+        """
+        Tests :func:`colour.models.rgb.transfer_functions.log.\
+log_decoding_Log2` definition nan support.
+        """
+
+        log_decoding_Log2(np.array([-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan]))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/colour/models/rgb/transfer_functions/tests/test_log.py
+++ b/colour/models/rgb/transfer_functions/tests/test_log.py
@@ -20,10 +20,7 @@ __maintainer__ = 'Colour Developers'
 __email__ = 'colour-developers@colour-science.org'
 __status__ = 'Production'
 
-__all__ = [
-    'TestLogEncoding_Log2',
-    'TestLogDecoding_Log2',
-]
+__all__ = ['TestLogEncoding_Log2', 'TestLogDecoding_Log2']
 
 
 class TestLogEncoding_Log2(unittest.TestCase):

--- a/docs/colour.models.rst
+++ b/docs/colour.models.rst
@@ -588,6 +588,8 @@ Log Encoding and Decoding
     log_decoding_VLog
     log_encoding_ViperLog
     log_decoding_ViperLog
+    log_encoding_Log2
+    log_decoding_Log2
 
 Colour Encodings
 ~~~~~~~~~~~~~~~~

--- a/docs/colour.models.rst
+++ b/docs/colour.models.rst
@@ -562,6 +562,8 @@ Log Encoding and Decoding
     log_decoding_ERIMMRGB
     log_encoding_FLog
     log_decoding_FLog
+    log_encoding_Log2
+    log_decoding_Log2
     LOG3G10_ENCODING_METHODS
     log_encoding_Log3G10
     LOG3G10_DECODING_METHODS
@@ -588,8 +590,6 @@ Log Encoding and Decoding
     log_decoding_VLog
     log_encoding_ViperLog
     log_decoding_ViperLog
-    log_encoding_Log2
-    log_decoding_Log2
 
 Colour Encodings
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This pull request adds the `log.py` module to the 'transfer functions' sub-package in colour models, and contains the following functions:
- `log_encoding_Log2`
- `log_decoding_Log2`