### PR TITLE
PR: Implement support for "Huang et al. (2015)" Power-Functions.

### DIFF
--- a/colour/__init__.py
+++ b/colour/__init__.py
@@ -89,7 +89,8 @@ from .appearance import (
     VIEWING_CONDITIONS_HUNT, VIEWING_CONDITIONS_LLAB, VIEWING_CONDITIONS_RLAB,
     XYZ_to_ATD95, XYZ_to_CAM16, XYZ_to_CIECAM02, XYZ_to_Hunt, XYZ_to_LLAB,
     XYZ_to_Nayatani95, XYZ_to_RLAB)
-from .difference import DELTA_E_METHODS, delta_E
+from .difference import (DELTA_E_METHODS, delta_E, INDEX_STRESS_METHODS,
+                         index_stress)
 from .geometry import (PRIMITIVE_METHODS, primitive,
                        PRIMITIVE_VERTICES_METHODS, primitive_vertices)
 from .io import (LUT1D, LUT3x1D, LUT3D, LUTSequence, READ_IMAGE_METHODS,
@@ -240,7 +241,9 @@ __all__ += [
     'XYZ_to_CIECAM02', 'XYZ_to_Hunt', 'XYZ_to_LLAB', 'XYZ_to_Nayatani95',
     'XYZ_to_RLAB'
 ]
-__all__ += ['DELTA_E_METHODS', 'delta_E']
+__all__ += [
+    'DELTA_E_METHODS', 'delta_E', 'INDEX_STRESS_METHODS', 'index_stress'
+]
 __all__ += [
     'PRIMITIVE_METHODS', 'primitive', 'PRIMITIVE_VERTICES_METHODS',
     'primitive_vertices'

--- a/colour/difference/__init__.py
+++ b/colour/difference/__init__.py
@@ -38,6 +38,7 @@ from .cam16_ucs import delta_E_CAM16LCD, delta_E_CAM16SCD, delta_E_CAM16UCS
 from .delta_e import (JND_CIE1976, delta_E_CIE1976, delta_E_CIE1994,
                       delta_E_CIE2000, delta_E_CMC)
 from .din99 import delta_E_DIN99
+from .huang2015 import power_function_Huang2015
 from .stress import index_stress_Garcia2007, INDEX_STRESS_METHODS, index_stress
 
 __all__ = ['delta_E_CAM02LCD', 'delta_E_CAM02SCD', 'delta_E_CAM02UCS']
@@ -47,6 +48,7 @@ __all__ += [
     'delta_E_CMC'
 ]
 __all__ += ['delta_E_DIN99']
+__all__ += ['power_function_Huang2015']
 __all__ += ['index_stress_Garcia2007', 'INDEX_STRESS_METHODS', 'index_stress']
 
 DELTA_E_METHODS = CaseInsensitiveMapping({

--- a/colour/difference/__init__.py
+++ b/colour/difference/__init__.py
@@ -38,6 +38,7 @@ from .cam16_ucs import delta_E_CAM16LCD, delta_E_CAM16SCD, delta_E_CAM16UCS
 from .delta_e import (JND_CIE1976, delta_E_CIE1976, delta_E_CIE1994,
                       delta_E_CIE2000, delta_E_CMC)
 from .din99 import delta_E_DIN99
+from .stress import index_stress_Garcia2007, INDEX_STRESS_METHODS, index_stress
 
 __all__ = ['delta_E_CAM02LCD', 'delta_E_CAM02SCD', 'delta_E_CAM02UCS']
 __all__ += ['delta_E_CAM16LCD', 'delta_E_CAM16SCD', 'delta_E_CAM16UCS']
@@ -46,6 +47,7 @@ __all__ += [
     'delta_E_CMC'
 ]
 __all__ += ['delta_E_DIN99']
+__all__ += ['index_stress_Garcia2007', 'INDEX_STRESS_METHODS', 'index_stress']
 
 DELTA_E_METHODS = CaseInsensitiveMapping({
     'CIE 1976': delta_E_CIE1976,

--- a/colour/difference/huang2015.py
+++ b/colour/difference/huang2015.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+"""
+Huang et al. (2015) Power-Functions
+===================================
+
+Defines the *Huang, Cui, Melgosa, Sanchez-Maranon, Li, Luo and Liu (2015)*
+power-functions improving the performance of colour-difference formulas:
+
+-   :func:`colour.difference.power_function_Huang2015`
+
+References
+----------
+-   :cite:`Huang2015` : Huang, M., Cui, G., Melgosa, M., Sanchez-Maranon, M.,
+    Li, C., Luo, M. R., & Liu, H. (2015). Power functions improving the
+    performance of color-difference formulas. Optical Society of America,
+    23(1), 597-610. doi:10.1364/OE.23.000597
+-   :cite:`Li2017` : Li, C., Li, Z., Wang, Z., Xu, Y., Luo, M. R., Cui, G.,
+    Melgosa, M., Brill, M. H., & Pointer, M. (2017). Comprehensive color
+    solutions: CAM16, CAT16, and CAM16-UCS. Color Research & Application,
+    42(6), 703-718. doi:10.1002/col.22131
+"""
+
+import numpy as np
+
+from colour.utilities import CaseInsensitiveMapping, tsplit
+
+__author__ = 'Colour Developers'
+__copyright__ = 'Copyright (C) 2013-2021 - Colour Developers'
+__license__ = 'New BSD License - https://opensource.org/licenses/BSD-3-Clause'
+__maintainer__ = 'Colour Developers'
+__email__ = 'colour-developers@colour-science.org'
+__status__ = 'Production'
+
+__all__ = ['power_function_Huang2015']
+
+COEFFICIENTS_HUANG2015 = CaseInsensitiveMapping({
+    'CIE 1976': np.array([1.26, 0.55]),
+    'CIE 1994': np.array([1.41, 0.70]),
+    'CIE 2000': np.array([1.43, 0.70]),
+    'CMC': np.array([1.34, 0.66]),
+    'CAM02-LCD': np.array([1.00, 0.85]),
+    'CAM02-SCD': np.array([1.45, 0.75]),
+    'CAM02-UCS': np.array([1.30, 0.75]),
+    'CAM16-UCS': np.array([1.41, 0.63]),
+    'DIN99d': np.array([1.28, 0.74]),
+    'OSA': np.array([3.32, 0.62]),
+    'OSA-GP-Euclidean': np.array([1.52, 0.76]),
+    'ULAB': np.array([1.17, 0.69]),
+})
+COEFFICIENTS_HUANG2015.__doc__ = """
+*Huang et al. (2015)* power-functions coefficients.
+
+References
+----------
+:cite:`Huang2015`, :cite:`Li2017`
+
+COEFFICIENTS_HUANG2015 : CaseInsensitiveMapping
+    **{'CIE 1976', 'CIE 1994', 'CIE 2000', 'CMC', 'CAM02-LCD', 'CAM02-SCD',
+    'CAM16-UCS', 'DIN99d', 'OSA', 'OSA-GP-Euclidean', 'ULAB'}**
+
+Notes
+-----
+-   :cite:`Li2017` does not give the coefficients for the *CAM16-LCD* and
+    *CAM16-SCD* colourspaces. *Ronnie Luo* has been contacted to know if they
+    have been computed.
+
+Aliases:
+
+-   'cie1976': 'CIE 1976'
+-   'cie1994': 'CIE 1994'
+-   'cie2000': 'CIE 2000'
+"""
+COEFFICIENTS_HUANG2015['cie1976'] = COEFFICIENTS_HUANG2015['CIE 1976']
+COEFFICIENTS_HUANG2015['cie1994'] = COEFFICIENTS_HUANG2015['CIE 1994']
+COEFFICIENTS_HUANG2015['cie2000'] = COEFFICIENTS_HUANG2015['CIE 2000']
+
+
+def power_function_Huang2015(d_E, coefficients='CIE 2000'):
+    """
+    Improves the performance of the :math:`\\Delta E` value for given
+    coefficients using
+    *Huang, Cui, Melgosa, Sanchez-Maranon, Li, Luo and Liu (2015)*
+    power-function: :math:`d_E^'=a*d_E^b`.
+
+    Parameters
+    ----------
+    d_E : array_like
+        Computed colour difference array :math:`\\Delta E`.
+    coefficients : unicode, optional
+        **{'CIE 1976', 'CIE 1994', 'CIE 2000', 'CMC', 'CAM02-LCD', 'CAM02-SCD',
+        'CAM16-UCS', 'DIN99d', 'OSA', 'OSA-GP-Euclidean', 'ULAB'}**,
+        Coefficients for the power-function.
+
+    Returns
+    -------
+    numeric or ndarray
+        Improved math:`\\Delta E` value.
+
+    References
+    ----------
+    :cite:`Huang2015`, :cite:`Li2017`
+
+    Examples
+    --------
+    >>> d_E = np.array([2.0425, 2.8615, 3.4412])
+    >>> power_function_Huang2015(d_E)  # doctest: +ELLIPSIS
+    array([ 2.3574879...,  2.9850503...,  3.3965106...])
+    """
+
+    a, b = tsplit(COEFFICIENTS_HUANG2015[coefficients])
+
+    d_E_p = a * d_E ** b
+
+    return d_E_p

--- a/colour/difference/stress.py
+++ b/colour/difference/stress.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+"""
+Standardized Residual Sum of Squares (STRESS) Index
+===================================================
+
+Defines the *Kruskal's Standardized Residual Sum of Squares (:math:`STRESS`)*
+index:
+
+-   :func:`colour.index_stress_Garcia2007`: :math:`STRESS` index computation
+    according to *García, Huertas, Melgosa and Cui (2007)* method.
+-   :func:`colour.index_stress`: *Lightness* :math:`STRESS` index computation
+    according to given method.
+
+References
+----------
+-   :cite:`Garcia2007` : García, P. A., Huertas, R., Melgosa, M., & Cui, G.
+    (2007). Measurement of the relationship between perceived and computed
+    color differences. Journal of the Optical Society of America A, 24(7),
+    1823. doi:10.1364/JOSAA.24.001823
+"""
+
+import numpy as np
+
+from colour.utilities import CaseInsensitiveMapping
+
+__author__ = 'Colour Developers'
+__copyright__ = 'Copyright (C) 2013-2021 - Colour Developers'
+__license__ = 'New BSD License - https://opensource.org/licenses/BSD-3-Clause'
+__maintainer__ = 'Colour Developers'
+__email__ = 'colour-developers@colour-science.org'
+__status__ = 'Production'
+
+__all__ = ['index_stress_Garcia2007', 'INDEX_STRESS_METHODS', 'index_stress']
+
+
+def index_stress_Garcia2007(d_E, d_V):
+    """
+    Computes the
+    *Kruskal's Standardized Residual Sum of Squares (:math:`STRESS`)*
+    index according to *García, Huertas, Melgosa and Cui (2007)* method.
+
+    Parameters
+    ----------
+    d_E : array_like
+        Computed colour difference array :math:`\\Delta E`.
+    d_V : array_like
+        Computed colour difference array :math:`\\Delta V`.
+
+    Returns
+    -------
+    numeric or ndarray
+        :math:`STRESS` index.
+
+    References
+    ----------
+    :cite:`Garcia2007`
+
+    Examples
+    --------
+    >>> d_E = np.array([2.0425, 2.8615, 3.4412])
+    >>> d_V = np.array([1.2644, 1.2630, 1.8731])
+    >>> index_stress_Garcia2007(d_E, d_V)  # doctest: +ELLIPSIS
+    0.1211709...
+    """
+
+    F_1 = np.sum(d_E ** 2) / np.sum(d_E * d_V)
+
+    stress = np.sqrt(
+        np.sum((d_E - F_1 * d_V) ** 2) / np.sum(F_1 ** 2 * d_V ** 2))
+
+    return stress
+
+
+INDEX_STRESS_METHODS = CaseInsensitiveMapping({
+    'Garcia 2007': index_stress_Garcia2007,
+})
+INDEX_STRESS_METHODS.__doc__ = """
+Supported :math:`STRESS` index computation methods.
+
+References
+----------
+:cite:`Garcia2007`
+
+INDEX_STRESS_METHODS : CaseInsensitiveMapping
+    **{'Garcia 2007'}**
+"""
+
+
+def index_stress(d_E, d_V, method='Garcia 2007'):
+    """
+    Computes the
+    *Kruskal's Standardized Residual Sum of Squares (:math:`STRESS`)*
+    index according to given method.
+
+    Parameters
+    ----------
+    d_E : array_like
+        Computed colour difference array :math:`\\Delta E`.
+    d_V : array_like
+        Computed colour difference array :math:`\\Delta V`.
+    method : unicode, optional
+        **{'Garcia 2007'}**,
+        Computation method.
+
+    Returns
+    -------
+    numeric or ndarray
+        :math:`STRESS` index.
+
+    References
+    ----------
+    :cite:`Garcia2007`
+
+    Examples
+    --------
+    >>> d_E = np.array([2.0425, 2.8615, 3.4412])
+    >>> d_V = np.array([1.2644, 1.2630, 1.8731])
+    >>> index_stress(d_E, d_V)  # doctest: +ELLIPSIS
+    0.1211709...
+    """
+
+    function = INDEX_STRESS_METHODS[method]
+
+    return function(d_E, d_V)

--- a/colour/difference/tests/test_huang2015.py
+++ b/colour/difference/tests/test_huang2015.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+"""
+Defines unit tests for :mod:`colour.difference.huang2015` module.
+"""
+
+import numpy as np
+import unittest
+
+from colour.difference import power_function_Huang2015
+
+__author__ = 'Colour Developers'
+__copyright__ = 'Copyright (C) 2013-2021 - Colour Developers'
+__license__ = 'New BSD License - https://opensource.org/licenses/BSD-3-Clause'
+__maintainer__ = 'Colour Developers'
+__email__ = 'colour-developers@colour-science.org'
+__status__ = 'Production'
+
+__all__ = ['TestPowerFunctionHuang2015']
+
+
+class TestPowerFunctionHuang2015(unittest.TestCase):
+    """
+    Defines :func:`colour.difference.huang2015.power_function_Huang2015`
+    definition unit tests methods.
+    """
+
+    def test_power_function_Huang2015(self):
+        """
+        Tests :func:`colour.difference.huang2015.power_function_Huang2015`
+        definition.
+        """
+
+        d_E = np.array([2.0425, 2.8615, 3.4412])
+
+        np.testing.assert_almost_equal(
+            power_function_Huang2015(d_E),
+            np.array([2.35748796, 2.98505036, 3.39651062]),
+            decimal=7)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/colour/difference/tests/test_stress.py
+++ b/colour/difference/tests/test_stress.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+"""
+Defines unit tests for :mod:`colour.difference.stress` module.
+"""
+
+import numpy as np
+import unittest
+
+from colour.difference import index_stress
+
+__author__ = 'Colour Developers'
+__copyright__ = 'Copyright (C) 2013-2021 - Colour Developers'
+__license__ = 'New BSD License - https://opensource.org/licenses/BSD-3-Clause'
+__maintainer__ = 'Colour Developers'
+__email__ = 'colour-developers@colour-science.org'
+__status__ = 'Production'
+
+__all__ = ['TestIndexStress']
+
+
+class TestIndexStress(unittest.TestCase):
+    """
+    Defines :func:`colour.difference.stress.index_stress_Garcia2007` definition
+    unit tests methods.
+    """
+
+    def test_index_stress(self):
+        """
+        Tests :func:`colour.difference.stress.index_stress_Garcia2007`
+        definition.
+        """
+
+        d_E = np.array([2.0425, 2.8615, 3.4412])
+        d_V = np.array([1.2644, 1.2630, 1.8731])
+
+        self.assertAlmostEqual(
+            index_stress(d_E, d_V), 0.121170939369957, places=7)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/docs/colour.difference.rst
+++ b/docs/colour.difference.rst
@@ -104,3 +104,25 @@ DIN99
     :toctree: generated/
 
     delta_E_DIN99
+
+Standardized Residual Sum of Squares (STRESS) Index
+---------------------------------------------------
+
+``colour``
+
+.. currentmodule:: colour
+
+.. autosummary::
+    :toctree: generated/
+
+    index_stress
+    INDEX_STRESS_METHODS
+
+``colour.difference``
+
+.. currentmodule:: colour.difference
+
+.. autosummary::
+    :toctree: generated/
+
+    index_stress_Garcia2017

--- a/docs/colour.difference.rst
+++ b/docs/colour.difference.rst
@@ -126,3 +126,15 @@ Standardized Residual Sum of Squares (STRESS) Index
     :toctree: generated/
 
     index_stress_Garcia2017
+
+Huang et al. (2015) Power-Functions
+-----------------------------------
+
+``colour.difference``
+
+.. currentmodule:: colour.difference
+
+.. autosummary::
+    :toctree: generated/
+
+    power_function_Huang2015


### PR DESCRIPTION
Long time coming! This PR implements support for *Huang et al. (2015)* Power-Functions. They basically improve the colour difference formulas by applying a simple power-function on the computed delta_E value:

- `colour.difference.power_function_Huang2015`

![image](https://user-images.githubusercontent.com/99779/106728873-c6592280-6671-11eb-879e-45f8e90d5616.png)

I also took that opportunity to implement the STRESS index as given by García et al. (2007):

- `colour.index_stress`, maybe we should call it `stress_index` but it is consistent right now.
- `colour.INDEX_STRESS_METHODS`
- `colour.difference.index_stress_Garcia2017`

![image](https://user-images.githubusercontent.com/99779/106729023-f1437680-6671-11eb-9a79-366c818f802f.png)