### PR TITLE
PR: docs: Fix a few typos

### DIFF
--- a/colour/graph/conversion.py
+++ b/colour/graph/conversion.py
@@ -910,7 +910,7 @@ verbose={'mode': 'Long'})
             Thus, decoding and encoding using the sRGB electro-optical transfer
             function (EOTF) and its inverse will be applied by default.
         -   Most of the colour appearance models have defaults set according to
-            *IEC 61966-2-1:1999* viewing conditions, i.e. *sRGB* 64 Lux ambiant
+            *IEC 61966-2-1:1999* viewing conditions, i.e. *sRGB* 64 Lux ambient
             illumination, 80 :math:`cd/m^2`, adapting field luminance about
             20% of a white object in the scene.
 

--- a/colour/models/cam02_ucs.py
+++ b/colour/models/cam02_ucs.py
@@ -602,7 +602,7 @@ def XYZ_to_UCS_Luo2006(XYZ, coefficients, **kwargs):
         {:func:`colour.XYZ_to_CIECAM02`},
         Please refer to the documentation of the previously listed definition.
         The default viewing conditions are that of *IEC 61966-2-1:1999*, i.e.
-        *sRGB* 64 Lux ambiant illumination, 80 :math:`cd/m^2`, adapting field
+        *sRGB* 64 Lux ambient illumination, 80 :math:`cd/m^2`, adapting field
         luminance about 20% of a white object in the scene.
 
     Returns
@@ -683,7 +683,7 @@ def UCS_Luo2006_to_XYZ(Jpapbp, coefficients, **kwargs):
         {:func:`colour.CIECAM02_to_XYZ`},
         Please refer to the documentation of the previously listed definition.
         The default viewing conditions are that of *IEC 61966-2-1:1999*, i.e.
-        *sRGB* 64 Lux ambiant illumination, 80 :math:`cd/m^2`, adapting field
+        *sRGB* 64 Lux ambient illumination, 80 :math:`cd/m^2`, adapting field
         luminance about 20% of a white object in the scene.
 
     Returns
@@ -764,7 +764,7 @@ def XYZ_to_CAM02LCD(XYZ, **kwargs):
         {:func:`colour.XYZ_to_CIECAM02`},
         Please refer to the documentation of the previously listed definition.
         The default viewing conditions are that of *IEC 61966-2-1:1999*, i.e.
-        *sRGB* 64 Lux ambiant illumination, 80 :math:`cd/m^2`, adapting field
+        *sRGB* 64 Lux ambient illumination, 80 :math:`cd/m^2`, adapting field
         luminance about 20% of a white object in the scene.
 
     Returns
@@ -828,7 +828,7 @@ def CAM02LCD_to_XYZ(Jpapbp, **kwargs):
         {:func:`colour.CIECAM02_to_XYZ`},
         Please refer to the documentation of the previously listed definition.
         The default viewing conditions are that of *IEC 61966-2-1:1999*, i.e.
-        *sRGB* 64 Lux ambiant illumination, 80 :math:`cd/m^2`, adapting field
+        *sRGB* 64 Lux ambient illumination, 80 :math:`cd/m^2`, adapting field
         luminance about 20% of a white object in the scene.
 
     Returns
@@ -892,7 +892,7 @@ def XYZ_to_CAM02SCD(XYZ, **kwargs):
         {:func:`colour.XYZ_to_CIECAM02`},
         Please refer to the documentation of the previously listed definition.
         The default viewing conditions are that of *IEC 61966-2-1:1999*, i.e.
-        *sRGB* 64 Lux ambiant illumination, 80 :math:`cd/m^2`, adapting field
+        *sRGB* 64 Lux ambient illumination, 80 :math:`cd/m^2`, adapting field
         luminance about 20% of a white object in the scene.
 
     Returns
@@ -956,7 +956,7 @@ def CAM02SCD_to_XYZ(Jpapbp, **kwargs):
         {:func:`colour.CIECAM02_to_XYZ`},
         Please refer to the documentation of the previously listed definition.
         The default viewing conditions are that of *IEC 61966-2-1:1999*, i.e.
-        *sRGB* 64 Lux ambiant illumination, 80 :math:`cd/m^2`, adapting field
+        *sRGB* 64 Lux ambient illumination, 80 :math:`cd/m^2`, adapting field
         luminance about 20% of a white object in the scene.
 
     Returns
@@ -1020,7 +1020,7 @@ def XYZ_to_CAM02UCS(XYZ, **kwargs):
         {:func:`colour.XYZ_to_CIECAM02`},
         Please refer to the documentation of the previously listed definition.
         The default viewing conditions are that of *IEC 61966-2-1:1999*, i.e.
-        *sRGB* 64 Lux ambiant illumination, 80 :math:`cd/m^2`, adapting field
+        *sRGB* 64 Lux ambient illumination, 80 :math:`cd/m^2`, adapting field
         luminance about 20% of a white object in the scene.
 
     Returns
@@ -1084,7 +1084,7 @@ def CAM02UCS_to_XYZ(Jpapbp, **kwargs):
         {:func:`colour.CIECAM02_to_XYZ`},
         Please refer to the documentation of the previously listed definition.
         The default viewing conditions are that of *IEC 61966-2-1:1999*, i.e.
-        *sRGB* 64 Lux ambiant illumination, 80 :math:`cd/m^2`, adapting field
+        *sRGB* 64 Lux ambient illumination, 80 :math:`cd/m^2`, adapting field
         luminance about 20% of a white object in the scene.
 
     Returns

--- a/colour/models/cam16_ucs.py
+++ b/colour/models/cam16_ucs.py
@@ -150,7 +150,7 @@ def XYZ_to_UCS_Li2017(XYZ, coefficients, **kwargs):
         {:func:`colour.XYZ_to_CAM16`},
         Please refer to the documentation of the previously listed definition.
         The default viewing conditions are that of *IEC 61966-2-1:1999*, i.e.
-        *sRGB* 64 Lux ambiant illumination, 80 :math:`cd/m^2`, adapting field
+        *sRGB* 64 Lux ambient illumination, 80 :math:`cd/m^2`, adapting field
         luminance about 20% of a white object in the scene.
 
     Returns
@@ -232,7 +232,7 @@ def UCS_Li2017_to_XYZ(Jpapbp, coefficients, **kwargs):
         {:func:`colour.CAM16_to_XYZ`},
         Please refer to the documentation of the previously listed definition.
         The default viewing conditions are that of *IEC 61966-2-1:1999*, i.e.
-        *sRGB* 64 Lux ambiant illumination, 80 :math:`cd/m^2`, adapting field
+        *sRGB* 64 Lux ambient illumination, 80 :math:`cd/m^2`, adapting field
         luminance about 20% of a white object in the scene.
 
     Returns

--- a/colour/utilities/array.py
+++ b/colour/utilities/array.py
@@ -1065,7 +1065,7 @@ def index_along_last_axis(a, indexes):
         Array to be indexed.
     indexes : ndarray, (Ni...)
         Integer array with the same shape as `a` but with one dimension fewer,
-        containing indixes to the last dimension of `a`. All elements must be
+        containing indices to the last dimension of `a`. All elements must be
         numbers between `0` and `m` - 1.
 
     Returns


### PR DESCRIPTION
There are small typos in:
- colour/graph/conversion.py
- colour/models/cam02_ucs.py
- colour/models/cam16_ucs.py
- colour/utilities/array.py

Fixes:
- Should read `ambient` rather than `ambiant`.
- Should read `indices` rather than `indixes`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md