### PR TITLE
PR: Implement support for "ICtCp" matrix as given in "ITU-R BT.2100-2" for "HLG".

### DIFF
--- a/colour/models/rgb/ictcp.py
+++ b/colour/models/rgb/ictcp.py
@@ -14,6 +14,12 @@ References
 ----------
 -   :cite:`Dolby2016a` : Dolby. (2016). WHAT IS ICtCp? - INTRODUCTION.
     https://www.dolby.com/us/en/technologies/dolby-vision/ICtCp-white-paper.pdf
+-   :cite:`InternationalTelecommunicationUnion2018` : International
+    Telecommunication Union. (2018). Recommendation ITU-R BT.2100-2 - Image
+    parameter values for high dynamic range television for use in production
+    and international programme exchange.
+    https://www.itu.int/dms_pubrec/itu-r/rec/bt/\
+R-REC-BT.2100-2-201807-I!!PDF-E.pdf
 -   :cite:`Lu2016c` : Lu, T., Pu, F., Yin, P., Chen, T., Husak, W., Pytlarz,
     J., Atkins, R., Froehlich, J., & Su, G.-M. (2016). ITP Colour Space and Its
     Compression Performance for High Dynamic Range and Wide Colour Gamut Video
@@ -39,7 +45,9 @@ __status__ = 'Production'
 __all__ = [
     'MATRIX_ICTCP_RGB_TO_LMS', 'MATRIX_ICTCP_LMS_TO_RGB',
     'MATRIX_ICTCP_LMS_P_TO_ICTCP', 'MATRIX_ICTCP_ICTCP_TO_LMS_P',
-    'RGB_to_ICtCp', 'ICtCp_to_RGB', 'XYZ_to_ICtCp', 'ICtCp_to_XYZ'
+    'MATRIX_ICTCP_LMS_P_TO_ICTCP_HLG_BT2100_2',
+    'MATRIX_ICTCP_ICTCP_TO_LMS_P_HLG_BT2100_2', 'RGB_to_ICtCp', 'ICtCp_to_RGB',
+    'XYZ_to_ICtCp', 'ICtCp_to_XYZ'
 ]
 
 MATRIX_ICTCP_RGB_TO_LMS = np.array([
@@ -81,8 +89,29 @@ normalised cone responses matrix.
 MATRIX_ICTCP_ICTCP_TO_LMS_P : array_like, (3, 3)
 """
 
+MATRIX_ICTCP_LMS_P_TO_ICTCP_HLG_BT2100_2 = np.array([
+    [2048, 2048, 0],
+    [3625, -7465, 3840],
+    [9500, -9212, -288],
+]) / 4096
+"""
+:math:`LMS_p` *SMPTE ST 2084:2014* encoded normalised cone responses to
+:math:`IC_TC_P` colour encoding matrix as given in *ITU-R BT.2100-2*.
 
-def RGB_to_ICtCp(RGB, L_p=10000):
+MATRIX_ICTCP_LMS_P_TO_ICTCP_HLG_BT2100_2 : array_like, (3, 3)
+"""
+
+MATRIX_ICTCP_ICTCP_TO_LMS_P_HLG_BT2100_2 = np.linalg.inv(
+    MATRIX_ICTCP_LMS_P_TO_ICTCP_HLG_BT2100_2)
+"""
+:math:`IC_TC_P` colour encoding to :math:`LMS_p` *SMPTE ST 2084:2014* encoded
+normalised cone responses matrix as given in *ITU-R BT.2100-2*.
+
+MATRIX_ICTCP_ICTCP_TO_LMS_P_HLG_BT2100_2 : array_like, (3, 3)
+"""
+
+
+def RGB_to_ICtCp(RGB, method='Dolby 2016', L_p=10000):
     """
     Converts from *ITU-R BT.2020* colourspace to :math:`IC_TC_P` colour
     encoding.
@@ -91,6 +120,9 @@ def RGB_to_ICtCp(RGB, L_p=10000):
     ----------
     RGB : array_like
         *ITU-R BT.2020* colourspace array.
+    method : unicode, optional
+        **{'Dolby 2016', 'ITU-R BT.2100-2 HLG'}**,
+        Computation method.
     L_p : numeric, optional
         Display peak luminance :math:`cd/m^2` for *SMPTE ST 2084:2014*
         non-linear encoding. This parameter should stay at its default
@@ -116,6 +148,8 @@ def RGB_to_ICtCp(RGB, L_p=10000):
         scale transformations. The effective domain of *SMPTE ST 2084:2014*
         inverse electro-optical transfer function (EOTF / EOCF) is
         [0.0001, 10000].
+    -   The *ITU-R BT.2100-2 HLG* method uses a different :math:`LMS_p` encoded
+        normalised cone responses to :math:`IC_TC_P` matrix.
 
     +------------+-----------------------+------------------+
     | **Domain** | **Scale - Reference** | **Scale - 1**    |
@@ -142,21 +176,27 @@ def RGB_to_ICtCp(RGB, L_p=10000):
     >>> RGB = np.array([0.45620519, 0.03081071, 0.04091952])
     >>> RGB_to_ICtCp(RGB)  # doctest: +ELLIPSIS
     array([ 0.0735136...,  0.0047525...,  0.0935159...])
+    >>> RGB_to_ICtCp(RGB, method='ITU-R BT.2100-2 HLG')  # doctest: +ELLIPSIS
+    array([ 0.0735136...,  0.0026085...,  0.0495414...])
     """
 
     RGB = to_domain_1(RGB)
+
+    is_dolby_method = method.lower() == 'dolby 2016'
 
     LMS = vector_dot(MATRIX_ICTCP_RGB_TO_LMS, RGB)
 
     with domain_range_scale('ignore'):
         LMS_p = eotf_inverse_ST2084(LMS, L_p)
 
-    ICtCp = vector_dot(MATRIX_ICTCP_LMS_P_TO_ICTCP, LMS_p)
+    ICtCp = (vector_dot(MATRIX_ICTCP_LMS_P_TO_ICTCP, LMS_p)
+             if is_dolby_method else vector_dot(
+                 MATRIX_ICTCP_LMS_P_TO_ICTCP_HLG_BT2100_2, LMS_p))
 
     return from_range_1(ICtCp)
 
 
-def ICtCp_to_RGB(ICtCp, L_p=10000):
+def ICtCp_to_RGB(ICtCp, method='Dolby 2016', L_p=10000):
     """
     Converts from :math:`IC_TC_P` colour encoding to *ITU-R BT.2020*
     colourspace.
@@ -165,6 +205,9 @@ def ICtCp_to_RGB(ICtCp, L_p=10000):
     ----------
     ICtCp : array_like
         :math:`IC_TC_P` colour encoding array.
+    method : unicode, optional
+        **{'Dolby 2016', 'ITU-R BT.2100-2 HLG'}**,
+        Computation method.
     L_p : numeric, optional
         Display peak luminance :math:`cd/m^2` for *SMPTE ST 2084:2014*
         non-linear encoding. This parameter should stay at its default
@@ -188,6 +231,8 @@ def ICtCp_to_RGB(ICtCp, L_p=10000):
         transfer function, thus the domain and range values for the *Reference*
         and *1* scales are only indicative that the data is not affected by
         scale transformations.
+    -   The *ITU-R BT.2100-2 HLG* method uses a different :math:`IC_TC_P` to
+        :math:`LMS_p` encoded normalised cone responses matrix.
 
     +------------+-----------------------+------------------+
     | **Domain** | **Scale - Reference** | **Scale - 1**    |
@@ -214,11 +259,18 @@ def ICtCp_to_RGB(ICtCp, L_p=10000):
     >>> ICtCp = np.array([0.07351364, 0.00475253, 0.09351596])
     >>> ICtCp_to_RGB(ICtCp)  # doctest: +ELLIPSIS
     array([ 0.4562052...,  0.0308107...,  0.0409195...])
+    >>> ICtCp = np.array([0.07351364, 0.00260851, 0.04954147])
+    >>> ICtCp_to_RGB(ICtCp, method='ITU-R BT.2100-2 HLG')  # doctest: +ELLIPSIS
+    array([ 0.4562051...,  0.0308107...,  0.0409195...])
     """
 
     ICtCp = to_domain_1(ICtCp)
 
-    LMS_p = vector_dot(MATRIX_ICTCP_ICTCP_TO_LMS_P, ICtCp)
+    is_dolby_method = method.lower() == 'dolby 2016'
+
+    LMS_p = (vector_dot(MATRIX_ICTCP_ICTCP_TO_LMS_P, ICtCp)
+             if is_dolby_method else vector_dot(
+                 MATRIX_ICTCP_ICTCP_TO_LMS_P_HLG_BT2100_2, ICtCp))
 
     with domain_range_scale('ignore'):
         LMS = eotf_ST2084(LMS_p, L_p)
@@ -232,6 +284,7 @@ def XYZ_to_ICtCp(XYZ,
                  illuminant=CCS_ILLUMINANTS[
                      'CIE 1931 2 Degree Standard Observer']['D65'],
                  chromatic_adaptation_transform='CAT02',
+                 method='Dolby 2016',
                  L_p=10000):
     """
     Converts from *CIE XYZ* tristimulus values to :math:`IC_TC_P` colour
@@ -248,6 +301,9 @@ def XYZ_to_ICtCp(XYZ,
         'Fairchild', 'CMCCAT97', 'CMCCAT2000', 'CAT02 Brill 2008',
         'Bianco 2010', 'Bianco PC 2010'}**,
         *Chromatic adaptation* transform.
+    method : unicode, optional
+        **{'Dolby 2016', 'ITU-R BT.2100-2 HLG'}**,
+        Computation method.
     L_p : numeric, optional
         Display peak luminance :math:`cd/m^2` for *SMPTE ST 2084:2014*
         non-linear encoding. This parameter should stay at its default
@@ -273,6 +329,8 @@ def XYZ_to_ICtCp(XYZ,
         scale transformations. The effective domain of *SMPTE ST 2084:2014*
         inverse electro-optical transfer function (EOTF / EOCF) is
         [0.0001, 10000].
+    -   The *ITU-R BT.2100-2 HLG* method uses a different :math:`LMS_p` encoded
+        normalised cone responses to :math:`IC_TC_P` matrix.
 
     +------------+-----------------------+------------------+
     | **Domain** | **Scale - Reference** | **Scale - 1**    |
@@ -299,6 +357,8 @@ def XYZ_to_ICtCp(XYZ,
     >>> XYZ = np.array([0.20654008, 0.12197225, 0.05136952])
     >>> XYZ_to_ICtCp(XYZ)  # doctest: +ELLIPSIS
     array([ 0.0685809..., -0.0028384...,  0.0602098...])
+    >>> XYZ_to_ICtCp(XYZ, method='ITU-R BT.2100-2 HLG')  # doctest: +ELLIPSIS
+    array([ 0.0685809..., -0.0015547...,  0.0318973...])
     """
 
     BT2020 = RGB_COLOURSPACES['ITU-R BT.2020']
@@ -311,13 +371,14 @@ def XYZ_to_ICtCp(XYZ,
         chromatic_adaptation_transform,
     )
 
-    return RGB_to_ICtCp(RGB, L_p)
+    return RGB_to_ICtCp(RGB, method, L_p)
 
 
 def ICtCp_to_XYZ(ICtCp,
                  illuminant=CCS_ILLUMINANTS[
                      'CIE 1931 2 Degree Standard Observer']['D65'],
                  chromatic_adaptation_transform='CAT02',
+                 method='Dolby 2016',
                  L_p=10000):
     """
     Converts from :math:`IC_TC_P` colour encoding to *CIE XYZ* tristimulus
@@ -334,6 +395,9 @@ def ICtCp_to_XYZ(ICtCp,
         'Fairchild', 'CMCCAT97', 'CMCCAT2000', 'CAT02 Brill 2008',
         'Bianco 2010', 'Bianco PC 2010'}**,
         *Chromatic adaptation* transform.
+    method : unicode, optional
+        **{'Dolby 2016', 'ITU-R BT.2100-2 HLG'}**,
+        Computation method.
     L_p : numeric, optional
         Display peak luminance :math:`cd/m^2` for *SMPTE ST 2084:2014*
         non-linear encoding. This parameter should stay at its default
@@ -357,6 +421,8 @@ def ICtCp_to_XYZ(ICtCp,
         transfer function, thus the domain and range values for the *Reference*
         and *1* scales are only indicative that the data is not affected by
         scale transformations.
+    -   The *ITU-R BT.2100-2 HLG* method uses a different :math:`IC_TC_P` to
+        :math:`LMS_p` encoded normalised cone responses matrix.
 
     +------------+-----------------------+------------------+
     | **Domain** | **Scale - Reference** | **Scale - 1**    |
@@ -383,9 +449,12 @@ def ICtCp_to_XYZ(ICtCp,
     >>> ICtCp = np.array([0.06858097, -0.00283842, 0.06020983])
     >>> ICtCp_to_XYZ(ICtCp)  # doctest: +ELLIPSIS
     array([ 0.2065400...,  0.1219722...,  0.0513695...])
+    >>> ICtCp = np.array([0.06858097, -0.00155479, 0.03189734])
+    >>> ICtCp_to_XYZ(ICtCp, method='ITU-R BT.2100-2 HLG')  # doctest: +ELLIPSIS
+    array([ 0.2065401...,  0.1219722...,  0.0513695...])
     """
 
-    RGB = ICtCp_to_RGB(ICtCp, L_p)
+    RGB = ICtCp_to_RGB(ICtCp, method, L_p)
 
     BT2020 = RGB_COLOURSPACES['ITU-R BT.2020']
 

--- a/colour/models/rgb/ictcp.py
+++ b/colour/models/rgb/ictcp.py
@@ -121,7 +121,7 @@ def RGB_to_ICtCp(RGB, method='Dolby 2016', L_p=10000):
     RGB : array_like
         *ITU-R BT.2020* colourspace array.
     method : unicode, optional
-        **{'Dolby 2016', 'ITU-R BT.2100-2 HLG'}**,
+        **{'Dolby 2016', 'ITU-R BT.2100-2 HLG', 'ITU-R BT.2100-2 PQ'}**,
         Computation method.
     L_p : numeric, optional
         Display peak luminance :math:`cd/m^2` for *SMPTE ST 2084:2014*
@@ -150,6 +150,8 @@ def RGB_to_ICtCp(RGB, method='Dolby 2016', L_p=10000):
         [0.0001, 10000].
     -   The *ITU-R BT.2100-2 HLG* method uses a different :math:`LMS_p` encoded
         normalised cone responses to :math:`IC_TC_P` matrix.
+    -   The *ITU-R BT.2100-2 PQ* method is an alias for the *Dolby 2016*
+        method.
 
     +------------+-----------------------+------------------+
     | **Domain** | **Scale - Reference** | **Scale - 1**    |
@@ -182,7 +184,7 @@ def RGB_to_ICtCp(RGB, method='Dolby 2016', L_p=10000):
 
     RGB = to_domain_1(RGB)
 
-    is_dolby_method = method.lower() == 'dolby 2016'
+    is_dolby_method = method.lower() in ('dolby 2016', 'ITU-R BT.2100-2 PQ')
 
     LMS = vector_dot(MATRIX_ICTCP_RGB_TO_LMS, RGB)
 
@@ -206,7 +208,7 @@ def ICtCp_to_RGB(ICtCp, method='Dolby 2016', L_p=10000):
     ICtCp : array_like
         :math:`IC_TC_P` colour encoding array.
     method : unicode, optional
-        **{'Dolby 2016', 'ITU-R BT.2100-2 HLG'}**,
+        **{'Dolby 2016', 'ITU-R BT.2100-2 HLG', 'ITU-R BT.2100-2 PQ'}**,
         Computation method.
     L_p : numeric, optional
         Display peak luminance :math:`cd/m^2` for *SMPTE ST 2084:2014*
@@ -233,6 +235,8 @@ def ICtCp_to_RGB(ICtCp, method='Dolby 2016', L_p=10000):
         scale transformations.
     -   The *ITU-R BT.2100-2 HLG* method uses a different :math:`IC_TC_P` to
         :math:`LMS_p` encoded normalised cone responses matrix.
+    -   The *ITU-R BT.2100-2 PQ* method is an alias for the *Dolby 2016*
+        method.
 
     +------------+-----------------------+------------------+
     | **Domain** | **Scale - Reference** | **Scale - 1**    |
@@ -266,7 +270,7 @@ def ICtCp_to_RGB(ICtCp, method='Dolby 2016', L_p=10000):
 
     ICtCp = to_domain_1(ICtCp)
 
-    is_dolby_method = method.lower() == 'dolby 2016'
+    is_dolby_method = method.lower() in ('dolby 2016', 'ITU-R BT.2100-2 PQ')
 
     LMS_p = (vector_dot(MATRIX_ICTCP_ICTCP_TO_LMS_P, ICtCp)
              if is_dolby_method else vector_dot(
@@ -302,7 +306,7 @@ def XYZ_to_ICtCp(XYZ,
         'Bianco 2010', 'Bianco PC 2010'}**,
         *Chromatic adaptation* transform.
     method : unicode, optional
-        **{'Dolby 2016', 'ITU-R BT.2100-2 HLG'}**,
+        **{'Dolby 2016', 'ITU-R BT.2100-2 HLG', 'ITU-R BT.2100-2 PQ'}**,
         Computation method.
     L_p : numeric, optional
         Display peak luminance :math:`cd/m^2` for *SMPTE ST 2084:2014*
@@ -331,6 +335,8 @@ def XYZ_to_ICtCp(XYZ,
         [0.0001, 10000].
     -   The *ITU-R BT.2100-2 HLG* method uses a different :math:`LMS_p` encoded
         normalised cone responses to :math:`IC_TC_P` matrix.
+    -   The *ITU-R BT.2100-2 PQ* method is an alias for the *Dolby 2016*
+        method.
 
     +------------+-----------------------+------------------+
     | **Domain** | **Scale - Reference** | **Scale - 1**    |
@@ -396,7 +402,7 @@ def ICtCp_to_XYZ(ICtCp,
         'Bianco 2010', 'Bianco PC 2010'}**,
         *Chromatic adaptation* transform.
     method : unicode, optional
-        **{'Dolby 2016', 'ITU-R BT.2100-2 HLG'}**,
+        **{'Dolby 2016', 'ITU-R BT.2100-2 HLG', 'ITU-R BT.2100-2 PQ'}**,
         Computation method.
     L_p : numeric, optional
         Display peak luminance :math:`cd/m^2` for *SMPTE ST 2084:2014*
@@ -423,6 +429,8 @@ def ICtCp_to_XYZ(ICtCp,
         scale transformations.
     -   The *ITU-R BT.2100-2 HLG* method uses a different :math:`IC_TC_P` to
         :math:`LMS_p` encoded normalised cone responses matrix.
+    -   The *ITU-R BT.2100-2 PQ* method is an alias for the *Dolby 2016*
+        method.
 
     +------------+-----------------------+------------------+
     | **Domain** | **Scale - Reference** | **Scale - 1**    |

--- a/colour/models/rgb/tests/test_ictcp.py
+++ b/colour/models/rgb/tests/test_ictcp.py
@@ -41,12 +41,21 @@ class TestRGB_to_ICtCp(unittest.TestCase):
             decimal=7)
 
         np.testing.assert_almost_equal(
-            RGB_to_ICtCp(np.array([0.45620519, 0.03081071, 0.04091952]), 4000),
+            RGB_to_ICtCp(
+                np.array([0.45620519, 0.03081071, 0.04091952]),
+                method='ITU-R BT.2100-2 HLG'),
+            np.array([0.07351364, 0.00260851, 0.04954147]),
+            decimal=7)
+
+        np.testing.assert_almost_equal(
+            RGB_to_ICtCp(
+                np.array([0.45620519, 0.03081071, 0.04091952]), L_p=4000),
             np.array([0.10516931, 0.00514031, 0.12318730]),
             decimal=7)
 
         np.testing.assert_almost_equal(
-            RGB_to_ICtCp(np.array([0.45620519, 0.03081071, 0.04091952]), 1000),
+            RGB_to_ICtCp(
+                np.array([0.45620519, 0.03081071, 0.04091952]), L_p=1000),
             np.array([0.17079612, 0.00485580, 0.17431356]),
             decimal=7)
 
@@ -113,12 +122,21 @@ class TestICtCp_to_RGB(unittest.TestCase):
             decimal=7)
 
         np.testing.assert_almost_equal(
-            ICtCp_to_RGB(np.array([0.10516931, 0.00514031, 0.12318730]), 4000),
+            ICtCp_to_RGB(
+                np.array([0.07351364, 0.00260851, 0.04954147]),
+                method='ITU-R BT.2100-2 HLG'),
             np.array([0.45620519, 0.03081071, 0.04091952]),
             decimal=7)
 
         np.testing.assert_almost_equal(
-            ICtCp_to_RGB(np.array([0.17079612, 0.00485580, 0.17431356]), 1000),
+            ICtCp_to_RGB(
+                np.array([0.10516931, 0.00514031, 0.12318730]), L_p=4000),
+            np.array([0.45620519, 0.03081071, 0.04091952]),
+            decimal=7)
+
+        np.testing.assert_almost_equal(
+            ICtCp_to_RGB(
+                np.array([0.17079612, 0.00485580, 0.17431356]), L_p=1000),
             np.array([0.45620519, 0.03081071, 0.04091952]),
             decimal=7)
 
@@ -197,6 +215,13 @@ class TestXYZ_to_ICtCp(unittest.TestCase):
                 np.array([0.34570, 0.35850]),
                 chromatic_adaptation_transform='Bradford'),
             np.array([0.06783951, 0.00476111, 0.05523093]),
+            decimal=7)
+
+        np.testing.assert_almost_equal(
+            XYZ_to_ICtCp(
+                np.array([0.20654008, 0.12197225, 0.05136952]),
+                method='ITU-R BT.2100-2 HLG'),
+            np.array([0.06858097, -0.00155479, 0.03189734]),
             decimal=7)
 
         np.testing.assert_almost_equal(
@@ -285,6 +310,13 @@ class TestICtCp_to_XYZ(unittest.TestCase):
                 np.array([0.06783951, 0.00476111, 0.05523093]),
                 np.array([0.34570, 0.35850]),
                 chromatic_adaptation_transform='Bradford'),
+            np.array([0.20654008, 0.12197225, 0.05136952]),
+            decimal=7)
+
+        np.testing.assert_almost_equal(
+            ICtCp_to_XYZ(
+                np.array([0.06858097, -0.00155479, 0.03189734]),
+                method='ITU-R BT.2100-2 HLG'),
             np.array([0.20654008, 0.12197225, 0.05136952]),
             decimal=7)
 


### PR DESCRIPTION
This PR implements the *ICtCp* matrix as given in *ITU-R BT.2100-2* for *HLG*.

**ITU-R BT.2100-1**

![image](https://user-images.githubusercontent.com/99779/104837358-cc809c80-5918-11eb-8e71-a8de76e00b75.png)

**ITU-R BT.2100-2**

![image](https://user-images.githubusercontent.com/99779/104837323-a4913900-5918-11eb-8f3c-dd655647ddaf.png)


Thanks @Valzapod for the heads-up!