### PR TITLE
PR: Add "colour.models.rgb.transfer_functions.exponent" module.

### DIFF
--- a/colour/models/rgb/transfer_functions/__init__.py
+++ b/colour/models/rgb/transfer_functions/__init__.py
@@ -22,6 +22,7 @@ from .cineon import log_encoding_Cineon, log_decoding_Cineon
 from .dcdm import eotf_inverse_DCDM, eotf_DCDM
 from .dicom_gsdf import eotf_inverse_DICOMGSDF, eotf_DICOMGSDF
 from .dji_dlog import log_encoding_DJIDLog, log_decoding_DJIDLog
+from .exponent import exponent_function_basic, exponent_function_monitor_curve
 from .filmic_pro import log_encoding_FilmicPro6, log_decoding_FilmicPro6
 from .filmlight_tlog import (log_encoding_FilmLightTLog,
                              log_decoding_FilmLightTLog)
@@ -77,6 +78,7 @@ __all__ += ['log_encoding_Cineon', 'log_decoding_Cineon']
 __all__ += ['eotf_inverse_DCDM', 'eotf_DCDM']
 __all__ += ['eotf_inverse_DICOMGSDF', 'eotf_DICOMGSDF']
 __all__ += ['log_encoding_DJIDLog', 'log_decoding_DJIDLog']
+__all__ += ['exponent_function_basic', 'exponent_function_monitor_curve']
 __all__ += ['log_encoding_FilmicPro6', 'log_decoding_FilmicPro6']
 __all__ += ['log_encoding_FilmLightTLog', 'log_decoding_FilmLightTLog']
 __all__ += ['log_encoding_Protune', 'log_decoding_Protune']

--- a/colour/models/rgb/transfer_functions/exponent.py
+++ b/colour/models/rgb/transfer_functions/exponent.py
@@ -250,9 +250,12 @@ def exponent_function_monitor_curve(x,
         """
 
         x_break = offset / (exponent - 1)
-        y = ((x + offset) / (1 + offset)) ** exponent
 
-        return np.where(x >= x_break, y, x * s)
+        return np.where(
+            x >= x_break,
+            ((x + offset) / (1 + offset)) ** exponent,
+            x * s,
+        )
 
     def monitor_curve_reverse(y):
         """
@@ -260,10 +263,13 @@ def exponent_function_monitor_curve(x,
         """
 
         y_break = ((exponent * offset) / (
-            (exponent - 1) * (offset + 1))) ** exponent
+            (exponent - 1) * (1 + offset))) ** exponent
 
-        return np.where(y >= y_break,
-                        ((1 + offset) * (y ** (1 / exponent))) - offset, y / s)
+        return np.where(
+            y >= y_break,
+            ((1 + offset) * (y ** (1 / exponent))) - offset,
+            y / s,
+        )
 
     style = style.lower()
     if style == 'moncurvefwd':
@@ -272,12 +278,18 @@ def exponent_function_monitor_curve(x,
         return as_float(monitor_curve_reverse(x))
     elif style == 'moncurvemirrorfwd':
         return as_float(
-            np.where(x >= 0, monitor_curve_forward(x),
-                     -monitor_curve_forward(-x)))
+            np.where(
+                x >= 0,
+                monitor_curve_forward(x),
+                -monitor_curve_forward(-x),
+            ))
     elif style == 'moncurvemirrorrev':
         return as_float(
-            np.where(x >= 0, monitor_curve_reverse(x),
-                     -monitor_curve_reverse(-x)))
+            np.where(
+                x >= 0,
+                monitor_curve_reverse(x),
+                -monitor_curve_reverse(-x),
+            ))
     else:
         raise ValueError(
             'Undefined style used: "{0}", must be one of the following: '

--- a/colour/models/rgb/transfer_functions/exponent.py
+++ b/colour/models/rgb/transfer_functions/exponent.py
@@ -1,4 +1,4 @@
-#
+# -*- coding: utf-8 -*-
 """
 Basic and Monitor-Curve Exponent Transfer Functions
 ===================================================
@@ -21,7 +21,7 @@ from __future__ import division, unicode_literals
 
 import numpy as np
 
-from colour.utilities import as_float_array
+from colour.utilities import as_float, as_float_array, suppress_warnings
 
 __author__ = 'Colour Developers'
 __copyright__ = 'Copyright (C) 2013-2020 - Colour Developers'
@@ -33,7 +33,7 @@ __status__ = 'Production'
 __all__ = ['exponent_function_basic', 'exponent_function_monitor_curve']
 
 
-def exponent_function_basic(x, exponent, style='basicFwd'):
+def exponent_function_basic(x, exponent=1, style='basicFwd'):
     """
     Defines the *basic* exponent transfer function.
 
@@ -41,7 +41,7 @@ def exponent_function_basic(x, exponent, style='basicFwd'):
     ----------
     x : numeric or array_like
         Data to undergo the basic exponent conversion.
-    exponent : numeric or array_like
+    exponent : numeric or array_like, optional
         Exponent value used for the conversion.
     style : unicode, optional
         **{'basicFwd', 'basicRev', 'basicMirrorFwd', 'basicMirrorRev',
@@ -85,30 +85,38 @@ def exponent_function_basic(x, exponent, style='basicFwd'):
 
     Examples
     --------
-    >>> exponent_function_basic(2, 2)
-    array(4.0)
-    >>> exponent_function_basic(-2, 2)
-    array(0.0)
-    >>> exponent_function_basic(4, 2, 'basicRev')
-    array(2.0)
-    >>> exponent_function_basic(-4, 2, 'basicRev')
-    array(0.0)
-    >>> exponent_function_basic(2, 2, 'basicMirrorFwd')
-    array(4.0)
-    >>> exponent_function_basic(-2, 2, 'basicMirrorFwd')
-    array(-4.0)
-    >>> exponent_function_basic(4, 2, 'basicMirrorRev')
-    array(2.0)
-    >>> exponent_function_basic(-4, 2, 'basicMirrorRev')
-    array(-2.0)
-    >>> exponent_function_basic(2, 2, 'basicPassThruFwd')
-    array(4.0)
-    >>> exponent_function_basic(-2, 2, 'basicPassThruFwd')
-    array(-2.0)
-    >>> exponent_function_basic(4, 2, 'basicPassThruRev')
-    array(2.0)
-    >>> exponent_function_basic(-4, 2, 'basicPassThruRev')
-    array(-4.0)
+    >>> exponent_function_basic(0.18, 2.2)  # doctest: +ELLIPSIS
+    0.0229932...
+    >>> exponent_function_basic(-0.18, 2.2)
+    0.0
+    >>> exponent_function_basic(0.18, 2.2, 'basicRev')  # doctest: +ELLIPSIS
+    0.4586564...
+    >>> exponent_function_basic(-0.18, 2.2, 'basicRev')
+    0.0
+    >>> exponent_function_basic(  # doctest: +ELLIPSIS
+    ...     0.18, 2.2, 'basicMirrorFwd')
+    0.0229932...
+    >>> exponent_function_basic(  # doctest: +ELLIPSIS
+    ...     -0.18, 2.2, 'basicMirrorFwd')
+    -0.0229932...
+    >>> exponent_function_basic(  # doctest: +ELLIPSIS
+    ...     0.18, 2.2, 'basicMirrorRev')
+    0.4586564...
+    >>> exponent_function_basic(  # doctest: +ELLIPSIS
+    ...     -0.18, 2.2, 'basicMirrorRev')
+    -0.4586564...
+    >>> exponent_function_basic(  # doctest: +ELLIPSIS
+    ...     0.18, 2.2, 'basicPassThruFwd')
+    0.0229932...
+    >>> exponent_function_basic(  # doctest: +ELLIPSIS
+    ...     -0.18, 2.2, 'basicPassThruFwd')
+    -0.1799999...
+    >>> exponent_function_basic(  # doctest: +ELLIPSIS
+    ...     0.18, 2.2, 'basicPassThruRev')
+    0.4586564...
+    >>> exponent_function_basic(  # doctest: +ELLIPSIS
+    ...     -0.18, 2.2, 'basicPassThruRev')
+    -0.1799999...
     """
 
     x = as_float_array(x)
@@ -119,8 +127,7 @@ def exponent_function_basic(x, exponent, style='basicFwd'):
         Returns the input raised to the exponent value.
         """
 
-        y = x ** exponent
-        return (y)
+        return x ** exponent
 
     def exponent_reverse(y):
         """
@@ -131,17 +138,19 @@ def exponent_function_basic(x, exponent, style='basicFwd'):
 
     style = style.lower()
     if style == 'basicfwd':
-        return np.where(x > 0, exponent_forward(x), 0)
+        return as_float(np.where(x > 0, exponent_forward(x), 0))
     elif style == 'basicrev':
-        return np.where(x > 0, exponent_reverse(x), 0)
+        return as_float(np.where(x > 0, exponent_reverse(x), 0))
     elif style == 'basicmirrorfwd':
-        return np.where(x >= 0, exponent_forward(x), -exponent_forward(-x))
+        return as_float(
+            np.where(x >= 0, exponent_forward(x), -exponent_forward(-x)))
     elif style == 'basicmirrorrev':
-        return np.where(x >= 0, exponent_reverse(x), -exponent_reverse(-x))
+        return as_float(
+            np.where(x >= 0, exponent_reverse(x), -exponent_reverse(-x)))
     elif style == 'basicpassthrufwd':
-        return np.where(x > 0, exponent_forward(x), x)
+        return as_float(np.where(x > 0, exponent_forward(x), x))
     elif style == 'basicpassthrurev':
-        return np.where(x > 0, exponent_reverse(x), x)
+        return as_float(np.where(x > 0, exponent_reverse(x), x))
     else:
         raise ValueError(
             'Undefined style used: "{0}", must be one of the following: '
@@ -152,7 +161,10 @@ def exponent_function_basic(x, exponent, style='basicFwd'):
                 ])))
 
 
-def exponent_function_monitor_curve(x, exponent, offset, style='monCurveFwd'):
+def exponent_function_monitor_curve(x,
+                                    exponent=1,
+                                    offset=0,
+                                    style='monCurveFwd'):
     """
     Defines the *Monitor Curve* exponent transfer function.
 
@@ -160,9 +172,9 @@ def exponent_function_monitor_curve(x, exponent, offset, style='monCurveFwd'):
     ----------
     x : numeric or array_like
         Data to undergo the monitor curve exponential conversion.
-    exponent : numeric or array_like
+    exponent : numeric or array_like, optional
         Exponent value used for the conversion.
-    offset: numeric or array_like
+    offset: numeric or array_like, optional
         Offset value used for the conversion.
     style : unicode, optional
         **{'monCurveFwd', 'monCurveRev', 'monCurveMirrorFwd',
@@ -196,78 +208,76 @@ def exponent_function_monitor_curve(x, exponent, offset, style='monCurveFwd'):
 
     Examples
     --------
-    >>> exponent_function_monitor_curve(2, 2, 2)
-    array(1.7777777777777777)
-    >>> exponent_function_monitor_curve(-2, 2, 2)
-    array(-1.7777777777777777)
-    >>> exponent_function_monitor_curve(\
-            1.7777777777777777, 2, 2, 'monCurveRev')  # doctest: +ELLIPSIS
-    array(2.0)
-    >>> exponent_function_monitor_curve(\
-            -1.7777777777777777, 2, 2, 'monCurveRev')  # doctest: +ELLIPSIS
-    array(-2.0)
-    >>> exponent_function_monitor_curve(\
-            2, 2, 2, 'monCurveMirrorFwd')
-    array(1.7777777777777777)
-    >>> exponent_function_monitor_curve(\
-            -2, 2, 2, 'monCurveMirrorFwd')
-    array(-1.7777777777777777)
-    >>> exponent_function_monitor_curve(\
-            1.7777777777777777, 2, 2,\
-            'monCurveMirrorRev')  # doctest: +ELLIPSIS
-    array(2.0)
-    >>> exponent_function_monitor_curve(\
-            -1.7777777777777777, 2, 2,\
-            'monCurveMirrorRev')  # doctest: +ELLIPSIS
-    array(-2.0)
+    >>> exponent_function_monitor_curve(  # doctest: +ELLIPSIS
+    ...     0.18, 2.2, 0.001)
+    0.0232240...
+    >>> exponent_function_monitor_curve(  # doctest: +ELLIPSIS
+    ...     -0.18, 2.2, 0.001)
+    -0.0002054...
+    >>> exponent_function_monitor_curve(  # doctest: +ELLIPSIS
+    ...     0.18, 2.2, 0.001, 'monCurveRev')
+    0.4581151...
+    >>> exponent_function_monitor_curve(  # doctest: +ELLIPSIS
+    ...     -0.18, 2.2, 0.001, 'monCurveRev')
+    -157.7302795...
+    >>> exponent_function_monitor_curve(  # doctest: +ELLIPSIS
+    ...     0.18, 2.2, 2, 'monCurveMirrorFwd')
+    0.1679399...
+    >>> exponent_function_monitor_curve(  # doctest: +ELLIPSIS
+    ...     -0.18, 2.2, 0.001, 'monCurveMirrorFwd')
+    -0.0232240...
+    >>> exponent_function_monitor_curve(  # doctest: +ELLIPSIS
+    ...     0.18, 2.2, 0.001, 'monCurveMirrorRev')
+    0.4581151...
+    >>> exponent_function_monitor_curve(  # doctest: +ELLIPSIS
+    ...     -0.18, 2.2, 0.001, 'monCurveMirrorRev')
+    -0.4581151...
     """
 
     x = as_float_array(x)
     exponent = as_float_array(exponent)
     offset = as_float_array(offset)
-    if offset == 0.0:
-        print(
-            "Setting the offest value as '0' can lead to a divide-by-zero error.\
-                Try again!")
-        return None
-    if exponent == 1.0:
-        print(
-            "Setting the exponent value as '1' can lead to a divide-by-zero error.\
-                Try again!")
-        return None
-    s = ((exponent - 1) / offset) * ((exponent * offset) / (
-        (exponent - 1) * (offset + 1))) ** exponent
+
+    with suppress_warnings(python_warnings=True):
+        s = as_float_array(((exponent - 1) / offset) * ((exponent * offset) / (
+            (exponent - 1) * (offset + 1))) ** exponent)
+
+        s[np.isnan(s)] = 1
 
     def monitor_curve_forward(x):
         """
         Defines the *Monitor Curve Forward* function.
         """
 
-        xBreak = offset / (exponent - 1)
+        x_break = offset / (exponent - 1)
         y = ((x + offset) / (1 + offset)) ** exponent
-        return np.where(x >= xBreak, y, x * s)
+
+        return np.where(x >= x_break, y, x * s)
 
     def monitor_curve_reverse(y):
         """
         Defines the *Monitor Curve Reverse* function.
         """
 
-        yBreak = ((exponent * offset) / (
+        y_break = ((exponent * offset) / (
             (exponent - 1) * (offset + 1))) ** exponent
-        return np.where(y >= yBreak,
+
+        return np.where(y >= y_break,
                         ((1 + offset) * (y ** (1 / exponent))) - offset, y / s)
 
     style = style.lower()
     if style == 'moncurvefwd':
-        return monitor_curve_forward(x)
+        return as_float(monitor_curve_forward(x))
     elif style == 'moncurverev':
-        return monitor_curve_reverse(x)
+        return as_float(monitor_curve_reverse(x))
     elif style == 'moncurvemirrorfwd':
-        return np.where(x >= 0, monitor_curve_forward(x),
-                        -monitor_curve_forward(-x))
+        return as_float(
+            np.where(x >= 0, monitor_curve_forward(x),
+                     -monitor_curve_forward(-x)))
     elif style == 'moncurvemirrorrev':
-        return np.where(x >= 0, monitor_curve_reverse(x),
-                        -monitor_curve_reverse(-x))
+        return as_float(
+            np.where(x >= 0, monitor_curve_reverse(x),
+                     -monitor_curve_reverse(-x)))
     else:
         raise ValueError(
             'Undefined style used: "{0}", must be one of the following: '

--- a/colour/models/rgb/transfer_functions/exponent.py
+++ b/colour/models/rgb/transfer_functions/exponent.py
@@ -1,0 +1,290 @@
+#
+"""
+Basic and Monitor-Curve Exponent Transfer Functions
+===================================================
+
+Defines exponent transfer function implementations:
+
+-   :func:`colour.models.exponent_function_basic`
+-   :func:`colour.models.exponent_function_monitor_curve`
+
+References
+----------
+-   :cite: `TheAcademyofMotionPictureArtsandSciences2020` :
+    The Academy of Motion Picture Arts and Sciences,
+    Science and Technology Council,
+    & Academy Color Encoding System (ACES) Project Subcommittee. (2020).
+    Specification S-2014-006 - Common LUT Format (CLF) -
+    A Common File Format for Look-Up Tables.
+    Retrieved June 24, 2020, from http://j.mp/S-2014-006
+"""
+
+from __future__ import division, unicode_literals
+
+import numpy as np
+
+from colour.utilities import as_float_array
+
+__author__ = 'Colour Developers'
+__copyright__ = 'Copyright (C) 2013-2020 - Colour Developers'
+__license__ = 'New BSD License - https://opensource.org/licenses/BSD-3-Clause'
+__maintainer__ = 'Colour Developers'
+__email__ = 'colour-developers@colour-science.org'
+__status__ = 'Production'
+
+__all__ = ['exponent_function_basic', 'exponent_function_monitor_curve']
+
+
+def exponent_function_basic(x, exponent, style='basicFwd'):
+    """
+    Defines the *basic* exponent transfer function.
+
+    Parameters
+    ----------
+    x : numeric or array_like
+        The data to undergo basic exponential transfer.
+    exponent : numeric or array_like
+        The exponent value used for the transfer.
+    style : unicode, optional
+        **{'basicFwd', 'basicRev', 'basicMirrorFwd', 'basicMirrorRev',
+        'basicPassThruFwd', 'basicPassThruRev'}**,
+        Defines the behaviour for the transfer function to operate:
+
+        -   *basicFwd*: *Basic Forward* exponential behaviour where the
+            function definition applies a basic power law using the exponent.
+            Values less than zero are clamped.
+
+        -   *basicRev*: *Basic Reverse* exponential behaviour where the
+            function definition applies a basic power law using the exponent.
+            Values less than zero are clamped.
+
+        -   *basicMirrorFwd*: *Basic Mirror Forward* exponential behaviour
+             where the function definition applies a basic power law using
+            the exponent for values greator than or equal to zero and mirrors
+            the function for values less than zero (i.e. rotationally symmetric
+            around the origin).
+
+        -   *basicMirrorRev*: *Basic Mirror Reverse* exponential behaviour
+             where the function definition applies a basic power law using
+            the exponent for values greator than or equal to zero and mirrors
+            the function for values less than zero (i.e. rotationally symmetric
+            around the origin).
+
+        -   *basicPassThruFwd*: *Basic Pass Forward* exponential behaviour
+            where the function definition applies a basic power law using
+            the exponent for values greator than or equal to zero and
+            passes values less than zero unchanged.
+
+        -   *basicPassThruRev*: *Basic Pass Reverse* exponential behaviour
+            where the function definition applies a basic power law using
+            the exponent for values greator than or equal to zero and
+            passes values less than zero unchanged.
+
+    Returns
+    -------
+    numeric or ndarray
+        *Basic* exponential transferred data.
+
+    Raises
+    ------
+    ValueError
+        If the *style* of function operation is not defined.
+
+    Examples
+    --------
+    The basic exponent function *styles* operate as follows:
+
+    >>> exponent_function_basic(2, 2)
+    array(4.0)
+    >>> exponent_function_basic(-2, 2)
+    array(0.0)
+    >>> exponent_function_basic(4, 2, 'basicRev')
+    array(2.0)
+    >>> exponent_function_basic(-4, 2, 'basicRev')
+    array(0.0)
+    >>> exponent_function_basic(2, 2, 'basicMirrorFwd')
+    array(4.0)
+    >>> exponent_function_basic(-2, 2, 'basicMirrorFwd')
+    array(-4.0)
+    >>> exponent_function_basic(4, 2, 'basicMirrorRev')
+    array(2.0)
+    >>> exponent_function_basic(-4, 2, 'basicMirrorRev')
+    array(-2.0)
+    >>> exponent_function_basic(2, 2, 'basicPassThruFwd')
+    array(4.0)
+    >>> exponent_function_basic(-2, 2, 'basicPassThruFwd')
+    array(-2.0)
+    >>> exponent_function_basic(4, 2, 'basicPassThruRev')
+    array(2.0)
+    >>> exponent_function_basic(-4, 2, 'basicPassThruRev')
+    array(-4.0)
+    """
+
+    x = as_float_array(x)
+    exponent = as_float_array(exponent)
+
+    def exponent_forward(x):
+        """
+        Returns the input raised to the exponent value.
+        """
+
+        y = x ** exponent
+        return (y)
+
+    def exponent_reverse(y):
+        """
+        Returns the input raised to the inverse exponent value.
+        """
+
+        return y ** (1 / exponent)
+
+    style = style.lower()
+    if style == 'basicfwd':
+        return np.where(x > 0, exponent_forward(x), 0)
+    elif style == 'basicrev':
+        return np.where(x > 0, exponent_reverse(x), 0)
+    elif style == 'basicmirrorfwd':
+        return np.where(x >= 0, exponent_forward(x), -exponent_forward(-x))
+    elif style == 'basicmirrorrev':
+        return np.where(x >= 0, exponent_reverse(x), -exponent_reverse(-x))
+    elif style == 'basicpassthrufwd':
+        return np.where(x > 0, exponent_forward(x), x)
+    elif style == 'basicpassthrurev':
+        return np.where(x > 0, exponent_reverse(x), x)
+    else:
+        raise ValueError(
+            'Undefined style used: "{0}", must be one of the following: '
+            '"{1}".'.format(
+                style, ', '.join([
+                    'basicFwd', 'basicRev', 'basicMirrorFwd', 'basicMirrorRev',
+                    'basicPassThruFwd', 'basicPassThruRev'
+                ])))
+
+
+def exponent_function_monitor_curve(x, exponent, offset, style='monCurveFwd'):
+    """
+    Defines the *Monitor Curve* exponent transfer function.
+
+    Parameters
+    ----------
+    x : numeric or array_like
+        The data to undergo monitor curve exponential transfer.
+    exponent : numeric or array_like
+        The exponent value used for the transfer.
+    offset: numeric or array_like
+        The offset value used for the transfer.
+    style : unicode, optional
+        **{'monCurveFwd', 'monCurveRev', 'monCurveMirrorFwd',
+        'monCurveMirrorRev'}**,
+        Defines the behaviour for the transfer function to operate:
+
+        -   *monCurveFwd*: *Monitor Curve Forward* exponential behaviour
+            where the function definition applies a power law function
+            with a linear segment near the origin.
+
+        -   *monCurveRev*: *Monitor Curve Reverse* exponential behaviour
+            where the function definition applies a power law function
+            with a linear segment near the origin.
+
+        -   *monCurveMirrorFwd*: *Monitor Curve Mirror Forward*
+            exponential behaviour where the function definition applies
+            a power law function with a linear segment near the origin
+            and mirrors the function for values less than zero
+            (i.e. rotationally symmetric around the origin).
+
+        -   *monCurveMirrorRev*: *Monitor Curve Mirror Reverse*
+            exponential behaviour where the function definition applies
+            a power law function with a linear segment near the origin
+            and mirrors the function for values less than zero
+            (i.e. rotationally symmetric around the origin).
+
+    Returns
+    -------
+    numeric or ndarray
+        *Monitor curve* exponentially transferred data.
+
+    Raises
+    ------
+    ValueError
+        If the *style* of function operation is not defined.
+
+    Examples
+    --------
+    The monitor curve exponent function *styles* operate as follows:
+
+    >>> exponent_function_monitor_curve(2, 2, 2)
+    array(1.7777777777777777)
+    >>> exponent_function_monitor_curve(-2, 2, 2)
+    array(-1.7777777777777777)
+    >>> exponent_function_monitor_curve(1.7777777777777777, 2, 2,
+    'monCurveRev')
+    array(2.0)
+    >>> exponent_function_monitor_curve(-1.7777777777777777, 2, 2,
+    'monCurveRev')
+    array(-2.0)
+    >>> exponent_function_monitor_curve(2, 2, 2, 'monCurveMirrorFwd')
+    array(1.7777777777777777)
+    >>> exponent_function_monitor_curve(-2, 2, 2, 'monCurveMirrorFwd')
+    array(-1.7777777777777777)
+    >>> exponent_function_monitor_curve(1.7777777777777777, 2, 2,
+    'monCurveMirrorRev')
+    array(2.0)
+    >>> exponent_function_monitor_curve(-1.7777777777777777, 2, 2,
+    'monCurveMirrorRev')
+    array(-2.0)
+    """
+
+    x = as_float_array(x)
+    exponent = as_float_array(exponent)
+    offset = as_float_array(offset)
+    if offset == 0.0:
+        print(
+            "Setting the offest value as '0' can lead to a divide-by-zero error.\
+                Try again!")
+        return None
+    if exponent == 1.0:
+        print(
+            "Setting the exponent value as '1' can lead to a divide-by-zero error.\
+                Try again!")
+        return None
+    s = ((exponent - 1) / offset) * ((exponent * offset) / (
+        (exponent - 1) * (offset + 1))) ** exponent
+
+    def monitor_curve_forward(x):
+        """
+        Monitor Curve Forward function definition.
+        """
+
+        xBreak = offset / (exponent - 1)
+        y = ((x + offset) / (1 + offset)) ** exponent
+        return np.where(x >= xBreak, y, x * s)
+
+    def monitor_curve_reverse(y):
+        """
+        Monitor Curve Reverse function definition.
+        """
+
+        yBreak = ((exponent * offset) / (
+            (exponent - 1) * (offset + 1))) ** exponent
+        return np.where(y >= yBreak,
+                        ((1 + offset) * (y ** (1 / exponent))) - offset, y / s)
+
+    style = style.lower()
+    if style == 'moncurvefwd':
+        return monitor_curve_forward(x)
+    elif style == 'moncurverev':
+        return monitor_curve_reverse(x)
+    elif style == 'moncurvemirrorfwd':
+        return np.where(x >= 0, monitor_curve_forward(x),
+                        -monitor_curve_forward(-x))
+    elif style == 'moncurvemirrorrev':
+        return np.where(x >= 0, monitor_curve_reverse(x),
+                        -monitor_curve_reverse(-x))
+    else:
+        raise ValueError(
+            'Undefined style used: "{0}", must be one of the following: '
+            '"{1}".'.format(
+                style, ', '.join([
+                    'monCurveFwd', 'monCurveRev', 'monCurveMirrorFwd',
+                    'monCurveMirrorRev'
+                ])))

--- a/colour/models/rgb/transfer_functions/exponent.py
+++ b/colour/models/rgb/transfer_functions/exponent.py
@@ -3,20 +3,18 @@
 Basic and Monitor-Curve Exponent Transfer Functions
 ===================================================
 
-Defines exponent transfer function implementations:
+Defines the exponent transfer functions:
 
 -   :func:`colour.models.exponent_function_basic`
 -   :func:`colour.models.exponent_function_monitor_curve`
 
 References
 ----------
--   :cite: `TheAcademyofMotionPictureArtsandSciences2020` :
-    The Academy of Motion Picture Arts and Sciences,
-    Science and Technology Council,
-    & Academy Color Encoding System (ACES) Project Subcommittee. (2020).
-    Specification S-2014-006 - Common LUT Format (CLF) -
-    A Common File Format for Look-Up Tables.
-    Retrieved June 24, 2020, from http://j.mp/S-2014-006
+-   :cite: `TheAcademyofMotionPictureArtsandSciences2020` : The Academy of
+    Motion Picture Arts and Sciences, Science and Technology Council, & Academy
+    Color Encoding System (ACES) Project Subcommittee. (2020). Specification
+    S-2014-006 - Common LUT Format (CLF) - A Common File Format for Look-Up
+    Tables. Retrieved June 24, 2020, from http://j.mp/S-2014-006
 """
 
 from __future__ import division, unicode_literals
@@ -42,58 +40,51 @@ def exponent_function_basic(x, exponent, style='basicFwd'):
     Parameters
     ----------
     x : numeric or array_like
-        The data to undergo basic exponential transfer.
+        Data to undergo the basic exponent conversion.
     exponent : numeric or array_like
-        The exponent value used for the transfer.
+        Exponent value used for the conversion.
     style : unicode, optional
         **{'basicFwd', 'basicRev', 'basicMirrorFwd', 'basicMirrorRev',
         'basicPassThruFwd', 'basicPassThruRev'}**,
         Defines the behaviour for the transfer function to operate:
 
         -   *basicFwd*: *Basic Forward* exponential behaviour where the
-            function definition applies a basic power law using the exponent.
-            Values less than zero are clamped.
-
+            definition applies a basic power law using the exponent. Values
+            less than zero are clamped.
         -   *basicRev*: *Basic Reverse* exponential behaviour where the
-            function definition applies a basic power law using the exponent.
-            Values less than zero are clamped.
-
+            definition applies a basic power law using the exponent. Values
+            less than zero are clamped.
         -   *basicMirrorFwd*: *Basic Mirror Forward* exponential behaviour
-            where the function definition applies a basic power law using
-            the exponent for values greator than or equal to zero and mirrors
-            the function for values less than zero (i.e. rotationally symmetric
+            where the definition applies a basic power law using the exponent
+            for values greater than or equal to zero and mirrors the function
+            for values less than zero (i.e. rotationally symmetric
             around the origin).
-
         -   *basicMirrorRev*: *Basic Mirror Reverse* exponential behaviour
-            where the function definition applies a basic power law using
-            the exponent for values greator than or equal to zero and mirrors
-            the function for values less than zero (i.e. rotationally symmetric
-            around the origin).
-
+            where the definition applies a basic power law using the exponent
+            for values greater than or equal to zero and mirrors the function
+            for values less than zero (i.e. rotationally symmetric around the
+            origin).
         -   *basicPassThruFwd*: *Basic Pass Forward* exponential behaviour
-            where the function definition applies a basic power law using
-            the exponent for values greator than or equal to zero and
-            passes values less than zero unchanged.
-
+            where the definition applies a basic power law using the exponent
+            for values greater than or equal to zero and passes values less
+            than zero unchanged.
         -   *basicPassThruRev*: *Basic Pass Reverse* exponential behaviour
-            where the function definition applies a basic power law using
-            the exponent for values greator than or equal to zero and
-            passes values less than zero unchanged.
+            where the definition applies a basic power law using the exponent
+            for values greater than or equal to zero and passes values less
+            than zero unchanged.
 
     Returns
     -------
     numeric or ndarray
-        *Basic* exponential transferred data.
+        Exponentially converted data.
 
     Raises
     ------
     ValueError
-        If the *style* of function operation is not defined.
+        If the *style* is not defined.
 
     Examples
     --------
-    The basic exponent function *styles* operate as follows:
-
     >>> exponent_function_basic(2, 2)
     array(4.0)
     >>> exponent_function_basic(-2, 2)
@@ -168,50 +159,43 @@ def exponent_function_monitor_curve(x, exponent, offset, style='monCurveFwd'):
     Parameters
     ----------
     x : numeric or array_like
-        The data to undergo monitor curve exponential transfer.
+        Data to undergo the monitor curve exponential conversion.
     exponent : numeric or array_like
-        The exponent value used for the transfer.
+        Exponent value used for the conversion.
     offset: numeric or array_like
-        The offset value used for the transfer.
+        Offset value used for the conversion.
     style : unicode, optional
         **{'monCurveFwd', 'monCurveRev', 'monCurveMirrorFwd',
         'monCurveMirrorRev'}**,
         Defines the behaviour for the transfer function to operate:
 
         -   *monCurveFwd*: *Monitor Curve Forward* exponential behaviour
-            where the function definition applies a power law function
-            with a linear segment near the origin.
-
+            where the definition applies a power law function with a linear
+            segment near the origin.
         -   *monCurveRev*: *Monitor Curve Reverse* exponential behaviour
-            where the function definition applies a power law function
-            with a linear segment near the origin.
-
-        -   *monCurveMirrorFwd*: *Monitor Curve Mirror Forward*
-            exponential behaviour where the function definition applies
-            a power law function with a linear segment near the origin
-            and mirrors the function for values less than zero
-            (i.e. rotationally symmetric around the origin).
-
-        -   *monCurveMirrorRev*: *Monitor Curve Mirror Reverse*
-            exponential behaviour where the function definition applies
-            a power law function with a linear segment near the origin
-            and mirrors the function for values less than zero
-            (i.e. rotationally symmetric around the origin).
+            where the definition applies a power law function with a linear
+            segment near the origin.
+        -   *monCurveMirrorFwd*: *Monitor Curve Mirror Forward* exponential
+            behaviour where the definition applies a power law function with a
+            linear segment near the origin and mirrors the function for values
+            less than zero (i.e. rotationally symmetric around the origin).
+        -   *monCurveMirrorRev*: *Monitor Curve Mirror Reverse* exponential
+            behaviour where the definition applies a power law function with a
+            linear segment near the origin and mirrors the function for values
+            less than zero (i.e. rotationally symmetric around the origin).
 
     Returns
     -------
     numeric or ndarray
-        *Monitor curve* exponentially transferred data.
+        Exponentially converted data.
 
     Raises
     ------
     ValueError
-        If the *style* of function operation is not defined.
+        If the *style* is not defined.
 
     Examples
     --------
-    The monitor curve exponent function *styles* operate as follows:
-
     >>> exponent_function_monitor_curve(2, 2, 2)
     array(1.7777777777777777)
     >>> exponent_function_monitor_curve(-2, 2, 2)
@@ -256,7 +240,7 @@ def exponent_function_monitor_curve(x, exponent, offset, style='monCurveFwd'):
 
     def monitor_curve_forward(x):
         """
-        Monitor Curve Forward function definition.
+        Defines the *Monitor Curve Forward* function.
         """
 
         xBreak = offset / (exponent - 1)
@@ -265,7 +249,7 @@ def exponent_function_monitor_curve(x, exponent, offset, style='monCurveFwd'):
 
     def monitor_curve_reverse(y):
         """
-        Monitor Curve Reverse function definition.
+        Defines the *Monitor Curve Reverse* function.
         """
 
         yBreak = ((exponent * offset) / (

--- a/colour/models/rgb/transfer_functions/exponent.py
+++ b/colour/models/rgb/transfer_functions/exponent.py
@@ -216,21 +216,25 @@ def exponent_function_monitor_curve(x, exponent, offset, style='monCurveFwd'):
     array(1.7777777777777777)
     >>> exponent_function_monitor_curve(-2, 2, 2)
     array(-1.7777777777777777)
-    >>> exponent_function_monitor_curve(1.7777777777777777, 2, 2,
-    'monCurveRev')
+    >>> exponent_function_monitor_curve(\
+            1.7777777777777777, 2, 2, 'monCurveRev')  # doctest: +ELLIPSIS
     array(2.0)
-    >>> exponent_function_monitor_curve(-1.7777777777777777, 2, 2,
-    'monCurveRev')
+    >>> exponent_function_monitor_curve(\
+            -1.7777777777777777, 2, 2, 'monCurveRev')  # doctest: +ELLIPSIS
     array(-2.0)
-    >>> exponent_function_monitor_curve(2, 2, 2, 'monCurveMirrorFwd')
+    >>> exponent_function_monitor_curve(\
+            2, 2, 2, 'monCurveMirrorFwd')
     array(1.7777777777777777)
-    >>> exponent_function_monitor_curve(-2, 2, 2, 'monCurveMirrorFwd')
+    >>> exponent_function_monitor_curve(\
+            -2, 2, 2, 'monCurveMirrorFwd')
     array(-1.7777777777777777)
-    >>> exponent_function_monitor_curve(1.7777777777777777, 2, 2,
-    'monCurveMirrorRev')
+    >>> exponent_function_monitor_curve(\
+            1.7777777777777777, 2, 2,\
+            'monCurveMirrorRev')  # doctest: +ELLIPSIS
     array(2.0)
-    >>> exponent_function_monitor_curve(-1.7777777777777777, 2, 2,
-    'monCurveMirrorRev')
+    >>> exponent_function_monitor_curve(\
+            -1.7777777777777777, 2, 2,\
+            'monCurveMirrorRev')  # doctest: +ELLIPSIS
     array(-2.0)
     """
 

--- a/colour/models/rgb/transfer_functions/exponent.py
+++ b/colour/models/rgb/transfer_functions/exponent.py
@@ -59,13 +59,13 @@ def exponent_function_basic(x, exponent, style='basicFwd'):
             Values less than zero are clamped.
 
         -   *basicMirrorFwd*: *Basic Mirror Forward* exponential behaviour
-             where the function definition applies a basic power law using
+            where the function definition applies a basic power law using
             the exponent for values greator than or equal to zero and mirrors
             the function for values less than zero (i.e. rotationally symmetric
             around the origin).
 
         -   *basicMirrorRev*: *Basic Mirror Reverse* exponential behaviour
-             where the function definition applies a basic power law using
+            where the function definition applies a basic power law using
             the exponent for values greator than or equal to zero and mirrors
             the function for values less than zero (i.e. rotationally symmetric
             around the origin).

--- a/colour/models/rgb/transfer_functions/exponent.py
+++ b/colour/models/rgb/transfer_functions/exponent.py
@@ -138,9 +138,9 @@ def exponent_function_basic(x, exponent=1, style='basicFwd'):
 
     style = style.lower()
     if style == 'basicfwd':
-        return as_float(np.where(x > 0, exponent_forward(x), 0))
+        return as_float(np.where(x >= 0, exponent_forward(x), 0))
     elif style == 'basicrev':
-        return as_float(np.where(x > 0, exponent_reverse(x), 0))
+        return as_float(np.where(x >= 0, exponent_reverse(x), 0))
     elif style == 'basicmirrorfwd':
         return as_float(
             np.where(x >= 0, exponent_forward(x), -exponent_forward(-x)))
@@ -148,9 +148,9 @@ def exponent_function_basic(x, exponent=1, style='basicFwd'):
         return as_float(
             np.where(x >= 0, exponent_reverse(x), -exponent_reverse(-x)))
     elif style == 'basicpassthrufwd':
-        return as_float(np.where(x > 0, exponent_forward(x), x))
+        return as_float(np.where(x >= 0, exponent_forward(x), x))
     elif style == 'basicpassthrurev':
-        return as_float(np.where(x > 0, exponent_reverse(x), x))
+        return as_float(np.where(x >= 0, exponent_reverse(x), x))
     else:
         raise ValueError(
             'Undefined style used: "{0}", must be one of the following: '

--- a/colour/models/rgb/transfer_functions/tests/test_exponent.py
+++ b/colour/models/rgb/transfer_functions/tests/test_exponent.py
@@ -35,62 +35,48 @@ exponent_function_basic` definition unit tests methods.
 exponent_function_basic` definition.
         """
 
-        self.assertAlmostEqual(
-            exponent_function_basic(2.0, 2.0), 4.0, places=7)
+        a = 2.0
+        a_p = 4.0
+        self.assertAlmostEqual(exponent_function_basic(a, 2.0), a_p, places=7)
 
         self.assertAlmostEqual(
-            exponent_function_basic(-2.0, 2.0), 0.0, places=7)
+            exponent_function_basic(a, 2.0, 'basicMirrorFwd'), a_p, places=7)
 
         self.assertAlmostEqual(
-            exponent_function_basic(0.18, 2.0), 0.0324, places=7)
+            exponent_function_basic(a, 2.0, 'basicPassThruFwd'), a_p, places=7)
+
+        a = 4.0
+        a_p = 2.0
 
         self.assertAlmostEqual(
-            exponent_function_basic(-0.18, 2.0), 0.0, places=7)
-
-        np.testing.assert_array_equal(exponent_function_basic(-0.18, 2.2), 0.0)
+            exponent_function_basic(a, 2.0, 'basicRev'), a_p, places=7)
 
         self.assertAlmostEqual(
-            exponent_function_basic(4.0, 2.0, 'basicRev'), 2.0, places=7)
+            exponent_function_basic(a, 2.0, 'basicMirrorRev'), a_p, places=7)
 
         self.assertAlmostEqual(
-            exponent_function_basic(2.0, 2.0, 'basicMirrorFwd'), 4.0, places=7)
+            exponent_function_basic(a, 2.0, 'basicPassThruRev'), a_p, places=7)
+
+        a = -2.0
+        self.assertAlmostEqual(exponent_function_basic(a, 2.0), 0.0, places=7)
 
         self.assertAlmostEqual(
-            exponent_function_basic(4.0, 2.0, 'basicMirrorRev'), 2.0, places=7)
+            exponent_function_basic(a, 2.0, 'basicMirrorFwd'), -4.0, places=7)
 
         self.assertAlmostEqual(
-            exponent_function_basic(2.0, 2.0, 'basicPassThruFwd'),
-            4.0,
-            places=7)
-
-        self.assertAlmostEqual(
-            exponent_function_basic(4.0, 2.0, 'basicPassThruRev'),
-            2.0,
-            places=7)
-
-        np.testing.assert_array_equal(
-            exponent_function_basic(-0.18, -2.2), 0.0)
-
-        self.assertAlmostEqual(
-            exponent_function_basic(-4.0, 2.0, 'basicRev'), 0.0, places=7)
-
-        self.assertAlmostEqual(
-            exponent_function_basic(-2.0, 2.0, 'basicMirrorFwd'),
-            -4.0,
-            places=7)
-
-        self.assertAlmostEqual(
-            exponent_function_basic(-4.0, 2.0, 'basicMirrorRev'),
+            exponent_function_basic(a, 2.0, 'basicPassThruFwd'),
             -2.0,
             places=7)
 
+        a = -4.0
         self.assertAlmostEqual(
-            exponent_function_basic(-2.0, 2.0, 'basicPassThruFwd'),
-            -2.0,
-            places=7)
+            exponent_function_basic(a, 2.0, 'basicRev'), 0.0, places=7)
 
         self.assertAlmostEqual(
-            exponent_function_basic(-4.0, 2.0, 'basicPassThruRev'),
+            exponent_function_basic(a, 2.0, 'basicMirrorRev'), -2.0, places=7)
+
+        self.assertAlmostEqual(
+            exponent_function_basic(a, 2.0, 'basicPassThruRev'),
             -4.0,
             places=7)
 
@@ -101,136 +87,90 @@ exponent_function_basic` definition n-dimensional arrays support.
         """
 
         a = 0.18
-        a_p = exponent_function_basic(a, 2.2)
-
-        a = np.tile(a, 6)
-        a_p = np.tile(a_p, 6)
-        np.testing.assert_almost_equal(
-            exponent_function_basic(a, 2.2), a_p, decimal=7)
-
-        a = np.reshape(a, (2, 3))
-        a_p = np.reshape(a_p, (2, 3))
-        np.testing.assert_almost_equal(
-            exponent_function_basic(a, 2.2), a_p, decimal=7)
-
-        a = np.reshape(a, (2, 3, 1))
-        a_p = np.reshape(a_p, (2, 3, 1))
-        np.testing.assert_almost_equal(
-            exponent_function_basic(a, 2.2), a_p, decimal=7)
-
-        a = 0.18
-        a_p = 0.4586564468643811
-        np.testing.assert_almost_equal(
-            exponent_function_basic(a, 2.2, 'basicRev'), a_p, decimal=7)
-
-        a = np.tile(a, 6)
-        a_p = np.tile(a_p, 6)
-        np.testing.assert_almost_equal(
-            exponent_function_basic(a, 2.2, 'basicRev'), a_p, decimal=7)
-
-        a = np.reshape(a, (2, 3))
-        a_p = np.reshape(a_p, (2, 3))
-        np.testing.assert_almost_equal(
-            exponent_function_basic(a, 2.2, 'basicRev'), a_p, decimal=7)
-
-        a = np.reshape(a, (2, 3, 1))
-        a_p = np.reshape(a_p, (2, 3, 1))
-        np.testing.assert_almost_equal(
-            exponent_function_basic(a, 2.2, 'basicRev'), a_p, decimal=7)
-
-        a = -0.18
-        a_p = -0.022993204992706778
-        np.testing.assert_almost_equal(
-            exponent_function_basic(a, 2.2, 'basicMirrorFwd'), a_p, decimal=7)
-
-        a = np.tile(a, 6)
-        a_p = np.tile(a_p, 6)
-        np.testing.assert_almost_equal(
-            exponent_function_basic(a, 2.2, 'basicMirrorFwd'), a_p, decimal=7)
-
-        a = np.reshape(a, (2, 3))
-        a_p = np.reshape(a_p, (2, 3))
-        np.testing.assert_almost_equal(
-            exponent_function_basic(a, 2.2, 'basicMirrorFwd'), a_p, decimal=7)
-
-        a = np.reshape(a, (2, 3, 1))
-        a_p = np.reshape(a_p, (2, 3, 1))
-        np.testing.assert_almost_equal(
-            exponent_function_basic(a, 2.2, 'basicMirrorFwd'), a_p, decimal=7)
-
-        a = -0.18
-        a_p = -0.4586564468643811
-        np.testing.assert_almost_equal(
-            exponent_function_basic(a, 2.2, 'BasicMirrorRev'), a_p, decimal=7)
-
-        a = np.tile(a, 6)
-        a_p = np.tile(a_p, 6)
-        np.testing.assert_almost_equal(
-            exponent_function_basic(a, 2.2, 'BasicMirrorRev'), a_p, decimal=7)
-
-        a = np.reshape(a, (2, 3))
-        a_p = np.reshape(a_p, (2, 3))
-        np.testing.assert_almost_equal(
-            exponent_function_basic(a, 2.2, 'BasicMirrorRev'), a_p, decimal=7)
-
-        a = np.reshape(a, (2, 3, 1))
-        a_p = np.reshape(a_p, (2, 3, 1))
-        np.testing.assert_almost_equal(
-            exponent_function_basic(a, 2.2, 'BasicMirrorRev'), a_p, decimal=7)
-
-        a = 0.18
         a_p = 0.022993204992706778
         np.testing.assert_almost_equal(
-            exponent_function_basic(a, 2.2, 'BasicPassThruFwd'),
+            exponent_function_basic(a, 2.2), a_p, decimal=7)
+        np.testing.assert_almost_equal(
+            exponent_function_basic(a, 2.2, 'basicMirrorFwd'), a_p, decimal=7)
+        np.testing.assert_almost_equal(
+            exponent_function_basic(a, 2.2, 'basicPassThruFwd'),
             a_p,
             decimal=7)
 
         a = np.tile(a, 6)
         a_p = np.tile(a_p, 6)
         np.testing.assert_almost_equal(
-            exponent_function_basic(a, 2.2, 'BasicPassThruFwd'),
+            exponent_function_basic(a, 2.2), a_p, decimal=7)
+        np.testing.assert_almost_equal(
+            exponent_function_basic(a, 2.2, 'basicMirrorFwd'), a_p, decimal=7)
+        np.testing.assert_almost_equal(
+            exponent_function_basic(a, 2.2, 'basicPassThruFwd'),
             a_p,
             decimal=7)
 
         a = np.reshape(a, (2, 3))
         a_p = np.reshape(a_p, (2, 3))
         np.testing.assert_almost_equal(
-            exponent_function_basic(a, 2.2, 'BasicPassThruFwd'),
+            exponent_function_basic(a, 2.2), a_p, decimal=7)
+        np.testing.assert_almost_equal(
+            exponent_function_basic(a, 2.2, 'basicMirrorFwd'), a_p, decimal=7)
+        np.testing.assert_almost_equal(
+            exponent_function_basic(a, 2.2, 'basicPassThruFwd'),
             a_p,
             decimal=7)
 
         a = np.reshape(a, (2, 3, 1))
         a_p = np.reshape(a_p, (2, 3, 1))
         np.testing.assert_almost_equal(
-            exponent_function_basic(a, 2.2, 'BasicPassThruFwd'),
+            exponent_function_basic(a, 2.2), a_p, decimal=7)
+        np.testing.assert_almost_equal(
+            exponent_function_basic(a, 2.2, 'basicMirrorFwd'), a_p, decimal=7)
+        np.testing.assert_almost_equal(
+            exponent_function_basic(a, 2.2, 'basicPassThruFwd'),
             a_p,
             decimal=7)
 
         a = 0.18
         a_p = 0.4586564468643811
         np.testing.assert_almost_equal(
-            exponent_function_basic(a, 2.2, 'BasicPassThruRev'),
+            exponent_function_basic(a, 2.2, 'basicRev'), a_p, decimal=7)
+        np.testing.assert_almost_equal(
+            exponent_function_basic(a, 2.2, 'basicMirrorRev'), a_p, decimal=7)
+        np.testing.assert_almost_equal(
+            exponent_function_basic(a, 2.2, 'basicPassThruRev'),
             a_p,
             decimal=7)
 
         a = np.tile(a, 6)
         a_p = np.tile(a_p, 6)
         np.testing.assert_almost_equal(
-            exponent_function_basic(a, 2.2, 'BasicPassThruRev'),
+            exponent_function_basic(a, 2.2, 'basicRev'), a_p, decimal=7)
+        np.testing.assert_almost_equal(
+            exponent_function_basic(a, 2.2, 'basicMirrorRev'), a_p, decimal=7)
+        np.testing.assert_almost_equal(
+            exponent_function_basic(a, 2.2, 'basicPassThruRev'),
             a_p,
             decimal=7)
 
         a = np.reshape(a, (2, 3))
         a_p = np.reshape(a_p, (2, 3))
         np.testing.assert_almost_equal(
-            exponent_function_basic(a, 2.2, 'BasicPassThruRev'),
+            exponent_function_basic(a, 2.2, 'basicRev'), a_p, decimal=7)
+        np.testing.assert_almost_equal(
+            exponent_function_basic(a, 2.2, 'basicMirrorRev'), a_p, decimal=7)
+        np.testing.assert_almost_equal(
+            exponent_function_basic(a, 2.2, 'basicPassThruRev'),
             a_p,
             decimal=7)
 
         a = np.reshape(a, (2, 3, 1))
         a_p = np.reshape(a_p, (2, 3, 1))
         np.testing.assert_almost_equal(
-            exponent_function_basic(a, 2.2, 'BasicPassThruRev'),
+            exponent_function_basic(a, 2.2, 'basicRev'), a_p, decimal=7)
+        np.testing.assert_almost_equal(
+            exponent_function_basic(a, 2.2, 'basicMirrorRev'), a_p, decimal=7)
+        np.testing.assert_almost_equal(
+            exponent_function_basic(a, 2.2, 'basicPassThruRev'),
             a_p,
             decimal=7)
 
@@ -268,68 +208,48 @@ exponent_function_monitor_curve` definition unit tests methods.
 exponent_function_monitor_curve` definition.
         """
 
+        a = 2.0
+        a_p = 1.7777777777777777
         self.assertAlmostEqual(
-            exponent_function_monitor_curve(2.0, 2.0, 2.0),
-            1.7777777777777777,
+            exponent_function_monitor_curve(a, 2.0, 2.0), a_p, places=7)
+
+        self.assertAlmostEqual(
+            exponent_function_monitor_curve(a, 2.0, 2.0, 'monCurveMirrorFwd'),
+            a_p,
+            places=7)
+
+        a = 1.7777777777777777
+        a_p = 2.0
+        self.assertAlmostEqual(
+            exponent_function_monitor_curve(a, 2.0, 2.0, 'monCurveRev'),
+            a_p,
             places=7)
 
         self.assertAlmostEqual(
-            exponent_function_monitor_curve(-2.0, 2.0, 2.0),
-            -1.7777777777777777,
+            exponent_function_monitor_curve(a, 2.0, 2.0, 'monCurveMirrorRev'),
+            a_p,
+            places=7)
+
+        a = -2.0
+        a_p = -1.7777777777777777
+        self.assertAlmostEqual(
+            exponent_function_monitor_curve(a, 2.0, 2.0), a_p, places=7)
+
+        self.assertAlmostEqual(
+            exponent_function_monitor_curve(a, 2.0, 2.0, 'monCurveMirrorFwd'),
+            a_p,
+            places=7)
+
+        a = -1.7777777777777777
+        a_p = -2.0
+        self.assertAlmostEqual(
+            exponent_function_monitor_curve(a, 2.0, 2.0, 'monCurveRev'),
+            a_p,
             places=7)
 
         self.assertAlmostEqual(
-            exponent_function_monitor_curve(0.18, 2.2, 2.0),
-            0.1679399973777068,
-            places=7)
-
-        self.assertAlmostEqual(
-            exponent_function_monitor_curve(-0.18, 2.2, 2.0),
-            -0.1679399973777068,
-            places=7)
-
-        np.testing.assert_array_equal(
-            exponent_function_monitor_curve(-0.18, 2.2, 2.0),
-            -0.1679399973777068)
-
-        self.assertAlmostEqual(
-            exponent_function_monitor_curve(1.7777777777777777, 2.0, 2.0,
-                                            'monCurveRev'),
-            2.0,
-            places=7)
-
-        self.assertAlmostEqual(
-            exponent_function_monitor_curve(2.0, 2.0, 2.0,
-                                            'monCurveMirrorFwd'),
-            1.7777777777777777,
-            places=7)
-
-        self.assertAlmostEqual(
-            exponent_function_monitor_curve(1.7777777777777777, 2.0, 2.0,
-                                            'monCurveMirrorRev'),
-            2.0,
-            places=7)
-
-        np.testing.assert_array_equal(
-            exponent_function_monitor_curve(-0.18, -2.2, 2.0),
-            3.002684532422741)
-
-        self.assertAlmostEqual(
-            exponent_function_monitor_curve(-1.7777777777777777, 2.0, 2.0,
-                                            'monCurveRev'),
-            -2.0,
-            places=7)
-
-        self.assertAlmostEqual(
-            exponent_function_monitor_curve(2.0, 2.0, 2.0,
-                                            'monCurveMirrorFwd'),
-            1.7777777777777777,
-            places=7)
-
-        self.assertAlmostEqual(
-            exponent_function_monitor_curve(-1.7777777777777777, 2.0, 2.0,
-                                            'monCurveMirrorRev'),
-            -2.0,
+            exponent_function_monitor_curve(a, 2.0, 2.0, 'monCurveMirrorRev'),
+            a_p,
             places=7)
 
     def test_n_dimensional_exponent_function_monitor_curve(self):
@@ -339,53 +259,9 @@ exponent_function_monitor_curve` definition n-dimensional arrays support.
         """
 
         a = 0.18
-        a_p = exponent_function_monitor_curve(a, 2.2, 2.0)
-
-        a = np.tile(a, 6)
-        a_p = np.tile(a_p, 6)
+        a_p = 0.1679399973777068
         np.testing.assert_almost_equal(
             exponent_function_monitor_curve(a, 2.2, 2.0), a_p, decimal=7)
-
-        a = np.reshape(a, (2, 3))
-        a_p = np.reshape(a_p, (2, 3))
-        np.testing.assert_almost_equal(
-            exponent_function_monitor_curve(a, 2.2, 2.0), a_p, decimal=7)
-
-        a = np.reshape(a, (2, 3, 1))
-        a_p = np.reshape(a_p, (2, 3, 1))
-        np.testing.assert_almost_equal(
-            exponent_function_monitor_curve(a, 2.2, 2.0), a_p, decimal=7)
-
-        a = -0.18
-        a_p = -0.19292604802851415
-        np.testing.assert_almost_equal(
-            exponent_function_monitor_curve(a, 2.2, 2.0, 'monCurveRev'),
-            a_p,
-            decimal=7)
-
-        a = np.tile(a, 6)
-        a_p = np.tile(a_p, 6)
-        np.testing.assert_almost_equal(
-            exponent_function_monitor_curve(a, 2.2, 2.0, 'monCurveRev'),
-            a_p,
-            decimal=7)
-
-        a = np.reshape(a, (2, 3))
-        a_p = np.reshape(a_p, (2, 3))
-        np.testing.assert_almost_equal(
-            exponent_function_monitor_curve(a, 2.2, 2.0, 'monCurveRev'),
-            a_p,
-            decimal=7)
-
-        a = np.reshape(a, (2, 3, 1))
-        a_p = np.reshape(a_p, (2, 3, 1))
-        np.testing.assert_almost_equal(
-            exponent_function_monitor_curve(a, 2.2, 2.0, 'monCurveRev'),
-            a_p,
-            decimal=7)
-
-        a = -0.18
-        a_p = -0.1679399973777068
         np.testing.assert_almost_equal(
             exponent_function_monitor_curve(a, 2.2, 2.0, 'monCurveMirrorFwd'),
             a_p,
@@ -394,6 +270,8 @@ exponent_function_monitor_curve` definition n-dimensional arrays support.
         a = np.tile(a, 6)
         a_p = np.tile(a_p, 6)
         np.testing.assert_almost_equal(
+            exponent_function_monitor_curve(a, 2.2, 2.0), a_p, decimal=7)
+        np.testing.assert_almost_equal(
             exponent_function_monitor_curve(a, 2.2, 2.0, 'monCurveMirrorFwd'),
             a_p,
             decimal=7)
@@ -401,12 +279,16 @@ exponent_function_monitor_curve` definition n-dimensional arrays support.
         a = np.reshape(a, (2, 3))
         a_p = np.reshape(a_p, (2, 3))
         np.testing.assert_almost_equal(
+            exponent_function_monitor_curve(a, 2.2, 2.0), a_p, decimal=7)
+        np.testing.assert_almost_equal(
             exponent_function_monitor_curve(a, 2.2, 2.0, 'monCurveMirrorFwd'),
             a_p,
             decimal=7)
 
         a = np.reshape(a, (2, 3, 1))
         a_p = np.reshape(a_p, (2, 3, 1))
+        np.testing.assert_almost_equal(
+            exponent_function_monitor_curve(a, 2.2, 2.0), a_p, decimal=7)
         np.testing.assert_almost_equal(
             exponent_function_monitor_curve(a, 2.2, 2.0, 'monCurveMirrorFwd'),
             a_p,
@@ -415,12 +297,20 @@ exponent_function_monitor_curve` definition n-dimensional arrays support.
         a = -0.18
         a_p = -0.19292604802851415
         np.testing.assert_almost_equal(
+            exponent_function_monitor_curve(a, 2.2, 2.0, 'monCurveRev'),
+            a_p,
+            decimal=7)
+        np.testing.assert_almost_equal(
             exponent_function_monitor_curve(a, 2.2, 2.0, 'monCurveMirrorRev'),
             a_p,
             decimal=7)
 
         a = np.tile(a, 6)
         a_p = np.tile(a_p, 6)
+        np.testing.assert_almost_equal(
+            exponent_function_monitor_curve(a, 2.2, 2.0, 'monCurveRev'),
+            a_p,
+            decimal=7)
         np.testing.assert_almost_equal(
             exponent_function_monitor_curve(a, 2.2, 2.0, 'monCurveMirrorRev'),
             a_p,
@@ -429,12 +319,20 @@ exponent_function_monitor_curve` definition n-dimensional arrays support.
         a = np.reshape(a, (2, 3))
         a_p = np.reshape(a_p, (2, 3))
         np.testing.assert_almost_equal(
+            exponent_function_monitor_curve(a, 2.2, 2.0, 'monCurveRev'),
+            a_p,
+            decimal=7)
+        np.testing.assert_almost_equal(
             exponent_function_monitor_curve(a, 2.2, 2.0, 'monCurveMirrorRev'),
             a_p,
             decimal=7)
 
         a = np.reshape(a, (2, 3, 1))
         a_p = np.reshape(a_p, (2, 3, 1))
+        np.testing.assert_almost_equal(
+            exponent_function_monitor_curve(a, 2.2, 2.0, 'monCurveRev'),
+            a_p,
+            decimal=7)
         np.testing.assert_almost_equal(
             exponent_function_monitor_curve(a, 2.2, 2.0, 'monCurveMirrorRev'),
             a_p,

--- a/colour/models/rgb/transfer_functions/tests/test_exponent.py
+++ b/colour/models/rgb/transfer_functions/tests/test_exponent.py
@@ -35,49 +35,50 @@ exponent_function_basic` definition unit tests methods.
 exponent_function_basic` definition.
         """
 
-        a = 2.0
-        a_p = 4.0
-        self.assertAlmostEqual(exponent_function_basic(a, 2.0), a_p, places=7)
+        a = 0.18
+        a_p = 0.022993204992706778
+        self.assertAlmostEqual(exponent_function_basic(a, 2.2), a_p, places=7)
 
         self.assertAlmostEqual(
-            exponent_function_basic(a, 2.0, 'basicMirrorFwd'), a_p, places=7)
+            exponent_function_basic(a, 2.2, 'basicMirrorFwd'), a_p, places=7)
 
         self.assertAlmostEqual(
-            exponent_function_basic(a, 2.0, 'basicPassThruFwd'), a_p, places=7)
+            exponent_function_basic(a, 2.2, 'basicPassThruFwd'), a_p, places=7)
 
-        a = 4.0
-        a_p = 2.0
+        a = 0.022993204992706778
+        a_p = 0.18
+        self.assertAlmostEqual(
+            exponent_function_basic(a, 2.2, 'basicRev'), a_p, places=7)
 
         self.assertAlmostEqual(
-            exponent_function_basic(a, 2.0, 'basicRev'), a_p, places=7)
+            exponent_function_basic(a, 2.2, 'basicMirrorRev'), a_p, places=7)
 
         self.assertAlmostEqual(
-            exponent_function_basic(a, 2.0, 'basicMirrorRev'), a_p, places=7)
+            exponent_function_basic(a, 2.2, 'basicPassThruRev'), a_p, places=7)
+
+        a = -0.18
+        self.assertAlmostEqual(exponent_function_basic(a, 2.2), 0.0, places=7)
 
         self.assertAlmostEqual(
-            exponent_function_basic(a, 2.0, 'basicPassThruRev'), a_p, places=7)
-
-        a = -2.0
-        self.assertAlmostEqual(exponent_function_basic(a, 2.0), 0.0, places=7)
-
-        self.assertAlmostEqual(
-            exponent_function_basic(a, 2.0, 'basicMirrorFwd'), -4.0, places=7)
-
-        self.assertAlmostEqual(
-            exponent_function_basic(a, 2.0, 'basicPassThruFwd'),
-            -2.0,
+            exponent_function_basic(a, 2.2, 'basicMirrorFwd'),
+            -0.022993204992706778,
             places=7)
 
-        a = -4.0
         self.assertAlmostEqual(
-            exponent_function_basic(a, 2.0, 'basicRev'), 0.0, places=7)
+            exponent_function_basic(a, 2.2, 'basicPassThruFwd'),
+            -0.18,
+            places=7)
+
+        a = -0.022993204992706778
+        self.assertAlmostEqual(
+            exponent_function_basic(a, 2.2, 'basicRev'), 0.0, places=7)
 
         self.assertAlmostEqual(
-            exponent_function_basic(a, 2.0, 'basicMirrorRev'), -2.0, places=7)
+            exponent_function_basic(a, 2.2, 'basicMirrorRev'), -0.18, places=7)
 
         self.assertAlmostEqual(
-            exponent_function_basic(a, 2.0, 'basicPassThruRev'),
-            -4.0,
+            exponent_function_basic(a, 2.2, 'basicPassThruRev'),
+            -0.022993204992706778,
             places=7)
 
     def test_n_dimensional_exponent_function_basic(self):
@@ -130,8 +131,8 @@ exponent_function_basic` definition n-dimensional arrays support.
             a_p,
             decimal=7)
 
-        a = 0.18
-        a_p = 0.4586564468643811
+        a = 0.022993204992706778
+        a_p = 0.18
         np.testing.assert_almost_equal(
             exponent_function_basic(a, 2.2, 'basicRev'), a_p, decimal=7)
         np.testing.assert_almost_equal(
@@ -208,48 +209,52 @@ exponent_function_monitor_curve` definition unit tests methods.
 exponent_function_monitor_curve` definition.
         """
 
-        a = 2.0
-        a_p = 1.777777777777777
+        a = 0.18
+        a_p = 0.023224046600190416
         self.assertAlmostEqual(
-            exponent_function_monitor_curve(a, 2.0, 2.0), a_p, places=7)
+            exponent_function_monitor_curve(a, 2.2, 0.001), a_p, places=7)
 
         self.assertAlmostEqual(
-            exponent_function_monitor_curve(a, 2.0, 2.0, 'monCurveMirrorFwd'),
+            exponent_function_monitor_curve(a, 2.2, 0.001,
+                                            'monCurveMirrorFwd'),
             a_p,
             places=7)
 
-        a = 1.777777777777777
-        a_p = 2.0
+        a = 0.023224046600190416
+        a_p = 0.18
         self.assertAlmostEqual(
-            exponent_function_monitor_curve(a, 2.0, 2.0, 'monCurveRev'),
-            a_p,
-            places=7)
-
-        self.assertAlmostEqual(
-            exponent_function_monitor_curve(a, 2.0, 2.0, 'monCurveMirrorRev'),
-            a_p,
-            places=7)
-
-        a = -2.0
-        a_p = -1.777777777777777
-        self.assertAlmostEqual(
-            exponent_function_monitor_curve(a, 2.0, 2.0), a_p, places=7)
-
-        self.assertAlmostEqual(
-            exponent_function_monitor_curve(a, 2.0, 2.0, 'monCurveMirrorFwd'),
-            a_p,
-            places=7)
-
-        a = -1.777777777777777
-        a_p = -2.0
-        self.assertAlmostEqual(
-            exponent_function_monitor_curve(a, 2.0, 2.0, 'monCurveRev'),
+            exponent_function_monitor_curve(a, 2.2, 0.001, 'monCurveRev'),
             a_p,
             places=7)
 
         self.assertAlmostEqual(
-            exponent_function_monitor_curve(a, 2.0, 2.0, 'monCurveMirrorRev'),
+            exponent_function_monitor_curve(a, 2.2, 0.001,
+                                            'monCurveMirrorRev'),
             a_p,
+            places=7)
+
+        a = -0.18
+        self.assertAlmostEqual(
+            exponent_function_monitor_curve(a, 2.2, 0.001),
+            -0.00020541395155301983,
+            places=7)
+
+        self.assertAlmostEqual(
+            exponent_function_monitor_curve(a, 2.2, 0.001,
+                                            'monCurveMirrorFwd'),
+            -0.023224046600190416,
+            places=7)
+
+        a = -0.00020541395155301983
+        self.assertAlmostEqual(
+            exponent_function_monitor_curve(a, 2.2, 0.001, 'monCurveRev'),
+            -0.18,
+            places=7)
+
+        self.assertAlmostEqual(
+            exponent_function_monitor_curve(a, 2.2, 0.001,
+                                            'monCurveMirrorRev'),
+            -0.020103611156568602,
             places=7)
 
     def test_n_dimensional_exponent_function_monitor_curve(self):
@@ -259,82 +264,90 @@ exponent_function_monitor_curve` definition n-dimensional arrays support.
         """
 
         a = 0.18
-        a_p = 0.1679399973777068
+        a_p = 0.023224046600190416
         np.testing.assert_almost_equal(
-            exponent_function_monitor_curve(a, 2.2, 2.0), a_p, decimal=7)
+            exponent_function_monitor_curve(a, 2.2, 0.001), a_p, decimal=7)
         np.testing.assert_almost_equal(
-            exponent_function_monitor_curve(a, 2.2, 2.0, 'monCurveMirrorFwd'),
+            exponent_function_monitor_curve(a, 2.2, 0.001,
+                                            'monCurveMirrorFwd'),
             a_p,
             decimal=7)
 
         a = np.tile(a, 6)
         a_p = np.tile(a_p, 6)
         np.testing.assert_almost_equal(
-            exponent_function_monitor_curve(a, 2.2, 2.0), a_p, decimal=7)
+            exponent_function_monitor_curve(a, 2.2, 0.001), a_p, decimal=7)
         np.testing.assert_almost_equal(
-            exponent_function_monitor_curve(a, 2.2, 2.0, 'monCurveMirrorFwd'),
+            exponent_function_monitor_curve(a, 2.2, 0.001,
+                                            'monCurveMirrorFwd'),
             a_p,
             decimal=7)
 
         a = np.reshape(a, (2, 3))
         a_p = np.reshape(a_p, (2, 3))
         np.testing.assert_almost_equal(
-            exponent_function_monitor_curve(a, 2.2, 2.0), a_p, decimal=7)
+            exponent_function_monitor_curve(a, 2.2, 0.001), a_p, decimal=7)
         np.testing.assert_almost_equal(
-            exponent_function_monitor_curve(a, 2.2, 2.0, 'monCurveMirrorFwd'),
+            exponent_function_monitor_curve(a, 2.2, 0.001,
+                                            'monCurveMirrorFwd'),
             a_p,
             decimal=7)
 
         a = np.reshape(a, (2, 3, 1))
         a_p = np.reshape(a_p, (2, 3, 1))
         np.testing.assert_almost_equal(
-            exponent_function_monitor_curve(a, 2.2, 2.0), a_p, decimal=7)
+            exponent_function_monitor_curve(a, 2.2, 0.001), a_p, decimal=7)
         np.testing.assert_almost_equal(
-            exponent_function_monitor_curve(a, 2.2, 2.0, 'monCurveMirrorFwd'),
+            exponent_function_monitor_curve(a, 2.2, 0.001,
+                                            'monCurveMirrorFwd'),
             a_p,
             decimal=7)
 
-        a = -0.18
-        a_p = -0.19292604802851415
+        a = 0.023224046600190416
+        a_p = 0.18
         np.testing.assert_almost_equal(
-            exponent_function_monitor_curve(a, 2.2, 2.0, 'monCurveRev'),
+            exponent_function_monitor_curve(a, 2.2, 0.001, 'monCurveRev'),
             a_p,
             decimal=7)
         np.testing.assert_almost_equal(
-            exponent_function_monitor_curve(a, 2.2, 2.0, 'monCurveMirrorRev'),
+            exponent_function_monitor_curve(a, 2.2, 0.001,
+                                            'monCurveMirrorRev'),
             a_p,
             decimal=7)
 
         a = np.tile(a, 6)
         a_p = np.tile(a_p, 6)
         np.testing.assert_almost_equal(
-            exponent_function_monitor_curve(a, 2.2, 2.0, 'monCurveRev'),
+            exponent_function_monitor_curve(a, 2.2, 0.001, 'monCurveRev'),
             a_p,
             decimal=7)
         np.testing.assert_almost_equal(
-            exponent_function_monitor_curve(a, 2.2, 2.0, 'monCurveMirrorRev'),
+            exponent_function_monitor_curve(a, 2.2, 0.001,
+                                            'monCurveMirrorRev'),
             a_p,
             decimal=7)
 
         a = np.reshape(a, (2, 3))
         a_p = np.reshape(a_p, (2, 3))
         np.testing.assert_almost_equal(
-            exponent_function_monitor_curve(a, 2.2, 2.0, 'monCurveRev'),
+            exponent_function_monitor_curve(a, 2.2, 0.001, 'monCurveRev'),
             a_p,
             decimal=7)
         np.testing.assert_almost_equal(
-            exponent_function_monitor_curve(a, 2.2, 2.0, 'monCurveMirrorRev'),
+            exponent_function_monitor_curve(a, 2.2, 0.001,
+                                            'monCurveMirrorRev'),
             a_p,
             decimal=7)
 
         a = np.reshape(a, (2, 3, 1))
         a_p = np.reshape(a_p, (2, 3, 1))
         np.testing.assert_almost_equal(
-            exponent_function_monitor_curve(a, 2.2, 2.0, 'monCurveRev'),
+            exponent_function_monitor_curve(a, 2.2, 0.001, 'monCurveRev'),
             a_p,
             decimal=7)
         np.testing.assert_almost_equal(
-            exponent_function_monitor_curve(a, 2.2, 2.0, 'monCurveMirrorRev'),
+            exponent_function_monitor_curve(a, 2.2, 0.001,
+                                            'monCurveMirrorRev'),
             a_p,
             decimal=7)
 

--- a/colour/models/rgb/transfer_functions/tests/test_exponent.py
+++ b/colour/models/rgb/transfer_functions/tests/test_exponent.py
@@ -1,4 +1,4 @@
-#
+# -*- coding: utf-8 -*-
 """
 Defines unit tests for :mod:`colour.models.rgb.transfer_functions.exponent`
 module.
@@ -209,7 +209,7 @@ exponent_function_monitor_curve` definition.
         """
 
         a = 2.0
-        a_p = 1.7777777777777777
+        a_p = 1.777777777777777
         self.assertAlmostEqual(
             exponent_function_monitor_curve(a, 2.0, 2.0), a_p, places=7)
 
@@ -218,7 +218,7 @@ exponent_function_monitor_curve` definition.
             a_p,
             places=7)
 
-        a = 1.7777777777777777
+        a = 1.777777777777777
         a_p = 2.0
         self.assertAlmostEqual(
             exponent_function_monitor_curve(a, 2.0, 2.0, 'monCurveRev'),
@@ -231,7 +231,7 @@ exponent_function_monitor_curve` definition.
             places=7)
 
         a = -2.0
-        a_p = -1.7777777777777777
+        a_p = -1.777777777777777
         self.assertAlmostEqual(
             exponent_function_monitor_curve(a, 2.0, 2.0), a_p, places=7)
 
@@ -240,7 +240,7 @@ exponent_function_monitor_curve` definition.
             a_p,
             places=7)
 
-        a = -1.7777777777777777
+        a = -1.777777777777777
         a_p = -2.0
         self.assertAlmostEqual(
             exponent_function_monitor_curve(a, 2.0, 2.0, 'monCurveRev'),

--- a/colour/models/rgb/transfer_functions/tests/test_exponent.py
+++ b/colour/models/rgb/transfer_functions/tests/test_exponent.py
@@ -1,0 +1,466 @@
+#
+"""
+Defines unit tests for :mod:`colour.models.rgb.transfer_functions.exponent`
+module.
+"""
+
+from __future__ import division, unicode_literals
+
+import numpy as np
+import unittest
+
+from colour.models.rgb.transfer_functions import (
+    exponent_function_basic, exponent_function_monitor_curve)
+from colour.utilities import ignore_numpy_errors
+
+__author__ = 'Colour Developers'
+__copyright__ = 'Copyright (C) 2013-2020 - Colour Developers'
+__license__ = 'New BSD License - https://opensource.org/licenses/BSD-3-Clause'
+__maintainer__ = 'Colour Developers'
+__email__ = 'colour-developers@colour-science.org'
+__status__ = 'Production'
+
+__all__ = ['TestBasicExponentFunction', 'TestMonitorCurveExponentFunction']
+
+
+class TestBasicExponentFunction(unittest.TestCase):
+    """
+    Defines :func:`colour.models.rgb.transfer_functions.exponent.\
+exponent_function_basic` definition unit tests methods.
+    """
+
+    def test_exponent_function_basic(self):
+        """
+        Tests :func:`colour.models.rgb.transfer_functions.exponent.\
+exponent_function_basic` definition.
+        """
+
+        self.assertAlmostEqual(
+            exponent_function_basic(2.0, 2.0), 4.0, places=7)
+
+        self.assertAlmostEqual(
+            exponent_function_basic(-2.0, 2.0), 0.0, places=7)
+
+        self.assertAlmostEqual(
+            exponent_function_basic(0.18, 2.0), 0.0324, places=7)
+
+        self.assertAlmostEqual(
+            exponent_function_basic(-0.18, 2.0), 0.0, places=7)
+
+        np.testing.assert_array_equal(exponent_function_basic(-0.18, 2.2), 0.0)
+
+        self.assertAlmostEqual(
+            exponent_function_basic(4.0, 2.0, 'basicRev'), 2.0, places=7)
+
+        self.assertAlmostEqual(
+            exponent_function_basic(2.0, 2.0, 'basicMirrorFwd'), 4.0, places=7)
+
+        self.assertAlmostEqual(
+            exponent_function_basic(4.0, 2.0, 'basicMirrorRev'), 2.0, places=7)
+
+        self.assertAlmostEqual(
+            exponent_function_basic(2.0, 2.0, 'basicPassThruFwd'),
+            4.0,
+            places=7)
+
+        self.assertAlmostEqual(
+            exponent_function_basic(4.0, 2.0, 'basicPassThruRev'),
+            2.0,
+            places=7)
+
+        np.testing.assert_array_equal(
+            exponent_function_basic(-0.18, -2.2), 0.0)
+
+        self.assertAlmostEqual(
+            exponent_function_basic(-4.0, 2.0, 'basicRev'), 0.0, places=7)
+
+        self.assertAlmostEqual(
+            exponent_function_basic(-2.0, 2.0, 'basicMirrorFwd'),
+            -4.0,
+            places=7)
+
+        self.assertAlmostEqual(
+            exponent_function_basic(-4.0, 2.0, 'basicMirrorRev'),
+            -2.0,
+            places=7)
+
+        self.assertAlmostEqual(
+            exponent_function_basic(-2.0, 2.0, 'basicPassThruFwd'),
+            -2.0,
+            places=7)
+
+        self.assertAlmostEqual(
+            exponent_function_basic(-4.0, 2.0, 'basicPassThruRev'),
+            -4.0,
+            places=7)
+
+    def test_n_dimensional_exponent_function_basic(self):
+        """
+        Tests :func:`colour.models.rgb.transfer_functions.exponent.\
+exponent_function_basic` definition n-dimensional arrays support.
+        """
+
+        a = 0.18
+        a_p = exponent_function_basic(a, 2.2)
+
+        a = np.tile(a, 6)
+        a_p = np.tile(a_p, 6)
+        np.testing.assert_almost_equal(
+            exponent_function_basic(a, 2.2), a_p, decimal=7)
+
+        a = np.reshape(a, (2, 3))
+        a_p = np.reshape(a_p, (2, 3))
+        np.testing.assert_almost_equal(
+            exponent_function_basic(a, 2.2), a_p, decimal=7)
+
+        a = np.reshape(a, (2, 3, 1))
+        a_p = np.reshape(a_p, (2, 3, 1))
+        np.testing.assert_almost_equal(
+            exponent_function_basic(a, 2.2), a_p, decimal=7)
+
+        a = 0.18
+        a_p = 0.4586564468643811
+        np.testing.assert_almost_equal(
+            exponent_function_basic(a, 2.2, 'basicRev'), a_p, decimal=7)
+
+        a = np.tile(a, 6)
+        a_p = np.tile(a_p, 6)
+        np.testing.assert_almost_equal(
+            exponent_function_basic(a, 2.2, 'basicRev'), a_p, decimal=7)
+
+        a = np.reshape(a, (2, 3))
+        a_p = np.reshape(a_p, (2, 3))
+        np.testing.assert_almost_equal(
+            exponent_function_basic(a, 2.2, 'basicRev'), a_p, decimal=7)
+
+        a = np.reshape(a, (2, 3, 1))
+        a_p = np.reshape(a_p, (2, 3, 1))
+        np.testing.assert_almost_equal(
+            exponent_function_basic(a, 2.2, 'basicRev'), a_p, decimal=7)
+
+        a = -0.18
+        a_p = -0.022993204992706778
+        np.testing.assert_almost_equal(
+            exponent_function_basic(a, 2.2, 'basicMirrorFwd'), a_p, decimal=7)
+
+        a = np.tile(a, 6)
+        a_p = np.tile(a_p, 6)
+        np.testing.assert_almost_equal(
+            exponent_function_basic(a, 2.2, 'basicMirrorFwd'), a_p, decimal=7)
+
+        a = np.reshape(a, (2, 3))
+        a_p = np.reshape(a_p, (2, 3))
+        np.testing.assert_almost_equal(
+            exponent_function_basic(a, 2.2, 'basicMirrorFwd'), a_p, decimal=7)
+
+        a = np.reshape(a, (2, 3, 1))
+        a_p = np.reshape(a_p, (2, 3, 1))
+        np.testing.assert_almost_equal(
+            exponent_function_basic(a, 2.2, 'basicMirrorFwd'), a_p, decimal=7)
+
+        a = -0.18
+        a_p = -0.4586564468643811
+        np.testing.assert_almost_equal(
+            exponent_function_basic(a, 2.2, 'BasicMirrorRev'), a_p, decimal=7)
+
+        a = np.tile(a, 6)
+        a_p = np.tile(a_p, 6)
+        np.testing.assert_almost_equal(
+            exponent_function_basic(a, 2.2, 'BasicMirrorRev'), a_p, decimal=7)
+
+        a = np.reshape(a, (2, 3))
+        a_p = np.reshape(a_p, (2, 3))
+        np.testing.assert_almost_equal(
+            exponent_function_basic(a, 2.2, 'BasicMirrorRev'), a_p, decimal=7)
+
+        a = np.reshape(a, (2, 3, 1))
+        a_p = np.reshape(a_p, (2, 3, 1))
+        np.testing.assert_almost_equal(
+            exponent_function_basic(a, 2.2, 'BasicMirrorRev'), a_p, decimal=7)
+
+        a = 0.18
+        a_p = 0.022993204992706778
+        np.testing.assert_almost_equal(
+            exponent_function_basic(a, 2.2, 'BasicPassThruFwd'),
+            a_p,
+            decimal=7)
+
+        a = np.tile(a, 6)
+        a_p = np.tile(a_p, 6)
+        np.testing.assert_almost_equal(
+            exponent_function_basic(a, 2.2, 'BasicPassThruFwd'),
+            a_p,
+            decimal=7)
+
+        a = np.reshape(a, (2, 3))
+        a_p = np.reshape(a_p, (2, 3))
+        np.testing.assert_almost_equal(
+            exponent_function_basic(a, 2.2, 'BasicPassThruFwd'),
+            a_p,
+            decimal=7)
+
+        a = np.reshape(a, (2, 3, 1))
+        a_p = np.reshape(a_p, (2, 3, 1))
+        np.testing.assert_almost_equal(
+            exponent_function_basic(a, 2.2, 'BasicPassThruFwd'),
+            a_p,
+            decimal=7)
+
+        a = 0.18
+        a_p = 0.4586564468643811
+        np.testing.assert_almost_equal(
+            exponent_function_basic(a, 2.2, 'BasicPassThruRev'),
+            a_p,
+            decimal=7)
+
+        a = np.tile(a, 6)
+        a_p = np.tile(a_p, 6)
+        np.testing.assert_almost_equal(
+            exponent_function_basic(a, 2.2, 'BasicPassThruRev'),
+            a_p,
+            decimal=7)
+
+        a = np.reshape(a, (2, 3))
+        a_p = np.reshape(a_p, (2, 3))
+        np.testing.assert_almost_equal(
+            exponent_function_basic(a, 2.2, 'BasicPassThruRev'),
+            a_p,
+            decimal=7)
+
+        a = np.reshape(a, (2, 3, 1))
+        a_p = np.reshape(a_p, (2, 3, 1))
+        np.testing.assert_almost_equal(
+            exponent_function_basic(a, 2.2, 'BasicPassThruRev'),
+            a_p,
+            decimal=7)
+
+    def test_raise_exception_exponent_function_basic(self):
+        """
+        Tests :func:`colour.models.rgb.transfer_functions.exponent.\
+exponent_function_basic` definition raised exception.
+        """
+
+        self.assertRaises(ValueError, exponent_function_basic, 0.18, 1,
+                          'Undefined')
+
+    @ignore_numpy_errors
+    def test_nan_exponent_function_basic(self):
+        """
+        Tests :func:`colour.models.rgb.transfer_functions.exponent.\
+exponent_function_basic` definition nan support.
+        """
+
+        cases = [-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan]
+
+        for case in cases:
+            exponent_function_basic(case, case)
+
+
+class TestMonitorCurveExponentFunction(unittest.TestCase):
+    """
+    Defines :func:`colour.models.rgb.transfer_functions.exponent.\
+exponent_function_monitor_curve` definition unit tests methods.
+    """
+
+    def test_exponent_function_monitor_curve(self):
+        """
+        Tests :func:`colour.models.rgb.transfer_functions.exponent.\
+exponent_function_monitor_curve` definition.
+        """
+
+        self.assertAlmostEqual(
+            exponent_function_monitor_curve(2.0, 2.0, 2.0),
+            1.7777777777777777,
+            places=7)
+
+        self.assertAlmostEqual(
+            exponent_function_monitor_curve(-2.0, 2.0, 2.0),
+            -1.7777777777777777,
+            places=7)
+
+        self.assertAlmostEqual(
+            exponent_function_monitor_curve(0.18, 2.2, 2.0),
+            0.1679399973777068,
+            places=7)
+
+        self.assertAlmostEqual(
+            exponent_function_monitor_curve(-0.18, 2.2, 2.0),
+            -0.1679399973777068,
+            places=7)
+
+        np.testing.assert_array_equal(
+            exponent_function_monitor_curve(-0.18, 2.2, 2.0),
+            -0.1679399973777068)
+
+        self.assertAlmostEqual(
+            exponent_function_monitor_curve(1.7777777777777777, 2.0, 2.0,
+                                            'monCurveRev'),
+            2.0,
+            places=7)
+
+        self.assertAlmostEqual(
+            exponent_function_monitor_curve(2.0, 2.0, 2.0,
+                                            'monCurveMirrorFwd'),
+            1.7777777777777777,
+            places=7)
+
+        self.assertAlmostEqual(
+            exponent_function_monitor_curve(1.7777777777777777, 2.0, 2.0,
+                                            'monCurveMirrorRev'),
+            2.0,
+            places=7)
+
+        np.testing.assert_array_equal(
+            exponent_function_monitor_curve(-0.18, -2.2, 2.0),
+            3.002684532422741)
+
+        self.assertAlmostEqual(
+            exponent_function_monitor_curve(-1.7777777777777777, 2.0, 2.0,
+                                            'monCurveRev'),
+            -2.0,
+            places=7)
+
+        self.assertAlmostEqual(
+            exponent_function_monitor_curve(2.0, 2.0, 2.0,
+                                            'monCurveMirrorFwd'),
+            1.7777777777777777,
+            places=7)
+
+        self.assertAlmostEqual(
+            exponent_function_monitor_curve(-1.7777777777777777, 2.0, 2.0,
+                                            'monCurveMirrorRev'),
+            -2.0,
+            places=7)
+
+    def test_n_dimensional_exponent_function_monitor_curve(self):
+        """
+        Tests :func:`colour.models.rgb.transfer_functions.exponent.\
+exponent_function_monitor_curve` definition n-dimensional arrays support.
+        """
+
+        a = 0.18
+        a_p = exponent_function_monitor_curve(a, 2.2, 2.0)
+
+        a = np.tile(a, 6)
+        a_p = np.tile(a_p, 6)
+        np.testing.assert_almost_equal(
+            exponent_function_monitor_curve(a, 2.2, 2.0), a_p, decimal=7)
+
+        a = np.reshape(a, (2, 3))
+        a_p = np.reshape(a_p, (2, 3))
+        np.testing.assert_almost_equal(
+            exponent_function_monitor_curve(a, 2.2, 2.0), a_p, decimal=7)
+
+        a = np.reshape(a, (2, 3, 1))
+        a_p = np.reshape(a_p, (2, 3, 1))
+        np.testing.assert_almost_equal(
+            exponent_function_monitor_curve(a, 2.2, 2.0), a_p, decimal=7)
+
+        a = -0.18
+        a_p = -0.19292604802851415
+        np.testing.assert_almost_equal(
+            exponent_function_monitor_curve(a, 2.2, 2.0, 'monCurveRev'),
+            a_p,
+            decimal=7)
+
+        a = np.tile(a, 6)
+        a_p = np.tile(a_p, 6)
+        np.testing.assert_almost_equal(
+            exponent_function_monitor_curve(a, 2.2, 2.0, 'monCurveRev'),
+            a_p,
+            decimal=7)
+
+        a = np.reshape(a, (2, 3))
+        a_p = np.reshape(a_p, (2, 3))
+        np.testing.assert_almost_equal(
+            exponent_function_monitor_curve(a, 2.2, 2.0, 'monCurveRev'),
+            a_p,
+            decimal=7)
+
+        a = np.reshape(a, (2, 3, 1))
+        a_p = np.reshape(a_p, (2, 3, 1))
+        np.testing.assert_almost_equal(
+            exponent_function_monitor_curve(a, 2.2, 2.0, 'monCurveRev'),
+            a_p,
+            decimal=7)
+
+        a = -0.18
+        a_p = -0.1679399973777068
+        np.testing.assert_almost_equal(
+            exponent_function_monitor_curve(a, 2.2, 2.0, 'monCurveMirrorFwd'),
+            a_p,
+            decimal=7)
+
+        a = np.tile(a, 6)
+        a_p = np.tile(a_p, 6)
+        np.testing.assert_almost_equal(
+            exponent_function_monitor_curve(a, 2.2, 2.0, 'monCurveMirrorFwd'),
+            a_p,
+            decimal=7)
+
+        a = np.reshape(a, (2, 3))
+        a_p = np.reshape(a_p, (2, 3))
+        np.testing.assert_almost_equal(
+            exponent_function_monitor_curve(a, 2.2, 2.0, 'monCurveMirrorFwd'),
+            a_p,
+            decimal=7)
+
+        a = np.reshape(a, (2, 3, 1))
+        a_p = np.reshape(a_p, (2, 3, 1))
+        np.testing.assert_almost_equal(
+            exponent_function_monitor_curve(a, 2.2, 2.0, 'monCurveMirrorFwd'),
+            a_p,
+            decimal=7)
+
+        a = -0.18
+        a_p = -0.19292604802851415
+        np.testing.assert_almost_equal(
+            exponent_function_monitor_curve(a, 2.2, 2.0, 'monCurveMirrorRev'),
+            a_p,
+            decimal=7)
+
+        a = np.tile(a, 6)
+        a_p = np.tile(a_p, 6)
+        np.testing.assert_almost_equal(
+            exponent_function_monitor_curve(a, 2.2, 2.0, 'monCurveMirrorRev'),
+            a_p,
+            decimal=7)
+
+        a = np.reshape(a, (2, 3))
+        a_p = np.reshape(a_p, (2, 3))
+        np.testing.assert_almost_equal(
+            exponent_function_monitor_curve(a, 2.2, 2.0, 'monCurveMirrorRev'),
+            a_p,
+            decimal=7)
+
+        a = np.reshape(a, (2, 3, 1))
+        a_p = np.reshape(a_p, (2, 3, 1))
+        np.testing.assert_almost_equal(
+            exponent_function_monitor_curve(a, 2.2, 2.0, 'monCurveMirrorRev'),
+            a_p,
+            decimal=7)
+
+    def test_raise_exception_exponent_function_monitor_curve(self):
+        """
+        Tests :func:`colour.models.rgb.transfer_functions.exponent.\
+exponent_function_monitor_curve` definition raised exception.
+        """
+
+        self.assertRaises(ValueError, exponent_function_monitor_curve, 0.18, 1,
+                          'Undefined')
+
+    @ignore_numpy_errors
+    def test_nan_exponent_function_monitor_curve(self):
+        """
+        Tests :func:`colour.models.rgb.transfer_functions.exponent.\
+exponent_function_monitor_curve` definition nan support.
+        """
+
+        cases = [-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan]
+
+        for case in cases:
+            exponent_function_monitor_curve(case, case, case)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/colour/models/rgb/transfer_functions/tests/test_exponent.py
+++ b/colour/models/rgb/transfer_functions/tests/test_exponent.py
@@ -36,7 +36,7 @@ exponent_function_basic` definition.
         """
 
         a = 0.18
-        a_p = 0.022993204992706778
+        a_p = 0.0229932049927
         self.assertAlmostEqual(exponent_function_basic(a, 2.2), a_p, places=7)
 
         self.assertAlmostEqual(
@@ -45,7 +45,7 @@ exponent_function_basic` definition.
         self.assertAlmostEqual(
             exponent_function_basic(a, 2.2, 'basicPassThruFwd'), a_p, places=7)
 
-        a = 0.022993204992706778
+        a = 0.0229932049927
         a_p = 0.18
         self.assertAlmostEqual(
             exponent_function_basic(a, 2.2, 'basicRev'), a_p, places=7)
@@ -61,7 +61,7 @@ exponent_function_basic` definition.
 
         self.assertAlmostEqual(
             exponent_function_basic(a, 2.2, 'basicMirrorFwd'),
-            -0.022993204992706778,
+            -0.0229932049927,
             places=7)
 
         self.assertAlmostEqual(
@@ -69,7 +69,7 @@ exponent_function_basic` definition.
             -0.18,
             places=7)
 
-        a = -0.022993204992706778
+        a = -0.0229932049927
         self.assertAlmostEqual(
             exponent_function_basic(a, 2.2, 'basicRev'), 0.0, places=7)
 
@@ -78,7 +78,7 @@ exponent_function_basic` definition.
 
         self.assertAlmostEqual(
             exponent_function_basic(a, 2.2, 'basicPassThruRev'),
-            -0.022993204992706778,
+            -0.0229932049927,
             places=7)
 
     def test_n_dimensional_exponent_function_basic(self):
@@ -88,15 +88,7 @@ exponent_function_basic` definition n-dimensional arrays support.
         """
 
         a = 0.18
-        a_p = 0.022993204992706778
-        np.testing.assert_almost_equal(
-            exponent_function_basic(a, 2.2), a_p, decimal=7)
-        np.testing.assert_almost_equal(
-            exponent_function_basic(a, 2.2, 'basicMirrorFwd'), a_p, decimal=7)
-        np.testing.assert_almost_equal(
-            exponent_function_basic(a, 2.2, 'basicPassThruFwd'),
-            a_p,
-            decimal=7)
+        a_p = 0.0229932049927
 
         a = np.tile(a, 6)
         a_p = np.tile(a_p, 6)
@@ -131,16 +123,8 @@ exponent_function_basic` definition n-dimensional arrays support.
             a_p,
             decimal=7)
 
-        a = 0.022993204992706778
+        a = 0.0229932049927
         a_p = 0.18
-        np.testing.assert_almost_equal(
-            exponent_function_basic(a, 2.2, 'basicRev'), a_p, decimal=7)
-        np.testing.assert_almost_equal(
-            exponent_function_basic(a, 2.2, 'basicMirrorRev'), a_p, decimal=7)
-        np.testing.assert_almost_equal(
-            exponent_function_basic(a, 2.2, 'basicPassThruRev'),
-            a_p,
-            decimal=7)
 
         a = np.tile(a, 6)
         a_p = np.tile(a_p, 6)
@@ -210,7 +194,7 @@ exponent_function_monitor_curve` definition.
         """
 
         a = 0.18
-        a_p = 0.023224046600190416
+        a_p = 0.0232240466001
         self.assertAlmostEqual(
             exponent_function_monitor_curve(a, 2.2, 0.001), a_p, places=7)
 
@@ -220,7 +204,7 @@ exponent_function_monitor_curve` definition.
             a_p,
             places=7)
 
-        a = 0.023224046600190416
+        a = 0.0232240466001
         a_p = 0.18
         self.assertAlmostEqual(
             exponent_function_monitor_curve(a, 2.2, 0.001, 'monCurveRev'),
@@ -236,16 +220,16 @@ exponent_function_monitor_curve` definition.
         a = -0.18
         self.assertAlmostEqual(
             exponent_function_monitor_curve(a, 2.2, 0.001),
-            -0.00020541395155301983,
+            -0.000205413951,
             places=7)
 
         self.assertAlmostEqual(
             exponent_function_monitor_curve(a, 2.2, 0.001,
                                             'monCurveMirrorFwd'),
-            -0.023224046600190416,
+            -0.0232240466001,
             places=7)
 
-        a = -0.00020541395155301983
+        a = -0.000205413951
         self.assertAlmostEqual(
             exponent_function_monitor_curve(a, 2.2, 0.001, 'monCurveRev'),
             -0.18,
@@ -254,7 +238,7 @@ exponent_function_monitor_curve` definition.
         self.assertAlmostEqual(
             exponent_function_monitor_curve(a, 2.2, 0.001,
                                             'monCurveMirrorRev'),
-            -0.020103611156568602,
+            -0.0201036111565,
             places=7)
 
     def test_n_dimensional_exponent_function_monitor_curve(self):
@@ -264,14 +248,7 @@ exponent_function_monitor_curve` definition n-dimensional arrays support.
         """
 
         a = 0.18
-        a_p = 0.023224046600190416
-        np.testing.assert_almost_equal(
-            exponent_function_monitor_curve(a, 2.2, 0.001), a_p, decimal=7)
-        np.testing.assert_almost_equal(
-            exponent_function_monitor_curve(a, 2.2, 0.001,
-                                            'monCurveMirrorFwd'),
-            a_p,
-            decimal=7)
+        a_p = 0.0232240466001
 
         a = np.tile(a, 6)
         a_p = np.tile(a_p, 6)
@@ -303,17 +280,8 @@ exponent_function_monitor_curve` definition n-dimensional arrays support.
             a_p,
             decimal=7)
 
-        a = 0.023224046600190416
+        a = 0.0232240466001
         a_p = 0.18
-        np.testing.assert_almost_equal(
-            exponent_function_monitor_curve(a, 2.2, 0.001, 'monCurveRev'),
-            a_p,
-            decimal=7)
-        np.testing.assert_almost_equal(
-            exponent_function_monitor_curve(a, 2.2, 0.001,
-                                            'monCurveMirrorRev'),
-            a_p,
-            decimal=7)
 
         a = np.tile(a, 6)
         a_p = np.tile(a_p, 6)

--- a/docs/colour.models.rst
+++ b/docs/colour.models.rst
@@ -377,6 +377,8 @@ Colour Component Transfer Functions
     CCTF_ENCODINGS
     cctf_decoding
     CCTF_DECODINGS
+    gamma_function
+    linear_function
 
 ``colour.models``
 
@@ -401,6 +403,18 @@ Colour Component Transfer Functions
 
     cctf_encoding_ProPhotoRGB
     cctf_decoding_ProPhotoRGB
+
+**Ancillary Objects**
+
+``colour.models``
+
+.. currentmodule:: colour.models
+
+.. autosummary::
+    :toctree: generated/
+
+    exponent_function_basic
+    exponent_function_monitor_curve
 
 Opto-Electronic Transfer Functions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -435,20 +449,6 @@ Opto-Electronic Transfer Functions
     oetf_BT709
     oetf_inverse_BT709
     oetf_SMPTE240M
-
-**Ancillary Objects**
-
-``colour``
-
-.. currentmodule:: colour
-
-.. autosummary::
-    :toctree: generated/
-
-    exponent_function_basic
-    exponent_function_monitor_curve
-    gamma_function
-    linear_function
 
 Electro-Optical Transfer Functions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/colour.models.rst
+++ b/docs/colour.models.rst
@@ -445,6 +445,8 @@ Opto-Electronic Transfer Functions
 .. autosummary::
     :toctree: generated/
 
+    exponent_function_basic
+    exponent_function_monitor_curve
     gamma_function
     linear_function
 


### PR DESCRIPTION
This pull request adds the `exponent.py` module to the 'transfer functions' sub-package in colour models, and contains the following functions:

* `exponent_function_basic`
* `exponent_function_monitor_curve`
