### PR TITLE
PR: Fix "CCT_to_xy_McCamy1992" comment typo.

### DIFF
--- a/colour/temperature/mccamy1992.py
+++ b/colour/temperature/mccamy1992.py
@@ -98,8 +98,8 @@ def CCT_to_xy_McCamy1992(CCT, optimisation_kwargs=None, **kwargs):
     Warnings
     --------
     *McCamy (1992)* method for computing *CIE xy* chromaticity coordinates
-    from given correlated colour temperature is a bijective function and might
-    produce unexpected results. It is given for consistency with other
+    from given correlated colour temperature is not a bijective function and
+    might produce unexpected results. It is given for consistency with other
     correlated colour temperature computation methods but should be avoided
     for practical applications.The current implementation relies on
     optimization using :func:`scipy.optimize.minimize` definition and thus has


### PR DESCRIPTION
I believe the comment should say "*not* a bijective function", in order to match the usage warning later in the same file.