### PR TITLE
PR: Convert CAM test to unit tests.

### DIFF
--- a/colour/appearance/tests/test_atd95.py
+++ b/colour/appearance/tests/test_atd95.py
@@ -6,8 +6,10 @@ Defines unit tests for :mod:`colour.appearance.atd95` module.
 
 from __future__ import division, unicode_literals
 
-import numpy as np
 from itertools import permutations
+from unittest import TestCase
+
+import numpy as np
 
 from colour.appearance import XYZ_to_ATD95
 from colour.appearance.tests.common import ColourAppearanceModelTest
@@ -23,7 +25,7 @@ __status__ = 'Production'
 __all__ = ['TestATD95ColourAppearanceModel']
 
 
-class TestATD95ColourAppearanceModel(ColourAppearanceModelTest):
+class TestATD95ColourAppearanceModel(ColourAppearanceModelTest, TestCase):
     """
     Defines :mod:`colour.appearance.atd95` module unit tests methods for
     *ATD (1995)* colour vision model.

--- a/colour/appearance/tests/test_cam16.py
+++ b/colour/appearance/tests/test_cam16.py
@@ -6,8 +6,10 @@ Defines unit tests for :mod:`colour.appearance.cam16` module.
 
 from __future__ import division, unicode_literals
 
-import numpy as np
 from itertools import permutations
+from unittest import TestCase
+
+import numpy as np
 
 from colour.appearance import (CAM16_VIEWING_CONDITIONS,
                                CAM16_InductionFactors, CAM16_Specification,
@@ -29,7 +31,8 @@ __all__ = [
 ]
 
 
-class TestCAM16ColourAppearanceModelForward(ColourAppearanceModelTest):
+class TestCAM16ColourAppearanceModelForward(ColourAppearanceModelTest,
+                                            TestCase):
     """
     Defines :mod:`colour.appearance.cam16` module units tests methods for
     *CAM16* colour appearance model forward implementation.

--- a/colour/appearance/tests/test_ciecam02.py
+++ b/colour/appearance/tests/test_ciecam02.py
@@ -6,8 +6,10 @@ Defines unit tests for :mod:`colour.appearance.ciecam02` module.
 
 from __future__ import division, unicode_literals
 
-import numpy as np
 from itertools import permutations
+from unittest import TestCase
+
+import numpy as np
 
 from colour.appearance import (
     CIECAM02_VIEWING_CONDITIONS, CIECAM02_InductionFactors,
@@ -29,7 +31,8 @@ __all__ = [
 ]
 
 
-class TestCIECAM02ColourAppearanceModelForward(ColourAppearanceModelTest):
+class TestCIECAM02ColourAppearanceModelForward(ColourAppearanceModelTest,
+                                               TestCase):
     """
     Defines :mod:`colour.appearance.ciecam02` module units tests methods for
     *CIECAM02* colour appearance model forward implementation.

--- a/colour/appearance/tests/test_hunt.py
+++ b/colour/appearance/tests/test_hunt.py
@@ -8,6 +8,7 @@ from __future__ import division, unicode_literals
 
 import numpy as np
 from itertools import permutations
+from unittest import TestCase
 
 from colour.appearance import (HUNT_VIEWING_CONDITIONS, Hunt_InductionFactors,
                                XYZ_to_Hunt)
@@ -24,7 +25,7 @@ __status__ = 'Production'
 __all__ = ['TestHuntColourAppearanceModel']
 
 
-class TestHuntColourAppearanceModel(ColourAppearanceModelTest):
+class TestHuntColourAppearanceModel(ColourAppearanceModelTest, TestCase):
     """
     Defines :mod:`colour.appearance.hunt` module unit tests methods for
     *Hunt* colour appearance model.

--- a/colour/appearance/tests/test_llab.py
+++ b/colour/appearance/tests/test_llab.py
@@ -13,7 +13,9 @@ try:
     from unittest import mock
 except ImportError:  # pragma: no cover
     import mock
+
 from itertools import permutations
+from unittest import TestCase
 
 from colour.appearance import (LLAB_VIEWING_CONDITIONS, LLAB_InductionFactors,
                                XYZ_to_LLAB, llab)
@@ -30,7 +32,7 @@ __status__ = 'Production'
 __all__ = ['TestLLABColourAppearanceModel']
 
 
-class TestLLABColourAppearanceModel(ColourAppearanceModelTest):
+class TestLLABColourAppearanceModel(ColourAppearanceModelTest, TestCase):
     """
     Defines :mod:`colour.appearance.llab` module unit tests methods for
     *LLAB(l:c)* colour appearance model.

--- a/colour/appearance/tests/test_nayatani95.py
+++ b/colour/appearance/tests/test_nayatani95.py
@@ -6,8 +6,10 @@ Defines unit tests for :mod:`colour.appearance.nayatani95` module.
 
 from __future__ import division, unicode_literals
 
-import numpy as np
 from itertools import permutations
+from unittest import TestCase
+
+import numpy as np
 
 from colour.appearance import XYZ_to_Nayatani95
 from colour.appearance.tests.common import ColourAppearanceModelTest
@@ -23,7 +25,7 @@ __status__ = 'Production'
 __all__ = ['TestNayatani95ColourAppearanceModel']
 
 
-class TestNayatani95ColourAppearanceModel(ColourAppearanceModelTest):
+class TestNayatani95ColourAppearanceModel(ColourAppearanceModelTest, TestCase):
     """
     Defines :mod:`colour.appearance.nayatani95` module unit tests methods for
     *Nayatani (1995)* colour appearance model.

--- a/colour/appearance/tests/test_rlab.py
+++ b/colour/appearance/tests/test_rlab.py
@@ -6,8 +6,10 @@ Defines unit tests for :mod:`colour.appearance.rlab` module.
 
 from __future__ import division, unicode_literals
 
-import numpy as np
 from itertools import permutations
+from unittest import TestCase
+
+import numpy as np
 
 from colour.appearance import (RLAB_D_FACTOR, RLAB_VIEWING_CONDITIONS,
                                XYZ_to_RLAB)
@@ -24,7 +26,7 @@ __status__ = 'Production'
 __all__ = ['TestRLABColourAppearanceModel']
 
 
-class TestRLABColourAppearanceModel(ColourAppearanceModelTest):
+class TestRLABColourAppearanceModel(ColourAppearanceModelTest, TestCase):
     """
     Defines :mod:`colour.appearance.rlab` module unit tests methods for
     *RLAB* colour appearance model.


### PR DESCRIPTION
Adds the `unittest.TestCase` as a base class to the CAM test to allow them to be run without `nose`.