### PR TITLE
PR: Implement support for "Manhattan" distance computation.

### DIFF
--- a/colour/algebra/__init__.py
+++ b/colour/algebra/__init__.py
@@ -6,11 +6,11 @@ from .common import (is_spow_enabled, set_spow_enable, spow_enable, spow,
                      smoothstep_function)
 from .extrapolation import Extrapolator
 from .geometry import (
-    normalise_vector, euclidean_distance, extend_line_segment,
-    LineSegmentsIntersections_Specification, intersect_line_segments,
-    ellipse_coefficients_general_form, ellipse_coefficients_canonical_form,
-    point_at_angle_on_ellipse, ellipse_fitting_Halir1998,
-    ELLIPSE_FITTING_METHODS, ellipse_fitting)
+    normalise_vector, euclidean_distance, manhattan_distance,
+    extend_line_segment, LineSegmentsIntersections_Specification,
+    intersect_line_segments, ellipse_coefficients_general_form,
+    ellipse_coefficients_canonical_form, point_at_angle_on_ellipse,
+    ellipse_fitting_Halir1998, ELLIPSE_FITTING_METHODS, ellipse_fitting)
 from .interpolation import (
     kernel_nearest_neighbour, kernel_linear, kernel_sinc, kernel_lanczos,
     kernel_cardinal_spline, KernelInterpolator, NearestNeighbourInterpolator,
@@ -30,11 +30,11 @@ __all__ += [
 ]
 __all__ += ['Extrapolator']
 __all__ += [
-    'normalise_vector', 'euclidean_distance', 'extend_line_segment',
-    'LineSegmentsIntersections_Specification', 'intersect_line_segments',
-    'ellipse_coefficients_general_form', 'ellipse_coefficients_canonical_form',
-    'point_at_angle_on_ellipse', 'ellipse_fitting_Halir1998',
-    'ELLIPSE_FITTING_METHODS', 'ellipse_fitting'
+    'normalise_vector', 'euclidean_distance', 'manhattan_distance',
+    'extend_line_segment', 'LineSegmentsIntersections_Specification',
+    'intersect_line_segments', 'ellipse_coefficients_general_form',
+    'ellipse_coefficients_canonical_form', 'point_at_angle_on_ellipse',
+    'ellipse_fitting_Halir1998', 'ELLIPSE_FITTING_METHODS', 'ellipse_fitting'
 ]
 __all__ += [
     'kernel_nearest_neighbour', 'kernel_linear', 'kernel_sinc',

--- a/colour/algebra/geometry.py
+++ b/colour/algebra/geometry.py
@@ -7,6 +7,7 @@ Defines objects related to geometrical computations:
 
 -   :func:`colour.algebra.normalise_vector`
 -   :func:`colour.algebra.euclidean_distance`
+-   :func:`colour.algebra.manhattan_distance`
 -   :func:`colour.algebra.extend_line_segment`
 -   :func:`colour.algebra.intersect_line_segments`
 -   :func:`colour.algebra.ellipse_coefficients_general_form`
@@ -110,6 +111,37 @@ def euclidean_distance(a, b):
     """
 
     return np.linalg.norm(as_float_array(a) - as_float_array(b), axis=-1)
+
+
+def manhattan_distance(a, b):
+    """
+    Returns the *Manhattan* (or *City-Block*) distance between point arrays
+    :math:`a` and :math:`b`.
+
+    For a two-dimensional space, the metric is as follows: \
+    :math:`M_D = |x_a - x_b| + |y_a - y_b|`
+
+    Parameters
+    ----------
+    a : array_like
+        Point array :math:`a`.
+    b : array_like
+        Point array :math:`b`.
+
+    Returns
+    -------
+    numeric or ndarray
+        *Manhattan* distance.
+
+    Examples
+    --------
+    >>> a = np.array([100.00000000, 21.57210357, 272.22819350])
+    >>> b = np.array([100.00000000, 426.67945353, 72.39590835])
+    >>> manhattan_distance(a, b)  # doctest: +ELLIPSIS
+    604.9396351...
+    """
+
+    return np.sum(np.abs(as_float_array(a) - as_float_array(b)), axis=-1)
 
 
 def extend_line_segment(a, b, distance=1):

--- a/colour/algebra/geometry.py
+++ b/colour/algebra/geometry.py
@@ -83,8 +83,11 @@ def normalise_vector(a):
 
 def euclidean_distance(a, b):
     """
-    Returns the euclidean distance between point arrays :math:`a` and
+    Returns the *Euclidean* distance between point arrays :math:`a` and
     :math:`b`.
+
+    For a two-dimensional space, the metric is as follows: \
+    :math:`E_D = [(x_a - x_b)^2 + (y_a - y_b)^2]^^{1/2}`
 
     Parameters
     ----------
@@ -96,7 +99,7 @@ def euclidean_distance(a, b):
     Returns
     -------
     numeric or ndarray
-        Euclidean distance.
+        *Euclidean* distance.
 
     Examples
     --------

--- a/colour/algebra/tests/test_geometry.py
+++ b/colour/algebra/tests/test_geometry.py
@@ -8,10 +8,10 @@ import unittest
 from itertools import permutations
 
 from colour.algebra import (
-    normalise_vector, euclidean_distance, extend_line_segment,
-    intersect_line_segments, ellipse_coefficients_general_form,
-    ellipse_coefficients_canonical_form, point_at_angle_on_ellipse,
-    ellipse_fitting_Halir1998)
+    normalise_vector, euclidean_distance, manhattan_distance,
+    extend_line_segment, intersect_line_segments,
+    ellipse_coefficients_general_form, ellipse_coefficients_canonical_form,
+    point_at_angle_on_ellipse, ellipse_fitting_Halir1998)
 from colour.utilities import ignore_numpy_errors
 
 __author__ = 'Colour Developers'
@@ -22,8 +22,9 @@ __email__ = 'colour-developers@colour-science.org'
 __status__ = 'Production'
 
 __all__ = [
-    'TestNormaliseVector', 'TestEuclideanDistance', 'TestExtendLineSegment',
-    'TestIntersectLineSegments', 'TestEllipseCoefficientsCanonicalForm',
+    'TestNormaliseVector', 'TestEuclideanDistance', 'TestManhattanDistance',
+    'TestExtendLineSegment', 'TestIntersectLineSegments',
+    'TestEllipseCoefficientsCanonicalForm',
     'TestEllipseCoefficientsGeneralForm', 'TestPointAtAngleOnEllipse',
     'TestEllipseFittingHalir1998'
 ]
@@ -123,6 +124,75 @@ class TestEuclideanDistance(unittest.TestCase):
             a = np.array(case)
             b = np.array(case)
             euclidean_distance(a, b)
+
+
+class TestManhattanDistance(unittest.TestCase):
+    """
+    Defines :func:`colour.algebra.geometry.manhattan_distance` definition unit
+    tests methods.
+    """
+
+    def test_manhattan_distance(self):
+        """
+        Tests :func:`colour.algebra.geometry.manhattan_distance` definition.
+        """
+
+        self.assertAlmostEqual(
+            manhattan_distance(
+                np.array([100.00000000, 21.57210357, 272.22819350]),
+                np.array([100.00000000, 426.67945353, 72.39590835])),
+            604.93963510999993,
+            places=7)
+
+        self.assertAlmostEqual(
+            manhattan_distance(
+                np.array([100.00000000, 21.57210357, 272.22819350]),
+                np.array([100.00000000, 74.05216981, 276.45318193])),
+            56.705054670000052,
+            places=7)
+
+        self.assertAlmostEqual(
+            manhattan_distance(
+                np.array([100.00000000, 21.57210357, 272.22819350]),
+                np.array([100.00000000, 8.32281957, -73.58297716])),
+            359.06045465999995,
+            places=7)
+
+    def test_n_dimensional_manhattan_distance(self):
+        """
+        Tests :func:`colour.algebra.geometry.manhattan_distance` definition
+        n-dimensional arrays support.
+        """
+
+        a = np.array([100.00000000, 21.57210357, 272.22819350])
+        b = np.array([100.00000000, 426.67945353, 72.39590835])
+        distance = manhattan_distance(a, b)
+
+        a = np.tile(a, (6, 1))
+        b = np.tile(b, (6, 1))
+        distance = np.tile(distance, 6)
+        np.testing.assert_almost_equal(
+            manhattan_distance(a, b), distance, decimal=7)
+
+        a = np.reshape(a, (2, 3, 3))
+        b = np.reshape(b, (2, 3, 3))
+        distance = np.reshape(distance, (2, 3))
+        np.testing.assert_almost_equal(
+            manhattan_distance(a, b), distance, decimal=7)
+
+    @ignore_numpy_errors
+    def test_nan_manhattan_distance(self):
+        """
+        Tests :func:`colour.algebra.geometry.manhattan_distance` definition nan
+        support.
+        """
+
+        cases = [-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan]
+        cases = set(permutations(cases * 3, r=3))
+        for case in cases:
+            a = np.array(case)
+            b = np.array(case)
+            manhattan_distance(a, b)
 
 
 class TestExtendLineSegment(unittest.TestCase):

--- a/docs/colour.algebra.rst
+++ b/docs/colour.algebra.rst
@@ -95,6 +95,7 @@ Geometry
 
     normalise_vector
     euclidean_distance
+    manhattan_distance
     extend_line_segment
     intersect_line_segments
     ellipse_coefficients_general_form


### PR DESCRIPTION
This PR implements support for the *Manhattan* distance computation, i.e. `|xa - xb| + |ya - yb|`.

Given the simplicity and as it follows the same structure than `colour.algebra.euclidean_distance`, I will merge directly when tests pass.