### PR TITLE
PR: Implement support for cache registry.

### DIFF
--- a/colour/__init__.py
+++ b/colour/__init__.py
@@ -431,3 +431,9 @@ if not is_documentation_building():
                                    build_API_changes(API_CHANGES))
 
     del ModuleAPI, is_documentation_building, build_API_changes, sys
+
+colour.__disable_lazy_load__ = True
+"""
+Ensures that the lazy loaded datasets are not transformed during import.
+See :class:`colour.utilities.LazyCaseInsensitiveMapping` for more information.
+"""

--- a/colour/blindness/machado2009.py
+++ b/colour/blindness/machado2009.py
@@ -95,6 +95,7 @@ def matrix_RGB_to_WSYBRG(cmfs, primaries):
     WSYBRG = vector_dot(MATRIX_LMS_TO_WSYBRG, cmfs.values)
     WS, YB, RG = tsplit(WSYBRG)
 
+    # pylint: disable=E1102
     primaries = reshape_msds(
         primaries,
         cmfs.shape,
@@ -278,6 +279,7 @@ def matrix_anomalous_trichromacy_Machado2009(cmfs, primaries, d_LMS):
     """
 
     if cmfs.shape.interval != 1:
+        # pylint: disable=E1102
         cmfs = reshape_msds(cmfs, SpectralShape(interval=1), 'Interpolate')
 
     M_n = matrix_RGB_to_WSYBRG(cmfs, primaries)

--- a/colour/blindness/machado2009.py
+++ b/colour/blindness/machado2009.py
@@ -31,7 +31,7 @@ import numpy as np
 
 from colour.algebra import matrix_dot, vector_dot
 from colour.blindness import CVD_MATRICES_MACHADO2010
-from colour.colorimetry import SpectralShape
+from colour.colorimetry import SpectralShape, reshape_msds
 from colour.utilities import tsplit, tstack, usage_warning
 
 __author__ = 'Colour Developers'
@@ -95,9 +95,14 @@ def matrix_RGB_to_WSYBRG(cmfs, primaries):
     WSYBRG = vector_dot(MATRIX_LMS_TO_WSYBRG, cmfs.values)
     WS, YB, RG = tsplit(WSYBRG)
 
-    extrapolator_kwargs = {'method': 'Constant', 'left': 0, 'right': 0}
-    primaries = primaries.copy().align(
-        cmfs.shape, extrapolator_kwargs=extrapolator_kwargs)
+    primaries = reshape_msds(
+        primaries,
+        cmfs.shape,
+        extrapolator_kwargs={
+            'method': 'Constant',
+            'left': 0,
+            'right': 0
+        })
 
     R, G, B = tsplit(primaries.values)
 
@@ -273,7 +278,7 @@ def matrix_anomalous_trichromacy_Machado2009(cmfs, primaries, d_LMS):
     """
 
     if cmfs.shape.interval != 1:
-        cmfs = cmfs.copy().interpolate(SpectralShape(interval=1))
+        cmfs = reshape_msds(cmfs, SpectralShape(interval=1), 'Interpolate')
 
     M_n = matrix_RGB_to_WSYBRG(cmfs, primaries)
     cmfs_a = msds_cmfs_anomalous_trichromacy_Machado2009(cmfs, d_LMS)

--- a/colour/characterisation/aces_it.py
+++ b/colour/characterisation/aces_it.py
@@ -537,6 +537,7 @@ def training_data_sds_to_RGB(training_data, sensitivities, illuminant):
     if training_data.shape != shape:
         runtime_warning('Aligning "{0}" training data shape to "{1}".'.format(
             training_data.name, shape))
+        # pylint: disable=E1102
         training_data = reshape_msds(training_data, shape)
 
     RGB_w = white_balance_multipliers(sensitivities, illuminant)
@@ -610,6 +611,7 @@ def training_data_sds_to_XYZ(training_data,
     if training_data.shape != shape:
         runtime_warning('Aligning "{0}" training data shape to "{1}".'.format(
             training_data.name, shape))
+        # pylint: disable=E1102
         training_data = reshape_msds(training_data, shape)
 
     XYZ = np.dot(
@@ -822,6 +824,7 @@ def matrix_idt(sensitivities,
         training_data = read_training_data_rawtoaces_v1()
 
     if cmfs is None:
+        # pylint: disable=E1102
         cmfs = reshape_msds(
             MSDS_CMFS_STANDARD_OBSERVER['CIE 1931 2 Degree Standard Observer'],
             SPECTRAL_SHAPE_RAWTOACES)
@@ -830,6 +833,7 @@ def matrix_idt(sensitivities,
     if sensitivities.shape != shape:
         runtime_warning('Aligning "{0}" sensitivities shape to "{1}".'.format(
             sensitivities.name, shape))
+        # pylint: disable=E1102
         sensitivities = reshape_msds(sensitivities, shape)
 
     if illuminant.shape != shape:
@@ -840,6 +844,7 @@ def matrix_idt(sensitivities,
     if training_data.shape != shape:
         runtime_warning('Aligning "{0}" training data shape to "{1}".'.format(
             training_data.name, shape))
+        # pylint: disable=E1102
         training_data = reshape_msds(training_data, shape)
 
     illuminant = normalise_illuminant(illuminant, sensitivities)

--- a/colour/characterisation/aces_it.py
+++ b/colour/characterisation/aces_it.py
@@ -56,8 +56,9 @@ from scipy.optimize import minimize
 from colour.adaptation import matrix_chromatic_adaptation_VonKries
 from colour.algebra import euclidean_distance, vector_dot
 from colour.colorimetry import (
-    MSDS_CMFS, SDS_ILLUMINANTS, SpectralShape, sds_and_msds_to_msds,
-    sd_CIE_illuminant_D_series, sd_blackbody, sd_to_XYZ)
+    MSDS_CMFS_STANDARD_OBSERVER, SDS_ILLUMINANTS, SpectralShape, reshape_msds,
+    reshape_sd, sds_and_msds_to_msds, sd_CIE_illuminant_D_series, sd_blackbody,
+    sd_to_XYZ)
 from colour.constants import DEFAULT_INT_DTYPE
 from colour.characterisation import MSDS_ACES_RICD
 from colour.io import read_sds_from_csv_file
@@ -66,8 +67,8 @@ from colour.models.rgb import (RGB_COLOURSPACE_ACES2065_1, RGB_to_XYZ,
                                XYZ_to_RGB, normalised_primary_matrix)
 from colour.temperature import CCT_to_xy_CIE_D
 from colour.utilities import (CaseInsensitiveMapping, as_float_array,
-                              from_range_1, runtime_warning, tsplit,
-                              suppress_warnings)
+                              from_range_1, runtime_warning, suppress_warnings,
+                              tsplit)
 
 __author__ = 'Colour Developers'
 __copyright__ = 'Copyright (C) 2013-2021 - Colour Developers'
@@ -104,7 +105,7 @@ S_FLARE_FACTOR : float
 
 def sd_to_aces_relative_exposure_values(
         sd,
-        illuminant=SDS_ILLUMINANTS['D65'],
+        illuminant=None,
         apply_chromatic_adaptation=False,
         chromatic_adaptation_transform='CAT02'):
     """
@@ -116,7 +117,8 @@ def sd_to_aces_relative_exposure_values(
     sd : SpectralDistribution
         Spectral distribution.
     illuminant : SpectralDistribution, optional
-        *Illuminant* spectral distribution.
+        *Illuminant* spectral distribution, default to
+        *CIE Standard Illuminant D65*.
     apply_chromatic_adaptation : bool, optional
         Whether to apply chromatic adaptation using given transform.
     chromatic_adaptation_transform : unicode, optional
@@ -162,12 +164,15 @@ def sd_to_aces_relative_exposure_values(
     array([ 0.1180779...,  0.0869031...,  0.0589125...])
     """
 
+    if illuminant is None:
+        illuminant = SDS_ILLUMINANTS['D65']
+
     shape = MSDS_ACES_RICD.shape
     if sd.shape != MSDS_ACES_RICD.shape:
-        sd = sd.copy().align(shape)
+        sd = reshape_sd(sd, shape)
 
     if illuminant.shape != MSDS_ACES_RICD.shape:
-        illuminant = illuminant.copy().align(shape)
+        illuminant = reshape_sd(illuminant, shape)
 
     s_v = sd.values
     i_v = illuminant.values
@@ -378,7 +383,7 @@ def white_balance_multipliers(sensitivities, illuminant):
     if illuminant.shape != shape:
         runtime_warning('Aligning "{0}" illuminant shape to "{1}".'.format(
             illuminant.name, shape))
-        illuminant = illuminant.copy().align(shape)
+        illuminant = reshape_sd(illuminant, shape)
 
     RGB_w = 1 / np.sum(
         sensitivities.values * illuminant.values[..., np.newaxis], axis=0)
@@ -473,7 +478,7 @@ def normalise_illuminant(illuminant, sensitivities):
     if illuminant.shape != shape:
         runtime_warning('Aligning "{0}" illuminant shape to "{1}".'.format(
             illuminant.name, shape))
-        illuminant = illuminant.copy().align(shape)
+        illuminant = reshape_sd(illuminant, shape)
 
     c_i = np.argmax(np.max(sensitivities.values, axis=0))
     k = 1 / np.sum(illuminant.values * sensitivities.values[..., c_i])
@@ -527,12 +532,12 @@ def training_data_sds_to_RGB(training_data, sensitivities, illuminant):
     if illuminant.shape != shape:
         runtime_warning('Aligning "{0}" illuminant shape to "{1}".'.format(
             illuminant.name, shape))
-        illuminant = illuminant.copy().align(shape)
+        illuminant = reshape_sd(illuminant, shape)
 
     if training_data.shape != shape:
         runtime_warning('Aligning "{0}" training data shape to "{1}".'.format(
             training_data.name, shape))
-        training_data = training_data.copy().align(shape)
+        training_data = reshape_msds(training_data, shape)
 
     RGB_w = white_balance_multipliers(sensitivities, illuminant)
 
@@ -579,7 +584,9 @@ def training_data_sds_to_XYZ(training_data,
     >>> path = os.path.join(
     ...     RESOURCES_DIRECTORY_RAWTOACES,
     ...     'CANON_EOS_5DMark_II_RGB_Sensitivities.csv')
-    >>> cmfs = MSDS_CMFS['CIE 1931 2 Degree Standard Observer']
+    >>> cmfs = (
+    ...     MSDS_CMFS_STANDARD_OBSERVER['CIE 1931 2 Degree Standard Observer']
+    ... )
     >>> sensitivities = sds_and_msds_to_msds(
     ...     read_sds_from_csv_file(path).values())
     >>> illuminant = normalise_illuminant(
@@ -598,12 +605,12 @@ def training_data_sds_to_XYZ(training_data,
     if illuminant.shape != shape:
         runtime_warning('Aligning "{0}" illuminant shape to "{1}".'.format(
             illuminant.name, shape))
-        illuminant = illuminant.copy().align(shape)
+        illuminant = reshape_sd(illuminant, shape)
 
     if training_data.shape != shape:
         runtime_warning('Aligning "{0}" training data shape to "{1}".'.format(
             training_data.name, shape))
-        training_data = training_data.copy().align(shape)
+        training_data = reshape_msds(training_data, shape)
 
     XYZ = np.dot(
         np.transpose(
@@ -724,8 +731,7 @@ def optimisation_factory_JzAzBz():
 def matrix_idt(sensitivities,
                illuminant,
                training_data=None,
-               cmfs=MSDS_CMFS['CIE 1931 2 Degree Standard Observer'].copy()
-               .align(SPECTRAL_SHAPE_RAWTOACES),
+               cmfs=None,
                optimisation_factory=optimisation_factory_rawtoaces_v1,
                optimisation_kwargs=None,
                chromatic_adaptation_transform='CAT02',
@@ -745,8 +751,9 @@ def matrix_idt(sensitivities,
     training_data : MultiSpectralDistributions, optional
         Training data multi-spectral distributions, defaults to using the
         *RAW to ACES* v1 190 patches.
-    cmfs : XYZ_ColourMatchingFunctions
-        Standard observer colour matching functions.
+    cmfs : XYZ_ColourMatchingFunctions, optional
+        Standard observer colour matching functions, default to the
+        *CIE 1931 2 Degree Standard Observer*.
     optimisation_factory : callable, optional
         Callable producing the objective function and the *CIE XYZ* to
         optimisation colour model function.
@@ -814,21 +821,26 @@ def matrix_idt(sensitivities,
     if training_data is None:
         training_data = read_training_data_rawtoaces_v1()
 
+    if cmfs is None:
+        cmfs = reshape_msds(
+            MSDS_CMFS_STANDARD_OBSERVER['CIE 1931 2 Degree Standard Observer'],
+            SPECTRAL_SHAPE_RAWTOACES)
+
     shape = cmfs.shape
     if sensitivities.shape != shape:
         runtime_warning('Aligning "{0}" sensitivities shape to "{1}".'.format(
             sensitivities.name, shape))
-        sensitivities = sensitivities.copy().align(shape)
+        sensitivities = reshape_msds(sensitivities, shape)
 
     if illuminant.shape != shape:
         runtime_warning('Aligning "{0}" illuminant shape to "{1}".'.format(
             illuminant.name, shape))
-        illuminant = illuminant.copy().align(shape)
+        illuminant = reshape_sd(illuminant, shape)
 
     if training_data.shape != shape:
         runtime_warning('Aligning "{0}" training data shape to "{1}".'.format(
             training_data.name, shape))
-        training_data = training_data.copy().align(shape)
+        training_data = reshape_msds(training_data, shape)
 
     illuminant = normalise_illuminant(illuminant, sensitivities)
 

--- a/colour/characterisation/datasets/cameras/__init__.py
+++ b/colour/characterisation/datasets/cameras/__init__.py
@@ -9,9 +9,9 @@ References
 """
 
 from .dslr import MSDS_CAMERA_SENSITIVITIES_DSLR
-from colour.utilities import CaseInsensitiveMapping
+from colour.utilities import LazyCaseInsensitiveMapping
 
-MSDS_CAMERA_SENSITIVITIES = CaseInsensitiveMapping(
+MSDS_CAMERA_SENSITIVITIES = LazyCaseInsensitiveMapping(
     MSDS_CAMERA_SENSITIVITIES_DSLR)
 MSDS_CAMERA_SENSITIVITIES.__doc__ = """
 Multi-spectral distributions of camera sensitivities.
@@ -20,7 +20,7 @@ References
 ----------
 :cite:`Darrodi2015a`
 
-MSDS_CAMERA_SENSITIVITIES : CaseInsensitiveMapping
+MSDS_CAMERA_SENSITIVITIES : LazyCaseInsensitiveMapping
     **{Nikon 5100 (NPL), Sigma SDMerill (NPL)}**
 """
 

--- a/colour/characterisation/datasets/cameras/dslr/sensitivities.py
+++ b/colour/characterisation/datasets/cameras/dslr/sensitivities.py
@@ -27,8 +27,10 @@ References
     doi:10.1364/JOSAA.32.000381
 """
 
+from functools import partial
+
 from colour.characterisation import RGB_CameraSensitivities
-from colour.utilities import CaseInsensitiveMapping
+from colour.utilities import LazyCaseInsensitiveMapping
 
 __author__ = 'Colour Developers'
 __copyright__ = 'Copyright (C) 2013-2021 - Colour Developers'
@@ -487,13 +489,15 @@ DATA_CAMERA_SENSITIVITIES_DSLR = {
     }
 }  # yapf: disable
 
-MSDS_CAMERA_SENSITIVITIES_DSLR = CaseInsensitiveMapping({
+MSDS_CAMERA_SENSITIVITIES_DSLR = LazyCaseInsensitiveMapping({
     'Nikon 5100 (NPL)':
-        RGB_CameraSensitivities(
+        partial(
+            RGB_CameraSensitivities,
             DATA_CAMERA_SENSITIVITIES_DSLR['Nikon 5100 (NPL)'],
             name='Nikon 5100 (NPL)'),
     'Sigma SDMerill (NPL)':
-        RGB_CameraSensitivities(
+        partial(
+            RGB_CameraSensitivities,
             DATA_CAMERA_SENSITIVITIES_DSLR['Sigma SDMerill (NPL)'],
             name='Sigma SDMerill (NPL)')
 })
@@ -504,6 +508,6 @@ References
 ----------
 :cite:`Darrodi2015a`
 
-MSDS_CAMERA_SENSITIVITIES_DSLR : CaseInsensitiveMapping
+MSDS_CAMERA_SENSITIVITIES_DSLR : LazyCaseInsensitiveMapping
     **{Nikon 5100 (NPL), Sigma SDMerill (NPL)}**
 """

--- a/colour/characterisation/datasets/colour_checkers/sds.py
+++ b/colour/characterisation/datasets/colour_checkers/sds.py
@@ -45,10 +45,11 @@ References
     engineering.
 """
 
-from colour.colorimetry import SpectralDistribution
-from colour.utilities import CaseInsensitiveMapping
-
 from collections import OrderedDict
+from functools import partial
+
+from colour.colorimetry import SpectralDistribution
+from colour.utilities import CaseInsensitiveMapping, LazyCaseInsensitiveMapping
 
 __author__ = 'Colour Developers'
 __copyright__ = 'Copyright (C) 2013-2021 - Colour Developers'
@@ -981,8 +982,8 @@ DATA_BABELCOLOR_AVERAGE = OrderedDict((
     }),
 ))
 
-SDS_BABELCOLOR_AVERAGE = OrderedDict(
-    (key, SpectralDistribution(value, name=key))
+SDS_BABELCOLOR_AVERAGE = LazyCaseInsensitiveMapping(
+    (key, partial(SpectralDistribution, value, name=key))
     for key, value in DATA_BABELCOLOR_AVERAGE.items())
 """
 Average data derived from measurements of 30 *ColorChecker Classic* charts.
@@ -2989,8 +2990,8 @@ DATA_COLORCHECKER_N_OHTA = OrderedDict((
     }),
 ))
 
-SDS_COLORCHECKER_N_OHTA = OrderedDict(
-    (key, SpectralDistribution(value, name=key))
+SDS_COLORCHECKER_N_OHTA = LazyCaseInsensitiveMapping(
+    (key, partial(SpectralDistribution, value, name=key))
     for key, value in DATA_COLORCHECKER_N_OHTA.items())
 """
 *ColorChecker Classic* data Measured by *Ohta (1997)*.

--- a/colour/characterisation/datasets/displays/__init__.py
+++ b/colour/characterisation/datasets/displays/__init__.py
@@ -14,9 +14,9 @@ context=article
 
 from .crt import MSDS_DISPLAY_PRIMARIES_CRT
 from .lcd import MSDS_DISPLAY_PRIMARIES_LCD
-from colour.utilities import CaseInsensitiveMapping
+from colour.utilities import LazyCaseInsensitiveMapping
 
-MSDS_DISPLAY_PRIMARIES = CaseInsensitiveMapping(MSDS_DISPLAY_PRIMARIES_CRT)
+MSDS_DISPLAY_PRIMARIES = LazyCaseInsensitiveMapping(MSDS_DISPLAY_PRIMARIES_CRT)
 MSDS_DISPLAY_PRIMARIES.update(MSDS_DISPLAY_PRIMARIES_LCD)
 MSDS_DISPLAY_PRIMARIES.__doc__ = """
 Primaries multi-spectral distributions of displays.
@@ -25,7 +25,7 @@ References
 ----------
 :cite:`Fairchild1998b`, :cite:`Machado2010a`
 
-MSDS_DISPLAY_PRIMARIES : CaseInsensitiveMapping
+MSDS_DISPLAY_PRIMARIES : LazyCaseInsensitiveMapping
     **{Apple Studio Display, Typical CRT Brainard 1997}**
 """
 

--- a/colour/characterisation/datasets/displays/crt/primaries.py
+++ b/colour/characterisation/datasets/displays/crt/primaries.py
@@ -26,8 +26,10 @@ References
     http://www.lume.ufrgs.br/handle/10183/26950
 """
 
+from functools import partial
+
 from colour.characterisation import RGB_DisplayPrimaries
-from colour.utilities import CaseInsensitiveMapping
+from colour.utilities import LazyCaseInsensitiveMapping
 
 __author__ = 'Colour Developers'
 __copyright__ = 'Copyright (C) 2013-2021 - Colour Developers'
@@ -124,9 +126,10 @@ DATA_DISPLAY_PRIMARIES_CRT = {
     }
 }
 
-MSDS_DISPLAY_PRIMARIES_CRT = CaseInsensitiveMapping({
+MSDS_DISPLAY_PRIMARIES_CRT = LazyCaseInsensitiveMapping({
     'Typical CRT Brainard 1997':
-        RGB_DisplayPrimaries(
+        partial(
+            RGB_DisplayPrimaries,
             DATA_DISPLAY_PRIMARIES_CRT['Typical CRT Brainard 1997'],
             name='Typical CRT Brainard 1997')
 })
@@ -137,6 +140,6 @@ References
 ----------
 :cite:`Machado2010a`
 
-MSDS_DISPLAY_PRIMARIES_CRT : CaseInsensitiveMapping
+MSDS_DISPLAY_PRIMARIES_CRT : LazyCaseInsensitiveMapping
     **{'Typical CRT Brainard 1997'}**
 """

--- a/colour/characterisation/datasets/displays/lcd/primaries.py
+++ b/colour/characterisation/datasets/displays/lcd/primaries.py
@@ -30,8 +30,10 @@ context=article
     http://www.lume.ufrgs.br/handle/10183/26950
 """
 
+from functools import partial
+
 from colour.characterisation import RGB_DisplayPrimaries
-from colour.utilities import CaseInsensitiveMapping
+from colour.utilities import LazyCaseInsensitiveMapping
 
 __author__ = 'Colour Developers'
 __copyright__ = 'Copyright (C) 2013-2021 - Colour Developers'
@@ -128,9 +130,10 @@ DATA_DISPLAY_PRIMARIES_LCD = {
     }
 }
 
-MSDS_DISPLAY_PRIMARIES_LCD = CaseInsensitiveMapping({
+MSDS_DISPLAY_PRIMARIES_LCD = LazyCaseInsensitiveMapping({
     'Apple Studio Display':
-        RGB_DisplayPrimaries(
+        partial(
+            RGB_DisplayPrimaries,
             DATA_DISPLAY_PRIMARIES_LCD['Apple Studio Display'],
             name='Apple Studio Display')
 })
@@ -141,6 +144,6 @@ References
 ----------
 :cite:`Fairchild1998b`, :cite:`Machado2010a`
 
-MSDS_DISPLAY_PRIMARIES_LCD : CaseInsensitiveMapping
+MSDS_DISPLAY_PRIMARIES_LCD : LazyCaseInsensitiveMapping
     **{'Apple Studio Display'}**
 """

--- a/colour/characterisation/datasets/filters/sds.py
+++ b/colour/characterisation/datasets/filters/sds.py
@@ -22,8 +22,10 @@ References
     daylight, incandescent tungsten and printer.
 """
 
+from functools import partial
+
 from colour.colorimetry import SpectralDistribution
-from colour.utilities import CaseInsensitiveMapping
+from colour.utilities import LazyCaseInsensitiveMapping
 
 __author__ = 'Colour Developers'
 __copyright__ = 'Copyright (C) 2013-2021 - Colour Developers'
@@ -61,10 +63,12 @@ DATA_FILTERS_ISO = {
     }
 }
 
-SDS_FILTERS_ISO = CaseInsensitiveMapping({
+SDS_FILTERS_ISO = LazyCaseInsensitiveMapping({
     'ISO 7589 Diffuser':
-        SpectralDistribution(
-            DATA_FILTERS_ISO['ISO 7589 Diffuser'], name='ISO 7589 Diffuser'),
+        partial(
+            SpectralDistribution,
+            DATA_FILTERS_ISO['ISO 7589 Diffuser'],
+            name='ISO 7589 Diffuser'),
 })
 SDS_FILTERS_ISO.__doc__ = """
 Spectral distributions of *ISO* filters.
@@ -76,7 +80,7 @@ References
 SDS_FILTERS_ISO : CaseInsensitiveMapping
 """
 
-SDS_FILTERS = CaseInsensitiveMapping(SDS_FILTERS_ISO)
+SDS_FILTERS = LazyCaseInsensitiveMapping(SDS_FILTERS_ISO)
 SDS_FILTERS.__doc__ = """
 Spectral distributions of filters.
 
@@ -84,5 +88,5 @@ References
 ----------
 :cite:`InternationalOrganizationforStandardization2002`
 
-SDS_FILTERS : CaseInsensitiveMapping
+SDS_FILTERS : LazyCaseInsensitiveMapping
 """

--- a/colour/characterisation/datasets/lenses/sds.py
+++ b/colour/characterisation/datasets/lenses/sds.py
@@ -22,8 +22,10 @@ References
     daylight, incandescent tungsten and printer.
 """
 
+from functools import partial
+
 from colour.colorimetry import SpectralDistribution
-from colour.utilities import CaseInsensitiveMapping
+from colour.utilities import LazyCaseInsensitiveMapping
 
 __author__ = 'Colour Developers'
 __copyright__ = 'Copyright (C) 2013-2021 - Colour Developers'
@@ -74,10 +76,12 @@ DATA_LENSES_ISO = {
     }
 }
 
-SDS_LENSES_ISO = CaseInsensitiveMapping({
+SDS_LENSES_ISO = LazyCaseInsensitiveMapping({
     'ISO Standard Lens':
-        SpectralDistribution(
-            DATA_LENSES_ISO['ISO Standard Lens'], name='ISO Standard Lens'),
+        partial(
+            SpectralDistribution,
+            DATA_LENSES_ISO['ISO Standard Lens'],
+            name='ISO Standard Lens'),
 })
 SDS_LENSES_ISO.__doc__ = """
 Spectral distributions of *ISO* lenses.
@@ -86,10 +90,10 @@ References
 ----------
 :cite:`InternationalOrganizationforStandardization2002`
 
-SDS_LENSES_ISO : CaseInsensitiveMapping
+SDS_LENSES_ISO : LazyCaseInsensitiveMapping
 """
 
-SDS_LENSES = CaseInsensitiveMapping(SDS_LENSES_ISO)
+SDS_LENSES = LazyCaseInsensitiveMapping(SDS_LENSES_ISO)
 SDS_LENSES.__doc__ = """
 Spectral distributions of lenses.
 
@@ -97,5 +101,5 @@ References
 ----------
 :cite:`InternationalOrganizationforStandardization2002`
 
-SDS_LENSES : CaseInsensitiveMapping
+SDS_LENSES : LazyCaseInsensitiveMapping
 """

--- a/colour/characterisation/tests/test_aces_it.py
+++ b/colour/characterisation/tests/test_aces_it.py
@@ -39,7 +39,7 @@ __all__ = [
     'TestCamera_RGB_to_ACES2065_1'
 ]
 
-_DEFAULT_MSDS_CMFS = 'CIE 1931 2 Degree Standard Observer'
+_MSDS_CMFS_DEFAULT = 'CIE 1931 2 Degree Standard Observer'
 
 MSDS_CANON_EOS_5DMARK_II = sds_and_msds_to_msds(
     read_sds_from_csv_file(
@@ -506,7 +506,7 @@ class TestTrainingDataSdsToXYZ(unittest.TestCase):
         np.testing.assert_almost_equal(
             training_data_sds_to_XYZ(
                 read_training_data_rawtoaces_v1(),
-                MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS],
+                MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT],
                 SDS_ILLUMINANTS['D55']),
             np.array([
                 [0.01743541, 0.01795040, 0.01961110],
@@ -707,7 +707,7 @@ class TestTrainingDataSdsToXYZ(unittest.TestCase):
 
         np.testing.assert_almost_equal(
             training_data_sds_to_XYZ(
-                training_data, MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS],
+                training_data, MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT],
                 SDS_ILLUMINANTS['D55']),
             np.array([
                 [0.11386016, 0.10184316, 0.06318332],
@@ -740,7 +740,7 @@ class TestTrainingDataSdsToXYZ(unittest.TestCase):
         np.testing.assert_almost_equal(
             training_data_sds_to_XYZ(
                 training_data,
-                MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS],
+                MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT],
                 SDS_ILLUMINANTS['D55'],
                 chromatic_adaptation_transform='Bradford'),
             np.array([

--- a/colour/characterisation/tests/test_aces_it.py
+++ b/colour/characterisation/tests/test_aces_it.py
@@ -888,6 +888,7 @@ class TestMatrixIdt(unittest.TestCase):
         training_data = sds_and_msds_to_msds(
             SDS_COLOURCHECKERS['BabelColor Average'].values())
 
+        # pylint: disable=E1102
         np.testing.assert_allclose(
             matrix_idt(
                 reshape_msds(MSDS_CAMERA_SENSITIVITIES['Nikon 5100 (NPL)'],

--- a/colour/characterisation/tests/test_aces_it.py
+++ b/colour/characterisation/tests/test_aces_it.py
@@ -15,7 +15,8 @@ from colour.characterisation import (
     training_data_sds_to_XYZ, optimisation_factory_rawtoaces_v1,
     optimisation_factory_JzAzBz, matrix_idt, camera_RGB_to_ACES2065_1)
 from colour.characterisation.aces_it import RESOURCES_DIRECTORY_RAWTOACES
-from colour.colorimetry import (MSDS_CMFS, SDS_ILLUMINANTS, SpectralShape,
+from colour.colorimetry import (MSDS_CMFS_STANDARD_OBSERVER, SDS_ILLUMINANTS,
+                                SpectralShape, reshape_msds,
                                 sds_and_msds_to_msds, sd_constant, sd_ones)
 from colour.io import read_sds_from_csv_file
 from colour.utilities import domain_range_scale
@@ -37,6 +38,8 @@ __all__ = [
     'TestOptimizationFactoryJzAzBz', 'TestMatrixIdt',
     'TestCamera_RGB_to_ACES2065_1'
 ]
+
+_DEFAULT_MSDS_CMFS = 'CIE 1931 2 Degree Standard Observer'
 
 MSDS_CANON_EOS_5DMARK_II = sds_and_msds_to_msds(
     read_sds_from_csv_file(
@@ -503,7 +506,7 @@ class TestTrainingDataSdsToXYZ(unittest.TestCase):
         np.testing.assert_almost_equal(
             training_data_sds_to_XYZ(
                 read_training_data_rawtoaces_v1(),
-                MSDS_CMFS['CIE 1931 2 Degree Standard Observer'],
+                MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS],
                 SDS_ILLUMINANTS['D55']),
             np.array([
                 [0.01743541, 0.01795040, 0.01961110],
@@ -704,8 +707,7 @@ class TestTrainingDataSdsToXYZ(unittest.TestCase):
 
         np.testing.assert_almost_equal(
             training_data_sds_to_XYZ(
-                training_data,
-                MSDS_CMFS['CIE 1931 2 Degree Standard Observer'],
+                training_data, MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS],
                 SDS_ILLUMINANTS['D55']),
             np.array([
                 [0.11386016, 0.10184316, 0.06318332],
@@ -738,7 +740,7 @@ class TestTrainingDataSdsToXYZ(unittest.TestCase):
         np.testing.assert_almost_equal(
             training_data_sds_to_XYZ(
                 training_data,
-                MSDS_CMFS['CIE 1931 2 Degree Standard Observer'],
+                MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS],
                 SDS_ILLUMINANTS['D55'],
                 chromatic_adaptation_transform='Bradford'),
             np.array([
@@ -888,8 +890,8 @@ class TestMatrixIdt(unittest.TestCase):
 
         np.testing.assert_allclose(
             matrix_idt(
-                MSDS_CAMERA_SENSITIVITIES['Nikon 5100 (NPL)'].copy().align(
-                    SpectralShape(400, 700, 10)),
+                reshape_msds(MSDS_CAMERA_SENSITIVITIES['Nikon 5100 (NPL)'],
+                             SpectralShape(400, 700, 10)),
                 SD_AMPAS_ISO7589_STUDIO_TUNGSTEN,
                 training_data=training_data)[0],
             np.array([

--- a/colour/colorimetry/__init__.py
+++ b/colour/colorimetry/__init__.py
@@ -2,7 +2,8 @@
 
 from .spectrum import (SpectralShape, SPECTRAL_SHAPE_DEFAULT,
                        SpectralDistribution, MultiSpectralDistributions,
-                       sds_and_msds_to_sds, sds_and_msds_to_msds)
+                       sds_and_msds_to_sds, sds_and_msds_to_msds, reshape_sd,
+                       reshape_msds)
 from .blackbody import sd_blackbody, blackbody_spectral_radiance, planck_law
 from .cmfs import (LMS_ConeFundamentals, RGB_ColourMatchingFunctions,
                    XYZ_ColourMatchingFunctions)
@@ -64,7 +65,8 @@ from .yellowness import (yellowness_ASTMD1925, yellowness_ASTME313_alternative,
 
 __all__ = [
     'SpectralShape', 'SPECTRAL_SHAPE_DEFAULT', 'SpectralDistribution',
-    'MultiSpectralDistributions', 'sds_and_msds_to_sds', 'sds_and_msds_to_msds'
+    'MultiSpectralDistributions', 'sds_and_msds_to_sds',
+    'sds_and_msds_to_msds', 'reshape_sd', 'reshape_msds'
 ]
 __all__ += ['sd_blackbody', 'blackbody_spectral_radiance', 'planck_law']
 __all__ += [

--- a/colour/colorimetry/datasets/cmfs.py
+++ b/colour/colorimetry/datasets/cmfs.py
@@ -62,10 +62,12 @@ References
     http://www.lume.ufrgs.br/handle/10183/26950
 """
 
+from functools import partial
+
 from colour.colorimetry import (LMS_ConeFundamentals,
                                 RGB_ColourMatchingFunctions,
                                 XYZ_ColourMatchingFunctions)
-from colour.utilities import CaseInsensitiveMapping
+from colour.utilities import LazyCaseInsensitiveMapping
 
 __author__ = 'Colour Developers'
 __copyright__ = 'Copyright (C) 2013-2021 - Colour Developers'
@@ -1053,19 +1055,22 @@ DATA_CMFS_LMS = {
     }
 }
 
-MSDS_CMFS_LMS = CaseInsensitiveMapping({
+MSDS_CMFS_LMS = LazyCaseInsensitiveMapping({
     'Stockman & Sharpe 2 Degree Cone Fundamentals':
-        LMS_ConeFundamentals(
+        partial(
+            LMS_ConeFundamentals,
             DATA_CMFS_LMS['Stockman & Sharpe 2 Degree Cone Fundamentals'],
             name='Stockman & Sharpe 2 Degree Cone Fundamentals',
             strict_name='Stockman & Sharpe 2$^\\circ$ Cone Fundamentals'),
     'Stockman & Sharpe 10 Degree Cone Fundamentals':
-        LMS_ConeFundamentals(
+        partial(
+            LMS_ConeFundamentals,
             DATA_CMFS_LMS['Stockman & Sharpe 10 Degree Cone Fundamentals'],
             name='Stockman & Sharpe 10 Degree Cone Fundamentals',
             strict_name='Stockman & Sharpe 10$^\\circ$ Cone Fundamentals'),
     'Smith & Pokorny 1975 Normal Trichromats':
-        LMS_ConeFundamentals(
+        partial(
+            LMS_ConeFundamentals,
             DATA_CMFS_LMS['Smith & Pokorny 1975 Normal Trichromats'],
             name='Smith & Pokorny 1975 Normal Trichromats',
             strict_name='Smith & Pokorny (1975) Normal Trichromats')
@@ -1077,7 +1082,7 @@ References
 ----------
 :cite:`CVRLu`, :cite:`Machado2010a`
 
-MSDS_CMFS_LMS : CaseInsensitiveMapping
+MSDS_CMFS_LMS : LazyCaseInsensitiveMapping
     {'Stockman & Sharpe 2 Degree Cone Fundamentals',
     'Stockman & Sharpe 10 Degree Cone Fundamentals',
     'Smith & Pokorny 1975 Normal Trichromats'}
@@ -1331,20 +1336,23 @@ DATA_CMFS_RGB = {
     }
 }
 
-MSDS_CMFS_RGB = CaseInsensitiveMapping({
+MSDS_CMFS_RGB = LazyCaseInsensitiveMapping({
     'Wright & Guild 1931 2 Degree RGB CMFs':
-        RGB_ColourMatchingFunctions(
+        partial(
+            RGB_ColourMatchingFunctions,
             DATA_CMFS_RGB['Wright & Guild 1931 2 Degree RGB CMFs'],
             name='Wright & Guild 1931 2 Degree RGB CMFs',
             strict_name='Wright & Guild (1931) 2$^\\circ$ RGB CMFs',
         ),
     'Stiles & Burch 1955 2 Degree RGB CMFs':
-        RGB_ColourMatchingFunctions(
+        partial(
+            RGB_ColourMatchingFunctions,
             DATA_CMFS_RGB['Stiles & Burch 1955 2 Degree RGB CMFs'],
             name='Stiles & Burch 1955 2 Degree RGB CMFs',
             strict_name='Stiles & Burch (1955) 2$^\\circ$ RGB CMFs'),
     'Stiles & Burch 1959 10 Degree RGB CMFs':
-        RGB_ColourMatchingFunctions(
+        partial(
+            RGB_ColourMatchingFunctions,
             DATA_CMFS_RGB['Stiles & Burch 1959 10 Degree RGB CMFs'],
             name='Stiles & Burch 1959 10 Degree RGB CMFs',
             strict_name='Stiles & Burch (1959) 10$^\\circ$ RGB CMFs')
@@ -1356,7 +1364,7 @@ References
 ----------
 :cite:`Broadbent2009a`, :cite:`CVRLt`, :cite:`CVRLw`
 
-MSDS_CMFS_RGB : CaseInsensitiveMapping
+MSDS_CMFS_RGB : LazyCaseInsensitiveMapping
     **{'Wright & Guild 1931 2 Degree RGB CMFs',
     'Stiles & Burch 1955 2 Degree RGB CMFs',
     'Stiles & Burch 1959 10 Degree RGB CMFs'}**
@@ -3197,25 +3205,29 @@ DATA_CMFS_STANDARD_OBSERVER = {
     }
 }
 
-MSDS_CMFS_STANDARD_OBSERVER = CaseInsensitiveMapping({
+MSDS_CMFS_STANDARD_OBSERVER = LazyCaseInsensitiveMapping({
     'CIE 1931 2 Degree Standard Observer':
-        XYZ_ColourMatchingFunctions(
+        partial(
+            XYZ_ColourMatchingFunctions,
             DATA_CMFS_STANDARD_OBSERVER['CIE 1931 2 Degree Standard Observer'],
             name='CIE 1931 2 Degree Standard Observer',
             strict_name='CIE 1931 2$^\\circ$ Standard Observer'),
     'CIE 1964 10 Degree Standard Observer':
-        XYZ_ColourMatchingFunctions(
+        partial(
+            XYZ_ColourMatchingFunctions,
             DATA_CMFS_STANDARD_OBSERVER[
                 'CIE 1964 10 Degree Standard Observer'],
             name='CIE 1964 10 Degree Standard Observer',
             strict_name='CIE 1964 10$^\\circ$ Standard Observer'),
     'CIE 2012 2 Degree Standard Observer':
-        XYZ_ColourMatchingFunctions(
+        partial(
+            XYZ_ColourMatchingFunctions,
             DATA_CMFS_STANDARD_OBSERVER['CIE 2012 2 Degree Standard Observer'],
             name='CIE 2012 2 Degree Standard Observer',
             strict_name='CIE 2012 2$^\\circ$ Standard Observer'),
     'CIE 2012 10 Degree Standard Observer':
-        XYZ_ColourMatchingFunctions(
+        partial(
+            XYZ_ColourMatchingFunctions,
             DATA_CMFS_STANDARD_OBSERVER[
                 'CIE 2012 10 Degree Standard Observer'],
             name='CIE 2012 10 Degree Standard Observer',
@@ -3229,7 +3241,7 @@ References
 ----------
 :cite:`CVRLr`, :cite:`CVRLs`
 
-MSDS_CMFS_STANDARD_OBSERVER : CaseInsensitiveMapping
+MSDS_CMFS_STANDARD_OBSERVER : LazyCaseInsensitiveMapping
     **{'CIE 1931 2 Degree Standard Observer',
     'CIE 1964 10 Degree Standard Observer',
     'CIE 2012 2 Degree Standard Observer',
@@ -3245,7 +3257,7 @@ MSDS_CMFS_STANDARD_OBSERVER['cie_2_1931'] = (
 MSDS_CMFS_STANDARD_OBSERVER['cie_10_1964'] = (
     MSDS_CMFS_STANDARD_OBSERVER['CIE 1964 10 Degree Standard Observer'])
 
-MSDS_CMFS = CaseInsensitiveMapping(MSDS_CMFS_LMS)
+MSDS_CMFS = LazyCaseInsensitiveMapping(MSDS_CMFS_LMS)
 MSDS_CMFS.__doc__ = """
 Multi-spectral distributions of the colour matching functions.
 
@@ -3254,7 +3266,7 @@ References
 :cite:`Broadbent2009a`, :cite:`CVRLr`, :cite:`CVRLs`, :cite:`CVRLt`,
 :cite:`CVRLu`, :cite:`CVRLw`, :cite:`Machado2010a`
 
-MSDS_CMFS : CaseInsensitiveMapping
+MSDS_CMFS : LazyCaseInsensitiveMapping
     **{'Stockman & Sharpe 10 Degree Cone Fundamentals',
     'Stockman & Sharpe 2 Degree Cone Fundamentals',
     'Wright & Guild 1931 2 Degree RGB CMFs',

--- a/colour/colorimetry/datasets/illuminants/sds.py
+++ b/colour/colorimetry/datasets/illuminants/sds.py
@@ -57,9 +57,11 @@ References
     daylight, incandescent tungsten and printer.
 """
 
+from functools import partial
+
 from colour.algebra import LinearInterpolator
 from colour.colorimetry.spectrum import SpectralDistribution
-from colour.utilities import CaseInsensitiveMapping
+from colour.utilities import LazyCaseInsensitiveMapping
 
 __author__ = 'Colour Developers'
 __copyright__ = 'Copyright (C) 2013-2021 - Colour Developers'
@@ -4574,113 +4576,11 @@ DATA_ILLUMINANTS_CIE = {
     }
 }
 
-SDS_ILLUMINANTS_CIE = CaseInsensitiveMapping({
-    'A':
-        SpectralDistribution(DATA_ILLUMINANTS_CIE['A'], name='A'),
-    'B':
-        SpectralDistribution(DATA_ILLUMINANTS_CIE['B'], name='B'),
-    'C':
-        SpectralDistribution(DATA_ILLUMINANTS_CIE['C'], name='C'),
-    'D50':
-        SpectralDistribution(DATA_ILLUMINANTS_CIE['D50'], name='D50'),
-    'D55':
-        SpectralDistribution(DATA_ILLUMINANTS_CIE['D55'], name='D55'),
-    'D60':
-        SpectralDistribution(DATA_ILLUMINANTS_CIE['D60'], name='D60'),
-    'D65':
-        SpectralDistribution(DATA_ILLUMINANTS_CIE['D65'], name='D65'),
-    'D75':
-        SpectralDistribution(DATA_ILLUMINANTS_CIE['D75'], name='D75'),
-    'E':
-        SpectralDistribution(DATA_ILLUMINANTS_CIE['E'], name='E'),
-    'FL1':
-        SpectralDistribution(DATA_ILLUMINANTS_CIE['FL1'], name='FL1'),
-    'FL2':
-        SpectralDistribution(DATA_ILLUMINANTS_CIE['FL2'], name='FL2'),
-    'FL3':
-        SpectralDistribution(DATA_ILLUMINANTS_CIE['FL3'], name='FL3'),
-    'FL4':
-        SpectralDistribution(DATA_ILLUMINANTS_CIE['FL4'], name='FL4'),
-    'FL5':
-        SpectralDistribution(DATA_ILLUMINANTS_CIE['FL5'], name='FL5'),
-    'FL6':
-        SpectralDistribution(DATA_ILLUMINANTS_CIE['FL6'], name='FL6'),
-    'FL7':
-        SpectralDistribution(DATA_ILLUMINANTS_CIE['FL7'], name='FL7'),
-    'FL8':
-        SpectralDistribution(DATA_ILLUMINANTS_CIE['FL8'], name='FL8'),
-    'FL9':
-        SpectralDistribution(DATA_ILLUMINANTS_CIE['FL9'], name='FL9'),
-    'FL10':
-        SpectralDistribution(DATA_ILLUMINANTS_CIE['FL10'], name='FL10'),
-    'FL11':
-        SpectralDistribution(DATA_ILLUMINANTS_CIE['FL11'], name='FL11'),
-    'FL12':
-        SpectralDistribution(DATA_ILLUMINANTS_CIE['FL12'], name='FL12'),
-    'FL3.1':
-        SpectralDistribution(DATA_ILLUMINANTS_CIE['FL3.1'], name='FL3.1'),
-    'FL3.2':
-        SpectralDistribution(DATA_ILLUMINANTS_CIE['FL3.2'], name='FL3.2'),
-    'FL3.3':
-        SpectralDistribution(DATA_ILLUMINANTS_CIE['FL3.3'], name='FL3.3'),
-    'FL3.4':
-        SpectralDistribution(DATA_ILLUMINANTS_CIE['FL3.4'], name='FL3.4'),
-    'FL3.5':
-        SpectralDistribution(DATA_ILLUMINANTS_CIE['FL3.5'], name='FL3.5'),
-    'FL3.6':
-        SpectralDistribution(DATA_ILLUMINANTS_CIE['FL3.6'], name='FL3.6'),
-    'FL3.7':
-        SpectralDistribution(DATA_ILLUMINANTS_CIE['FL3.7'], name='FL3.7'),
-    'FL3.8':
-        SpectralDistribution(DATA_ILLUMINANTS_CIE['FL3.8'], name='FL3.8'),
-    'FL3.9':
-        SpectralDistribution(DATA_ILLUMINANTS_CIE['FL3.9'], name='FL3.9'),
-    'FL3.10':
-        SpectralDistribution(DATA_ILLUMINANTS_CIE['FL3.10'], name='FL3.10'),
-    'FL3.11':
-        SpectralDistribution(DATA_ILLUMINANTS_CIE['FL3.11'], name='FL3.11'),
-    'FL3.12':
-        SpectralDistribution(DATA_ILLUMINANTS_CIE['FL3.12'], name='FL3.12'),
-    'FL3.13':
-        SpectralDistribution(DATA_ILLUMINANTS_CIE['FL3.13'], name='FL3.13'),
-    'FL3.14':
-        SpectralDistribution(DATA_ILLUMINANTS_CIE['FL3.14'], name='FL3.14'),
-    'FL3.15':
-        SpectralDistribution(DATA_ILLUMINANTS_CIE['FL3.15'], name='FL3.15'),
-    'HP1':
-        SpectralDistribution(DATA_ILLUMINANTS_CIE['HP1'], name='HP1'),
-    'HP2':
-        SpectralDistribution(DATA_ILLUMINANTS_CIE['HP2'], name='HP2'),
-    'HP3':
-        SpectralDistribution(DATA_ILLUMINANTS_CIE['HP3'], name='HP3'),
-    'HP4':
-        SpectralDistribution(DATA_ILLUMINANTS_CIE['HP4'], name='HP4'),
-    'HP5':
-        SpectralDistribution(DATA_ILLUMINANTS_CIE['HP5'], name='HP5'),
-    'LED-B1':
-        SpectralDistribution(DATA_ILLUMINANTS_CIE['LED-B1'], name='LED-B1'),
-    'LED-B2':
-        SpectralDistribution(DATA_ILLUMINANTS_CIE['LED-B2'], name='LED-B2'),
-    'LED-B3':
-        SpectralDistribution(DATA_ILLUMINANTS_CIE['LED-B3'], name='LED-B3'),
-    'LED-B4':
-        SpectralDistribution(DATA_ILLUMINANTS_CIE['LED-B4'], name='LED-B4'),
-    'LED-B5':
-        SpectralDistribution(DATA_ILLUMINANTS_CIE['LED-B5'], name='LED-B5'),
-    'LED-BH1':
-        SpectralDistribution(DATA_ILLUMINANTS_CIE['LED-BH1'], name='LED-BH1'),
-    'LED-RGB1':
-        SpectralDistribution(
-            DATA_ILLUMINANTS_CIE['LED-RGB1'], name='LED-RGB1'),
-    'LED-V1':
-        SpectralDistribution(DATA_ILLUMINANTS_CIE['LED-V1'], name='LED-V1'),
-    'LED-V2':
-        SpectralDistribution(DATA_ILLUMINANTS_CIE['LED-V2'], name='LED-V2'),
-    'ID65':
-        SpectralDistribution(DATA_ILLUMINANTS_CIE['ID65'], name='ID65'),
-    'ID50':
-        SpectralDistribution(DATA_ILLUMINANTS_CIE['ID50'], name='ID50'),
-})
+SDS_ILLUMINANTS_CIE = LazyCaseInsensitiveMapping((
+    key,
+    partial(
+        SpectralDistribution, value, name=key, interpolator=LinearInterpolator)
+) for key, value in DATA_ILLUMINANTS_CIE.items())
 SDS_ILLUMINANTS_CIE.__doc__ = """
 Spectral distributions of the *CIE* illuminants.
 
@@ -4699,7 +4599,7 @@ References
 ----------
 :cite:`Carter2018`, :cite:`CIEce`, :cite:`CIEcf`
 
-SDS_ILLUMINANTS_CIE : CaseInsensitiveMapping
+SDS_ILLUMINANTS_CIE : LazyCaseInsensitiveMapping
 """
 
 DATA_ILLUMINANTS_ISO = {
@@ -4951,36 +4851,11 @@ DATA_ILLUMINANTS_ISO = {
     }
 }
 
-SDS_ILLUMINANTS_ISO = CaseInsensitiveMapping({
-    'ISO 7589 Photographic Daylight':
-        SpectralDistribution(
-            DATA_ILLUMINANTS_ISO['ISO 7589 Photographic Daylight'],
-            name='ISO 7589 Photographic Daylight'),
-    'ISO 7589 Sensitometric Daylight':
-        SpectralDistribution(
-            DATA_ILLUMINANTS_ISO['ISO 7589 Sensitometric Daylight'],
-            name='ISO 7589 Sensitometric Daylight'),
-    'ISO 7589 Studio Tungsten':
-        SpectralDistribution(
-            DATA_ILLUMINANTS_ISO['ISO 7589 Studio Tungsten'],
-            name='ISO 7589 Studio Tungsten'),
-    'ISO 7589 Sensitometric Studio Tungsten':
-        SpectralDistribution(
-            DATA_ILLUMINANTS_ISO['ISO 7589 Sensitometric Studio Tungsten'],
-            name='ISO 7589 Sensitometric Studio Tungsten'),
-    'ISO 7589 Photoflood':
-        SpectralDistribution(
-            DATA_ILLUMINANTS_ISO['ISO 7589 Photoflood'],
-            name='ISO 7589 Photoflood'),
-    'ISO 7589 Sensitometric Photoflood':
-        SpectralDistribution(
-            DATA_ILLUMINANTS_ISO['ISO 7589 Sensitometric Photoflood'],
-            name='ISO 7589 Sensitometric Photoflood'),
-    'ISO 7589 Sensitometric Printer':
-        SpectralDistribution(
-            DATA_ILLUMINANTS_ISO['ISO 7589 Sensitometric Printer'],
-            name='ISO 7589 Sensitometric Printer'),
-})
+SDS_ILLUMINANTS_ISO = LazyCaseInsensitiveMapping((
+    key,
+    partial(
+        SpectralDistribution, value, name=key, interpolator=LinearInterpolator)
+) for key, value in DATA_ILLUMINANTS_ISO.items())
 SDS_ILLUMINANTS_ISO.__doc__ = """
 Spectral distributions of the *ISO* illuminants.
 
@@ -5005,25 +4880,25 @@ References
 ----------
 :cite:`InternationalOrganizationforStandardization2002`
 
-SDS_ILLUMINANTS_ISO : CaseInsensitiveMapping
+SDS_ILLUMINANTS_ISO : LazyCaseInsensitiveMapping
 """
 
-SDS_ILLUMINANTS = CaseInsensitiveMapping(SDS_ILLUMINANTS_CIE)
+SDS_ILLUMINANTS = LazyCaseInsensitiveMapping(SDS_ILLUMINANTS_CIE)
 SDS_ILLUMINANTS.__doc__ = """
 Spectral distributions of the illuminants.
+
+Notes
+-----
+-   *CIE 15:2004* recommends using linear interpolation for
+    *CIE Standard Illuminant D Series*, for consistency all the illuminants are
+    using a linear interpolator.
 
 References
 ----------
 :cite:`Carter2018`, :cite:`CIEce`, :cite:`CIEcf`,
 :cite:`InternationalOrganizationforStandardization2002`
 
-SDS_ILLUMINANTS : CaseInsensitiveMapping
+SDS_ILLUMINANTS : LazyCaseInsensitiveMapping
 """
 
 SDS_ILLUMINANTS.update(SDS_ILLUMINANTS_ISO)
-
-# *CIE 15:2004* recommends using linear interpolation for
-# *CIE Standard Illuminant D Series*, for consistency all the illuminants are
-# using a linear interpolator.
-for _sd in SDS_ILLUMINANTS.values():
-    _sd.interpolator = LinearInterpolator

--- a/colour/colorimetry/datasets/illuminants/sds_d_illuminant_series.py
+++ b/colour/colorimetry/datasets/illuminants/sds_d_illuminant_series.py
@@ -18,8 +18,10 @@ References
     ISBN:978-0-471-39918-6
 """
 
+from functools import partial
+
 from colour.colorimetry import SpectralDistribution
-from colour.utilities import CaseInsensitiveMapping
+from colour.utilities import LazyCaseInsensitiveMapping
 
 __author__ = 'Colour Developers'
 __copyright__ = 'Copyright (C) 2013-2021 - Colour Developers'
@@ -363,16 +365,22 @@ DATA_BASIS_FUNCTIONS_CIE_ILLUMINANT_D_SERIES = {
     }
 }
 
-SDS_BASIS_FUNCTIONS_CIE_ILLUMINANT_D_SERIES = CaseInsensitiveMapping({
+SDS_BASIS_FUNCTIONS_CIE_ILLUMINANT_D_SERIES = LazyCaseInsensitiveMapping({
     'S0':
-        SpectralDistribution(
-            DATA_BASIS_FUNCTIONS_CIE_ILLUMINANT_D_SERIES['S0'], name='S0'),
+        partial(
+            SpectralDistribution,
+            DATA_BASIS_FUNCTIONS_CIE_ILLUMINANT_D_SERIES['S0'],
+            name='S0'),
     'S1':
-        SpectralDistribution(
-            DATA_BASIS_FUNCTIONS_CIE_ILLUMINANT_D_SERIES['S1'], name='S1'),
+        partial(
+            SpectralDistribution,
+            DATA_BASIS_FUNCTIONS_CIE_ILLUMINANT_D_SERIES['S1'],
+            name='S1'),
     'S2':
-        SpectralDistribution(
-            DATA_BASIS_FUNCTIONS_CIE_ILLUMINANT_D_SERIES['S2'], name='S2')
+        partial(
+            SpectralDistribution,
+            DATA_BASIS_FUNCTIONS_CIE_ILLUMINANT_D_SERIES['S2'],
+            name='S2')
 })
 SDS_BASIS_FUNCTIONS_CIE_ILLUMINANT_D_SERIES.__doc__ = """
 *CIE Illuminant D Series* :math:`S_n(\\lambda)` spectral distributions.
@@ -381,6 +389,6 @@ References
 ----------
 :cite:`Lindbloom2007a`, :cite:`Wyszecki2000z`
 
-SDS_BASIS_FUNCTIONS_CIE_ILLUMINANT_D_SERIES : CaseInsensitiveMapping
+SDS_BASIS_FUNCTIONS_CIE_ILLUMINANT_D_SERIES : LazyCaseInsensitiveMapping
    **{'S0', 'S1', 'S1'}**
 """

--- a/colour/colorimetry/datasets/lefs.py
+++ b/colour/colorimetry/datasets/lefs.py
@@ -42,8 +42,10 @@ References
     http://en.wikipedia.org/wiki/Mesopic_vision#Mesopic_weighting_function
 """
 
+from functools import partial
+
 from colour.colorimetry import SpectralDistribution
-from colour.utilities import CaseInsensitiveMapping
+from colour.utilities import CaseInsensitiveMapping, LazyCaseInsensitiveMapping
 
 __author__ = 'Colour Developers'
 __copyright__ = 'Copyright (C) 2013-2021 - Colour Developers'
@@ -2338,35 +2340,41 @@ DATA_LEFS_PHOTOPIC = {
     }
 }
 
-SDS_LEFS_PHOTOPIC = CaseInsensitiveMapping({
+SDS_LEFS_PHOTOPIC = LazyCaseInsensitiveMapping({
     'CIE 1924 Photopic Standard Observer':
-        SpectralDistribution(
+        partial(
+            SpectralDistribution,
             DATA_LEFS_PHOTOPIC['CIE 1924 Photopic Standard Observer'],
             name='CIE 1924 Photopic Standard Observer'),
     'Judd Modified CIE 1951 Photopic Standard Observer':
-        SpectralDistribution(
+        partial(
+            SpectralDistribution,
             DATA_LEFS_PHOTOPIC[
                 'Judd Modified CIE 1951 Photopic Standard Observer'],
             name='Judd Modified CIE 1951 Photopic Standard Observer'),
     'Judd-Vos Modified CIE 1978 Photopic Standard Observer':
-        SpectralDistribution(
+        partial(
+            SpectralDistribution,
             DATA_LEFS_PHOTOPIC[
                 'Judd-Vos Modified CIE 1978 Photopic Standard Observer'],
             name='Judd-Vos Modified CIE 1978 Photopic Standard Observer'),
     'CIE 1964 Photopic 10 Degree Standard Observer':
-        SpectralDistribution(
+        partial(
+            SpectralDistribution,
             DATA_LEFS_PHOTOPIC[
                 'CIE 1964 Photopic 10 Degree Standard Observer'],
             name='CIE 1964 Photopic 10 Degree Standard Observer',
             strict_name='CIE 1964 Photopic 10$^\\circ$ Standard Observer'),
     'CIE 2008 2 Degree Physiologically Relevant LEF':
-        SpectralDistribution(
+        partial(
+            SpectralDistribution,
             DATA_LEFS_PHOTOPIC[
                 'CIE 2008 2 Degree Physiologically Relevant LEF'],
             name='CIE 2008 2 Degree Physiologically Relevant LEF',
             strict_name='CIE 2008 2$^\\circ$ Physiologically Relevant LEF'),
     'CIE 2008 10 Degree Physiologically Relevant LEF':
-        SpectralDistribution(
+        partial(
+            SpectralDistribution,
             DATA_LEFS_PHOTOPIC[
                 'CIE 2008 10 Degree Physiologically Relevant LEF'],
             name='CIE 2008 10 Degree Physiologically Relevant LEF',
@@ -2379,7 +2387,7 @@ References
 ----------
 :cite:`CVRLq`, :cite:`CVRLs`
 
-SDS_LEFS_PHOTOPIC : CaseInsensitiveMapping
+SDS_LEFS_PHOTOPIC : LazyCaseInsensitiveMapping
     **{'CIE 1924 Photopic Standard Observer',
     'Judd Modified CIE 1951 Photopic Standard Observer',
     'Judd-Vos Modified CIE 1978 Photopic Standard Observer',
@@ -2803,9 +2811,10 @@ DATA_LEFS_SCOTOPIC = {
     }
 }
 
-SDS_LEFS_SCOTOPIC = CaseInsensitiveMapping({
+SDS_LEFS_SCOTOPIC = LazyCaseInsensitiveMapping({
     'CIE 1951 Scotopic Standard Observer':
-        SpectralDistribution(
+        partial(
+            SpectralDistribution,
             DATA_LEFS_SCOTOPIC['CIE 1951 Scotopic Standard Observer'],
             name='CIE 1951 Scotopic Standard Observer')
 })
@@ -2816,7 +2825,7 @@ References
 ----------
 :cite:`CVRLs`
 
-SDS_LEFS_SCOTOPIC : CaseInsensitiveMapping
+SDS_LEFS_SCOTOPIC : LazyCaseInsensitiveMapping
     **{'CIE 1951 Scotopic Standard Observer', }**
 
 Aliases:
@@ -2826,7 +2835,7 @@ Aliases:
 SDS_LEFS_SCOTOPIC['cie_1951'] = (
     SDS_LEFS_SCOTOPIC['CIE 1951 Scotopic Standard Observer'])
 
-SDS_LEFS = CaseInsensitiveMapping(SDS_LEFS_PHOTOPIC)
+SDS_LEFS = LazyCaseInsensitiveMapping(SDS_LEFS_PHOTOPIC)
 SDS_LEFS.__doc__ = """
 Spectral distributions of the luminous efficiency functions.
 
@@ -2834,7 +2843,7 @@ References
 ----------
 :cite:`CVRLq`, :cite:`CVRLs`, :cite:`Wikipedia2005d`
 
-SDS_LEFS : CaseInsensitiveMapping
+SDS_LEFS : LazyCaseInsensitiveMapping
     **{'CIE 1924 Photopic Standard Observer',
     'Judd Modified CIE 1951 Photopic Standard Observer',
     'Judd-Vos Modified CIE 1978 Photopic Standard Observer',

--- a/colour/colorimetry/datasets/light_sources/sds.py
+++ b/colour/colorimetry/datasets/light_sources/sds.py
@@ -49,9 +49,11 @@ usp=sharing
     http://www.cis.rit.edu/research/mcsl2/online/PointerData.xls
 """
 
+from functools import partial
+
 from colour.algebra import LinearInterpolator
 from colour.colorimetry.spectrum import SpectralDistribution
-from colour.utilities import CaseInsensitiveMapping
+from colour.utilities import LazyCaseInsensitiveMapping
 
 __author__ = 'Colour Developers'
 __copyright__ = 'Copyright (C) 2013-2021 - Colour Developers'
@@ -736,41 +738,12 @@ DATA_LIGHT_SOURCES_RIT = {
     }
 }
 
-SDS_LIGHT_SOURCES_RIT = CaseInsensitiveMapping({
-    'Natural':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_RIT['Natural'],
-            name='Natural'),
-    'Philips TL-84':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_RIT['Philips TL-84'],
-            name='Philips TL-84'),
-    'SA':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_RIT['SA'],
-            name='SA'),
-    'SC':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_RIT['SC'],
-            name='SC'),
-    'T8 Luxline Plus White':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_RIT['T8 Luxline Plus White'],
-            name='T8 Luxline Plus White'),
-    'T8 Polylux 3000':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_RIT['T8 Polylux 3000'],
-            name='T8 Polylux 3000'),
-    'T8 Polylux 4000':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_RIT['T8 Polylux 4000'],
-            name='T8 Polylux 4000'),
-    'Thorn Kolor-rite':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_RIT['Thorn Kolor-rite'],
-            name='Thorn Kolor-rite')
-})  # yapf: disable
-"""
+SDS_LIGHT_SOURCES_RIT = LazyCaseInsensitiveMapping((
+    key,
+    partial(
+        SpectralDistribution, value, name=key, interpolator=LinearInterpolator)
+) for key, value in DATA_LIGHT_SOURCES_RIT.items())
+SDS_LIGHT_SOURCES_RIT.__doc__ = """
 Spectral distributions of the light sources from the *RIT* *PointerData.xls*
 spreadsheet.
 
@@ -784,7 +757,7 @@ References
 ----------
 :cite:`Pointer1980a`
 
-DATA_LIGHT_SOURCES_RIT : CaseInsensitiveMapping
+DATA_LIGHT_SOURCES_RIT : LazyCaseInsensitiveMapping
     **{'Natural', 'Philips TL-84', 'T8 Luxline Plus White', 'SA', 'SC',
     'T8 Polylux 3000', 'T8 Polylux 4000', 'Thorn Kolor-rite'}**
 """
@@ -1622,46 +1595,12 @@ DATA_LIGHT_SOURCES_NIST_TRADITIONAL = {
     }
 }
 
-SDS_LIGHT_SOURCES_NIST_TRADITIONAL = CaseInsensitiveMapping({
-    'Cool White FL':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_NIST_TRADITIONAL['Cool White FL'],
-            name='Cool White FL'),
-    'Daylight FL':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_NIST_TRADITIONAL['Daylight FL'],
-            name='Daylight FL'),
-    'HPS':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_NIST_TRADITIONAL['HPS'], name='HPS'),
-    'Incandescent':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_NIST_TRADITIONAL['Incandescent'],
-            name='Incandescent'),
-    'LPS':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_NIST_TRADITIONAL['LPS'], name='LPS'),
-    'Mercury':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_NIST_TRADITIONAL['Mercury'], name='Mercury'),
-    'Metal Halide':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_NIST_TRADITIONAL['Metal Halide'],
-            name='Metal Halide'),
-    'Neodimium Incandescent':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_NIST_TRADITIONAL['Neodimium Incandescent'],
-            name='Neodimium Incandescent'),
-    'Super HPS':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_NIST_TRADITIONAL['Super HPS'],
-            name='Super HPS'),
-    'Triphosphor FL':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_NIST_TRADITIONAL['Triphosphor FL'],
-            name='Triphosphor FL')
-})
-"""
+SDS_LIGHT_SOURCES_NIST_TRADITIONAL = LazyCaseInsensitiveMapping((
+    key,
+    partial(
+        SpectralDistribution, value, name=key, interpolator=LinearInterpolator)
+) for key, value in DATA_LIGHT_SOURCES_NIST_TRADITIONAL.items())
+SDS_LIGHT_SOURCES_NIST_TRADITIONAL.__doc__ = """
 Spectral distributions of the traditional light sources from the *NIST*
 *NIST CQS simulation 7.4.xls* spreadsheet.
 
@@ -1669,7 +1608,7 @@ References
 ----------
 :cite:`Ohno2008a`
 
-SDS_LIGHT_SOURCES_NIST_TRADITIONAL : CaseInsensitiveMapping
+SDS_LIGHT_SOURCES_NIST_TRADITIONAL : LazyCaseInsensitiveMapping
     **{'Cool White FL', 'Daylight FL', 'HPS', 'Incandescent', 'LPS', 'Mercury',
     'Metal Halide', 'Neodimium Incandescent', 'Super HPS', 'Triphosphor FL'}**
 """
@@ -2922,68 +2861,16 @@ DATA_LIGHT_SOURCES_NIST_LED = {
     }
 }
 
-SDS_LIGHT_SOURCES_NIST_LED = CaseInsensitiveMapping({
-    '3-LED-1 (457/540/605)':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_NIST_LED['3-LED-1 (457/540/605)'],
-            name='3-LED-1 (457/540/605)'),
-    '3-LED-2 (473/545/616)':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_NIST_LED['3-LED-2 (473/545/616)'],
-            name='3-LED-2 (473/545/616)'),
-    '3-LED-2 Yellow':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_NIST_LED['3-LED-2 Yellow'],
-            name='3-LED-2 Yellow'),
-    '3-LED-3 (465/546/614)':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_NIST_LED['3-LED-3 (465/546/614)'],
-            name='3-LED-3 (465/546/614)'),
-    '3-LED-4 (455/547/623)':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_NIST_LED['3-LED-4 (455/547/623)'],
-            name='3-LED-4 (455/547/623)'),
-    '4-LED No Yellow':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_NIST_LED['4-LED No Yellow'],
-            name='4-LED No Yellow'),
-    '4-LED Yellow':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_NIST_LED['4-LED Yellow'], name='4-LED Yellow'),
-    '4-LED-1 (461/526/576/624)':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_NIST_LED['4-LED-1 (461/526/576/624)'],
-            name='4-LED-1 (461/526/576/624)'),
-    '4-LED-2 (447/512/573/627)':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_NIST_LED['4-LED-2 (447/512/573/627)'],
-            name='4-LED-2 (447/512/573/627)'),
-    'Luxeon WW 2880':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_NIST_LED['Luxeon WW 2880'],
-            name='Luxeon WW 2880'),
-    'PHOS-1':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_NIST_LED['PHOS-1'], name='PHOS-1'),
-    'PHOS-2':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_NIST_LED['PHOS-2'], name='PHOS-2'),
-    'PHOS-3':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_NIST_LED['PHOS-3'], name='PHOS-3'),
-    'PHOS-4':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_NIST_LED['PHOS-4'], name='PHOS-4'),
-    'Phosphor LED YAG':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_NIST_LED['Phosphor LED YAG'],
-            name='Phosphor LED YAG')
-})
-"""
+SDS_LIGHT_SOURCES_NIST_LED = LazyCaseInsensitiveMapping((
+    key,
+    partial(
+        SpectralDistribution, value, name=key, interpolator=LinearInterpolator)
+) for key, value in DATA_LIGHT_SOURCES_NIST_LED.items())
+SDS_LIGHT_SOURCES_NIST_LED.__doc__ = """
 Spectral distributions of the LED light sources from the *NIST*
 *NIST CQS simulation 7.4.xls* spreadsheet.
 
-SDS_LIGHT_SOURCES_NIST_LED : CaseInsensitiveMapping
+SDS_LIGHT_SOURCES_NIST_LED : LazyCaseInsensitiveMapping
     **{'3-LED-1 (457/540/605)', '3-LED-2 (473/545/616)', '3-LED-2 Yellow',
     '3-LED-3 (465/546/614)', '3-LED-4 (455/547/623)', '4-LED No Yellow',
     '4-LED Yellow', '4-LED-1 (461/526/576/624)', '4-LED-2 (447/512/573/627)',
@@ -4820,101 +4707,16 @@ DATA_LIGHT_SOURCES_NIST_PHILIPS = {
     }
 }
 
-SDS_LIGHT_SOURCES_NIST_PHILIPS = CaseInsensitiveMapping({
-    '60 A/W (Soft White)':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_NIST_PHILIPS['60 A/W (Soft White)'],
-            name='60 A/W (Soft White)'),
-    'C100S54 (HPS)':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_NIST_PHILIPS['C100S54 (HPS)'],
-            name='C100S54 (HPS)'),
-    'C100S54C (HPS)':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_NIST_PHILIPS['C100S54C (HPS)'],
-            name='C100S54C (HPS)'),
-    'F32T8/TL830 (Triphosphor)':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_NIST_PHILIPS['F32T8/TL830 (Triphosphor)'],
-            name='F32T8/TL830 (Triphosphor)'),
-    'F32T8/TL835 (Triphosphor)':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_NIST_PHILIPS['F32T8/TL835 (Triphosphor)'],
-            name='F32T8/TL835 (Triphosphor)'),
-    'F32T8/TL841 (Triphosphor)':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_NIST_PHILIPS['F32T8/TL841 (Triphosphor)'],
-            name='F32T8/TL841 (Triphosphor)'),
-    'F32T8/TL850 (Triphosphor)':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_NIST_PHILIPS['F32T8/TL850 (Triphosphor)'],
-            name='F32T8/TL850 (Triphosphor)'),
-    'F32T8/TL865 /PLUS (Triphosphor)':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_NIST_PHILIPS['F32T8/TL865 /PLUS (Triphosphor)'],
-            name='F32T8/TL865 /PLUS (Triphosphor)'),
-    'F34/CW/RS/EW (Cool White FL)':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_NIST_PHILIPS['F34/CW/RS/EW (Cool White FL)'],
-            name='F34/CW/RS/EW (Cool White FL)'),
-    'F34T12/LW/RS /EW':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_NIST_PHILIPS['F34T12/LW/RS /EW'],
-            name='F34T12/LW/RS /EW'),
-    'F34T12WW/RS /EW (Warm White FL)':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_NIST_PHILIPS['F34T12WW/RS /EW (Warm White FL)'],
-            name='F34T12WW/RS /EW (Warm White FL)'),
-    'F40/C50 (Broadband FL)':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_NIST_PHILIPS['F40/C50 (Broadband FL)'],
-            name='F40/C50 (Broadband FL)'),
-    'F40/C75 (Broadband FL)':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_NIST_PHILIPS['F40/C75 (Broadband FL)'],
-            name='F40/C75 (Broadband FL)'),
-    'F40/CWX (Broadband FL)':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_NIST_PHILIPS['F40/CWX (Broadband FL)'],
-            name='F40/CWX (Broadband FL)'),
-    'F40/DX (Broadband FL)':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_NIST_PHILIPS['F40/DX (Broadband FL)'],
-            name='F40/DX (Broadband FL)'),
-    'F40/DXTP (Delux FL)':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_NIST_PHILIPS['F40/DXTP (Delux FL)'],
-            name='F40/DXTP (Delux FL)'),
-    'F40/N (Natural FL)':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_NIST_PHILIPS['F40/N (Natural FL)'],
-            name='F40/N (Natural FL)'),
-    'H38HT-100 (Mercury)':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_NIST_PHILIPS['H38HT-100 (Mercury)'],
-            name='H38HT-100 (Mercury)'),
-    'H38JA-100/DX (Mercury DX)':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_NIST_PHILIPS['H38JA-100/DX (Mercury DX)'],
-            name='H38JA-100/DX (Mercury DX)'),
-    'MHC100/U/MP /3K':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_NIST_PHILIPS['MHC100/U/MP /3K'],
-            name='MHC100/U/MP /3K'),
-    'MHC100/U/MP /4K':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_NIST_PHILIPS['MHC100/U/MP /4K'],
-            name='MHC100/U/MP /4K'),
-    'SDW-T 100W/LV (Super HPS)':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_NIST_PHILIPS['SDW-T 100W/LV (Super HPS)'],
-            name='SDW-T 100W/LV (Super HPS)')
-})
-"""
+SDS_LIGHT_SOURCES_NIST_PHILIPS = LazyCaseInsensitiveMapping((
+    key,
+    partial(
+        SpectralDistribution, value, name=key, interpolator=LinearInterpolator)
+) for key, value in DATA_LIGHT_SOURCES_NIST_PHILIPS.items())
+SDS_LIGHT_SOURCES_NIST_PHILIPS.__doc__ = """
 Spectral distributions of the Philips light sources from the *NIST*
 *NIST CQS simulation 7.4.xls* spreadsheet.
 
-SDS_LIGHT_SOURCES_NIST_PHILIPS : CaseInsensitiveMapping
+SDS_LIGHT_SOURCES_NIST_PHILIPS : LazyCaseInsensitiveMapping
     **{'60 A/W (Soft White)', 'C100S54 (HPS)', 'C100S54C (HPS)',
     'F32T8/TL830 (Triphosphor)', 'F32T8/TL835 (Triphosphor)',
     'F32T8/TL841 (Triphosphor)', 'F32T8/TL850 (Triphosphor)',
@@ -5132,10 +4934,13 @@ DATA_LIGHT_SOURCES_COMMON = {
     }
 }
 
-SDS_LIGHT_SOURCES_COMMON = CaseInsensitiveMapping({
+SDS_LIGHT_SOURCES_COMMON = LazyCaseInsensitiveMapping({
     'Kinoton 75P':
-        SpectralDistribution(
-            DATA_LIGHT_SOURCES_COMMON['Kinoton 75P'], name='Kinoton 75P')
+        partial(
+            SpectralDistribution,
+            DATA_LIGHT_SOURCES_COMMON['Kinoton 75P'],
+            name='Kinoton 75P',
+            interpolator=LinearInterpolator)
 })
 """
 Spectral distributions of the common light sources.
@@ -5144,28 +4949,28 @@ References
 ----------
 :cite:`Houston2015a`
 
-SDS_LIGHT_SOURCES_COMMON : CaseInsensitiveMapping
+SDS_LIGHT_SOURCES_COMMON : LazyCaseInsensitiveMapping
     **{'Kinoton 75P', }**
 """
 
-SDS_LIGHT_SOURCES = CaseInsensitiveMapping(SDS_LIGHT_SOURCES_RIT)
+SDS_LIGHT_SOURCES = LazyCaseInsensitiveMapping(SDS_LIGHT_SOURCES_RIT)
 SDS_LIGHT_SOURCES.__doc__ = """
 Spectral distributions of the light sources.
+
+Notes
+-----
+-   *CIE 15:2004* recommends using linear interpolation for
+    *CIE Standard Illuminant D Series*, for consistency all the illuminants are
+    using a linear interpolator.
 
 References
 ----------
 :cite:`Houston2015a`, :cite:`Ohno2008a`, :cite:`Pointer1980a`
 
-SDS_LIGHT_SOURCES : CaseInsensitiveMapping
+SDS_LIGHT_SOURCES : LazyCaseInsensitiveMapping
 """
 
 SDS_LIGHT_SOURCES.update(SDS_LIGHT_SOURCES_NIST_TRADITIONAL)
 SDS_LIGHT_SOURCES.update(SDS_LIGHT_SOURCES_NIST_LED)
 SDS_LIGHT_SOURCES.update(SDS_LIGHT_SOURCES_NIST_PHILIPS)
 SDS_LIGHT_SOURCES.update(SDS_LIGHT_SOURCES_COMMON)
-
-# *CIE 15:2004* recommends using linear interpolation for
-# *CIE Standard Illuminant D Series*, for consistency all the light sources are
-# using a linear interpolator.
-for _sd in SDS_LIGHT_SOURCES.values():
-    _sd.interpolator = LinearInterpolator

--- a/colour/colorimetry/dominant.py
+++ b/colour/colorimetry/dominant.py
@@ -43,7 +43,7 @@ __all__ = [
     'complementary_wavelength', 'excitation_purity', 'colorimetric_purity'
 ]
 
-_DEFAULT_MSDS_CMFS = 'CIE 1931 2 Degree Standard Observer'
+_MSDS_CMFS_DEFAULT = 'CIE 1931 2 Degree Standard Observer'
 
 
 def closest_spectral_locus_wavelength(xy, xy_n, xy_s, inverse=False):
@@ -185,7 +185,7 @@ def dominant_wavelength(xy, xy_n, cmfs=None, inverse=False):
     """
 
     if cmfs is None:
-        cmfs = MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS]
+        cmfs = MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT]
 
     xy = as_float_array(xy)
     xy_n = np.resize(xy_n, xy.shape)
@@ -276,7 +276,7 @@ def complementary_wavelength(xy, xy_n, cmfs=None):
     """
 
     if cmfs is None:
-        cmfs = MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS]
+        cmfs = MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT]
 
     return dominant_wavelength(xy, xy_n, cmfs, True)
 
@@ -317,7 +317,7 @@ def excitation_purity(xy, xy_n, cmfs=None):
     """
 
     if cmfs is None:
-        cmfs = MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS]
+        cmfs = MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT]
 
     _wl, xy_wl, _xy_cwl = dominant_wavelength(xy, xy_n, cmfs)
 
@@ -362,7 +362,7 @@ def colorimetric_purity(xy, xy_n, cmfs=None):
     """
 
     if cmfs is None:
-        cmfs = MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS]
+        cmfs = MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT]
 
     xy = as_float_array(xy)
 

--- a/colour/colorimetry/dominant.py
+++ b/colour/colorimetry/dominant.py
@@ -27,7 +27,7 @@ import scipy.spatial.distance
 
 from colour.algebra import (euclidean_distance, extend_line_segment,
                             intersect_line_segments)
-from colour.colorimetry import MSDS_CMFS
+from colour.colorimetry import MSDS_CMFS_STANDARD_OBSERVER
 from colour.models import XYZ_to_xy
 from colour.utilities import as_float_array
 
@@ -42,6 +42,8 @@ __all__ = [
     'closest_spectral_locus_wavelength', 'dominant_wavelength',
     'complementary_wavelength', 'excitation_purity', 'colorimetric_purity'
 ]
+
+_DEFAULT_MSDS_CMFS = 'CIE 1931 2 Degree Standard Observer'
 
 
 def closest_spectral_locus_wavelength(xy, xy_n, xy_s, inverse=False):
@@ -76,7 +78,9 @@ def closest_spectral_locus_wavelength(xy, xy_n, xy_s, inverse=False):
 
     Examples
     --------
-    >>> cmfs = MSDS_CMFS['CIE 1931 2 Degree Standard Observer']
+    >>> cmfs = (
+    ...     MSDS_CMFS_STANDARD_OBSERVER['CIE 1931 2 Degree Standard Observer']
+    ... )
     >>> xy = np.array([0.54369557, 0.32107944])
     >>> xy_n = np.array([0.31270000, 0.32900000])
     >>> xy_s = XYZ_to_xy(cmfs.values)
@@ -115,10 +119,7 @@ def closest_spectral_locus_wavelength(xy, xy_n, xy_s, inverse=False):
     return i_wl, xy_wl
 
 
-def dominant_wavelength(xy,
-                        xy_n,
-                        cmfs=MSDS_CMFS['CIE 1931 2 Degree Standard Observer'],
-                        inverse=False):
+def dominant_wavelength(xy, xy_n, cmfs=None, inverse=False):
     """
     Returns the *dominant wavelength* :math:`\\lambda_d` for given colour
     stimulus :math:`xy` and the related :math:`xy_wl` first and :math:`xy_{cw}`
@@ -141,7 +142,8 @@ def dominant_wavelength(xy,
     xy_n : array_like
         Achromatic stimulus *CIE xy* chromaticity coordinates.
     cmfs : XYZ_ColourMatchingFunctions, optional
-        Standard observer colour matching functions.
+        Standard observer colour matching functions, default to the
+        *CIE 1931 2 Degree Standard Observer*.
     inverse : bool, optional
         Inverse the computation direction to retrieve the
         *complementary wavelength*.
@@ -164,7 +166,9 @@ def dominant_wavelength(xy,
     >>> from pprint import pprint
     >>> xy = np.array([0.54369557, 0.32107944])
     >>> xy_n = np.array([0.31270000, 0.32900000])
-    >>> cmfs = MSDS_CMFS['CIE 1931 2 Degree Standard Observer']
+    >>> cmfs = (
+    ...     MSDS_CMFS_STANDARD_OBSERVER['CIE 1931 2 Degree Standard Observer']
+    ... )
     >>> pprint(dominant_wavelength(xy, xy_n, cmfs))  # doctest: +ELLIPSIS
     (array(616...),
      array([ 0.6835474...,  0.3162840...]),
@@ -179,6 +183,9 @@ def dominant_wavelength(xy,
      array([ 0.4572314...,  0.1362814...]),
      array([ 0.0104096...,  0.7320745...]))
     """
+
+    if cmfs is None:
+        cmfs = MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS]
 
     xy = as_float_array(xy)
     xy_n = np.resize(xy_n, xy.shape)
@@ -206,8 +213,7 @@ def dominant_wavelength(xy,
     return wl, np.squeeze(xy_wl), np.squeeze(xy_cwl)
 
 
-def complementary_wavelength(
-        xy, xy_n, cmfs=MSDS_CMFS['CIE 1931 2 Degree Standard Observer']):
+def complementary_wavelength(xy, xy_n, cmfs=None):
     """
     Returns the *complementary wavelength* :math:`\\lambda_c` for given colour
     stimulus :math:`xy` and the related :math:`xy_wl` first and :math:`xy_{cw}`
@@ -230,7 +236,8 @@ def complementary_wavelength(
     xy_n : array_like
         Achromatic stimulus *CIE xy* chromaticity coordinates.
     cmfs : XYZ_ColourMatchingFunctions, optional
-        Standard observer colour matching functions.
+        Standard observer colour matching functions, default to the
+        *CIE 1931 2 Degree Standard Observer*.
 
     Returns
     -------
@@ -250,7 +257,9 @@ def complementary_wavelength(
     >>> from pprint import pprint
     >>> xy = np.array([0.37605506, 0.24452225])
     >>> xy_n = np.array([0.31270000, 0.32900000])
-    >>> cmfs = MSDS_CMFS['CIE 1931 2 Degree Standard Observer']
+    >>> cmfs = (
+    ...     MSDS_CMFS_STANDARD_OBSERVER['CIE 1931 2 Degree Standard Observer']
+    ... )
     >>> pprint(complementary_wavelength(xy, xy_n, cmfs))  # doctest: +ELLIPSIS
     (array(509.0),
      array([ 0.0104096...,  0.7320745...]),
@@ -266,12 +275,13 @@ def complementary_wavelength(
      array([ 0.0364795 ,  0.3384712...]))
     """
 
+    if cmfs is None:
+        cmfs = MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS]
+
     return dominant_wavelength(xy, xy_n, cmfs, True)
 
 
-def excitation_purity(xy,
-                      xy_n,
-                      cmfs=MSDS_CMFS['CIE 1931 2 Degree Standard Observer']):
+def excitation_purity(xy, xy_n, cmfs=None):
     """
     Returns the *excitation purity* :math:`P_e` for given colour stimulus
     :math:`xy`.
@@ -283,7 +293,8 @@ def excitation_purity(xy,
     xy_n : array_like
         Achromatic stimulus *CIE xy* chromaticity coordinates.
     cmfs : XYZ_ColourMatchingFunctions, optional
-        Standard observer colour matching functions.
+        Standard observer colour matching functions, default to the
+        *CIE 1931 2 Degree Standard Observer*.
 
     Returns
     -------
@@ -298,10 +309,15 @@ def excitation_purity(xy,
     --------
     >>> xy = np.array([0.54369557, 0.32107944])
     >>> xy_n = np.array([0.31270000, 0.32900000])
-    >>> cmfs = MSDS_CMFS['CIE 1931 2 Degree Standard Observer']
+    >>> cmfs = (
+    ...     MSDS_CMFS_STANDARD_OBSERVER['CIE 1931 2 Degree Standard Observer']
+    ... )
     >>> excitation_purity(xy, xy_n, cmfs)  # doctest: +ELLIPSIS
     0.6228856...
     """
+
+    if cmfs is None:
+        cmfs = MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS]
 
     _wl, xy_wl, _xy_cwl = dominant_wavelength(xy, xy_n, cmfs)
 
@@ -310,9 +326,7 @@ def excitation_purity(xy,
     return P_e
 
 
-def colorimetric_purity(xy,
-                        xy_n,
-                        cmfs=MSDS_CMFS['CIE 1931 2 Degree Standard Observer']):
+def colorimetric_purity(xy, xy_n, cmfs=None):
     """
     Returns the *colorimetric purity* :math:`P_c` for given colour stimulus
     :math:`xy`.
@@ -324,7 +338,8 @@ def colorimetric_purity(xy,
     xy_n : array_like
         Achromatic stimulus *CIE xy* chromaticity coordinates.
     cmfs : XYZ_ColourMatchingFunctions, optional
-        Standard observer colour matching functions.
+        Standard observer colour matching functions, default to the
+        *CIE 1931 2 Degree Standard Observer*.
 
     Returns
     -------
@@ -339,10 +354,15 @@ def colorimetric_purity(xy,
     --------
     >>> xy = np.array([0.54369557, 0.32107944])
     >>> xy_n = np.array([0.31270000, 0.32900000])
-    >>> cmfs = MSDS_CMFS['CIE 1931 2 Degree Standard Observer']
+    >>> cmfs = (
+    ...     MSDS_CMFS_STANDARD_OBSERVER['CIE 1931 2 Degree Standard Observer']
+    ... )
     >>> colorimetric_purity(xy, xy_n, cmfs)  # doctest: +ELLIPSIS
     0.6135828...
     """
+
+    if cmfs is None:
+        cmfs = MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS]
 
     xy = as_float_array(xy)
 

--- a/colour/colorimetry/lefs.py
+++ b/colour/colorimetry/lefs.py
@@ -29,13 +29,12 @@ __all__ = [
 ]
 
 
-def mesopic_weighting_function(
-        wavelength,
-        Lp,
-        source='Blue Heavy',
-        method='MOVE',
-        photopic_lef=SDS_LEFS_PHOTOPIC['CIE 1924 Photopic Standard Observer'],
-        scotopic_lef=SDS_LEFS_SCOTOPIC['CIE 1951 Scotopic Standard Observer']):
+def mesopic_weighting_function(wavelength,
+                               Lp,
+                               source='Blue Heavy',
+                               method='MOVE',
+                               photopic_lef=None,
+                               scotopic_lef=None):
     """
     Calculates the mesopic weighting function factor at given wavelength
     :math:`\\lambda` using the photopic luminance :math:`L_p`.
@@ -54,9 +53,11 @@ def mesopic_weighting_function(
         **{'MOVE', 'LRC'}**,
         Method to calculate the weighting factor.
     photopic_lef : SpectralDistribution, optional
-        :math:`V(\\lambda)` photopic luminous efficiency function.
+        :math:`V(\\lambda)` photopic luminous efficiency function, default to
+        the *CIE 1924 Photopic Standard Observer*.
     scotopic_lef : SpectralDistribution, optional
-        :math:`V^\\prime(\\lambda)` scotopic luminous efficiency function.
+        :math:`V^\\prime(\\lambda)` scotopic luminous efficiency function,
+        default to the *CIE 1951 Scotopic Standard Observer*.
 
     Returns
     -------
@@ -72,6 +73,12 @@ def mesopic_weighting_function(
     >>> mesopic_weighting_function(500, 0.2)  # doctest: +ELLIPSIS
     0.7052200...
     """
+
+    if photopic_lef is None:
+        photopic_lef = SDS_LEFS_PHOTOPIC['CIE 1924 Photopic Standard Observer']
+
+    if scotopic_lef is None:
+        scotopic_lef = SDS_LEFS_SCOTOPIC['CIE 1951 Scotopic Standard Observer']
 
     source = validate_method(
         source, ['Blue Heavy', 'Red Heavy'],
@@ -89,12 +96,11 @@ def mesopic_weighting_function(
     return Vm
 
 
-def sd_mesopic_luminous_efficiency_function(
-        Lp,
-        source='Blue Heavy',
-        method='MOVE',
-        photopic_lef=SDS_LEFS_PHOTOPIC['CIE 1924 Photopic Standard Observer'],
-        scotopic_lef=SDS_LEFS_SCOTOPIC['CIE 1951 Scotopic Standard Observer']):
+def sd_mesopic_luminous_efficiency_function(Lp,
+                                            source='Blue Heavy',
+                                            method='MOVE',
+                                            photopic_lef=None,
+                                            scotopic_lef=None):
     """
     Returns the mesopic luminous efficiency function :math:`V_m(\\lambda)` for
     given photopic luminance :math:`L_p`.
@@ -110,9 +116,11 @@ def sd_mesopic_luminous_efficiency_function(
         **{'MOVE', 'LRC'}**,
         Method to calculate the weighting factor.
     photopic_lef : SpectralDistribution, optional
-        :math:`V(\\lambda)` photopic luminous efficiency function.
+        :math:`V(\\lambda)` photopic luminous efficiency function, default to
+        the *CIE 1924 Photopic Standard Observer*.
     scotopic_lef : SpectralDistribution, optional
-        :math:`V^\\prime(\\lambda)` scotopic luminous efficiency function.
+        :math:`V^\\prime(\\lambda)` scotopic luminous efficiency function,
+        default to the *CIE 1951 Scotopic Standard Observer*.
 
     Returns
     -------
@@ -534,6 +542,12 @@ def sd_mesopic_luminous_efficiency_function(
                          extrapolator=Extrapolator,
                          extrapolator_kwargs={...})
     """
+
+    if photopic_lef is None:
+        photopic_lef = SDS_LEFS_PHOTOPIC['CIE 1924 Photopic Standard Observer']
+
+    if scotopic_lef is None:
+        scotopic_lef = SDS_LEFS_SCOTOPIC['CIE 1951 Scotopic Standard Observer']
 
     photopic_lef_shape = photopic_lef.shape
     scotopic_lef_shape = scotopic_lef.shape

--- a/colour/colorimetry/photometry.py
+++ b/colour/colorimetry/photometry.py
@@ -16,7 +16,7 @@ References
 
 import numpy as np
 
-from colour.colorimetry import SDS_LEFS_PHOTOPIC
+from colour.colorimetry import SDS_LEFS_PHOTOPIC, reshape_sd
 from colour.constants import CONSTANT_K_M
 from colour.utilities import as_float
 
@@ -30,9 +30,7 @@ __status__ = 'Production'
 __all__ = ['luminous_flux', 'luminous_efficiency', 'luminous_efficacy']
 
 
-def luminous_flux(sd,
-                  lef=SDS_LEFS_PHOTOPIC['CIE 1924 Photopic Standard Observer'],
-                  K_m=CONSTANT_K_M):
+def luminous_flux(sd, lef=None, K_m=CONSTANT_K_M):
     """
     Returns the *luminous flux* for given spectral distribution using given
     luminous efficiency function.
@@ -42,7 +40,8 @@ def luminous_flux(sd,
     sd : SpectralDistribution
         test spectral distribution
     lef : SpectralDistribution, optional
-        :math:`V(\\lambda)` luminous efficiency function.
+        :math:`V(\\lambda)` luminous efficiency function, default to the
+        *CIE 1924 Photopic Standard Observer*.
     K_m : numeric, optional
         :math:`lm\\cdot W^{-1}` maximum photopic luminous efficiency
 
@@ -63,7 +62,11 @@ def luminous_flux(sd,
     23807.6555273...
     """
 
-    lef = lef.copy().align(
+    if lef is None:
+        lef = SDS_LEFS_PHOTOPIC['CIE 1924 Photopic Standard Observer']
+
+    lef = reshape_sd(
+        lef,
         sd.shape,
         extrapolator_kwargs={
             'method': 'Constant',
@@ -77,8 +80,7 @@ def luminous_flux(sd,
     return as_float(flux)
 
 
-def luminous_efficiency(
-        sd, lef=SDS_LEFS_PHOTOPIC['CIE 1924 Photopic Standard Observer']):
+def luminous_efficiency(sd, lef=None):
     """
     Returns the *luminous efficiency* of given spectral distribution using
     given luminous efficiency function.
@@ -88,7 +90,8 @@ def luminous_efficiency(
     sd : SpectralDistribution
         test spectral distribution
     lef : SpectralDistribution, optional
-        :math:`V(\\lambda)` luminous efficiency function.
+        :math:`V(\\lambda)` luminous efficiency function, default to the
+        *CIE 1924 Photopic Standard Observer*.
 
     Returns
     -------
@@ -107,7 +110,11 @@ def luminous_efficiency(
     0.1994393...
     """
 
-    lef = lef.copy().align(
+    if lef is None:
+        lef = SDS_LEFS_PHOTOPIC['CIE 1924 Photopic Standard Observer']
+
+    lef = reshape_sd(
+        lef,
         sd.shape,
         extrapolator_kwargs={
             'method': 'Constant',
@@ -122,8 +129,7 @@ def luminous_efficiency(
     return efficiency
 
 
-def luminous_efficacy(
-        sd, lef=SDS_LEFS_PHOTOPIC['CIE 1924 Photopic Standard Observer']):
+def luminous_efficacy(sd, lef=None):
     """
     Returns the *luminous efficacy* in :math:`lm\\cdot W^{-1}` of given
     spectral distribution using given luminous efficiency function.
@@ -133,7 +139,8 @@ def luminous_efficacy(
     sd : SpectralDistribution
         test spectral distribution
     lef : SpectralDistribution, optional
-        :math:`V(\\lambda)` luminous efficiency function.
+        :math:`V(\\lambda)` luminous efficiency function, default to the
+        *CIE 1924 Photopic Standard Observer*.
 
     Returns
     -------
@@ -151,6 +158,9 @@ def luminous_efficacy(
     >>> luminous_efficacy(sd)  # doctest: +ELLIPSIS
     136.2170803...
     """
+
+    if lef is None:
+        lef = SDS_LEFS_PHOTOPIC['CIE 1924 Photopic Standard Observer']
 
     efficacy = CONSTANT_K_M * luminous_efficiency(sd, lef)
 

--- a/colour/colorimetry/spectrum.py
+++ b/colour/colorimetry/spectrum.py
@@ -33,10 +33,10 @@ from colour.algebra import (Extrapolator, CubicSplineInterpolator,
                             SpragueInterpolator)
 from colour.constants import DEFAULT_FLOAT_DTYPE
 from colour.continuous import Signal, MultiSignals
-from colour.utilities import (as_float, as_int, copy_definition, filter_kwargs,
-                              first_item, is_iterable, is_numeric, is_string,
-                              is_uniform, interval, runtime_warning, tstack,
-                              validate_method)
+from colour.utilities import (
+    CACHE_REGISTRY, as_float, as_int, copy_definition, filter_kwargs,
+    first_item, is_iterable, is_numeric, is_string, is_uniform, interval,
+    runtime_warning, tstack, validate_method)
 
 __author__ = 'Colour Developers'
 __copyright__ = 'Copyright (C) 2013-2021 - Colour Developers'
@@ -2666,7 +2666,8 @@ def sds_and_msds_to_msds(sds):
     return msds
 
 
-_CACHE_RESHAPED_SDS_AND_MSDS = {}
+_CACHE_RESHAPED_SDS_AND_MSDS = CACHE_REGISTRY.register_cache(
+    '{0}._CACHE_RESHAPED_SDS_AND_MSDS'.format(__name__))
 
 
 def reshape_sd(sd, shape=SPECTRAL_SHAPE_DEFAULT, method='Align', **kwargs):

--- a/colour/colorimetry/spectrum.py
+++ b/colour/colorimetry/spectrum.py
@@ -11,6 +11,8 @@ Defines the classes and objects handling spectral data computations:
 -   :class:`colour.MultiSpectralDistributions`
 -   :func:`colour.colorimetry.sds_and_msds_to_sds`
 -   :func:`colour.colorimetry.sds_and_msds_to_msds`
+-   :func:`colour.colorimetry.reshape_sd`
+-   :func:`colour.colorimetry.reshape_msds`
 
 References
 ----------
@@ -25,14 +27,16 @@ References
 """
 
 import numpy as np
+from collections.abc import Mapping
 
 from colour.algebra import (Extrapolator, CubicSplineInterpolator,
                             SpragueInterpolator)
 from colour.constants import DEFAULT_FLOAT_DTYPE
 from colour.continuous import Signal, MultiSignals
-from colour.utilities import (as_float, as_int, first_item, is_iterable,
-                              is_numeric, is_string, is_uniform, interval,
-                              runtime_warning, tstack)
+from colour.utilities import (as_float, as_int, copy_definition, filter_kwargs,
+                              first_item, is_iterable, is_numeric, is_string,
+                              is_uniform, interval, runtime_warning, tstack,
+                              validate_method)
 
 __author__ = 'Colour Developers'
 __copyright__ = 'Copyright (C) 2013-2021 - Colour Developers'
@@ -43,7 +47,8 @@ __status__ = 'Production'
 
 __all__ = [
     'SpectralShape', 'SPECTRAL_SHAPE_DEFAULT', 'SpectralDistribution',
-    'MultiSpectralDistributions', 'sds_and_msds_to_sds', 'sds_and_msds_to_msds'
+    'MultiSpectralDistributions', 'sds_and_msds_to_sds',
+    'sds_and_msds_to_msds', 'reshape_sd', 'reshape_msds'
 ]
 
 
@@ -2659,3 +2664,75 @@ def sds_and_msds_to_msds(sds):
             tstack(values), shape.range(), labels, strict_labels=strict_labels)
 
     return msds
+
+
+_CACHE_RESHAPED_SDS_AND_MSDS = {}
+
+
+def reshape_sd(sd, shape=SPECTRAL_SHAPE_DEFAULT, method='Align', **kwargs):
+    """
+    Reshape given spectral distribution with given spectral shape.
+
+    The reshaped object is cached, thus another call to the definition with the
+    same arguments will yield the cached object immediately.
+
+    Parameters
+    ----------
+    sd : SpectralDistribution
+        Spectral distribution to reshape.
+    shape : SpectralShape, optional
+        Spectral shape to reshape the spectral distribution with.
+    method : unicode, optional
+        {'Align', 'Extrapolate', 'Interpolate', 'Trim'}
+        Correction method.
+        Reshape method.
+
+    Other Parameters
+    ----------------
+    \\**kwargs : dict, optional
+        {:func:`colour.SpectralDistribution.align`,
+        :func:`colour.SpectralDistribution.extrapolate`,
+        :func:`colour.SpectralDistribution.interpolate`,
+        :func:`colour.SpectralDistribution.trim`},
+        Please refer to the documentation of the previously listed methods.
+
+    Returns
+    -------
+    SpectralDistribution
+
+    Warnings
+    --------
+    Contrary to *Numpy*, reshaping a spectral distribution alters its data!
+    """
+
+    method = validate_method(
+        method, valid_methods=['Align', 'Extrapolate', 'Interpolate', 'Trim'])
+
+    # Handling dict-like keyword arguments.
+    kwargs_items = list(kwargs.items())
+    for i, (keyword, value) in enumerate(kwargs_items):
+        if isinstance(value, Mapping):
+            kwargs_items[i] = (keyword, tuple(value.items()))
+
+    hash_key = tuple(
+        [hash(arg) for arg in (sd, shape, method, tuple(kwargs_items))])
+    if hash_key in _CACHE_RESHAPED_SDS_AND_MSDS:
+        return _CACHE_RESHAPED_SDS_AND_MSDS[hash_key].copy()
+
+    function = getattr(sd, method)
+
+    reshaped_sd = getattr(sd.copy(), method)(shape, **filter_kwargs(
+        function, **kwargs))
+
+    _CACHE_RESHAPED_SDS_AND_MSDS[hash_key] = reshaped_sd
+
+    return reshaped_sd
+
+
+reshape_msds = copy_definition(reshape_sd, 'reshape_msds')
+reshape_msds.__doc__ = reshape_msds.__doc__.replace(
+    'SpectralDistribution', 'MultiSpectralDistributions')
+reshape_msds.__doc__ = reshape_msds.__doc__.replace(
+    'spectral distribution', 'multi-spectral distributions')
+reshape_msds.__doc__ = reshape_msds.__doc__.replace(
+    'Spectral distribution', 'Multi-spectral distributions')

--- a/colour/colorimetry/tests/test_dominant.py
+++ b/colour/colorimetry/tests/test_dominant.py
@@ -27,9 +27,9 @@ __all__ = [
     'TestColorimetricPurity'
 ]
 
-_DEFAULT_MSDS_CMFS = 'CIE 1931 2 Degree Standard Observer'
+_MSDS_CMFS_DEFAULT = 'CIE 1931 2 Degree Standard Observer'
 
-_CCS_DEFAULT_ILLUMINANT = CCS_ILLUMINANTS[_DEFAULT_MSDS_CMFS]['D65']
+_CCS_ILLUMINANT_DEFAULT = CCS_ILLUMINANTS[_MSDS_CMFS_DEFAULT]['D65']
 
 
 class TestClosestSpectralLocusWavelength(unittest.TestCase):
@@ -44,7 +44,7 @@ closest_spectral_locus_wavelength` definition unit tests methods.
         """
 
         self._xy_s = XYZ_to_xy(
-            MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS].values)
+            MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT].values)
 
     def test_closest_spectral_locus_wavelength(self):
         """
@@ -53,7 +53,7 @@ closest_spectral_locus_wavelength` definition.
         """
 
         xy = np.array([0.54369557, 0.32107944])
-        xy_n = _CCS_DEFAULT_ILLUMINANT
+        xy_n = _CCS_ILLUMINANT_DEFAULT
         i_wl, xy_wl = closest_spectral_locus_wavelength(xy, xy_n, self._xy_s)
 
         self.assertEqual(i_wl, np.array(256))
@@ -74,7 +74,7 @@ closest_spectral_locus_wavelength` definition n-dimensional arrays support.
         """
 
         xy = np.array([0.54369557, 0.32107944])
-        xy_n = _CCS_DEFAULT_ILLUMINANT
+        xy_n = _CCS_ILLUMINANT_DEFAULT
         i_wl, xy_wl = closest_spectral_locus_wavelength(xy, xy_n, self._xy_s)
         i_wl_r, xy_wl_r = np.array(256), np.array([0.68354746, 0.31628409])
         np.testing.assert_almost_equal(i_wl, i_wl_r)
@@ -125,9 +125,9 @@ class TestDominantWavelength(unittest.TestCase):
         """
 
         xy = np.array([0.54369557, 0.32107944])
-        xy_n = _CCS_DEFAULT_ILLUMINANT
+        xy_n = _CCS_ILLUMINANT_DEFAULT
         wl, xy_wl, xy_cwl = dominant_wavelength(
-            xy, xy_n, MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS])
+            xy, xy_n, MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT])
 
         self.assertEqual(wl, np.array(616.0))
         np.testing.assert_almost_equal(
@@ -137,7 +137,7 @@ class TestDominantWavelength(unittest.TestCase):
 
         xy = np.array([0.37605506, 0.24452225])
         i_wl, xy_wl, xy_cwl = dominant_wavelength(
-            xy, xy_n, MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS])
+            xy, xy_n, MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT])
 
         self.assertEqual(i_wl, np.array(-509.0))
         np.testing.assert_almost_equal(
@@ -152,9 +152,9 @@ class TestDominantWavelength(unittest.TestCase):
         """
 
         xy = np.array([0.54369557, 0.32107944])
-        xy_n = _CCS_DEFAULT_ILLUMINANT
+        xy_n = _CCS_ILLUMINANT_DEFAULT
         wl, xy_wl, xy_cwl = dominant_wavelength(
-            xy, xy_n, MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS])
+            xy, xy_n, MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT])
         wl_r, xy_wl_r, xy_cwl_r = (np.array(616.0),
                                    np.array([0.68354746, 0.31628409]),
                                    np.array([0.68354746, 0.31628409]))
@@ -165,7 +165,7 @@ class TestDominantWavelength(unittest.TestCase):
         xy = np.tile(xy, (6, 1))
         xy_n = np.tile(xy_n, (6, 1))
         wl, xy_wl, xy_cwl = dominant_wavelength(
-            xy, xy_n, MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS])
+            xy, xy_n, MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT])
         wl_r = np.tile(wl_r, 6)
         xy_wl_r = np.tile(xy_wl_r, (6, 1))
         xy_cwl_r = np.tile(xy_cwl_r, (6, 1))
@@ -176,7 +176,7 @@ class TestDominantWavelength(unittest.TestCase):
         xy = np.reshape(xy, (2, 3, 2))
         xy_n = np.reshape(xy_n, (2, 3, 2))
         wl, xy_wl, xy_cwl = dominant_wavelength(
-            xy, xy_n, MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS])
+            xy, xy_n, MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT])
         wl_r = np.reshape(wl_r, (2, 3))
         xy_wl_r = np.reshape(xy_wl_r, (2, 3, 2))
         xy_cwl_r = np.reshape(xy_cwl_r, (2, 3, 2))
@@ -197,7 +197,7 @@ class TestDominantWavelength(unittest.TestCase):
             try:
                 dominant_wavelength(
                     case, case,
-                    MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS])
+                    MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT])
             except ValueError:
                 pass
 
@@ -215,9 +215,9 @@ class TestComplementaryWavelength(unittest.TestCase):
         """
 
         xy = np.array([0.54369557, 0.32107944])
-        xy_n = _CCS_DEFAULT_ILLUMINANT
+        xy_n = _CCS_ILLUMINANT_DEFAULT
         wl, xy_wl, xy_cwl = complementary_wavelength(
-            xy, xy_n, MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS])
+            xy, xy_n, MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT])
 
         self.assertEqual(wl, np.array(492.0))
         np.testing.assert_almost_equal(
@@ -227,7 +227,7 @@ class TestComplementaryWavelength(unittest.TestCase):
 
         xy = np.array([0.37605506, 0.24452225])
         i_wl, xy_wl, xy_cwl = complementary_wavelength(
-            xy, xy_n, MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS])
+            xy, xy_n, MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT])
 
         self.assertEqual(i_wl, np.array(509.0))
         np.testing.assert_almost_equal(
@@ -242,9 +242,9 @@ class TestComplementaryWavelength(unittest.TestCase):
         """
 
         xy = np.array([0.54369557, 0.32107944])
-        xy_n = _CCS_DEFAULT_ILLUMINANT
+        xy_n = _CCS_ILLUMINANT_DEFAULT
         wl, xy_wl, xy_cwl = complementary_wavelength(
-            xy, xy_n, MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS])
+            xy, xy_n, MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT])
         wl_r, xy_wl_r, xy_cwl_r = (np.array(492.0),
                                    np.array([0.03647950, 0.33847127]),
                                    np.array([0.03647950, 0.33847127]))
@@ -255,7 +255,7 @@ class TestComplementaryWavelength(unittest.TestCase):
         xy = np.tile(xy, (6, 1))
         xy_n = np.tile(xy_n, (6, 1))
         wl, xy_wl, xy_cwl = complementary_wavelength(
-            xy, xy_n, MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS])
+            xy, xy_n, MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT])
         wl_r = np.tile(wl_r, 6)
         xy_wl_r = np.tile(xy_wl_r, (6, 1))
         xy_cwl_r = np.tile(xy_cwl_r, (6, 1))
@@ -266,7 +266,7 @@ class TestComplementaryWavelength(unittest.TestCase):
         xy = np.reshape(xy, (2, 3, 2))
         xy_n = np.reshape(xy_n, (2, 3, 2))
         wl, xy_wl, xy_cwl = complementary_wavelength(
-            xy, xy_n, MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS])
+            xy, xy_n, MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT])
         wl_r = np.reshape(wl_r, (2, 3))
         xy_wl_r = np.reshape(xy_wl_r, (2, 3, 2))
         xy_cwl_r = np.reshape(xy_cwl_r, (2, 3, 2))
@@ -287,7 +287,7 @@ class TestComplementaryWavelength(unittest.TestCase):
             try:
                 complementary_wavelength(
                     case, case,
-                    MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS])
+                    MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT])
             except ValueError:
                 pass
 
@@ -304,18 +304,18 @@ class TestExcitationPurity(unittest.TestCase):
         """
 
         xy = np.array([0.54369557, 0.32107944])
-        xy_n = _CCS_DEFAULT_ILLUMINANT
+        xy_n = _CCS_ILLUMINANT_DEFAULT
 
         self.assertAlmostEqual(
             excitation_purity(xy, xy_n,
-                              MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS]),
+                              MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT]),
             0.622885671878446,
             places=7)
 
         xy = np.array([0.37605506, 0.24452225])
         self.assertAlmostEqual(
             excitation_purity(xy, xy_n,
-                              MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS]),
+                              MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT]),
             0.438347859215887,
             places=7)
 
@@ -326,16 +326,16 @@ class TestExcitationPurity(unittest.TestCase):
         """
 
         xy = np.array([0.54369557, 0.32107944])
-        xy_n = _CCS_DEFAULT_ILLUMINANT
+        xy_n = _CCS_ILLUMINANT_DEFAULT
         P_e = excitation_purity(
-            xy, xy_n, MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS])
+            xy, xy_n, MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT])
 
         xy = np.tile(xy, (6, 1))
         xy_n = np.tile(xy_n, (6, 1))
         P_e = np.tile(P_e, 6)
         np.testing.assert_almost_equal(
             excitation_purity(xy, xy_n,
-                              MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS]),
+                              MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT]),
             P_e,
             decimal=7)
 
@@ -344,7 +344,7 @@ class TestExcitationPurity(unittest.TestCase):
         P_e = np.reshape(P_e, (2, 3))
         np.testing.assert_almost_equal(
             excitation_purity(xy, xy_n,
-                              MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS]),
+                              MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT]),
             P_e,
             decimal=7)
 
@@ -361,7 +361,7 @@ class TestExcitationPurity(unittest.TestCase):
             try:
                 excitation_purity(
                     case, case,
-                    MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS])
+                    MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT])
             except ValueError:
                 pass
 
@@ -379,18 +379,18 @@ class TestColorimetricPurity(unittest.TestCase):
         """
 
         xy = np.array([0.54369557, 0.32107944])
-        xy_n = _CCS_DEFAULT_ILLUMINANT
+        xy_n = _CCS_ILLUMINANT_DEFAULT
 
         self.assertAlmostEqual(
             colorimetric_purity(
-                xy, xy_n, MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS]),
+                xy, xy_n, MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT]),
             0.613582813175483,
             places=7)
 
         xy = np.array([0.37605506, 0.24452225])
         self.assertAlmostEqual(
             colorimetric_purity(
-                xy, xy_n, MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS]),
+                xy, xy_n, MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT]),
             0.244307811178847,
             places=7)
 
@@ -401,16 +401,16 @@ class TestColorimetricPurity(unittest.TestCase):
         """
 
         xy = np.array([0.54369557, 0.32107944])
-        xy_n = _CCS_DEFAULT_ILLUMINANT
+        xy_n = _CCS_ILLUMINANT_DEFAULT
         P_e = colorimetric_purity(
-            xy, xy_n, MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS])
+            xy, xy_n, MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT])
 
         xy = np.tile(xy, (6, 1))
         xy_n = np.tile(xy_n, (6, 1))
         P_e = np.tile(P_e, 6)
         np.testing.assert_almost_equal(
             colorimetric_purity(
-                xy, xy_n, MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS]),
+                xy, xy_n, MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT]),
             P_e,
             decimal=7)
 
@@ -419,7 +419,7 @@ class TestColorimetricPurity(unittest.TestCase):
         P_e = np.reshape(P_e, (2, 3))
         np.testing.assert_almost_equal(
             colorimetric_purity(
-                xy, xy_n, MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS]),
+                xy, xy_n, MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT]),
             P_e,
             decimal=7)
 
@@ -436,7 +436,7 @@ class TestColorimetricPurity(unittest.TestCase):
             try:
                 colorimetric_purity(
                     case, case,
-                    MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS])
+                    MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT])
             except ValueError:
                 pass
 

--- a/colour/colorimetry/tests/test_dominant.py
+++ b/colour/colorimetry/tests/test_dominant.py
@@ -7,7 +7,7 @@ import numpy as np
 import unittest
 from itertools import permutations
 
-from colour.colorimetry import (MSDS_CMFS, CCS_ILLUMINANTS,
+from colour.colorimetry import (MSDS_CMFS_STANDARD_OBSERVER, CCS_ILLUMINANTS,
                                 dominant_wavelength, complementary_wavelength,
                                 excitation_purity, colorimetric_purity)
 from colour.colorimetry.dominant import (closest_spectral_locus_wavelength)
@@ -22,15 +22,14 @@ __email__ = 'colour-developers@colour-science.org'
 __status__ = 'Production'
 
 __all__ = [
-    'CMFS_STANDARD_OBSERVER_2_DEGREE_CIE1931', 'CCS_D65',
     'TestClosestSpectralLocusWavelength', 'TestDominantWavelength',
     'TestComplementaryWavelength', 'TestExcitationPurity',
     'TestColorimetricPurity'
 ]
 
-CMFS_STANDARD_OBSERVER_2_DEGREE_CIE1931 = MSDS_CMFS[
-    'CIE 1931 2 Degree Standard Observer']
-CCS_D65 = CCS_ILLUMINANTS['CIE 1931 2 Degree Standard Observer']['D65']
+_DEFAULT_MSDS_CMFS = 'CIE 1931 2 Degree Standard Observer'
+
+_CCS_DEFAULT_ILLUMINANT = CCS_ILLUMINANTS[_DEFAULT_MSDS_CMFS]['D65']
 
 
 class TestClosestSpectralLocusWavelength(unittest.TestCase):
@@ -44,7 +43,8 @@ closest_spectral_locus_wavelength` definition unit tests methods.
         Initialises common tests attributes.
         """
 
-        self._xy_s = XYZ_to_xy(CMFS_STANDARD_OBSERVER_2_DEGREE_CIE1931.values)
+        self._xy_s = XYZ_to_xy(
+            MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS].values)
 
     def test_closest_spectral_locus_wavelength(self):
         """
@@ -53,7 +53,7 @@ closest_spectral_locus_wavelength` definition.
         """
 
         xy = np.array([0.54369557, 0.32107944])
-        xy_n = CCS_D65
+        xy_n = _CCS_DEFAULT_ILLUMINANT
         i_wl, xy_wl = closest_spectral_locus_wavelength(xy, xy_n, self._xy_s)
 
         self.assertEqual(i_wl, np.array(256))
@@ -74,7 +74,7 @@ closest_spectral_locus_wavelength` definition n-dimensional arrays support.
         """
 
         xy = np.array([0.54369557, 0.32107944])
-        xy_n = CCS_D65
+        xy_n = _CCS_DEFAULT_ILLUMINANT
         i_wl, xy_wl = closest_spectral_locus_wavelength(xy, xy_n, self._xy_s)
         i_wl_r, xy_wl_r = np.array(256), np.array([0.68354746, 0.31628409])
         np.testing.assert_almost_equal(i_wl, i_wl_r)
@@ -125,9 +125,9 @@ class TestDominantWavelength(unittest.TestCase):
         """
 
         xy = np.array([0.54369557, 0.32107944])
-        xy_n = CCS_D65
+        xy_n = _CCS_DEFAULT_ILLUMINANT
         wl, xy_wl, xy_cwl = dominant_wavelength(
-            xy, xy_n, CMFS_STANDARD_OBSERVER_2_DEGREE_CIE1931)
+            xy, xy_n, MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS])
 
         self.assertEqual(wl, np.array(616.0))
         np.testing.assert_almost_equal(
@@ -137,7 +137,7 @@ class TestDominantWavelength(unittest.TestCase):
 
         xy = np.array([0.37605506, 0.24452225])
         i_wl, xy_wl, xy_cwl = dominant_wavelength(
-            xy, xy_n, CMFS_STANDARD_OBSERVER_2_DEGREE_CIE1931)
+            xy, xy_n, MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS])
 
         self.assertEqual(i_wl, np.array(-509.0))
         np.testing.assert_almost_equal(
@@ -152,9 +152,9 @@ class TestDominantWavelength(unittest.TestCase):
         """
 
         xy = np.array([0.54369557, 0.32107944])
-        xy_n = CCS_D65
+        xy_n = _CCS_DEFAULT_ILLUMINANT
         wl, xy_wl, xy_cwl = dominant_wavelength(
-            xy, xy_n, CMFS_STANDARD_OBSERVER_2_DEGREE_CIE1931)
+            xy, xy_n, MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS])
         wl_r, xy_wl_r, xy_cwl_r = (np.array(616.0),
                                    np.array([0.68354746, 0.31628409]),
                                    np.array([0.68354746, 0.31628409]))
@@ -165,7 +165,7 @@ class TestDominantWavelength(unittest.TestCase):
         xy = np.tile(xy, (6, 1))
         xy_n = np.tile(xy_n, (6, 1))
         wl, xy_wl, xy_cwl = dominant_wavelength(
-            xy, xy_n, CMFS_STANDARD_OBSERVER_2_DEGREE_CIE1931)
+            xy, xy_n, MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS])
         wl_r = np.tile(wl_r, 6)
         xy_wl_r = np.tile(xy_wl_r, (6, 1))
         xy_cwl_r = np.tile(xy_cwl_r, (6, 1))
@@ -176,7 +176,7 @@ class TestDominantWavelength(unittest.TestCase):
         xy = np.reshape(xy, (2, 3, 2))
         xy_n = np.reshape(xy_n, (2, 3, 2))
         wl, xy_wl, xy_cwl = dominant_wavelength(
-            xy, xy_n, CMFS_STANDARD_OBSERVER_2_DEGREE_CIE1931)
+            xy, xy_n, MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS])
         wl_r = np.reshape(wl_r, (2, 3))
         xy_wl_r = np.reshape(xy_wl_r, (2, 3, 2))
         xy_cwl_r = np.reshape(xy_cwl_r, (2, 3, 2))
@@ -195,8 +195,9 @@ class TestDominantWavelength(unittest.TestCase):
         cases = set(permutations(cases * 3, r=2))
         for case in cases:
             try:
-                dominant_wavelength(case, case,
-                                    CMFS_STANDARD_OBSERVER_2_DEGREE_CIE1931)
+                dominant_wavelength(
+                    case, case,
+                    MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS])
             except ValueError:
                 pass
 
@@ -214,9 +215,9 @@ class TestComplementaryWavelength(unittest.TestCase):
         """
 
         xy = np.array([0.54369557, 0.32107944])
-        xy_n = CCS_D65
+        xy_n = _CCS_DEFAULT_ILLUMINANT
         wl, xy_wl, xy_cwl = complementary_wavelength(
-            xy, xy_n, CMFS_STANDARD_OBSERVER_2_DEGREE_CIE1931)
+            xy, xy_n, MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS])
 
         self.assertEqual(wl, np.array(492.0))
         np.testing.assert_almost_equal(
@@ -226,7 +227,7 @@ class TestComplementaryWavelength(unittest.TestCase):
 
         xy = np.array([0.37605506, 0.24452225])
         i_wl, xy_wl, xy_cwl = complementary_wavelength(
-            xy, xy_n, CMFS_STANDARD_OBSERVER_2_DEGREE_CIE1931)
+            xy, xy_n, MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS])
 
         self.assertEqual(i_wl, np.array(509.0))
         np.testing.assert_almost_equal(
@@ -241,9 +242,9 @@ class TestComplementaryWavelength(unittest.TestCase):
         """
 
         xy = np.array([0.54369557, 0.32107944])
-        xy_n = CCS_D65
+        xy_n = _CCS_DEFAULT_ILLUMINANT
         wl, xy_wl, xy_cwl = complementary_wavelength(
-            xy, xy_n, CMFS_STANDARD_OBSERVER_2_DEGREE_CIE1931)
+            xy, xy_n, MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS])
         wl_r, xy_wl_r, xy_cwl_r = (np.array(492.0),
                                    np.array([0.03647950, 0.33847127]),
                                    np.array([0.03647950, 0.33847127]))
@@ -254,7 +255,7 @@ class TestComplementaryWavelength(unittest.TestCase):
         xy = np.tile(xy, (6, 1))
         xy_n = np.tile(xy_n, (6, 1))
         wl, xy_wl, xy_cwl = complementary_wavelength(
-            xy, xy_n, CMFS_STANDARD_OBSERVER_2_DEGREE_CIE1931)
+            xy, xy_n, MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS])
         wl_r = np.tile(wl_r, 6)
         xy_wl_r = np.tile(xy_wl_r, (6, 1))
         xy_cwl_r = np.tile(xy_cwl_r, (6, 1))
@@ -265,7 +266,7 @@ class TestComplementaryWavelength(unittest.TestCase):
         xy = np.reshape(xy, (2, 3, 2))
         xy_n = np.reshape(xy_n, (2, 3, 2))
         wl, xy_wl, xy_cwl = complementary_wavelength(
-            xy, xy_n, CMFS_STANDARD_OBSERVER_2_DEGREE_CIE1931)
+            xy, xy_n, MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS])
         wl_r = np.reshape(wl_r, (2, 3))
         xy_wl_r = np.reshape(xy_wl_r, (2, 3, 2))
         xy_cwl_r = np.reshape(xy_cwl_r, (2, 3, 2))
@@ -285,7 +286,8 @@ class TestComplementaryWavelength(unittest.TestCase):
         for case in cases:
             try:
                 complementary_wavelength(
-                    case, case, CMFS_STANDARD_OBSERVER_2_DEGREE_CIE1931)
+                    case, case,
+                    MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS])
             except ValueError:
                 pass
 
@@ -302,18 +304,18 @@ class TestExcitationPurity(unittest.TestCase):
         """
 
         xy = np.array([0.54369557, 0.32107944])
-        xy_n = CCS_D65
+        xy_n = _CCS_DEFAULT_ILLUMINANT
 
         self.assertAlmostEqual(
             excitation_purity(xy, xy_n,
-                              CMFS_STANDARD_OBSERVER_2_DEGREE_CIE1931),
+                              MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS]),
             0.622885671878446,
             places=7)
 
         xy = np.array([0.37605506, 0.24452225])
         self.assertAlmostEqual(
             excitation_purity(xy, xy_n,
-                              CMFS_STANDARD_OBSERVER_2_DEGREE_CIE1931),
+                              MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS]),
             0.438347859215887,
             places=7)
 
@@ -324,16 +326,16 @@ class TestExcitationPurity(unittest.TestCase):
         """
 
         xy = np.array([0.54369557, 0.32107944])
-        xy_n = CCS_D65
-        P_e = excitation_purity(xy, xy_n,
-                                CMFS_STANDARD_OBSERVER_2_DEGREE_CIE1931)
+        xy_n = _CCS_DEFAULT_ILLUMINANT
+        P_e = excitation_purity(
+            xy, xy_n, MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS])
 
         xy = np.tile(xy, (6, 1))
         xy_n = np.tile(xy_n, (6, 1))
         P_e = np.tile(P_e, 6)
         np.testing.assert_almost_equal(
             excitation_purity(xy, xy_n,
-                              CMFS_STANDARD_OBSERVER_2_DEGREE_CIE1931),
+                              MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS]),
             P_e,
             decimal=7)
 
@@ -342,7 +344,7 @@ class TestExcitationPurity(unittest.TestCase):
         P_e = np.reshape(P_e, (2, 3))
         np.testing.assert_almost_equal(
             excitation_purity(xy, xy_n,
-                              CMFS_STANDARD_OBSERVER_2_DEGREE_CIE1931),
+                              MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS]),
             P_e,
             decimal=7)
 
@@ -357,8 +359,9 @@ class TestExcitationPurity(unittest.TestCase):
         cases = set(permutations(cases * 3, r=2))
         for case in cases:
             try:
-                excitation_purity(case, case,
-                                  CMFS_STANDARD_OBSERVER_2_DEGREE_CIE1931)
+                excitation_purity(
+                    case, case,
+                    MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS])
             except ValueError:
                 pass
 
@@ -376,18 +379,18 @@ class TestColorimetricPurity(unittest.TestCase):
         """
 
         xy = np.array([0.54369557, 0.32107944])
-        xy_n = CCS_D65
+        xy_n = _CCS_DEFAULT_ILLUMINANT
 
         self.assertAlmostEqual(
-            colorimetric_purity(xy, xy_n,
-                                CMFS_STANDARD_OBSERVER_2_DEGREE_CIE1931),
+            colorimetric_purity(
+                xy, xy_n, MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS]),
             0.613582813175483,
             places=7)
 
         xy = np.array([0.37605506, 0.24452225])
         self.assertAlmostEqual(
-            colorimetric_purity(xy, xy_n,
-                                CMFS_STANDARD_OBSERVER_2_DEGREE_CIE1931),
+            colorimetric_purity(
+                xy, xy_n, MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS]),
             0.244307811178847,
             places=7)
 
@@ -398,16 +401,16 @@ class TestColorimetricPurity(unittest.TestCase):
         """
 
         xy = np.array([0.54369557, 0.32107944])
-        xy_n = CCS_D65
-        P_e = colorimetric_purity(xy, xy_n,
-                                  CMFS_STANDARD_OBSERVER_2_DEGREE_CIE1931)
+        xy_n = _CCS_DEFAULT_ILLUMINANT
+        P_e = colorimetric_purity(
+            xy, xy_n, MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS])
 
         xy = np.tile(xy, (6, 1))
         xy_n = np.tile(xy_n, (6, 1))
         P_e = np.tile(P_e, 6)
         np.testing.assert_almost_equal(
-            colorimetric_purity(xy, xy_n,
-                                CMFS_STANDARD_OBSERVER_2_DEGREE_CIE1931),
+            colorimetric_purity(
+                xy, xy_n, MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS]),
             P_e,
             decimal=7)
 
@@ -415,8 +418,8 @@ class TestColorimetricPurity(unittest.TestCase):
         xy_n = np.reshape(xy_n, (2, 3, 2))
         P_e = np.reshape(P_e, (2, 3))
         np.testing.assert_almost_equal(
-            colorimetric_purity(xy, xy_n,
-                                CMFS_STANDARD_OBSERVER_2_DEGREE_CIE1931),
+            colorimetric_purity(
+                xy, xy_n, MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS]),
             P_e,
             decimal=7)
 
@@ -431,8 +434,9 @@ class TestColorimetricPurity(unittest.TestCase):
         cases = set(permutations(cases * 3, r=2))
         for case in cases:
             try:
-                colorimetric_purity(case, case,
-                                    CMFS_STANDARD_OBSERVER_2_DEGREE_CIE1931)
+                colorimetric_purity(
+                    case, case,
+                    MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS])
             except ValueError:
                 pass
 

--- a/colour/colorimetry/tests/test_spectrum.py
+++ b/colour/colorimetry/tests/test_spectrum.py
@@ -1684,6 +1684,7 @@ MultiSpectralDistributions.__init__` method.
 MultiSpectralDistributions.interpolate` method.
         """
 
+        # pylint: disable=E1102
         msds = reshape_msds(
             self._sample_msds, SpectralShape(interval=1), 'Interpolate')
         for signal in msds.signals.values():
@@ -1696,6 +1697,7 @@ MultiSpectralDistributions.interpolate` method.
         if LooseVersion(scipy.__version__) < LooseVersion('0.19.0'):
             return  # pragma: no cover
 
+        # pylint: disable=E1102
         msds = reshape_msds(
             self._non_uniform_sample_msds,
             SpectralShape(interval=1),

--- a/colour/colorimetry/tests/test_tristimulus_values.py
+++ b/colour/colorimetry/tests/test_tristimulus_values.py
@@ -541,6 +541,7 @@ tristimulus_weighting_factors_ASTME2022` definition raised exception.
         shape = SpectralShape(360, 830, 10)
         cmfs_1 = MSDS_CMFS_STANDARD_OBSERVER[
             'CIE 1964 10 Degree Standard Observer']
+        # pylint: disable=E1102
         cmfs_2 = reshape_msds(cmfs_1, shape)
         A_1 = sd_CIE_standard_illuminant_A(cmfs_1.shape)
         A_2 = sd_CIE_standard_illuminant_A(cmfs_2.shape)
@@ -1116,6 +1117,7 @@ msds_to_XYZ_ASTME308` definition.
 
         cmfs = MSDS_CMFS_STANDARD_OBSERVER[
             'CIE 1931 2 Degree Standard Observer']
+        # pylint: disable=E1102
         msds = reshape_msds(MSDS_TWO, SpectralShape(400, 700, 20))
         np.testing.assert_almost_equal(
             msds_to_XYZ_ASTME308(msds, cmfs, SDS_ILLUMINANTS['D65']),
@@ -1138,6 +1140,7 @@ msds_to_XYZ_ASTME308` definition domain and range scale support.
         d_r = (('reference', 1), (1, 0.01), (100, 1))
         for scale, factor in d_r:
             with domain_range_scale(scale):
+                # pylint: disable=E1102
                 np.testing.assert_almost_equal(
                     msds_to_XYZ_ASTME308(
                         reshape_msds(MSDS_TWO, SpectralShape(400, 700, 20)),

--- a/colour/colorimetry/tests/test_tristimulus_values.py
+++ b/colour/colorimetry/tests/test_tristimulus_values.py
@@ -14,9 +14,10 @@ import numpy as np
 import unittest
 
 from colour.algebra import LinearInterpolator
-from colour.colorimetry import (MSDS_CMFS, sd_CIE_standard_illuminant_A,
-                                SDS_ILLUMINANTS, MultiSpectralDistributions,
-                                SpectralDistribution, SpectralShape)
+from colour.colorimetry import (
+    MSDS_CMFS_STANDARD_OBSERVER, SDS_ILLUMINANTS, MultiSpectralDistributions,
+    SpectralDistribution, SpectralShape, reshape_msds, reshape_sd,
+    sd_CIE_standard_illuminant_A)
 from colour.colorimetry import (
     lagrange_coefficients_ASTME2022, tristimulus_weighting_factors_ASTME2022,
     adjust_tristimulus_weighting_factors_ASTME308, sd_to_XYZ_integration,
@@ -484,7 +485,8 @@ tristimulus_weighting_factors_ASTME2022` definition.
         :cite:`ASTMInternational2015b`
         """
 
-        cmfs = MSDS_CMFS['CIE 1964 10 Degree Standard Observer']
+        cmfs = MSDS_CMFS_STANDARD_OBSERVER[
+            'CIE 1964 10 Degree Standard Observer']
         A = sd_CIE_standard_illuminant_A(cmfs.shape)
 
         twf = tristimulus_weighting_factors_ASTME2022(
@@ -497,9 +499,12 @@ tristimulus_weighting_factors_ASTME2022` definition.
         np.testing.assert_almost_equal(
             np.round(twf, 3), TWF_A_CIE_1964_10_20, decimal=3)
 
-        cmfs = MSDS_CMFS['CIE 1931 2 Degree Standard Observer']
-        D65 = SDS_ILLUMINANTS['D65'].copy().align(
-            cmfs.shape, interpolator=LinearInterpolator)
+        cmfs = MSDS_CMFS_STANDARD_OBSERVER[
+            'CIE 1931 2 Degree Standard Observer']
+        D65 = reshape_sd(
+            SDS_ILLUMINANTS['D65'],
+            cmfs.shape,
+            interpolator=LinearInterpolator)
         twf = tristimulus_weighting_factors_ASTME2022(
             cmfs, D65, SpectralShape(360, 830, 20))
         np.testing.assert_almost_equal(
@@ -511,7 +516,8 @@ tristimulus_weighting_factors_ASTME2022` definition.
             twf, TWF_D65_CIE_1931_2_20_K1, decimal=7)
 
         # Testing that the cache returns a copy of the data.
-        cmfs = MSDS_CMFS['CIE 1964 10 Degree Standard Observer']
+        cmfs = MSDS_CMFS_STANDARD_OBSERVER[
+            'CIE 1964 10 Degree Standard Observer']
         twf = tristimulus_weighting_factors_ASTME2022(
             cmfs, A, SpectralShape(360, 830, 10))
         np.testing.assert_almost_equal(
@@ -533,8 +539,9 @@ tristimulus_weighting_factors_ASTME2022` definition raised exception.
         """
 
         shape = SpectralShape(360, 830, 10)
-        cmfs_1 = MSDS_CMFS['CIE 1964 10 Degree Standard Observer']
-        cmfs_2 = cmfs_1.copy().align(shape)
+        cmfs_1 = MSDS_CMFS_STANDARD_OBSERVER[
+            'CIE 1964 10 Degree Standard Observer']
+        cmfs_2 = reshape_msds(cmfs_1, shape)
         A_1 = sd_CIE_standard_illuminant_A(cmfs_1.shape)
         A_2 = sd_CIE_standard_illuminant_A(cmfs_2.shape)
 
@@ -577,13 +584,15 @@ class TestSd_to_XYZ_integration(unittest.TestCase):
 sd_to_XYZ_integration` definition.
         """
 
-        cmfs = MSDS_CMFS['CIE 1931 2 Degree Standard Observer']
+        cmfs = MSDS_CMFS_STANDARD_OBSERVER[
+            'CIE 1931 2 Degree Standard Observer']
         np.testing.assert_almost_equal(
             sd_to_XYZ_integration(SD_SAMPLE, cmfs, SDS_ILLUMINANTS['A']),
             np.array([14.46341147, 10.85819624, 2.04695585]),
             decimal=7)
 
-        cmfs = MSDS_CMFS['CIE 1964 10 Degree Standard Observer']
+        cmfs = MSDS_CMFS_STANDARD_OBSERVER[
+            'CIE 1964 10 Degree Standard Observer']
         np.testing.assert_almost_equal(
             sd_to_XYZ_integration(SD_SAMPLE, cmfs, SDS_ILLUMINANTS['C']),
             np.array([10.77002699, 9.44876636, 6.62415290]),
@@ -606,7 +615,8 @@ sd_to_XYZ_integration` definition.
 sd_to_XYZ_integration` definition domain and range scale support.
         """
 
-        cmfs = MSDS_CMFS['CIE 1931 2 Degree Standard Observer']
+        cmfs = MSDS_CMFS_STANDARD_OBSERVER[
+            'CIE 1931 2 Degree Standard Observer']
         XYZ = sd_to_XYZ_integration(SD_SAMPLE, cmfs, SDS_ILLUMINANTS['A'])
 
         d_r = (('reference', 1), (1, 0.01), (100, 1))
@@ -633,14 +643,16 @@ sd_to_XYZ_tristimulus_weighting_factors_ASTME308`
         definition.
         """
 
-        cmfs = MSDS_CMFS['CIE 1931 2 Degree Standard Observer']
+        cmfs = MSDS_CMFS_STANDARD_OBSERVER[
+            'CIE 1931 2 Degree Standard Observer']
         np.testing.assert_almost_equal(
             sd_to_XYZ_tristimulus_weighting_factors_ASTME308(
                 SD_SAMPLE, cmfs, SDS_ILLUMINANTS['A']),
             np.array([14.46341867, 10.85820227, 2.04697034]),
             decimal=7)
 
-        cmfs = MSDS_CMFS['CIE 1964 10 Degree Standard Observer']
+        cmfs = MSDS_CMFS_STANDARD_OBSERVER[
+            'CIE 1964 10 Degree Standard Observer']
         np.testing.assert_almost_equal(
             sd_to_XYZ_tristimulus_weighting_factors_ASTME308(
                 SD_SAMPLE, cmfs, SDS_ILLUMINANTS['C']),
@@ -655,28 +667,29 @@ sd_to_XYZ_tristimulus_weighting_factors_ASTME308`
 
         np.testing.assert_almost_equal(
             sd_to_XYZ_tristimulus_weighting_factors_ASTME308(
-                SD_SAMPLE.copy().trim(SpectralShape(400, 700, 5)), cmfs,
-                SDS_ILLUMINANTS['A']),
+                reshape_sd(SD_SAMPLE, SpectralShape(400, 700, 5), 'Trim'),
+                cmfs, SDS_ILLUMINANTS['A']),
             np.array([14.38153638, 10.74503131, 2.01613844]),
             decimal=7)
 
         np.testing.assert_almost_equal(
             sd_to_XYZ_tristimulus_weighting_factors_ASTME308(
-                SD_SAMPLE.copy().interpolate(SpectralShape(400, 700, 10)),
-                cmfs, SDS_ILLUMINANTS['A']),
+                reshape_sd(SD_SAMPLE, SpectralShape(400, 700, 10),
+                           'Interpolate'), cmfs, SDS_ILLUMINANTS['A']),
             np.array([14.38257202, 10.74568178, 2.01588427]),
             decimal=7)
 
         np.testing.assert_almost_equal(
             sd_to_XYZ_tristimulus_weighting_factors_ASTME308(
-                SD_SAMPLE.copy().interpolate(SpectralShape(400, 700, 20)),
-                cmfs, SDS_ILLUMINANTS['A']),
+                reshape_sd(SD_SAMPLE, SpectralShape(400, 700, 20),
+                           'Interpolate'), cmfs, SDS_ILLUMINANTS['A']),
             np.array([14.38329645, 10.74603515, 2.01561113]),
             decimal=7)
 
         np.testing.assert_almost_equal(
             sd_to_XYZ_tristimulus_weighting_factors_ASTME308(
-                SD_SAMPLE.copy().interpolate(SpectralShape(400, 700, 20)),
+                reshape_sd(SD_SAMPLE, SpectralShape(400, 700, 20),
+                           'Interpolate'),
                 cmfs,
                 SDS_ILLUMINANTS['A'],
                 k=1),
@@ -690,7 +703,8 @@ sd_to_XYZ_tristimulus_weighting_factors_ASTME308` definition domain and
 range scale support.
         """
 
-        cmfs = MSDS_CMFS['CIE 1931 2 Degree Standard Observer']
+        cmfs = MSDS_CMFS_STANDARD_OBSERVER[
+            'CIE 1931 2 Degree Standard Observer']
         XYZ = sd_to_XYZ_tristimulus_weighting_factors_ASTME308(
             SD_SAMPLE, cmfs, SDS_ILLUMINANTS['A'])
 
@@ -716,7 +730,8 @@ class TestSd_to_XYZ_ASTME308(unittest.TestCase):
         """
 
         self._sd = SD_SAMPLE.copy()
-        self._cmfs = MSDS_CMFS['CIE 1931 2 Degree Standard Observer']
+        self._cmfs = MSDS_CMFS_STANDARD_OBSERVER[
+            'CIE 1931 2 Degree Standard Observer']
         self._A = sd_CIE_standard_illuminant_A(self._cmfs.shape)
 
     def test_sd_to_XYZ_ASTME308_mi_1nm(self):
@@ -726,14 +741,14 @@ class TestSd_to_XYZ_ASTME308(unittest.TestCase):
         """
 
         np.testing.assert_almost_equal(
-            sd_to_XYZ_ASTME308(self._sd.copy().align(self._cmfs.shape),
-                               self._cmfs, self._A),
+            sd_to_XYZ_ASTME308(
+                reshape_sd(self._sd, self._cmfs.shape), self._cmfs, self._A),
             np.array([14.46372680, 10.85832950, 2.04663200]),
             decimal=7)
 
         np.testing.assert_almost_equal(
             sd_to_XYZ_ASTME308(
-                self._sd.copy().align(self._cmfs.shape),
+                reshape_sd(self._sd, self._cmfs.shape),
                 self._cmfs,
                 self._A,
                 use_practice_range=False),
@@ -742,14 +757,14 @@ class TestSd_to_XYZ_ASTME308(unittest.TestCase):
 
         np.testing.assert_almost_equal(
             sd_to_XYZ_ASTME308(
-                self._sd.copy().align(SpectralShape(400, 700, 1)), self._cmfs,
+                reshape_sd(self._sd, SpectralShape(400, 700, 1)), self._cmfs,
                 self._A),
             np.array([14.54173397, 10.88628632, 2.04965822]),
             decimal=7)
 
         np.testing.assert_almost_equal(
             sd_to_XYZ_ASTME308(
-                self._sd.copy().align(SpectralShape(400, 700, 1)),
+                reshape_sd(self._sd, SpectralShape(400, 700, 1)),
                 self._cmfs,
                 self._A,
                 use_practice_range=False),
@@ -758,7 +773,7 @@ class TestSd_to_XYZ_ASTME308(unittest.TestCase):
 
         np.testing.assert_almost_equal(
             sd_to_XYZ_ASTME308(
-                self._sd.copy().align(SpectralShape(400, 700, 1)),
+                reshape_sd(self._sd, SpectralShape(400, 700, 1)),
                 self._cmfs,
                 self._A,
                 k=1),
@@ -773,14 +788,14 @@ class TestSd_to_XYZ_ASTME308(unittest.TestCase):
 
         np.testing.assert_almost_equal(
             sd_to_XYZ_ASTME308(
-                self._sd.copy().align(SpectralShape(360, 830, 5)), self._cmfs,
+                reshape_sd(self._sd, SpectralShape(360, 830, 5)), self._cmfs,
                 self._A),
             np.array([14.46372173, 10.85832502, 2.04664734]),
             decimal=7)
 
         np.testing.assert_almost_equal(
             sd_to_XYZ_ASTME308(
-                self._sd.copy().align(SpectralShape(360, 830, 5)),
+                reshape_sd(self._sd, SpectralShape(360, 830, 5)),
                 self._cmfs,
                 self._A,
                 use_practice_range=False),
@@ -789,7 +804,7 @@ class TestSd_to_XYZ_ASTME308(unittest.TestCase):
 
         np.testing.assert_almost_equal(
             sd_to_XYZ_ASTME308(
-                self._sd.copy().align(SpectralShape(360, 830, 5)),
+                reshape_sd(self._sd, SpectralShape(360, 830, 5)),
                 self._cmfs,
                 self._A,
                 mi_5nm_omission_method=False),
@@ -798,14 +813,14 @@ class TestSd_to_XYZ_ASTME308(unittest.TestCase):
 
         np.testing.assert_almost_equal(
             sd_to_XYZ_ASTME308(
-                self._sd.copy().align(SpectralShape(400, 700, 5)), self._cmfs,
+                reshape_sd(self._sd, SpectralShape(400, 700, 5)), self._cmfs,
                 self._A),
             np.array([14.54025742, 10.88576251, 2.04950226]),
             decimal=7)
 
         np.testing.assert_almost_equal(
             sd_to_XYZ_ASTME308(
-                self._sd.copy().align(SpectralShape(400, 700, 5)),
+                reshape_sd(self._sd, SpectralShape(400, 700, 5)),
                 self._cmfs,
                 self._A,
                 use_practice_range=False),
@@ -814,7 +829,7 @@ class TestSd_to_XYZ_ASTME308(unittest.TestCase):
 
         np.testing.assert_almost_equal(
             sd_to_XYZ_ASTME308(
-                self._sd.copy().align(SpectralShape(400, 700, 5)),
+                reshape_sd(self._sd, SpectralShape(400, 700, 5)),
                 self._cmfs,
                 self._A,
                 mi_5nm_omission_method=False),
@@ -823,7 +838,7 @@ class TestSd_to_XYZ_ASTME308(unittest.TestCase):
 
         np.testing.assert_almost_equal(
             sd_to_XYZ_ASTME308(
-                self._sd.copy().align(SpectralShape(360, 830, 5)),
+                reshape_sd(self._sd, SpectralShape(360, 830, 5)),
                 self._cmfs,
                 self._A,
                 use_practice_range=False,
@@ -833,7 +848,7 @@ class TestSd_to_XYZ_ASTME308(unittest.TestCase):
 
         np.testing.assert_almost_equal(
             sd_to_XYZ_ASTME308(
-                self._sd.copy().align(SpectralShape(400, 700, 5)),
+                reshape_sd(self._sd, SpectralShape(400, 700, 5)),
                 self._cmfs,
                 self._A,
                 use_practice_range=False,
@@ -843,7 +858,7 @@ class TestSd_to_XYZ_ASTME308(unittest.TestCase):
 
         np.testing.assert_almost_equal(
             sd_to_XYZ_ASTME308(
-                self._sd.copy().align(SpectralShape(400, 700, 5)),
+                reshape_sd(self._sd, SpectralShape(400, 700, 5)),
                 self._cmfs,
                 self._A,
                 k=1),
@@ -858,14 +873,14 @@ class TestSd_to_XYZ_ASTME308(unittest.TestCase):
 
         np.testing.assert_almost_equal(
             sd_to_XYZ_ASTME308(
-                self._sd.copy().align(SpectralShape(360, 830, 10)), self._cmfs,
+                reshape_sd(self._sd, SpectralShape(360, 830, 10)), self._cmfs,
                 self._A),
             np.array([14.47779980, 10.86358645, 2.04751388]),
             decimal=7)
 
         np.testing.assert_almost_equal(
             sd_to_XYZ_ASTME308(
-                self._sd.copy().align(SpectralShape(360, 830, 10)),
+                reshape_sd(self._sd, SpectralShape(360, 830, 10)),
                 self._cmfs,
                 self._A,
                 use_practice_range=False),
@@ -874,14 +889,14 @@ class TestSd_to_XYZ_ASTME308(unittest.TestCase):
 
         np.testing.assert_almost_equal(
             sd_to_XYZ_ASTME308(
-                self._sd.copy().align(SpectralShape(400, 700, 10)), self._cmfs,
+                reshape_sd(self._sd, SpectralShape(400, 700, 10)), self._cmfs,
                 self._A),
             np.array([14.54137532, 10.88641727, 2.04931318]),
             decimal=7)
 
         np.testing.assert_almost_equal(
             sd_to_XYZ_ASTME308(
-                self._sd.copy().align(SpectralShape(400, 700, 10)),
+                reshape_sd(self._sd, SpectralShape(400, 700, 10)),
                 self._cmfs,
                 self._A,
                 use_practice_range=False),
@@ -890,7 +905,7 @@ class TestSd_to_XYZ_ASTME308(unittest.TestCase):
 
         np.testing.assert_almost_equal(
             sd_to_XYZ_ASTME308(
-                self._sd.copy().align(SpectralShape(400, 700, 10)),
+                reshape_sd(self._sd, SpectralShape(400, 700, 10)),
                 self._cmfs,
                 self._A,
                 k=1),
@@ -905,14 +920,14 @@ class TestSd_to_XYZ_ASTME308(unittest.TestCase):
 
         np.testing.assert_almost_equal(
             sd_to_XYZ_ASTME308(
-                self._sd.copy().align(SpectralShape(360, 820, 20)), self._cmfs,
+                reshape_sd(self._sd, SpectralShape(360, 820, 20)), self._cmfs,
                 self._A),
             np.array([14.50187464, 10.87217124, 2.04918305]),
             decimal=7)
 
         np.testing.assert_almost_equal(
             sd_to_XYZ_ASTME308(
-                self._sd.copy().align(SpectralShape(360, 820, 20)),
+                reshape_sd(self._sd, SpectralShape(360, 820, 20)),
                 self._cmfs,
                 self._A,
                 use_practice_range=False),
@@ -921,7 +936,7 @@ class TestSd_to_XYZ_ASTME308(unittest.TestCase):
 
         np.testing.assert_almost_equal(
             sd_to_XYZ_ASTME308(
-                self._sd.copy().align(SpectralShape(360, 820, 20)),
+                reshape_sd(self._sd, SpectralShape(360, 820, 20)),
                 self._cmfs,
                 self._A,
                 mi_20nm_interpolation_method=False),
@@ -930,14 +945,14 @@ class TestSd_to_XYZ_ASTME308(unittest.TestCase):
 
         np.testing.assert_almost_equal(
             sd_to_XYZ_ASTME308(
-                self._sd.copy().align(SpectralShape(400, 700, 20)), self._cmfs,
+                reshape_sd(self._sd, SpectralShape(400, 700, 20)), self._cmfs,
                 self._A),
             np.array([14.54114025, 10.88634755, 2.04916445]),
             decimal=7)
 
         np.testing.assert_almost_equal(
             sd_to_XYZ_ASTME308(
-                self._sd.copy().align(SpectralShape(400, 700, 20)),
+                reshape_sd(self._sd, SpectralShape(400, 700, 20)),
                 self._cmfs,
                 self._A,
                 use_practice_range=False),
@@ -946,7 +961,7 @@ class TestSd_to_XYZ_ASTME308(unittest.TestCase):
 
         np.testing.assert_almost_equal(
             sd_to_XYZ_ASTME308(
-                self._sd.copy().align(SpectralShape(400, 700, 20)),
+                reshape_sd(self._sd, SpectralShape(400, 700, 20)),
                 self._cmfs,
                 self._A,
                 mi_20nm_interpolation_method=False),
@@ -955,7 +970,7 @@ class TestSd_to_XYZ_ASTME308(unittest.TestCase):
 
         np.testing.assert_almost_equal(
             sd_to_XYZ_ASTME308(
-                self._sd.copy().align(SpectralShape(360, 820, 20)),
+                reshape_sd(self._sd, SpectralShape(360, 820, 20)),
                 self._cmfs,
                 self._A,
                 use_practice_range=False,
@@ -965,7 +980,7 @@ class TestSd_to_XYZ_ASTME308(unittest.TestCase):
 
         np.testing.assert_almost_equal(
             sd_to_XYZ_ASTME308(
-                self._sd.copy().align(SpectralShape(400, 700, 20)),
+                reshape_sd(self._sd, SpectralShape(400, 700, 20)),
                 self._cmfs,
                 self._A,
                 use_practice_range=False,
@@ -975,7 +990,7 @@ class TestSd_to_XYZ_ASTME308(unittest.TestCase):
 
         np.testing.assert_almost_equal(
             sd_to_XYZ_ASTME308(
-                self._sd.copy().align(SpectralShape(400, 700, 20)),
+                reshape_sd(self._sd, SpectralShape(400, 700, 20)),
                 self._cmfs,
                 self._A,
                 k=1),
@@ -989,7 +1004,7 @@ class TestSd_to_XYZ_ASTME308(unittest.TestCase):
         """
 
         self.assertRaises(ValueError, sd_to_XYZ_ASTME308,
-                          self._sd.copy().align(SpectralShape(360, 820, 2)))
+                          reshape_sd(self._sd, SpectralShape(360, 820, 2)))
 
 
 class TestSd_to_XYZ(unittest.TestCase):
@@ -1003,9 +1018,10 @@ class TestSd_to_XYZ(unittest.TestCase):
         Initialises common tests attributes.
         """
 
-        self._cmfs = MSDS_CMFS['CIE 1931 2 Degree Standard Observer']
+        self._cmfs = MSDS_CMFS_STANDARD_OBSERVER[
+            'CIE 1931 2 Degree Standard Observer']
         self._A = sd_CIE_standard_illuminant_A(self._cmfs.shape)
-        self._sd = SD_SAMPLE.copy().align(self._cmfs.shape)
+        self._sd = reshape_sd(SD_SAMPLE, self._cmfs.shape)
 
     def test_sd_to_XYZ(self):
         """
@@ -1039,7 +1055,8 @@ msds_to_XYZ_integration` definition unit tests methods.
 msds_to_XYZ_integration` definition.
         """
 
-        cmfs = MSDS_CMFS['CIE 1931 2 Degree Standard Observer']
+        cmfs = MSDS_CMFS_STANDARD_OBSERVER[
+            'CIE 1931 2 Degree Standard Observer']
         np.testing.assert_almost_equal(
             msds_to_XYZ_integration(MSDS_TWO, cmfs, SDS_ILLUMINANTS['D65']),
             TVS_D65_INTEGRATION_MSDS,
@@ -1070,7 +1087,8 @@ msds_to_XYZ_integration` definition.
 msds_to_XYZ_integration` definition domain and range scale support.
         """
 
-        cmfs = MSDS_CMFS['CIE 1931 2 Degree Standard Observer']
+        cmfs = MSDS_CMFS_STANDARD_OBSERVER[
+            'CIE 1931 2 Degree Standard Observer']
         d_r = (('reference', 1), (1, 0.01), (100, 1))
         for scale, factor in d_r:
             with domain_range_scale(scale):
@@ -1096,8 +1114,9 @@ class TestMsds_to_XYZ_ASTME308(unittest.TestCase):
 msds_to_XYZ_ASTME308` definition.
         """
 
-        cmfs = MSDS_CMFS['CIE 1931 2 Degree Standard Observer']
-        msds = MSDS_TWO.copy().align(SpectralShape(400, 700, 20))
+        cmfs = MSDS_CMFS_STANDARD_OBSERVER[
+            'CIE 1931 2 Degree Standard Observer']
+        msds = reshape_msds(MSDS_TWO, SpectralShape(400, 700, 20))
         np.testing.assert_almost_equal(
             msds_to_XYZ_ASTME308(msds, cmfs, SDS_ILLUMINANTS['D65']),
             TVS_D65_ASTME308_MSDS,
@@ -1114,13 +1133,14 @@ msds_to_XYZ_ASTME308` definition.
 msds_to_XYZ_ASTME308` definition domain and range scale support.
         """
 
-        cmfs = MSDS_CMFS['CIE 1931 2 Degree Standard Observer']
+        cmfs = MSDS_CMFS_STANDARD_OBSERVER[
+            'CIE 1931 2 Degree Standard Observer']
         d_r = (('reference', 1), (1, 0.01), (100, 1))
         for scale, factor in d_r:
             with domain_range_scale(scale):
                 np.testing.assert_almost_equal(
                     msds_to_XYZ_ASTME308(
-                        MSDS_TWO.copy().align(SpectralShape(400, 700, 20)),
+                        reshape_msds(MSDS_TWO, SpectralShape(400, 700, 20)),
                         cmfs, SDS_ILLUMINANTS['D65']),
                     TVS_D65_ASTME308_MSDS * factor,
                     decimal=7)
@@ -1148,19 +1168,22 @@ class TestWavelength_to_XYZ(unittest.TestCase):
 
         np.testing.assert_almost_equal(
             wavelength_to_XYZ(
-                480, MSDS_CMFS['CIE 1931 2 Degree Standard Observer']),
+                480, MSDS_CMFS_STANDARD_OBSERVER[
+                    'CIE 1931 2 Degree Standard Observer']),
             np.array([0.09564, 0.13902, 0.81295]),
             decimal=7)
 
         np.testing.assert_almost_equal(
             wavelength_to_XYZ(
-                480, MSDS_CMFS['CIE 2012 2 Degree Standard Observer']),
+                480, MSDS_CMFS_STANDARD_OBSERVER[
+                    'CIE 2012 2 Degree Standard Observer']),
             np.array([0.08182895, 0.17880480, 0.75523790]),
             decimal=7)
 
         np.testing.assert_almost_equal(
             wavelength_to_XYZ(
-                641.5, MSDS_CMFS['CIE 2012 2 Degree Standard Observer']),
+                641.5, MSDS_CMFS_STANDARD_OBSERVER[
+                    'CIE 2012 2 Degree Standard Observer']),
             np.array([0.44575583, 0.18184213, 0.00000000]),
             decimal=7)
 
@@ -1180,7 +1203,8 @@ class TestWavelength_to_XYZ(unittest.TestCase):
         definition n-dimensional arrays support.
         """
 
-        cmfs = MSDS_CMFS['CIE 1931 2 Degree Standard Observer']
+        cmfs = MSDS_CMFS_STANDARD_OBSERVER[
+            'CIE 1931 2 Degree Standard Observer']
         wl = 480
         XYZ = wavelength_to_XYZ(wl, cmfs)
 

--- a/colour/colorimetry/transformations.py
+++ b/colour/colorimetry/transformations.py
@@ -34,7 +34,8 @@ References
 import numpy as np
 
 from colour.algebra import vector_dot
-from colour.colorimetry import MSDS_CMFS_LMS, MSDS_CMFS_RGB, SDS_LEFS_PHOTOPIC
+from colour.colorimetry import (MSDS_CMFS_LMS, MSDS_CMFS_RGB,
+                                SDS_LEFS_PHOTOPIC, reshape_sd)
 from colour.utilities import tstack
 
 __author__ = 'Colour Developers'
@@ -108,8 +109,8 @@ def RGB_2_degree_cmfs_to_XYZ_2_degree_cmfs(wavelength):
 
     x, y, z = xyz[..., 0], xyz[..., 1], xyz[..., 2]
 
-    V = SDS_LEFS_PHOTOPIC['CIE 1924 Photopic Standard Observer'].copy()
-    V.align(cmfs.shape)
+    V = reshape_sd(SDS_LEFS_PHOTOPIC['CIE 1924 Photopic Standard Observer'],
+                   cmfs.shape)
     L = V[wavelength]
 
     x_bar = x / y * L

--- a/colour/colorimetry/tristimulus_values.py
+++ b/colour/colorimetry/tristimulus_values.py
@@ -74,7 +74,7 @@ References
 SPECTRAL_SHAPE_ASTME308 : SpectralShape
 """
 
-_DEFAULT_MSDS_CMFS = 'CIE 1931 2 Degree Standard Observer'
+_MSDS_CMFS_DEFAULT = 'CIE 1931 2 Degree Standard Observer'
 
 _CACHE_LAGRANGE_INTERPOLATING_COEFFICIENTS = None
 
@@ -475,7 +475,7 @@ def sd_to_XYZ_integration(sd, cmfs=None, illuminant=None, k=None):
     """
 
     if cmfs is None:
-        cmfs = reshape_msds(MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS],
+        cmfs = reshape_msds(MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT],
                             SPECTRAL_SHAPE_DEFAULT)
 
     if illuminant is None:
@@ -592,7 +592,7 @@ def sd_to_XYZ_tristimulus_weighting_factors_ASTME308(sd,
     """
 
     if cmfs is None:
-        cmfs = reshape_msds(MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS],
+        cmfs = reshape_msds(MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT],
                             SPECTRAL_SHAPE_ASTME308, 'Trim')
 
     if illuminant is None:
@@ -726,7 +726,7 @@ def sd_to_XYZ_ASTME308(sd,
     """
 
     if cmfs is None:
-        cmfs = reshape_msds(MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS],
+        cmfs = reshape_msds(MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT],
                             SPECTRAL_SHAPE_ASTME308, 'Trim')
 
     if illuminant is None:
@@ -917,7 +917,7 @@ def sd_to_XYZ(sd,
     """
 
     if cmfs is None:
-        cmfs = reshape_msds(MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS],
+        cmfs = reshape_msds(MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT],
                             SPECTRAL_SHAPE_DEFAULT)
 
     if illuminant is None:
@@ -1085,7 +1085,7 @@ def msds_to_XYZ_integration(msds,
     """
 
     if cmfs is None:
-        cmfs = reshape_msds(MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS],
+        cmfs = reshape_msds(MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT],
                             SPECTRAL_SHAPE_DEFAULT)
 
     if illuminant is None:
@@ -1246,7 +1246,7 @@ def msds_to_XYZ_ASTME308(msds,
     """
 
     if cmfs is None:
-        cmfs = reshape_msds(MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS],
+        cmfs = reshape_msds(MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT],
                             SPECTRAL_SHAPE_ASTME308, 'Trim')
 
     if illuminant is None:
@@ -1448,7 +1448,7 @@ def msds_to_XYZ(msds,
     """
 
     if cmfs is None:
-        cmfs = reshape_msds(MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS],
+        cmfs = reshape_msds(MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT],
                             SPECTRAL_SHAPE_DEFAULT)
 
     if illuminant is None:
@@ -1512,7 +1512,7 @@ def wavelength_to_XYZ(wavelength, cmfs=None):
     """
 
     if cmfs is None:
-        cmfs = MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS]
+        cmfs = MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT]
 
     cmfs_shape = cmfs.shape
     if (np.min(wavelength) < cmfs_shape.start or

--- a/colour/colorimetry/tristimulus_values.py
+++ b/colour/colorimetry/tristimulus_values.py
@@ -475,6 +475,7 @@ def sd_to_XYZ_integration(sd, cmfs=None, illuminant=None, k=None):
     """
 
     if cmfs is None:
+        # pylint: disable=E1102
         cmfs = reshape_msds(MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT],
                             SPECTRAL_SHAPE_DEFAULT)
 
@@ -592,6 +593,7 @@ def sd_to_XYZ_tristimulus_weighting_factors_ASTME308(sd,
     """
 
     if cmfs is None:
+        # pylint: disable=E1102
         cmfs = reshape_msds(MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT],
                             SPECTRAL_SHAPE_ASTME308, 'Trim')
 
@@ -601,6 +603,7 @@ def sd_to_XYZ_tristimulus_weighting_factors_ASTME308(sd,
     if cmfs.shape.interval != 1:
         runtime_warning('Interpolating "{0}" cmfs to 1nm interval.'.format(
             cmfs.name))
+        # pylint: disable=E1102
         cmfs = reshape_msds(cmfs, SpectralShape(interval=1), 'Interpolate')
 
     if illuminant.shape != cmfs.shape:
@@ -726,6 +729,7 @@ def sd_to_XYZ_ASTME308(sd,
     """
 
     if cmfs is None:
+        # pylint: disable=E1102
         cmfs = reshape_msds(MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT],
                             SPECTRAL_SHAPE_ASTME308, 'Trim')
 
@@ -739,6 +743,7 @@ def sd_to_XYZ_ASTME308(sd,
             'with measurement interval of 1, 5, 10 or 20nm!')
 
     if use_practice_range:
+        # pylint: disable=E1102
         cmfs = reshape_msds(cmfs, SPECTRAL_SHAPE_ASTME308, 'Trim')
 
     method = sd_to_XYZ_tristimulus_weighting_factors_ASTME308
@@ -746,6 +751,7 @@ def sd_to_XYZ_ASTME308(sd,
         method = sd_to_XYZ_integration
     elif sd.shape.interval == 5 and mi_5nm_omission_method:
         if cmfs.shape.interval != 5:
+            # pylint: disable=E1102
             cmfs = reshape_msds(cmfs, SpectralShape(interval=5), 'Interpolate')
         method = sd_to_XYZ_integration
     elif sd.shape.interval == 20 and mi_20nm_interpolation_method:
@@ -917,6 +923,7 @@ def sd_to_XYZ(sd,
     """
 
     if cmfs is None:
+        # pylint: disable=E1102
         cmfs = reshape_msds(MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT],
                             SPECTRAL_SHAPE_DEFAULT)
 
@@ -1085,6 +1092,7 @@ def msds_to_XYZ_integration(msds,
     """
 
     if cmfs is None:
+        # pylint: disable=E1102
         cmfs = reshape_msds(MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT],
                             SPECTRAL_SHAPE_DEFAULT)
 
@@ -1108,6 +1116,7 @@ def msds_to_XYZ_integration(msds,
         if cmfs.shape != shape:
             runtime_warning('Aligning "{0}" cmfs shape to "{1}".'.format(
                 cmfs.name, shape))
+            # pylint: disable=E1102
             cmfs = reshape_msds(cmfs, shape)
 
         if illuminant.shape != shape:
@@ -1246,6 +1255,7 @@ def msds_to_XYZ_ASTME308(msds,
     """
 
     if cmfs is None:
+        # pylint: disable=E1102
         cmfs = reshape_msds(MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT],
                             SPECTRAL_SHAPE_ASTME308, 'Trim')
 
@@ -1448,6 +1458,7 @@ def msds_to_XYZ(msds,
     """
 
     if cmfs is None:
+        # pylint: disable=E1102
         cmfs = reshape_msds(MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT],
                             SPECTRAL_SHAPE_DEFAULT)
 

--- a/colour/colorimetry/tristimulus_values.py
+++ b/colour/colorimetry/tristimulus_values.py
@@ -42,9 +42,10 @@ from colour.colorimetry import (MSDS_CMFS_STANDARD_OBSERVER,
                                 MultiSpectralDistributions, SpectralShape,
                                 reshape_msds, reshape_sd, sd_ones)
 from colour.constants import DEFAULT_INT_DTYPE
-from colour.utilities import (
-    CaseInsensitiveMapping, as_float_array, filter_kwargs, from_range_100,
-    get_domain_range_scale, runtime_warning, tsplit, validate_method)
+from colour.utilities import (CACHE_REGISTRY, CaseInsensitiveMapping,
+                              as_float_array, filter_kwargs, from_range_100,
+                              get_domain_range_scale, runtime_warning, tsplit,
+                              validate_method)
 
 __author__ = 'Colour Developers'
 __copyright__ = 'Copyright (C) 2013-2021 - Colour Developers'
@@ -76,11 +77,16 @@ SPECTRAL_SHAPE_ASTME308 : SpectralShape
 
 _MSDS_CMFS_DEFAULT = 'CIE 1931 2 Degree Standard Observer'
 
-_CACHE_LAGRANGE_INTERPOLATING_COEFFICIENTS = None
+_CACHE_LAGRANGE_INTERPOLATING_COEFFICIENTS = {}
 
-_CACHE_TRISTIMULUS_WEIGHTING_FACTORS = None
+_CACHE_LAGRANGE_INTERPOLATING_COEFFICIENTS = CACHE_REGISTRY.register_cache(
+    '{0}._CACHE_LAGRANGE_INTERPOLATING_COEFFICIENTS'.format(__name__))
 
-_CACHE_SD_TO_XYZ = None
+_CACHE_TRISTIMULUS_WEIGHTING_FACTORS = CACHE_REGISTRY.register_cache(
+    '{0}._CACHE_TRISTIMULUS_WEIGHTING_FACTORS'.format(__name__))
+
+_CACHE_SD_TO_XYZ = CACHE_REGISTRY.register_cache(
+    '{0}._CACHE_SD_TO_XYZ'.format(__name__))
 
 
 def lagrange_coefficients_ASTME2022(interval=10, interval_type='inner'):
@@ -133,8 +139,6 @@ def lagrange_coefficients_ASTME2022(interval=10, interval_type='inner'):
     """
 
     global _CACHE_LAGRANGE_INTERPOLATING_COEFFICIENTS
-    if _CACHE_LAGRANGE_INTERPOLATING_COEFFICIENTS is None:
-        _CACHE_LAGRANGE_INTERPOLATING_COEFFICIENTS = {}
 
     hash_key = tuple([hash(arg) for arg in (interval, interval_type)])
     if hash_key in _CACHE_LAGRANGE_INTERPOLATING_COEFFICIENTS:
@@ -255,8 +259,6 @@ def tristimulus_weighting_factors_ASTME2022(cmfs, illuminant, shape, k=None):
             '"{0}" shape "interval" must be 1!'.format(illuminant))
 
     global _CACHE_TRISTIMULUS_WEIGHTING_FACTORS
-    if _CACHE_TRISTIMULUS_WEIGHTING_FACTORS is None:
-        _CACHE_TRISTIMULUS_WEIGHTING_FACTORS = {}
 
     hash_key = tuple([
         hash(arg) for arg in (cmfs, illuminant, shape, k,
@@ -933,8 +935,6 @@ def sd_to_XYZ(sd,
     method = validate_method(method, SD_TO_XYZ_METHODS)
 
     global _CACHE_SD_TO_XYZ
-    if _CACHE_SD_TO_XYZ is None:
-        _CACHE_SD_TO_XYZ = {}
 
     hash_key = tuple([
         hash(arg) for arg in (sd, cmfs, illuminant, k, method,

--- a/colour/examples/recovery/examples_mallet2019.py
+++ b/colour/examples/recovery/examples_mallet2019.py
@@ -27,8 +27,8 @@ print('\n')
 
 message_box('Generating the "Mallett et al. (2019)" basis functions for the '
             '*Pal/Secam* colourspace:')
-cmfs = (colour.MSDS_CMFS['CIE 1931 2 Degree Standard Observer'].copy().align(
-    colour.SpectralShape(360, 780, 10)))
+cmfs = colour.MSDS_CMFS['CIE 1931 2 Degree Standard Observer'].copy().align(
+    colour.SpectralShape(360, 780, 10))
 illuminant = colour.SDS_ILLUMINANTS['D65'].copy().align(cmfs.shape)
 
 print(

--- a/colour/graph/conversion.py
+++ b/colour/graph/conversion.py
@@ -16,13 +16,14 @@ from copy import copy
 from functools import partial
 from pprint import pformat
 
+import colour
 from colour.colorimetry import (CCS_ILLUMINANTS, SDS_ILLUMINANTS,
                                 TVS_ILLUMINANTS_HUNTERLAB)
 from colour.colorimetry import (colorimetric_purity, complementary_wavelength,
                                 dominant_wavelength, excitation_purity,
                                 lightness, luminance, luminous_efficacy,
-                                luminous_efficiency, luminous_flux, sd_to_XYZ,
-                                whiteness, yellowness, wavelength_to_XYZ)
+                                luminous_efficiency, luminous_flux, whiteness,
+                                yellowness, wavelength_to_XYZ)
 from colour.recovery import XYZ_to_sd
 from colour.models import RGB_COLOURSPACE_sRGB
 from colour.models import (
@@ -67,7 +68,7 @@ __email__ = 'colour-developers@colour-science.org'
 __status__ = 'Production'
 
 __all__ = [
-    'Conversion_Specification', 'CIECAM02_to_JMh_CIECAM02',
+    'Conversion_Specification', 'sd_to_XYZ', 'CIECAM02_to_JMh_CIECAM02',
     'JMh_CIECAM02_to_CIECAM02', 'CAM16_to_JMh_CAM16', 'JMh_CAM16_to_CAM16',
     'XYZ_to_luminance', 'RGB_luminance_to_RGB',
     'CONVERSION_SPECIFICATIONS_DATA', 'CONVERSION_GRAPH_NODE_LABELS',
@@ -96,6 +97,23 @@ class Conversion_Specification(
     def __new__(cls, source=None, target=None, conversion_function=None):
         return super(Conversion_Specification, cls).__new__(
             cls, source.lower(), target.lower(), conversion_function)
+
+
+def sd_to_XYZ(sd,
+              cmfs=None,
+              illuminant=None,
+              k=None,
+              method='ASTM E308',
+              **kwargs):
+    if illuminant is None:
+        illuminant = SDS_ILLUMINANTS[_DEFAULT_ILLUMINANT]
+
+    return colour.sd_to_XYZ(sd, cmfs, illuminant, k, method, **kwargs)
+
+
+sd_to_XYZ.__doc__ = colour.sd_to_XYZ.__doc__.replace(
+    'Illuminant spectral distribution.', 'Illuminant spectral distribution, '
+    'default to *CIE Standard Illuminant D65*.')
 
 
 def CIECAM02_to_JMh_CIECAM02(CAM_Specification_CIECAM02):
@@ -273,13 +291,6 @@ Default automatic colour conversion graph illuminant name.
 _DEFAULT_ILLUMINANT : unicode
 """
 
-_SD_DEFAULT_ILLUMINANT = SDS_ILLUMINANTS[_DEFAULT_ILLUMINANT]
-"""
-Default automatic colour conversion graph illuminant spectral distribution.
-
-_SD_DEFAULT_ILLUMINANT : SpectralDistribution
-"""
-
 _CCS_DEFAULT_ILLUMINANT = CCS_ILLUMINANTS[
     'CIE 1931 2 Degree Standard Observer'][_DEFAULT_ILLUMINANT]
 """
@@ -321,8 +332,7 @@ _CAM_KWARGS_CIECAM02_sRGB['XYZ_w'] = _CAM_KWARGS_CIECAM02_sRGB['XYZ_w'] / 100
 
 CONVERSION_SPECIFICATIONS_DATA = [
     # Colorimetry
-    ('Spectral Distribution', 'CIE XYZ',
-     partial(sd_to_XYZ, illuminant=_SD_DEFAULT_ILLUMINANT)),
+    ('Spectral Distribution', 'CIE XYZ', sd_to_XYZ),
     ('CIE XYZ', 'Spectral Distribution', XYZ_to_sd),
     ('Spectral Distribution', 'Luminous Flux', luminous_flux),
     ('Spectral Distribution', 'Luminous Efficiency', luminous_efficiency),

--- a/colour/graph/conversion.py
+++ b/colour/graph/conversion.py
@@ -106,7 +106,7 @@ def sd_to_XYZ(sd,
               method='ASTM E308',
               **kwargs):
     if illuminant is None:
-        illuminant = SDS_ILLUMINANTS[_DEFAULT_ILLUMINANT]
+        illuminant = SDS_ILLUMINANTS[_ILLUMINANT_DEFAULT]
 
     return colour.sd_to_XYZ(sd, cmfs, illuminant, k, method, **kwargs)
 
@@ -284,28 +284,28 @@ def RGB_luminance_to_RGB(Y):
     return tstack([Y, Y, Y])
 
 
-_DEFAULT_ILLUMINANT = 'D65'
+_ILLUMINANT_DEFAULT = 'D65'
 """
 Default automatic colour conversion graph illuminant name.
 
-_DEFAULT_ILLUMINANT : unicode
+_ILLUMINANT_DEFAULT : unicode
 """
 
-_CCS_DEFAULT_ILLUMINANT = CCS_ILLUMINANTS[
-    'CIE 1931 2 Degree Standard Observer'][_DEFAULT_ILLUMINANT]
+_CCS_ILLUMINANT_DEFAULT = CCS_ILLUMINANTS[
+    'CIE 1931 2 Degree Standard Observer'][_ILLUMINANT_DEFAULT]
 """
 Default automatic colour conversion graph illuminant *CIE xy* chromaticity
 coordinates.
 
-_CCS_DEFAULT_ILLUMINANT : ndarray
+_CCS_ILLUMINANT_DEFAULT : ndarray
 """
 
-_TVS_DEFAULT_ILLUMINANT = xy_to_XYZ(_CCS_DEFAULT_ILLUMINANT)
+_TVS_ILLUMINANT_DEFAULT = xy_to_XYZ(_CCS_ILLUMINANT_DEFAULT)
 """
 Default automatic colour conversion graph illuminant *CIE XYZ* tristimulus
 values.
 
-_TVS_DEFAULT_ILLUMINANT : ndarray
+_TVS_ILLUMINANT_DEFAULT : ndarray
 """
 
 _RGB_COLOURSPACE_DEFAULT = RGB_COLOURSPACE_sRGB
@@ -341,16 +341,16 @@ CONVERSION_SPECIFICATIONS_DATA = [
     ('Luminance', 'Lightness', lightness),
     ('Lightness', 'Luminance', luminance),
     ('CIE XYZ', 'Whiteness', partial(whiteness,
-                                     XYZ_0=_TVS_DEFAULT_ILLUMINANT)),
+                                     XYZ_0=_TVS_ILLUMINANT_DEFAULT)),
     ('CIE XYZ', 'Yellowness', yellowness),
     ('CIE xy', 'Colorimetric Purity',
-     partial(colorimetric_purity, xy_n=_CCS_DEFAULT_ILLUMINANT)),
+     partial(colorimetric_purity, xy_n=_CCS_ILLUMINANT_DEFAULT)),
     ('CIE xy', 'Complementary Wavelength',
-     partial(complementary_wavelength, xy_n=_CCS_DEFAULT_ILLUMINANT)),
+     partial(complementary_wavelength, xy_n=_CCS_ILLUMINANT_DEFAULT)),
     ('CIE xy', 'Dominant Wavelength',
-     partial(dominant_wavelength, xy_n=_CCS_DEFAULT_ILLUMINANT)),
+     partial(dominant_wavelength, xy_n=_CCS_ILLUMINANT_DEFAULT)),
     ('CIE xy', 'Excitation Purity',
-     partial(excitation_purity, xy_n=_CCS_DEFAULT_ILLUMINANT)),
+     partial(excitation_purity, xy_n=_CCS_ILLUMINANT_DEFAULT)),
     ('Wavelength', 'CIE XYZ', wavelength_to_XYZ),
     # Colour Models
     ('CIE XYZ', 'CIE xyY', XYZ_to_xyY),
@@ -487,14 +487,14 @@ CONVERSION_SPECIFICATIONS_DATA = [
     ('CIE XYZ', 'Hunt',
      partial(
          XYZ_to_Hunt,
-         XYZ_w=_TVS_DEFAULT_ILLUMINANT,
-         XYZ_b=_TVS_DEFAULT_ILLUMINANT,
+         XYZ_w=_TVS_ILLUMINANT_DEFAULT,
+         XYZ_b=_TVS_ILLUMINANT_DEFAULT,
          L_A=80 * 0.2,
          CCT_w=6504)),
     ('CIE XYZ', 'ATD95',
      partial(
          XYZ_to_ATD95,
-         XYZ_0=_TVS_DEFAULT_ILLUMINANT,
+         XYZ_0=_TVS_ILLUMINANT_DEFAULT,
          Y_0=80 * 0.2,
          k_1=0,
          k_2=(15 + 50) / 2)),
@@ -509,16 +509,16 @@ CONVERSION_SPECIFICATIONS_DATA = [
     ('CAM16', 'CAM16 JMh', CAM16_to_JMh_CAM16),
     ('CAM16 JMh', 'CAM16', JMh_CAM16_to_CAM16),
     ('CIE XYZ', 'LLAB',
-     partial(XYZ_to_LLAB, XYZ_0=_TVS_DEFAULT_ILLUMINANT, Y_b=80 * 0.2, L=80)),
+     partial(XYZ_to_LLAB, XYZ_0=_TVS_ILLUMINANT_DEFAULT, Y_b=80 * 0.2, L=80)),
     ('CIE XYZ', 'Nayatani95',
      partial(
          XYZ_to_Nayatani95,
-         XYZ_n=_TVS_DEFAULT_ILLUMINANT,
+         XYZ_n=_TVS_ILLUMINANT_DEFAULT,
          Y_o=0.2,
          E_o=1000,
          E_or=1000)),
     ('CIE XYZ', 'RLAB',
-     partial(XYZ_to_RLAB, XYZ_n=_TVS_DEFAULT_ILLUMINANT, Y_n=20)),
+     partial(XYZ_to_RLAB, XYZ_n=_TVS_ILLUMINANT_DEFAULT, Y_n=20)),
     ('CIECAM02 JMh', 'CAM02LCD', JMh_CIECAM02_to_CAM02LCD),
     ('CAM02LCD', 'CIECAM02 JMh', CAM02LCD_to_JMh_CIECAM02),
     ('CIECAM02 JMh', 'CAM02SCD', JMh_CIECAM02_to_CAM02SCD),

--- a/colour/plotting/temperature.py
+++ b/colour/plotting/temperature.py
@@ -14,7 +14,7 @@ plot_planckian_locus_in_chromaticity_diagram_CIE1960UCS`
 
 import numpy as np
 
-from colour.colorimetry import MSDS_CMFS, CCS_ILLUMINANTS
+from colour.colorimetry import MSDS_CMFS_STANDARD_OBSERVER, CCS_ILLUMINANTS
 from colour.models import (UCS_uv_to_xy, XYZ_to_UCS, UCS_to_uv, xy_to_XYZ)
 from colour.temperature import CCT_to_uv
 from colour.plotting import (
@@ -291,7 +291,7 @@ Plot_Planckian_Locus_In_Chromaticity_Diagram.png
         :alt: plot_planckian_locus_in_chromaticity_diagram
     """
 
-    cmfs = MSDS_CMFS['CIE 1931 2 Degree Standard Observer']
+    cmfs = MSDS_CMFS_STANDARD_OBSERVER['CIE 1931 2 Degree Standard Observer']
 
     illuminants = filter_passthrough(
         CCS_ILLUMINANTS.get(cmfs.name), illuminants)

--- a/colour/plotting/tests/test_diagrams.py
+++ b/colour/plotting/tests/test_diagrams.py
@@ -70,6 +70,7 @@ class TestPlotSpectralLocus(unittest.TestCase):
         self.assertIsInstance(figure, Figure)
         self.assertIsInstance(axes, Axes)
 
+        # pylint: disable=E1102
         figure, axes = plot_spectral_locus(
             reshape_msds(
                 MSDS_CMFS_STANDARD_OBSERVER[

--- a/colour/plotting/tests/test_diagrams.py
+++ b/colour/plotting/tests/test_diagrams.py
@@ -6,8 +6,8 @@ Defines the unit tests for the :mod:`colour.plotting.diagrams` module.
 import unittest
 from matplotlib.pyplot import Axes, Figure
 
-from colour.colorimetry import (SDS_ILLUMINANTS, SpectralShape,
-                                MSDS_CMFS_STANDARD_OBSERVER)
+from colour.colorimetry import (MSDS_CMFS_STANDARD_OBSERVER, SDS_ILLUMINANTS,
+                                SpectralShape, reshape_msds)
 from colour.plotting import (plot_chromaticity_diagram_CIE1931,
                              plot_chromaticity_diagram_CIE1960UCS,
                              plot_chromaticity_diagram_CIE1976UCS,
@@ -70,8 +70,10 @@ class TestPlotSpectralLocus(unittest.TestCase):
         self.assertIsInstance(figure, Figure)
         self.assertIsInstance(axes, Axes)
 
-        figure, axes = plot_spectral_locus(MSDS_CMFS_STANDARD_OBSERVER[
-            'CIE 1931 2 Degree Standard Observer'].copy().align(
+        figure, axes = plot_spectral_locus(
+            reshape_msds(
+                MSDS_CMFS_STANDARD_OBSERVER[
+                    'CIE 1931 2 Degree Standard Observer'],
                 SpectralShape(400, 700, 10)))
 
         self.assertIsInstance(figure, Figure)

--- a/colour/plotting/tests/test_quality.py
+++ b/colour/plotting/tests/test_quality.py
@@ -7,7 +7,7 @@ import unittest
 from matplotlib.pyplot import Axes, Figure
 
 from colour.colorimetry import (SDS_ILLUMINANTS, SDS_LIGHT_SOURCES,
-                                SpectralShape)
+                                SpectralShape, reshape_sd)
 from colour.plotting import (plot_single_sd_colour_rendering_index_bars,
                              plot_multi_sds_colour_rendering_indexes_bars,
                              plot_single_sd_colour_quality_scale_bars,
@@ -44,7 +44,7 @@ class TestPlotColourQualityBars(unittest.TestCase):
 
         illuminant = SDS_ILLUMINANTS['FL2']
         light_source = SDS_LIGHT_SOURCES['Kinoton 75P']
-        light_source = light_source.copy().align(SpectralShape(360, 830, 1))
+        light_source = reshape_sd(light_source, SpectralShape(360, 830, 1))
         cqs_i = colour_quality_scale(illuminant, additional_data=True)
         cqs_l = colour_quality_scale(light_source, additional_data=True)
 

--- a/colour/quality/cfi2017.py
+++ b/colour/quality/cfi2017.py
@@ -156,10 +156,12 @@ def colour_fidelity_index_CIE2017(sd_test, additional_data=False):
 
     # NOTE: All computations except CCT calculation use the
     # "CIE 1964 10 Degree Standard Observer".
+    # pylint: disable=E1102
     cmfs_10 = reshape_msds(
         MSDS_CMFS_STANDARD_OBSERVER['CIE 1964 10 Degree Standard Observer'],
         shape)
 
+    # pylint: disable=E1102
     sds_tcs = reshape_msds(load_TCS_CIE2017(shape), shape)
 
     test_tcs_colorimetry_data = tcs_colorimetry_data(sd_test, sds_tcs, cmfs_10)

--- a/colour/quality/cfi2017.py
+++ b/colour/quality/cfi2017.py
@@ -26,7 +26,7 @@ from colour.colorimetry import (
     sd_CIE_illuminant_D_series)
 from colour.models import XYZ_to_UCS, UCS_to_uv, JMh_CIECAM02_to_CAM02UCS
 from colour.temperature import uv_to_CCT_Ohno2013, CCT_to_xy_CIE_D
-from colour.utilities import as_int, usage_warning
+from colour.utilities import CACHE_REGISTRY, as_int, usage_warning
 
 __author__ = 'Colour Developers'
 __copyright__ = 'Copyright (C) 2013-2021 - Colour Developers'
@@ -59,7 +59,8 @@ RESOURCES_DIRECTORY_CIE2017 = os.path.join(
 RESOURCES_DIRECTORY_CIE2017 : unicode
 """
 
-_CACHE_TCS_CIE2017 = {}
+_CACHE_TCS_CIE2017 = CACHE_REGISTRY.register_cache(
+    '{0}._CACHE_TCS_CIE2017'.format(__name__))
 
 
 class TCS_ColorimetryData_CIE2017(

--- a/colour/quality/cfi2017.py
+++ b/colour/quality/cfi2017.py
@@ -21,8 +21,9 @@ from collections import namedtuple
 from colour.algebra import Extrapolator, euclidean_distance, linstep_function
 from colour.appearance import XYZ_to_CIECAM02, VIEWING_CONDITIONS_CIECAM02
 from colour.colorimetry import (
-    SpectralShape, SpectralDistribution, MultiSpectralDistributions, sd_to_XYZ,
-    sd_blackbody, MSDS_CMFS, sd_ones, sd_CIE_illuminant_D_series)
+    MSDS_CMFS_STANDARD_OBSERVER, MultiSpectralDistributions, SpectralShape,
+    SpectralDistribution, sd_to_XYZ, sd_blackbody, reshape_msds, sd_ones,
+    sd_CIE_illuminant_D_series)
 from colour.models import XYZ_to_UCS, UCS_to_uv, JMh_CIECAM02_to_CAM02UCS
 from colour.temperature import uv_to_CCT_Ohno2013, CCT_to_xy_CIE_D
 from colour.utilities import as_int, usage_warning
@@ -155,10 +156,11 @@ def colour_fidelity_index_CIE2017(sd_test, additional_data=False):
 
     # NOTE: All computations except CCT calculation use the
     # "CIE 1964 10 Degree Standard Observer".
-    cmfs_10 = MSDS_CMFS['CIE 1964 10 Degree Standard Observer'].copy().align(
+    cmfs_10 = reshape_msds(
+        MSDS_CMFS_STANDARD_OBSERVER['CIE 1964 10 Degree Standard Observer'],
         shape)
 
-    sds_tcs = load_TCS_CIE2017(shape).align(shape)
+    sds_tcs = reshape_msds(load_TCS_CIE2017(shape), shape)
 
     test_tcs_colorimetry_data = tcs_colorimetry_data(sd_test, sds_tcs, cmfs_10)
     reference_tcs_colorimetry_data = tcs_colorimetry_data(

--- a/colour/quality/cqs.py
+++ b/colour/quality/cqs.py
@@ -26,9 +26,10 @@ import numpy as np
 from collections import namedtuple
 
 from colour.algebra import euclidean_distance
-from colour.colorimetry import (
-    SPECTRAL_SHAPE_DEFAULT, sd_CIE_illuminant_D_series, CCS_ILLUMINANTS,
-    MSDS_CMFS_STANDARD_OBSERVER, sd_blackbody, sd_to_XYZ)
+from colour.colorimetry import (CCS_ILLUMINANTS, MSDS_CMFS_STANDARD_OBSERVER,
+                                SPECTRAL_SHAPE_DEFAULT, reshape_msds,
+                                reshape_sd, sd_CIE_illuminant_D_series,
+                                sd_blackbody, sd_to_XYZ)
 from colour.quality.datasets.vs import INDEXES_TO_NAMES_VS, SDS_VS
 from colour.models import (Lab_to_LCHab, UCS_to_uv, XYZ_to_Lab, XYZ_to_UCS,
                            XYZ_to_xy, xy_to_XYZ)
@@ -170,16 +171,13 @@ def colour_quality_scale(sd_test, additional_data=False,
 
     method = validate_method(method, COLOUR_QUALITY_SCALE_METHODS)
 
-    cmfs = MSDS_CMFS_STANDARD_OBSERVER[
-        'CIE 1931 2 Degree Standard Observer'].copy().trim(
-            SPECTRAL_SHAPE_DEFAULT)
+    cmfs = reshape_msds(
+        MSDS_CMFS_STANDARD_OBSERVER['CIE 1931 2 Degree Standard Observer'],
+        SPECTRAL_SHAPE_DEFAULT)
 
     shape = cmfs.shape
-    sd_test = sd_test.copy().align(shape)
-    vs_sds = {
-        sd.name: sd.copy().align(shape)
-        for sd in SDS_VS[method].values()
-    }
+    sd_test = reshape_sd(sd_test, shape)
+    vs_sds = {sd.name: reshape_sd(sd, shape) for sd in SDS_VS[method].values()}
 
     with domain_range_scale('1'):
         XYZ = sd_to_XYZ(sd_test, cmfs)

--- a/colour/quality/cqs.py
+++ b/colour/quality/cqs.py
@@ -171,6 +171,7 @@ def colour_quality_scale(sd_test, additional_data=False,
 
     method = validate_method(method, COLOUR_QUALITY_SCALE_METHODS)
 
+    # pylint: disable=E1102
     cmfs = reshape_msds(
         MSDS_CMFS_STANDARD_OBSERVER['CIE 1931 2 Degree Standard Observer'],
         SPECTRAL_SHAPE_DEFAULT)

--- a/colour/quality/cri.py
+++ b/colour/quality/cri.py
@@ -110,6 +110,7 @@ def colour_rendering_index(sd_test, additional_data=False):
     64.2337241...
     """
 
+    # pylint: disable=E1102
     cmfs = reshape_msds(
         MSDS_CMFS_STANDARD_OBSERVER['CIE 1931 2 Degree Standard Observer'],
         SPECTRAL_SHAPE_DEFAULT)

--- a/colour/quality/cri.py
+++ b/colour/quality/cri.py
@@ -20,9 +20,10 @@ import numpy as np
 from collections import namedtuple
 
 from colour.algebra import euclidean_distance, spow
-from colour.colorimetry import (
-    SPECTRAL_SHAPE_DEFAULT, sd_CIE_illuminant_D_series,
-    MSDS_CMFS_STANDARD_OBSERVER, sd_blackbody, sd_to_XYZ)
+from colour.colorimetry import (MSDS_CMFS_STANDARD_OBSERVER,
+                                SPECTRAL_SHAPE_DEFAULT,
+                                sd_CIE_illuminant_D_series, reshape_msds,
+                                reshape_sd, sd_blackbody, sd_to_XYZ)
 from colour.quality.datasets.tcs import INDEXES_TO_NAMES_TCS, SDS_TCS
 from colour.models import UCS_to_uv, XYZ_to_UCS, XYZ_to_xyY
 from colour.temperature import CCT_to_xy_CIE_D, uv_to_CCT_Robertson1968
@@ -109,13 +110,13 @@ def colour_rendering_index(sd_test, additional_data=False):
     64.2337241...
     """
 
-    cmfs = MSDS_CMFS_STANDARD_OBSERVER[
-        'CIE 1931 2 Degree Standard Observer'].copy().trim(
-            SPECTRAL_SHAPE_DEFAULT)
+    cmfs = reshape_msds(
+        MSDS_CMFS_STANDARD_OBSERVER['CIE 1931 2 Degree Standard Observer'],
+        SPECTRAL_SHAPE_DEFAULT)
 
     shape = cmfs.shape
-    sd_test = sd_test.copy().align(shape)
-    tcs_sds = {sd.name: sd.copy().align(shape) for sd in SDS_TCS.values()}
+    sd_test = reshape_sd(sd_test, shape)
+    tcs_sds = {sd.name: reshape_sd(sd, shape) for sd in SDS_TCS.values()}
 
     with domain_range_scale('1'):
         XYZ = sd_to_XYZ(sd_test, cmfs)

--- a/colour/quality/ssi.py
+++ b/colour/quality/ssi.py
@@ -18,7 +18,7 @@ import numpy as np
 from scipy.ndimage.filters import convolve1d
 
 from colour.algebra import LinearInterpolator
-from colour.colorimetry import SpectralShape
+from colour.colorimetry import SpectralShape, reshape_sd
 from colour.utilities import zeros
 
 __author__ = 'Colour Developers'
@@ -93,8 +93,8 @@ def spectral_similarity_index(sd_test, sd_reference):
         }
     }
 
-    sd_test = sd_test.copy().align(SPECTRAL_SHAPE_SSI, **settings)
-    sd_reference = sd_reference.copy().align(SPECTRAL_SHAPE_SSI, **settings)
+    sd_test = reshape_sd(sd_test, SPECTRAL_SHAPE_SSI, **settings)
+    sd_reference = reshape_sd(sd_reference, SPECTRAL_SHAPE_SSI, **settings)
 
     test_i = np.dot(_MATRIX_INTEGRATION, sd_test.values)
     reference_i = np.dot(_MATRIX_INTEGRATION, sd_reference.values)

--- a/colour/quality/tests/test_cfi2017.py
+++ b/colour/quality/tests/test_cfi2017.py
@@ -11,8 +11,8 @@ Notes
 import numpy as np
 import unittest
 
-from colour.colorimetry import (SpectralShape, SpectralDistribution,
-                                sd_blackbody, SDS_ILLUMINANTS)
+from colour.colorimetry import (SDS_ILLUMINANTS, SpectralShape,
+                                SpectralDistribution, reshape_sd, sd_blackbody)
 from colour.quality.cfi2017 import (CCT_reference_illuminant,
                                     sd_reference_illuminant,
                                     colour_fidelity_index_CIE2017)
@@ -589,10 +589,10 @@ class TestColourFidelityIndexCIE2017(unittest.TestCase):
         definition raised exception.
         """
 
-        sd = SDS_ILLUMINANTS['FL2'].copy().align(SpectralShape(400, 700, 5))
+        sd = reshape_sd(SDS_ILLUMINANTS['FL2'], SpectralShape(400, 700, 5))
         self.assertWarns(ColourUsageWarning, colour_fidelity_index_CIE2017, sd)
 
-        sd = SDS_ILLUMINANTS['FL2'].copy().align(SpectralShape(380, 780, 10))
+        sd = reshape_sd(SDS_ILLUMINANTS['FL2'], SpectralShape(380, 780, 10))
         self.assertRaises(ValueError, colour_fidelity_index_CIE2017, sd)
 
 

--- a/colour/recovery/__init__.py
+++ b/colour/recovery/__init__.py
@@ -149,14 +149,12 @@ def XYZ_to_sd(XYZ, method='Meng 2015', **kwargs):
     *Jakob and Hanika (2009)* reflectance recovery:
 
     >>> import numpy as np
-    >>> from colour.colorimetry import (
-    ...     MSDS_CMFS_STANDARD_OBSERVER, SDS_ILLUMINANTS, SpectralShape,
-    ...     sd_to_XYZ_integration
-    ... )
+    >>> from colour import MSDS_CMFS, SDS_ILLUMINANTS, SpectralShape
+    >>> from colour.colorimetry import sd_to_XYZ_integration
     >>> from colour.utilities import numpy_print_options
     >>> XYZ = np.array([0.20654008, 0.12197225, 0.05136952])
     >>> cmfs = (
-    ...     MSDS_CMFS_STANDARD_OBSERVER['CIE 1931 2 Degree Standard Observer'].
+    ...     MSDS_CMFS['CIE 1931 2 Degree Standard Observer'].
     ...     copy().align(SpectralShape(360, 780, 10))
     ... )
     >>> illuminant = SDS_ILLUMINANTS['D65'].copy().align(cmfs.shape)
@@ -217,7 +215,7 @@ def XYZ_to_sd(XYZ, method='Meng 2015', **kwargs):
     *Mallett and Yuksel (2019)* reflectance recovery:
 
     >>> cmfs = (
-    ...     MSDS_CMFS_STANDARD_OBSERVER['CIE 1931 2 Degree Standard Observer'].
+    ...     MSDS_CMFS['CIE 1931 2 Degree Standard Observer'].
     ...     copy().align(SPECTRAL_SHAPE_sRGB_MALLETT2019)
     ... )
     >>> illuminant = SDS_ILLUMINANTS['D65'].copy().align(cmfs.shape)
@@ -316,7 +314,7 @@ def XYZ_to_sd(XYZ, method='Meng 2015', **kwargs):
     *Meng (2015)* reflectance recovery:
 
     >>> cmfs = (
-    ...     MSDS_CMFS_STANDARD_OBSERVER['CIE 1931 2 Degree Standard Observer'].
+    ...     MSDS_CMFS['CIE 1931 2 Degree Standard Observer'].
     ...     copy().align(SpectralShape(360, 780, 10))
     ... )
     >>> illuminant = SDS_ILLUMINANTS['D65'].copy().align(cmfs.shape)
@@ -377,7 +375,7 @@ def XYZ_to_sd(XYZ, method='Meng 2015', **kwargs):
     *Otsu, Yamamoto and Hachisuka (2018)* reflectance recovery:
 
     >>> cmfs = (
-    ...     MSDS_CMFS_STANDARD_OBSERVER['CIE 1931 2 Degree Standard Observer'].
+    ...     MSDS_CMFS['CIE 1931 2 Degree Standard Observer'].
     ...     copy().align(SPECTRAL_SHAPE_OTSU2018)
     ... )
     >>> illuminant = SDS_ILLUMINANTS['D65'].copy().align(cmfs.shape)
@@ -431,7 +429,7 @@ def XYZ_to_sd(XYZ, method='Meng 2015', **kwargs):
     *Smits (1999)* reflectance recovery:
 
     >>> cmfs = (
-    ...     MSDS_CMFS_STANDARD_OBSERVER['CIE 1931 2 Degree Standard Observer'].
+    ...     MSDS_CMFS['CIE 1931 2 Degree Standard Observer'].
     ...     copy().align(SpectralShape(360, 780, 10))
     ... )
     >>> illuminant = SDS_ILLUMINANTS['E'].copy().align(cmfs.shape)

--- a/colour/recovery/jakob2019.py
+++ b/colour/recovery/jakob2019.py
@@ -61,9 +61,9 @@ Spectral shape for *Jakob and Hanika (2019)* method.
 SPECTRAL_SHAPE_JAKOB2019 : SpectralShape
 """
 
-_DEFAULT_MSDS_CMFS = 'CIE 1931 2 Degree Standard Observer'
+_MSDS_CMFS_DEFAULT = 'CIE 1931 2 Degree Standard Observer'
 
-_DEFAULT_ILLUMINANT = 'D65'
+_ILLUMINANT_DEFAULT = 'D65'
 
 
 class StopMinimizationEarly(Exception):
@@ -394,11 +394,11 @@ def find_coefficients_Jakob2019(XYZ,
     """
 
     if cmfs is None:
-        cmfs = reshape_msds(MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS],
+        cmfs = reshape_msds(MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT],
                             SPECTRAL_SHAPE_JAKOB2019)
 
     if illuminant is None:
-        illuminant = reshape_sd(SDS_ILLUMINANTS[_DEFAULT_ILLUMINANT],
+        illuminant = reshape_sd(SDS_ILLUMINANTS[_ILLUMINANT_DEFAULT],
                                 SPECTRAL_SHAPE_JAKOB2019)
 
     shape = cmfs.shape
@@ -567,11 +567,11 @@ def XYZ_to_sd_Jakob2019(XYZ,
     """
 
     if cmfs is None:
-        cmfs = reshape_msds(MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS],
+        cmfs = reshape_msds(MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT],
                             SPECTRAL_SHAPE_JAKOB2019)
 
     if illuminant is None:
-        illuminant = reshape_sd(SDS_ILLUMINANTS[_DEFAULT_ILLUMINANT],
+        illuminant = reshape_sd(SDS_ILLUMINANTS[_ILLUMINANT_DEFAULT],
                                 SPECTRAL_SHAPE_JAKOB2019)
 
     XYZ = to_domain_1(XYZ)
@@ -830,11 +830,11 @@ class LUT3D_Jakob2019:
 
         if cmfs is None:
             cmfs = reshape_msds(
-                MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS],
+                MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT],
                 SPECTRAL_SHAPE_JAKOB2019)
 
         if illuminant is None:
-            illuminant = reshape_sd(SDS_ILLUMINANTS[_DEFAULT_ILLUMINANT],
+            illuminant = reshape_sd(SDS_ILLUMINANTS[_ILLUMINANT_DEFAULT],
                                     SPECTRAL_SHAPE_JAKOB2019)
 
         shape = cmfs.shape

--- a/colour/recovery/jakob2019.py
+++ b/colour/recovery/jakob2019.py
@@ -394,6 +394,7 @@ def find_coefficients_Jakob2019(XYZ,
     """
 
     if cmfs is None:
+        # pylint: disable=E1102
         cmfs = reshape_msds(MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT],
                             SPECTRAL_SHAPE_JAKOB2019)
 
@@ -567,6 +568,7 @@ def XYZ_to_sd_Jakob2019(XYZ,
     """
 
     if cmfs is None:
+        # pylint: disable=E1102
         cmfs = reshape_msds(MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT],
                             SPECTRAL_SHAPE_JAKOB2019)
 
@@ -829,6 +831,7 @@ class LUT3D_Jakob2019:
         """
 
         if cmfs is None:
+            # pylint: disable=E1102
             cmfs = reshape_msds(
                 MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT],
                 SPECTRAL_SHAPE_JAKOB2019)

--- a/colour/recovery/meng2015.py
+++ b/colour/recovery/meng2015.py
@@ -154,6 +154,7 @@ def XYZ_to_sd_Meng2015(XYZ,
     """
 
     if cmfs is None:
+        # pylint: disable=E1102
         cmfs = reshape_msds(
             MSDS_CMFS_STANDARD_OBSERVER['CIE 1931 2 Degree Standard Observer'],
             SPECTRAL_SHAPE_MENG2015, 'Trim')

--- a/colour/recovery/otsu2018.py
+++ b/colour/recovery/otsu2018.py
@@ -49,9 +49,9 @@ __all__ = [
     'PartitionAxis', 'Data', 'Node', 'NodeTree_Otsu2018'
 ]
 
-_DEFAULT_MSDS_CMFS = 'CIE 1931 2 Degree Standard Observer'
+_MSDS_CMFS_DEFAULT = 'CIE 1931 2 Degree Standard Observer'
 
-_DEFAULT_ILLUMINANT = 'D65'
+_ILLUMINANT_DEFAULT = 'D65'
 
 
 class Dataset_Otsu2018:
@@ -441,11 +441,11 @@ def XYZ_to_sd_Otsu2018(XYZ,
     """
 
     if cmfs is None:
-        cmfs = reshape_msds(MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS],
+        cmfs = reshape_msds(MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT],
                             SPECTRAL_SHAPE_OTSU2018)
 
     if illuminant is None:
-        illuminant = reshape_sd(SDS_ILLUMINANTS[_DEFAULT_ILLUMINANT],
+        illuminant = reshape_sd(SDS_ILLUMINANTS[_ILLUMINANT_DEFAULT],
                                 SPECTRAL_SHAPE_OTSU2018)
 
     XYZ = to_domain_1(XYZ)
@@ -1262,11 +1262,11 @@ class NodeTree_Otsu2018(Node):
 
         if cmfs is None:
             cmfs = reshape_msds(
-                MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS],
+                MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT],
                 SPECTRAL_SHAPE_OTSU2018)
 
         if illuminant is None:
-            illuminant = reshape_sd(SDS_ILLUMINANTS[_DEFAULT_ILLUMINANT],
+            illuminant = reshape_sd(SDS_ILLUMINANTS[_ILLUMINANT_DEFAULT],
                                     SPECTRAL_SHAPE_OTSU2018)
 
         self._cmfs = cmfs

--- a/colour/recovery/otsu2018.py
+++ b/colour/recovery/otsu2018.py
@@ -441,6 +441,7 @@ def XYZ_to_sd_Otsu2018(XYZ,
     """
 
     if cmfs is None:
+        # pylint: disable=E1102
         cmfs = reshape_msds(MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT],
                             SPECTRAL_SHAPE_OTSU2018)
 
@@ -1261,6 +1262,7 @@ class NodeTree_Otsu2018(Node):
         self._reflectances = as_float_array(reflectances)
 
         if cmfs is None:
+            # pylint: disable=E1102
             cmfs = reshape_msds(
                 MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT],
                 SPECTRAL_SHAPE_OTSU2018)

--- a/colour/recovery/otsu2018.py
+++ b/colour/recovery/otsu2018.py
@@ -20,9 +20,9 @@ References
 import numpy as np
 from collections import namedtuple
 
-from colour.colorimetry import (MSDS_CMFS_STANDARD_OBSERVER, SDS_ILLUMINANTS,
-                                SpectralDistribution, SpectralShape,
-                                msds_to_XYZ, sd_to_XYZ)
+from colour.colorimetry import (
+    MSDS_CMFS_STANDARD_OBSERVER, SDS_ILLUMINANTS, SpectralDistribution,
+    SpectralShape, msds_to_XYZ, sd_to_XYZ, reshape_msds, reshape_sd)
 from colour.models import XYZ_to_xy
 from colour.recovery import (SPECTRAL_SHAPE_OTSU2018, BASIS_FUNCTIONS_OTSU2018,
                              CLUSTER_MEANS_OTSU2018, SELECTOR_ARRAY_OTSU2018)
@@ -48,6 +48,10 @@ __all__ = [
     'Dataset_Otsu2018', 'DATASET_REFERENCE_OTSU2018', 'XYZ_to_sd_Otsu2018',
     'PartitionAxis', 'Data', 'Node', 'NodeTree_Otsu2018'
 ]
+
+_DEFAULT_MSDS_CMFS = 'CIE 1931 2 Degree Standard Observer'
+
+_DEFAULT_ILLUMINANT = 'D65'
 
 
 class Dataset_Otsu2018:
@@ -340,14 +344,11 @@ Builtin *Otsu et al. (2018)* dataset as a
 """
 
 
-def XYZ_to_sd_Otsu2018(
-        XYZ,
-        cmfs=MSDS_CMFS_STANDARD_OBSERVER['CIE 1931 2 Degree Standard Observer']
-        .copy().align(SPECTRAL_SHAPE_OTSU2018),
-        illuminant=SDS_ILLUMINANTS['D65'].copy().align(
-            SPECTRAL_SHAPE_OTSU2018),
-        dataset=DATASET_REFERENCE_OTSU2018,
-        clip=True):
+def XYZ_to_sd_Otsu2018(XYZ,
+                       cmfs=None,
+                       illuminant=None,
+                       dataset=DATASET_REFERENCE_OTSU2018,
+                       clip=True):
     """
     Recovers the spectral distribution of given *CIE XYZ* tristimulus values
     using *Otsu et al. (2018)* method.
@@ -357,9 +358,11 @@ def XYZ_to_sd_Otsu2018(
     XYZ : array_like, (3,)
         *CIE XYZ* tristimulus values to recover the spectral distribution from.
     cmfs : XYZ_ColourMatchingFunctions, optional
-        Standard observer colour matching functions.
+        Standard observer colour matching functions, default to the
+        *CIE 1931 2 Degree Standard Observer*.
     illuminant : SpectralDistribution, optional
-        Illuminant spectral distribution.
+        Illuminant spectral distribution, default to
+        *CIE Standard Illuminant D65*.
     dataset : Dataset_Otsu2018, optional
         Dataset to use for reconstruction. The default is to use the published
         data.
@@ -381,12 +384,12 @@ def XYZ_to_sd_Otsu2018(
 
     Examples
     --------
-    >>> from colour.colorimetry import CCS_ILLUMINANTS, sd_to_XYZ_integration
-    >>> from colour.models import XYZ_to_sRGB
+    >>> from colour import CCS_ILLUMINANTS, MSDS_CMFS, XYZ_to_sRGB
+    >>> from colour.colorimetry import sd_to_XYZ_integration
     >>> from colour.utilities import numpy_print_options
     >>> XYZ = np.array([0.20654008, 0.12197225, 0.05136952])
     >>> cmfs = (
-    ...     MSDS_CMFS_STANDARD_OBSERVER['CIE 1931 2 Degree Standard Observer'].
+    ...     MSDS_CMFS['CIE 1931 2 Degree Standard Observer'].
     ...     copy().align(SPECTRAL_SHAPE_OTSU2018)
     ... )
     >>> illuminant = SDS_ILLUMINANTS['D65'].copy().align(cmfs.shape)
@@ -436,6 +439,14 @@ def XYZ_to_sd_Otsu2018(
     >>> sd_to_XYZ_integration(sd, cmfs, illuminant) / 100  # doctest: +ELLIPSIS
     array([ 0.2065494...,  0.1219712...,  0.0514002...])
     """
+
+    if cmfs is None:
+        cmfs = reshape_msds(MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS],
+                            SPECTRAL_SHAPE_OTSU2018)
+
+    if illuminant is None:
+        illuminant = reshape_sd(SDS_ILLUMINANTS[_DEFAULT_ILLUMINANT],
+                                SPECTRAL_SHAPE_OTSU2018)
 
     XYZ = to_domain_1(XYZ)
     xy = XYZ_to_xy(XYZ)
@@ -1145,9 +1156,11 @@ class NodeTree_Otsu2018(Node):
     reflectances : ndarray, (n, m)
         Reflectances of the *n* reference colours to use for optimisation.
     cmfs : XYZ_ColourMatchingFunctions, optional
-        Standard observer colour matching functions.
+        Standard observer colour matching functions, default to the
+        *CIE 1931 2 Degree Standard Observer*.
     illuminant : SpectralDistribution, optional
-        Illuminant spectral distribution.
+        Illuminant spectral distribution, default to
+        *CIE Standard Illuminant D65*.
 
     Attributes
     ----------
@@ -1172,11 +1185,11 @@ class NodeTree_Otsu2018(Node):
     --------
     >>> import os
     >>> import colour
-    >>> from colour.characterisation import SDS_COLOURCHECKERS
+    >>> from colour import MSDS_CMFS, SDS_COLOURCHECKERS
     >>> from colour.utilities import numpy_print_options
     >>> XYZ = np.array([0.20654008, 0.12197225, 0.05136952])
     >>> cmfs = (
-    ...     MSDS_CMFS_STANDARD_OBSERVER['CIE 1931 2 Degree Standard Observer'].
+    ...     MSDS_CMFS['CIE 1931 2 Degree Standard Observer'].
     ...     copy().align(SpectralShape(360, 780, 10))
     ... )
     >>> illuminant = SDS_ILLUMINANTS['D65'].copy().align(cmfs.shape)
@@ -1244,14 +1257,17 @@ class NodeTree_Otsu2018(Node):
                          extrapolator_kwargs={...})
     """
 
-    def __init__(self,
-                 reflectances,
-                 cmfs=MSDS_CMFS_STANDARD_OBSERVER[
-                     'CIE 1931 2 Degree Standard Observer'].copy().align(
-                         SPECTRAL_SHAPE_OTSU2018),
-                 illuminant=SDS_ILLUMINANTS['D65'].copy().align(
-                     SPECTRAL_SHAPE_OTSU2018)):
+    def __init__(self, reflectances, cmfs=None, illuminant=None):
         self._reflectances = as_float_array(reflectances)
+
+        if cmfs is None:
+            cmfs = reshape_msds(
+                MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS],
+                SPECTRAL_SHAPE_OTSU2018)
+
+        if illuminant is None:
+            illuminant = reshape_sd(SDS_ILLUMINANTS[_DEFAULT_ILLUMINANT],
+                                    SPECTRAL_SHAPE_OTSU2018)
 
         self._cmfs = cmfs
 
@@ -1261,7 +1277,7 @@ class NodeTree_Otsu2018(Node):
             runtime_warning(
                 'Aligning "{0}" illuminant shape to "{1}" colour matching '
                 'functions shape.'.format(illuminant.name, cmfs.name))
-            illuminant = illuminant.copy().align(cmfs.shape)
+            illuminant = reshape_sd(illuminant, cmfs.shape)
 
         self._illuminant = illuminant
 
@@ -1437,10 +1453,11 @@ class NodeTree_Otsu2018(Node):
         --------
         >>> import os
         >>> import colour
-        >>> from colour.characterisation import SDS_COLOURCHECKERS
-        >>> cmfs = MSDS_CMFS_STANDARD_OBSERVER[
-        ...         'CIE 1931 2 Degree Standard Observer'].copy().align(
-        ...             SpectralShape(360, 780, 10))
+        >>> from colour import MSDS_CMFS, SDS_COLOURCHECKERS
+        >>> cmfs = (
+        ...     MSDS_CMFS['CIE 1931 2 Degree Standard Observer']
+        ...     .copy().align(SpectralShape(360, 780, 10))
+        ... )
         >>> illuminant = SDS_ILLUMINANTS['D65'].copy().align(cmfs.shape)
         >>> reflectances = [
         ...     sd.copy().align(cmfs.shape).values

--- a/colour/recovery/smits1999.py
+++ b/colour/recovery/smits1999.py
@@ -119,15 +119,13 @@ def RGB_to_sd_Smits1999(RGB):
 
     Examples
     --------
-    >>> from colour.colorimetry import (
-    ...     MSDS_CMFS_STANDARD_OBSERVER, SDS_ILLUMINANTS,
-    ...     SpectralShape, sd_to_XYZ_integration
-    ... )
+    >>> from colour import MSDS_CMFS, SDS_ILLUMINANTS, SpectralShape
+    >>> from colour.colorimetry import sd_to_XYZ_integration
     >>> from colour.utilities import numpy_print_options
     >>> XYZ = np.array([0.20654008, 0.12197225, 0.05136952])
     >>> RGB = XYZ_to_RGB_Smits1999(XYZ)
     >>> cmfs = (
-    ...     MSDS_CMFS_STANDARD_OBSERVER['CIE 1931 2 Degree Standard Observer'].
+    ...     MSDS_CMFS['CIE 1931 2 Degree Standard Observer'].
     ...     copy().align(SpectralShape(360, 780, 10))
     ... )
     >>> illuminant = SDS_ILLUMINANTS['E'].copy().align(cmfs.shape)

--- a/colour/recovery/tests/test__init__.py
+++ b/colour/recovery/tests/test__init__.py
@@ -8,7 +8,8 @@ import numpy as np
 import unittest
 
 from colour.colorimetry import (MSDS_CMFS_STANDARD_OBSERVER, SDS_ILLUMINANTS,
-                                SpectralShape, sd_to_XYZ_integration)
+                                SpectralShape, reshape_msds, reshape_sd,
+                                sd_to_XYZ_integration)
 from colour.recovery import XYZ_to_sd
 from colour.utilities import domain_range_scale
 
@@ -33,11 +34,11 @@ class TestXYZ_to_sd(unittest.TestCase):
         Initialises common tests attributes.
         """
 
-        self._cmfs = MSDS_CMFS_STANDARD_OBSERVER[
-            'CIE 1931 2 Degree Standard Observer'].copy().align(
-                SpectralShape(360, 780, 10))
+        self._cmfs = reshape_msds(
+            MSDS_CMFS_STANDARD_OBSERVER['CIE 1931 2 Degree Standard Observer'],
+            SpectralShape(360, 780, 10))
 
-        self._sd_D65 = SDS_ILLUMINANTS['D65'].copy().align(self._cmfs.shape)
+        self._sd_D65 = reshape_sd(SDS_ILLUMINANTS['D65'], self._cmfs.shape)
 
     def test_domain_range_scale_XYZ_to_sd(self):
         """

--- a/colour/recovery/tests/test__init__.py
+++ b/colour/recovery/tests/test__init__.py
@@ -34,6 +34,7 @@ class TestXYZ_to_sd(unittest.TestCase):
         Initialises common tests attributes.
         """
 
+        # pylint: disable=E1102
         self._cmfs = reshape_msds(
             MSDS_CMFS_STANDARD_OBSERVER['CIE 1931 2 Degree Standard Observer'],
             SpectralShape(360, 780, 10))

--- a/colour/recovery/tests/test_jakob2019.py
+++ b/colour/recovery/tests/test_jakob2019.py
@@ -31,9 +31,9 @@ __all__ = [
     'TestErrorFunction', 'TestXYZ_to_sd_Jakob2019', 'TestLUT3D_Jakob2019'
 ]
 
-_DEFAULT_MSDS_CMFS = 'CIE 1931 2 Degree Standard Observer'
+_MSDS_CMFS_DEFAULT = 'CIE 1931 2 Degree Standard Observer'
 
-_DEFAULT_ILLUMINANT = 'D65'
+_ILLUMINANT_DEFAULT = 'D65'
 
 
 class TestErrorFunction(unittest.TestCase):
@@ -49,13 +49,13 @@ class TestErrorFunction(unittest.TestCase):
 
         self._shape = SPECTRAL_SHAPE_JAKOB2019
         self._cmfs = reshape_msds(
-            MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS], self._shape)
+            MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT], self._shape)
 
-        self._sd_D65 = reshape_sd(SDS_ILLUMINANTS[_DEFAULT_ILLUMINANT],
+        self._sd_D65 = reshape_sd(SDS_ILLUMINANTS[_ILLUMINANT_DEFAULT],
                                   self._shape)
         self._XYZ_D65 = sd_to_XYZ(self._sd_D65)
         self._XYZ_D65 /= self._XYZ_D65[1]
-        self._xy_D65 = CCS_ILLUMINANTS[_DEFAULT_MSDS_CMFS][_DEFAULT_ILLUMINANT]
+        self._xy_D65 = CCS_ILLUMINANTS[_MSDS_CMFS_DEFAULT][_ILLUMINANT_DEFAULT]
 
         self._Lab_e = np.array([72, -20, 61])
 
@@ -150,8 +150,8 @@ class TestXYZ_to_sd_Jakob2019(unittest.TestCase):
 
         self._shape = SPECTRAL_SHAPE_JAKOB2019
         self._cmfs = reshape_msds(
-            MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS], self._shape)
-        self._sd_D65 = reshape_sd(SDS_ILLUMINANTS[_DEFAULT_ILLUMINANT],
+            MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT], self._shape)
+        self._sd_D65 = reshape_sd(SDS_ILLUMINANTS[_ILLUMINANT_DEFAULT],
                                   self._shape)
 
     def test_XYZ_to_sd_Jakob2019(self):
@@ -207,11 +207,11 @@ class TestLUT3D_Jakob2019(unittest.TestCase):
 
         self._shape = SPECTRAL_SHAPE_JAKOB2019
         self._cmfs = reshape_msds(
-            MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS], self._shape)
+            MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT], self._shape)
 
-        self._sd_D65 = reshape_sd(SDS_ILLUMINANTS[_DEFAULT_ILLUMINANT],
+        self._sd_D65 = reshape_sd(SDS_ILLUMINANTS[_ILLUMINANT_DEFAULT],
                                   self._shape)
-        self._xy_D65 = CCS_ILLUMINANTS[_DEFAULT_MSDS_CMFS][_DEFAULT_ILLUMINANT]
+        self._xy_D65 = CCS_ILLUMINANTS[_MSDS_CMFS_DEFAULT][_ILLUMINANT_DEFAULT]
 
         self._temporary_directory = tempfile.mkdtemp()
 

--- a/colour/recovery/tests/test_jakob2019.py
+++ b/colour/recovery/tests/test_jakob2019.py
@@ -10,8 +10,9 @@ import tempfile
 import unittest
 
 from colour.characterisation import SDS_COLOURCHECKERS
-from colour.colorimetry import (CCS_ILLUMINANTS, SDS_ILLUMINANTS,
-                                MSDS_CMFS_STANDARD_OBSERVER, sd_to_XYZ)
+from colour.colorimetry import (MSDS_CMFS_STANDARD_OBSERVER, CCS_ILLUMINANTS,
+                                SDS_ILLUMINANTS, reshape_msds, reshape_sd,
+                                sd_to_XYZ)
 from colour.difference import JND_CIE1976, delta_E_CIE1976
 from colour.models import RGB_COLOURSPACE_sRGB, RGB_to_XYZ, XYZ_to_Lab
 from colour.recovery.jakob2019 import (
@@ -30,6 +31,10 @@ __all__ = [
     'TestErrorFunction', 'TestXYZ_to_sd_Jakob2019', 'TestLUT3D_Jakob2019'
 ]
 
+_DEFAULT_MSDS_CMFS = 'CIE 1931 2 Degree Standard Observer'
+
+_DEFAULT_ILLUMINANT = 'D65'
+
 
 class TestErrorFunction(unittest.TestCase):
     """
@@ -43,14 +48,14 @@ class TestErrorFunction(unittest.TestCase):
         """
 
         self._shape = SPECTRAL_SHAPE_JAKOB2019
-        self._cmfs = MSDS_CMFS_STANDARD_OBSERVER[
-            'CIE 1931 2 Degree Standard Observer'].copy().align(self._shape)
+        self._cmfs = reshape_msds(
+            MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS], self._shape)
 
-        self._sd_D65 = SDS_ILLUMINANTS['D65'].copy().align(self._shape)
+        self._sd_D65 = reshape_sd(SDS_ILLUMINANTS[_DEFAULT_ILLUMINANT],
+                                  self._shape)
         self._XYZ_D65 = sd_to_XYZ(self._sd_D65)
         self._XYZ_D65 /= self._XYZ_D65[1]
-        self._xy_D65 = CCS_ILLUMINANTS['CIE 1931 2 Degree Standard Observer'][
-            'D65']
+        self._xy_D65 = CCS_ILLUMINANTS[_DEFAULT_MSDS_CMFS][_DEFAULT_ILLUMINANT]
 
         self._Lab_e = np.array([72, -20, 61])
 
@@ -144,9 +149,10 @@ class TestXYZ_to_sd_Jakob2019(unittest.TestCase):
         """
 
         self._shape = SPECTRAL_SHAPE_JAKOB2019
-        self._cmfs = MSDS_CMFS_STANDARD_OBSERVER[
-            'CIE 1931 2 Degree Standard Observer'].copy().align(self._shape)
-        self._sd_D65 = SDS_ILLUMINANTS['D65'].copy().align(self._shape)
+        self._cmfs = reshape_msds(
+            MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS], self._shape)
+        self._sd_D65 = reshape_sd(SDS_ILLUMINANTS[_DEFAULT_ILLUMINANT],
+                                  self._shape)
 
     def test_XYZ_to_sd_Jakob2019(self):
         """
@@ -200,12 +206,12 @@ class TestLUT3D_Jakob2019(unittest.TestCase):
         self._RGB_colourspace = RGB_COLOURSPACE_sRGB
 
         self._shape = SPECTRAL_SHAPE_JAKOB2019
-        self._cmfs = MSDS_CMFS_STANDARD_OBSERVER[
-            'CIE 1931 2 Degree Standard Observer'].copy().align(self._shape)
+        self._cmfs = reshape_msds(
+            MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS], self._shape)
 
-        self._sd_D65 = SDS_ILLUMINANTS['D65'].copy().align(self._shape)
-        self._xy_D65 = CCS_ILLUMINANTS['CIE 1931 2 Degree Standard Observer'][
-            'D65']
+        self._sd_D65 = reshape_sd(SDS_ILLUMINANTS[_DEFAULT_ILLUMINANT],
+                                  self._shape)
+        self._xy_D65 = CCS_ILLUMINANTS[_DEFAULT_MSDS_CMFS][_DEFAULT_ILLUMINANT]
 
         self._temporary_directory = tempfile.mkdtemp()
 

--- a/colour/recovery/tests/test_jakob2019.py
+++ b/colour/recovery/tests/test_jakob2019.py
@@ -48,6 +48,7 @@ class TestErrorFunction(unittest.TestCase):
         """
 
         self._shape = SPECTRAL_SHAPE_JAKOB2019
+        # pylint: disable=E1102
         self._cmfs = reshape_msds(
             MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT], self._shape)
 
@@ -149,6 +150,7 @@ class TestXYZ_to_sd_Jakob2019(unittest.TestCase):
         """
 
         self._shape = SPECTRAL_SHAPE_JAKOB2019
+        # pylint: disable=E1102
         self._cmfs = reshape_msds(
             MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT], self._shape)
         self._sd_D65 = reshape_sd(SDS_ILLUMINANTS[_ILLUMINANT_DEFAULT],
@@ -206,6 +208,7 @@ class TestLUT3D_Jakob2019(unittest.TestCase):
         self._RGB_colourspace = RGB_COLOURSPACE_sRGB
 
         self._shape = SPECTRAL_SHAPE_JAKOB2019
+        # pylint: disable=E1102
         self._cmfs = reshape_msds(
             MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT], self._shape)
 

--- a/colour/recovery/tests/test_mallett2019.py
+++ b/colour/recovery/tests/test_mallett2019.py
@@ -40,6 +40,7 @@ class TestMixinMallett2019:
         Initialises common tests attributes for the mixin.
         """
 
+        # pylint: disable=E1102
         self._cmfs = reshape_msds(
             MSDS_CMFS_STANDARD_OBSERVER['CIE 1931 2 Degree Standard Observer'],
             SpectralShape(360, 780, 10))

--- a/colour/recovery/tests/test_mallett2019.py
+++ b/colour/recovery/tests/test_mallett2019.py
@@ -7,8 +7,9 @@ import unittest
 import numpy as np
 
 from colour.characterisation import SDS_COLOURCHECKERS
-from colour.colorimetry import (SpectralShape, MSDS_CMFS_STANDARD_OBSERVER,
-                                SDS_ILLUMINANTS, CCS_ILLUMINANTS, sd_to_XYZ)
+from colour.colorimetry import (MSDS_CMFS_STANDARD_OBSERVER, CCS_ILLUMINANTS,
+                                SDS_ILLUMINANTS, SpectralShape, reshape_msds,
+                                reshape_sd, sd_to_XYZ)
 from colour.difference import JND_CIE1976, delta_E_CIE1976
 from colour.models import (RGB_COLOURSPACE_PAL_SECAM, RGB_COLOURSPACE_sRGB,
                            XYZ_to_RGB, XYZ_to_Lab)
@@ -39,10 +40,10 @@ class TestMixinMallett2019:
         Initialises common tests attributes for the mixin.
         """
 
-        self._cmfs = MSDS_CMFS_STANDARD_OBSERVER[
-            'CIE 1931 2 Degree Standard Observer'].copy().align(
-                SpectralShape(360, 780, 10))
-        self._sd_D65 = SDS_ILLUMINANTS['D65'].copy().align(self._cmfs.shape)
+        self._cmfs = reshape_msds(
+            MSDS_CMFS_STANDARD_OBSERVER['CIE 1931 2 Degree Standard Observer'],
+            SpectralShape(360, 780, 10))
+        self._sd_D65 = reshape_sd(SDS_ILLUMINANTS['D65'], self._cmfs.shape)
         self._xy_D65 = CCS_ILLUMINANTS['CIE 1931 2 Degree Standard Observer'][
             'D65']
 

--- a/colour/recovery/tests/test_meng2015.py
+++ b/colour/recovery/tests/test_meng2015.py
@@ -6,8 +6,9 @@ Defines the unit tests for the :mod:`colour.recovery.meng2015` module.
 import numpy as np
 import unittest
 
-from colour.colorimetry import (MSDS_CMFS_STANDARD_OBSERVER, SpectralShape,
-                                SDS_ILLUMINANTS, sd_to_XYZ_integration)
+from colour.colorimetry import (MSDS_CMFS_STANDARD_OBSERVER, SDS_ILLUMINANTS,
+                                SpectralShape, reshape_msds, reshape_sd,
+                                sd_to_XYZ_integration)
 from colour.recovery import XYZ_to_sd_Meng2015
 from colour.utilities import domain_range_scale
 
@@ -32,11 +33,11 @@ class TestXYZ_to_sd_Meng2015(unittest.TestCase):
         Initialises common tests attributes.
         """
 
-        self._cmfs = MSDS_CMFS_STANDARD_OBSERVER[
-            'CIE 1931 2 Degree Standard Observer'].copy().align(
-                SpectralShape(360, 780, 10))
-        self._sd_D65 = SDS_ILLUMINANTS['D65'].copy().align(self._cmfs.shape)
-        self._sd_E = SDS_ILLUMINANTS['E'].copy().align(self._cmfs.shape)
+        self._cmfs = reshape_msds(
+            MSDS_CMFS_STANDARD_OBSERVER['CIE 1931 2 Degree Standard Observer'],
+            SpectralShape(360, 780, 10))
+        self._sd_D65 = reshape_sd(SDS_ILLUMINANTS['D65'], self._cmfs.shape)
+        self._sd_E = reshape_sd(SDS_ILLUMINANTS['E'], self._cmfs.shape)
 
     def test_XYZ_to_sd_Meng2015(self):
         """
@@ -71,7 +72,7 @@ class TestXYZ_to_sd_Meng2015(unittest.TestCase):
             decimal=7)
 
         shape = SpectralShape(400, 700, 5)
-        cmfs = self._cmfs.copy().align(shape)
+        cmfs = reshape_msds(self._cmfs, shape)
         np.testing.assert_almost_equal(
             sd_to_XYZ_integration(
                 XYZ_to_sd_Meng2015(XYZ, cmfs, self._sd_D65), cmfs,

--- a/colour/recovery/tests/test_meng2015.py
+++ b/colour/recovery/tests/test_meng2015.py
@@ -33,6 +33,7 @@ class TestXYZ_to_sd_Meng2015(unittest.TestCase):
         Initialises common tests attributes.
         """
 
+        # pylint: disable=E1102
         self._cmfs = reshape_msds(
             MSDS_CMFS_STANDARD_OBSERVER['CIE 1931 2 Degree Standard Observer'],
             SpectralShape(360, 780, 10))
@@ -72,6 +73,7 @@ class TestXYZ_to_sd_Meng2015(unittest.TestCase):
             decimal=7)
 
         shape = SpectralShape(400, 700, 5)
+        # pylint: disable=E1102
         cmfs = reshape_msds(self._cmfs, shape)
         np.testing.assert_almost_equal(
             sd_to_XYZ_integration(

--- a/colour/recovery/tests/test_otsu2018.py
+++ b/colour/recovery/tests/test_otsu2018.py
@@ -77,6 +77,7 @@ class TestXYZ_to_sd_Otsu2018(unittest.TestCase):
         """
 
         self._shape = SPECTRAL_SHAPE_OTSU2018
+        # pylint: disable=E1102
         self._cmfs = reshape_msds(
             MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT], self._shape)
 
@@ -204,6 +205,7 @@ class TestNodeTree_Otsu2018(unittest.TestCase):
         """
 
         self._shape = SPECTRAL_SHAPE_OTSU2018
+        # pylint: disable=E1102
         self._cmfs = reshape_msds(
             MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT], self._shape)
 

--- a/colour/recovery/tests/test_otsu2018.py
+++ b/colour/recovery/tests/test_otsu2018.py
@@ -32,9 +32,9 @@ __all__ = [
     'TestNodeTree_Otsu2018'
 ]
 
-_DEFAULT_MSDS_CMFS = 'CIE 1931 2 Degree Standard Observer'
+_MSDS_CMFS_DEFAULT = 'CIE 1931 2 Degree Standard Observer'
 
-_DEFAULT_ILLUMINANT = 'D65'
+_ILLUMINANT_DEFAULT = 'D65'
 
 
 class TestDataset_Otsu2018(unittest.TestCase):
@@ -78,11 +78,11 @@ class TestXYZ_to_sd_Otsu2018(unittest.TestCase):
 
         self._shape = SPECTRAL_SHAPE_OTSU2018
         self._cmfs = reshape_msds(
-            MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS], self._shape)
+            MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT], self._shape)
 
-        self._sd_D65 = reshape_sd(SDS_ILLUMINANTS[_DEFAULT_ILLUMINANT],
+        self._sd_D65 = reshape_sd(SDS_ILLUMINANTS[_ILLUMINANT_DEFAULT],
                                   self._shape)
-        self._xy_D65 = CCS_ILLUMINANTS[_DEFAULT_MSDS_CMFS][_DEFAULT_ILLUMINANT]
+        self._xy_D65 = CCS_ILLUMINANTS[_MSDS_CMFS_DEFAULT][_ILLUMINANT_DEFAULT]
 
     def test_XYZ_to_sd_Otsu2018(self):
         """
@@ -205,11 +205,11 @@ class TestNodeTree_Otsu2018(unittest.TestCase):
 
         self._shape = SPECTRAL_SHAPE_OTSU2018
         self._cmfs = reshape_msds(
-            MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS], self._shape)
+            MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT], self._shape)
 
-        self._sd_D65 = reshape_sd(SDS_ILLUMINANTS[_DEFAULT_ILLUMINANT],
+        self._sd_D65 = reshape_sd(SDS_ILLUMINANTS[_ILLUMINANT_DEFAULT],
                                   self._shape)
-        self._xy_D65 = CCS_ILLUMINANTS[_DEFAULT_MSDS_CMFS][_DEFAULT_ILLUMINANT]
+        self._xy_D65 = CCS_ILLUMINANTS[_MSDS_CMFS_DEFAULT][_ILLUMINANT_DEFAULT]
 
         self._temporary_directory = tempfile.mkdtemp()
 

--- a/colour/temperature/ohno2013.py
+++ b/colour/temperature/ohno2013.py
@@ -43,7 +43,7 @@ __all__ = [
     'CCT_to_uv_Ohno2013'
 ]
 
-_DEFAULT_MSDS_CMFS = 'CIE 1931 2 Degree Standard Observer'
+_MSDS_CMFS_DEFAULT = 'CIE 1931 2 Degree Standard Observer'
 
 PLANCKIAN_TABLE_TUVD = namedtuple('PlanckianTable_Tuvdi',
                                   ('Ti', 'ui', 'vi', 'di'))
@@ -202,7 +202,7 @@ def _uv_to_CCT_Ohno2013(uv,
     """
 
     if cmfs is None:
-        cmfs = reshape_msds(MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS],
+        cmfs = reshape_msds(MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT],
                             SPECTRAL_SHAPE_DEFAULT, 'Trim')
 
     # Ensuring we do at least one iteration to initialise variables.
@@ -314,7 +314,7 @@ def uv_to_CCT_Ohno2013(uv,
     """
 
     if cmfs is None:
-        cmfs = reshape_msds(MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS],
+        cmfs = reshape_msds(MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT],
                             SPECTRAL_SHAPE_DEFAULT, 'Trim')
 
     uv = as_float_array(uv)
@@ -348,7 +348,7 @@ def _CCT_to_uv_Ohno2013(CCT_D_uv, cmfs=None):
     """
 
     if cmfs is None:
-        cmfs = reshape_msds(MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS],
+        cmfs = reshape_msds(MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT],
                             SPECTRAL_SHAPE_DEFAULT, 'Trim')
 
     CCT, D_uv = tsplit(CCT_D_uv)
@@ -420,7 +420,7 @@ def CCT_to_uv_Ohno2013(CCT_D_uv, cmfs=None):
     """
 
     if cmfs is None:
-        cmfs = reshape_msds(MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS],
+        cmfs = reshape_msds(MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT],
                             SPECTRAL_SHAPE_DEFAULT, 'Trim')
 
     CCT_D_uv = as_float_array(CCT_D_uv)

--- a/colour/temperature/ohno2013.py
+++ b/colour/temperature/ohno2013.py
@@ -23,9 +23,9 @@ References
 import numpy as np
 from collections import namedtuple
 
-from colour.colorimetry import (SPECTRAL_SHAPE_DEFAULT,
-                                MSDS_CMFS_STANDARD_OBSERVER, sd_blackbody,
-                                sd_to_XYZ)
+from colour.colorimetry import (MSDS_CMFS_STANDARD_OBSERVER,
+                                SPECTRAL_SHAPE_DEFAULT, reshape_msds,
+                                sd_blackbody, sd_to_XYZ)
 from colour.models import UCS_to_uv, XYZ_to_UCS
 from colour.utilities import as_float_array, runtime_warning, tsplit
 
@@ -42,6 +42,8 @@ __all__ = [
     'planckian_table_minimal_distance_index', 'uv_to_CCT_Ohno2013',
     'CCT_to_uv_Ohno2013'
 ]
+
+_DEFAULT_MSDS_CMFS = 'CIE 1931 2 Degree Standard Observer'
 
 PLANCKIAN_TABLE_TUVD = namedtuple('PlanckianTable_Tuvdi',
                                   ('Ti', 'ui', 'vi', 'di'))
@@ -78,11 +80,10 @@ def planckian_table(uv, cmfs, start, end, count):
 
     Examples
     --------
-    >>> from colour.colorimetry import (
-    ...     SPECTRAL_SHAPE_DEFAULT, MSDS_CMFS_STANDARD_OBSERVER)
     >>> from pprint import pprint
+    >>> from colour import MSDS_CMFS, SPECTRAL_SHAPE_DEFAULT
     >>> cmfs = (
-    ...     MSDS_CMFS_STANDARD_OBSERVER['CIE 1931 2 Degree Standard Observer'].
+    ...     MSDS_CMFS['CIE 1931 2 Degree Standard Observer'].
     ...     copy().align(SPECTRAL_SHAPE_DEFAULT)
     ... )
     >>> uv = np.array([0.1978, 0.3122])
@@ -112,7 +113,7 @@ ui=0.4456351..., vi=0.3548306..., di=0.2514749...)]
 
     ux, vx = uv
 
-    cmfs = cmfs.copy().trim(SPECTRAL_SHAPE_DEFAULT)
+    cmfs = reshape_msds(cmfs, SPECTRAL_SHAPE_DEFAULT, 'Trim')
 
     shape = cmfs.shape
 
@@ -146,10 +147,10 @@ def planckian_table_minimal_distance_index(planckian_table_):
 
     Examples
     --------
-    >>> from colour.colorimetry import (
-    ...     SPECTRAL_SHAPE_DEFAULT, MSDS_CMFS_STANDARD_OBSERVER)
+    >>> from colour import MSDS_CMFS, SPECTRAL_SHAPE_DEFAULT
+    >>> from colour.colorimetry import sd_to_XYZ_integration
     >>> cmfs = (
-    ...     MSDS_CMFS_STANDARD_OBSERVER['CIE 1931 2 Degree Standard Observer'].
+    ...     MSDS_CMFS['CIE 1931 2 Degree Standard Observer'].
     ...     copy().align(SPECTRAL_SHAPE_DEFAULT)
     ... )
     >>> uv = np.array([0.1978, 0.3122])
@@ -162,14 +163,12 @@ def planckian_table_minimal_distance_index(planckian_table_):
     return distances.index(min(distances))
 
 
-def _uv_to_CCT_Ohno2013(
-        uv,
-        cmfs=MSDS_CMFS_STANDARD_OBSERVER['CIE 1931 2 Degree Standard Observer']
-        .copy().trim(SPECTRAL_SHAPE_DEFAULT),
-        start=CCT_MINIMAL,
-        end=CCT_MAXIMAL,
-        count=CCT_SAMPLES,
-        iterations=CCT_CALCULATION_ITERATIONS):
+def _uv_to_CCT_Ohno2013(uv,
+                        cmfs=None,
+                        start=CCT_MINIMAL,
+                        end=CCT_MAXIMAL,
+                        count=CCT_SAMPLES,
+                        iterations=CCT_CALCULATION_ITERATIONS):
     """
     Returns the correlated colour temperature :math:`T_{cp}` and
     :math:`\\Delta_{uv}` from given *CIE UCS* colourspace *uv* chromaticity
@@ -185,7 +184,8 @@ def _uv_to_CCT_Ohno2013(
     uv : array_like
         *CIE UCS* colourspace *uv* chromaticity coordinates.
     cmfs : XYZ_ColourMatchingFunctions, optional
-        Standard observer colour matching functions.
+        Standard observer colour matching functions, default to the
+        *CIE 1931 2 Degree Standard Observer*.
     start : numeric, optional
         Temperature range start in kelvins.
     end : numeric, optional
@@ -200,6 +200,10 @@ def _uv_to_CCT_Ohno2013(
     ndarray
         Correlated colour temperature :math:`T_{cp}`, :math:`\\Delta_{uv}`.
     """
+
+    if cmfs is None:
+        cmfs = reshape_msds(MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS],
+                            SPECTRAL_SHAPE_DEFAULT, 'Trim')
 
     # Ensuring we do at least one iteration to initialise variables.
     iterations = max(iterations, 1)
@@ -256,8 +260,7 @@ def _uv_to_CCT_Ohno2013(
 
 
 def uv_to_CCT_Ohno2013(uv,
-                       cmfs=MSDS_CMFS_STANDARD_OBSERVER[
-                           'CIE 1931 2 Degree Standard Observer'],
+                       cmfs=None,
                        start=CCT_MINIMAL,
                        end=CCT_MAXIMAL,
                        count=CCT_SAMPLES,
@@ -277,7 +280,8 @@ def uv_to_CCT_Ohno2013(uv,
     uv : array_like
         *CIE UCS* colourspace *uv* chromaticity coordinates.
     cmfs : XYZ_ColourMatchingFunctions, optional
-        Standard observer colour matching functions.
+        Standard observer colour matching functions, default to the
+        *CIE 1931 2 Degree Standard Observer*.
     start : numeric, optional
         Temperature range start in kelvins.
     end : numeric, optional
@@ -298,16 +302,20 @@ def uv_to_CCT_Ohno2013(uv,
 
     Examples
     --------
-    >>> from colour.colorimetry import (
-    ...     SPECTRAL_SHAPE_DEFAULT, MSDS_CMFS_STANDARD_OBSERVER)
+    >>> from pprint import pprint
+    >>> from colour import MSDS_CMFS, SPECTRAL_SHAPE_DEFAULT
     >>> cmfs = (
-    ...     MSDS_CMFS_STANDARD_OBSERVER['CIE 1931 2 Degree Standard Observer'].
+    ...     MSDS_CMFS['CIE 1931 2 Degree Standard Observer'].
     ...     copy().align(SPECTRAL_SHAPE_DEFAULT)
     ... )
     >>> uv = np.array([0.1978, 0.3122])
     >>> uv_to_CCT_Ohno2013(uv, cmfs)  # doctest: +ELLIPSIS
     array([  6.5074738...e+03,   3.2233460...e-03])
     """
+
+    if cmfs is None:
+        cmfs = reshape_msds(MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS],
+                            SPECTRAL_SHAPE_DEFAULT, 'Trim')
 
     uv = as_float_array(uv)
 
@@ -319,9 +327,7 @@ def uv_to_CCT_Ohno2013(uv,
     return as_float_array(CCT_D_uv).reshape(uv.shape)
 
 
-def _CCT_to_uv_Ohno2013(CCT_D_uv,
-                        cmfs=MSDS_CMFS_STANDARD_OBSERVER[
-                            'CIE 1931 2 Degree Standard Observer']):
+def _CCT_to_uv_Ohno2013(CCT_D_uv, cmfs=None):
     """
     Returns the *CIE UCS* colourspace *uv* chromaticity coordinates from given
     correlated colour temperature :math:`T_{cp}`, :math:`\\Delta_{uv}` and
@@ -332,7 +338,8 @@ def _CCT_to_uv_Ohno2013(CCT_D_uv,
     CCT_D_uv : ndarray
         Correlated colour temperature :math:`T_{cp}`, :math:`\\Delta_{uv}`.
     cmfs : XYZ_ColourMatchingFunctions, optional
-        Standard observer colour matching functions.
+        Standard observer colour matching functions, default to the
+        *CIE 1931 2 Degree Standard Observer*.
 
     Returns
     -------
@@ -340,9 +347,13 @@ def _CCT_to_uv_Ohno2013(CCT_D_uv,
         *CIE UCS* colourspace *uv* chromaticity coordinates.
     """
 
+    if cmfs is None:
+        cmfs = reshape_msds(MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS],
+                            SPECTRAL_SHAPE_DEFAULT, 'Trim')
+
     CCT, D_uv = tsplit(CCT_D_uv)
 
-    cmfs = cmfs.copy().trim(SPECTRAL_SHAPE_DEFAULT)
+    cmfs = reshape_msds(cmfs, SPECTRAL_SHAPE_DEFAULT, 'Trim')
 
     shape = cmfs.shape
 
@@ -372,9 +383,7 @@ def _CCT_to_uv_Ohno2013(CCT_D_uv,
         return np.array([u, v])
 
 
-def CCT_to_uv_Ohno2013(CCT_D_uv,
-                       cmfs=MSDS_CMFS_STANDARD_OBSERVER[
-                           'CIE 1931 2 Degree Standard Observer']):
+def CCT_to_uv_Ohno2013(CCT_D_uv, cmfs=None):
     """
     Returns the *CIE UCS* colourspace *uv* chromaticity coordinates from given
     correlated colour temperature :math:`T_{cp}`, :math:`\\Delta_{uv}` and
@@ -385,7 +394,8 @@ def CCT_to_uv_Ohno2013(CCT_D_uv,
     CCT_D_uv : ndarray
         Correlated colour temperature :math:`T_{cp}`, :math:`\\Delta_{uv}`.
     cmfs : XYZ_ColourMatchingFunctions, optional
-        Standard observer colour matching functions.
+        Standard observer colour matching functions, default to the
+        *CIE 1931 2 Degree Standard Observer*.
 
     Returns
     -------
@@ -398,16 +408,20 @@ def CCT_to_uv_Ohno2013(CCT_D_uv,
 
     Examples
     --------
-    >>> from colour.colorimetry import (
-    ...     SPECTRAL_SHAPE_DEFAULT, MSDS_CMFS_STANDARD_OBSERVER)
+    >>> from pprint import pprint
+    >>> from colour import MSDS_CMFS, SPECTRAL_SHAPE_DEFAULT
     >>> cmfs = (
-    ...     MSDS_CMFS_STANDARD_OBSERVER['CIE 1931 2 Degree Standard Observer'].
+    ...     MSDS_CMFS['CIE 1931 2 Degree Standard Observer'].
     ...     copy().align(SPECTRAL_SHAPE_DEFAULT)
     ... )
     >>> CCT_D_uv = np.array([6507.4342201047066, 0.003223690901513])
     >>> CCT_to_uv_Ohno2013(CCT_D_uv, cmfs)  # doctest: +ELLIPSIS
     array([ 0.1977999...,  0.3122004...])
     """
+
+    if cmfs is None:
+        cmfs = reshape_msds(MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS],
+                            SPECTRAL_SHAPE_DEFAULT, 'Trim')
 
     CCT_D_uv = as_float_array(CCT_D_uv)
 

--- a/colour/temperature/ohno2013.py
+++ b/colour/temperature/ohno2013.py
@@ -113,6 +113,7 @@ ui=0.4456351..., vi=0.3548306..., di=0.2514749...)]
 
     ux, vx = uv
 
+    # pylint: disable=E1102
     cmfs = reshape_msds(cmfs, SPECTRAL_SHAPE_DEFAULT, 'Trim')
 
     shape = cmfs.shape
@@ -202,6 +203,7 @@ def _uv_to_CCT_Ohno2013(uv,
     """
 
     if cmfs is None:
+        # pylint: disable=E1102
         cmfs = reshape_msds(MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT],
                             SPECTRAL_SHAPE_DEFAULT, 'Trim')
 
@@ -314,6 +316,7 @@ def uv_to_CCT_Ohno2013(uv,
     """
 
     if cmfs is None:
+        # pylint: disable=E1102
         cmfs = reshape_msds(MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT],
                             SPECTRAL_SHAPE_DEFAULT, 'Trim')
 
@@ -348,11 +351,13 @@ def _CCT_to_uv_Ohno2013(CCT_D_uv, cmfs=None):
     """
 
     if cmfs is None:
+        # pylint: disable=E1102
         cmfs = reshape_msds(MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT],
                             SPECTRAL_SHAPE_DEFAULT, 'Trim')
 
     CCT, D_uv = tsplit(CCT_D_uv)
 
+    # pylint: disable=E1102
     cmfs = reshape_msds(cmfs, SPECTRAL_SHAPE_DEFAULT, 'Trim')
 
     shape = cmfs.shape
@@ -420,6 +425,7 @@ def CCT_to_uv_Ohno2013(CCT_D_uv, cmfs=None):
     """
 
     if cmfs is None:
+        # pylint: disable=E1102
         cmfs = reshape_msds(MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT],
                             SPECTRAL_SHAPE_DEFAULT, 'Trim')
 

--- a/colour/temperature/tests/test_ohno2013.py
+++ b/colour/temperature/tests/test_ohno2013.py
@@ -25,6 +25,8 @@ __all__ = [
     'Testuv_to_CCT_Ohno2013', 'TestCCT_to_uv_Ohno2013'
 ]
 
+_DEFAULT_MSDS_CMFS = 'CIE 1931 2 Degree Standard Observer'
+
 PLANCKIAN_TABLE = np.array([
     [1000.00000000, 0.44796288, 0.35462962, 0.25373557],
     [1001.11111111, 0.44770303, 0.35465214, 0.25348315],
@@ -50,8 +52,7 @@ class TestPlanckianTable(unittest.TestCase):
         Tests :func:`colour.temperature.ohno2013.planckian_table` definition.
         """
 
-        cmfs = MSDS_CMFS_STANDARD_OBSERVER[
-            'CIE 1931 2 Degree Standard Observer']
+        cmfs = MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS]
 
         np.testing.assert_almost_equal(
             [(x.Ti, x.ui, x.vi, x.di) for x in planckian_table(
@@ -71,8 +72,7 @@ planckian_table_minimal_distance_index` definition unit tests methods.
 planckian_table_minimal_distance_index` definition.
         """
 
-        cmfs = MSDS_CMFS_STANDARD_OBSERVER[
-            'CIE 1931 2 Degree Standard Observer']
+        cmfs = MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS]
         self.assertEqual(
             planckian_table_minimal_distance_index(
                 planckian_table(
@@ -91,8 +91,7 @@ class Testuv_to_CCT_Ohno2013(unittest.TestCase):
         definition.
         """
 
-        cmfs = MSDS_CMFS_STANDARD_OBSERVER[
-            'CIE 1931 2 Degree Standard Observer']
+        cmfs = MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS]
         np.testing.assert_almost_equal(
             uv_to_CCT_Ohno2013(np.array([0.1978, 0.3122]), cmfs),
             np.array([6507.47380460, 0.00322335]),
@@ -153,8 +152,7 @@ class TestCCT_to_uv_Ohno2013(unittest.TestCase):
         definition.
         """
 
-        cmfs = MSDS_CMFS_STANDARD_OBSERVER[
-            'CIE 1931 2 Degree Standard Observer']
+        cmfs = MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS]
         np.testing.assert_almost_equal(
             CCT_to_uv_Ohno2013(np.array([6507.47380460, 0.00322335]), cmfs),
             np.array([0.19779997, 0.31219997]),
@@ -176,8 +174,7 @@ class TestCCT_to_uv_Ohno2013(unittest.TestCase):
         n-dimensional arrays support.
         """
 
-        cmfs = MSDS_CMFS_STANDARD_OBSERVER[
-            'CIE 1931 2 Degree Standard Observer']
+        cmfs = MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS]
         CCT_D_uv = np.array([6507.47380460, 0.00322335])
         uv = CCT_to_uv_Ohno2013(CCT_D_uv, cmfs)
 

--- a/colour/temperature/tests/test_ohno2013.py
+++ b/colour/temperature/tests/test_ohno2013.py
@@ -25,7 +25,7 @@ __all__ = [
     'Testuv_to_CCT_Ohno2013', 'TestCCT_to_uv_Ohno2013'
 ]
 
-_DEFAULT_MSDS_CMFS = 'CIE 1931 2 Degree Standard Observer'
+_MSDS_CMFS_DEFAULT = 'CIE 1931 2 Degree Standard Observer'
 
 PLANCKIAN_TABLE = np.array([
     [1000.00000000, 0.44796288, 0.35462962, 0.25373557],
@@ -52,7 +52,7 @@ class TestPlanckianTable(unittest.TestCase):
         Tests :func:`colour.temperature.ohno2013.planckian_table` definition.
         """
 
-        cmfs = MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS]
+        cmfs = MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT]
 
         np.testing.assert_almost_equal(
             [(x.Ti, x.ui, x.vi, x.di) for x in planckian_table(
@@ -72,7 +72,7 @@ planckian_table_minimal_distance_index` definition unit tests methods.
 planckian_table_minimal_distance_index` definition.
         """
 
-        cmfs = MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS]
+        cmfs = MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT]
         self.assertEqual(
             planckian_table_minimal_distance_index(
                 planckian_table(
@@ -91,7 +91,7 @@ class Testuv_to_CCT_Ohno2013(unittest.TestCase):
         definition.
         """
 
-        cmfs = MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS]
+        cmfs = MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT]
         np.testing.assert_almost_equal(
             uv_to_CCT_Ohno2013(np.array([0.1978, 0.3122]), cmfs),
             np.array([6507.47380460, 0.00322335]),
@@ -152,7 +152,7 @@ class TestCCT_to_uv_Ohno2013(unittest.TestCase):
         definition.
         """
 
-        cmfs = MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS]
+        cmfs = MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT]
         np.testing.assert_almost_equal(
             CCT_to_uv_Ohno2013(np.array([6507.47380460, 0.00322335]), cmfs),
             np.array([0.19779997, 0.31219997]),
@@ -174,7 +174,7 @@ class TestCCT_to_uv_Ohno2013(unittest.TestCase):
         n-dimensional arrays support.
         """
 
-        cmfs = MSDS_CMFS_STANDARD_OBSERVER[_DEFAULT_MSDS_CMFS]
+        cmfs = MSDS_CMFS_STANDARD_OBSERVER[_MSDS_CMFS_DEFAULT]
         CCT_D_uv = np.array([6507.47380460, 0.00322335])
         uv = CCT_to_uv_Ohno2013(CCT_D_uv, cmfs)
 

--- a/colour/utilities/__init__.py
+++ b/colour/utilities/__init__.py
@@ -5,16 +5,17 @@ import sys
 from .data_structures import (Lookup, Structure, CaseInsensitiveMapping,
                               LazyCaseInsensitiveMapping)
 from .common import (
-    handle_numpy_errors, ignore_numpy_errors, raise_numpy_errors,
-    print_numpy_errors, warn_numpy_errors, ignore_python_warnings, batch,
-    disable_multiprocessing, multiprocessing_pool, is_matplotlib_installed,
-    is_networkx_installed, is_openimageio_installed, is_pandas_installed,
-    is_tqdm_installed, required, is_iterable, is_string, is_numeric,
-    is_integer, is_sibling, filter_kwargs, filter_mapping, first_item,
-    get_domain_range_scale, set_domain_range_scale, domain_range_scale,
-    to_domain_1, to_domain_10, to_domain_100, to_domain_degrees, to_domain_int,
-    from_range_1, from_range_10, from_range_100, from_range_degrees,
-    from_range_int, copy_definition, validate_method)
+    CacheRegistry, CACHE_REGISTRY, handle_numpy_errors, ignore_numpy_errors,
+    raise_numpy_errors, print_numpy_errors, warn_numpy_errors,
+    ignore_python_warnings, batch, disable_multiprocessing,
+    multiprocessing_pool, is_matplotlib_installed, is_networkx_installed,
+    is_openimageio_installed, is_pandas_installed, is_tqdm_installed, required,
+    is_iterable, is_string, is_numeric, is_integer, is_sibling, filter_kwargs,
+    filter_mapping, first_item, get_domain_range_scale, set_domain_range_scale,
+    domain_range_scale, to_domain_1, to_domain_10, to_domain_100,
+    to_domain_degrees, to_domain_int, from_range_1, from_range_10,
+    from_range_100, from_range_degrees, from_range_int, copy_definition,
+    validate_method)
 from .verbose import (
     ColourWarning, ColourUsageWarning, ColourRuntimeWarning, message_box,
     show_warning, warning, runtime_warning, usage_warning, filter_warnings,
@@ -39,9 +40,10 @@ __all__ = [
     'LazyCaseInsensitiveMapping'
 ]
 __all__ += [
-    'handle_numpy_errors', 'ignore_numpy_errors', 'raise_numpy_errors',
-    'print_numpy_errors', 'warn_numpy_errors', 'ignore_python_warnings',
-    'batch', 'disable_multiprocessing', 'multiprocessing_pool',
+    'CacheRegistry', 'CACHE_REGISTRY', 'handle_numpy_errors',
+    'ignore_numpy_errors', 'raise_numpy_errors', 'print_numpy_errors',
+    'warn_numpy_errors', 'ignore_python_warnings', 'batch',
+    'disable_multiprocessing', 'multiprocessing_pool',
     'is_matplotlib_installed', 'is_networkx_installed',
     'is_openimageio_installed', 'is_pandas_installed', 'is_tqdm_installed',
     'required', 'is_iterable', 'is_string', 'is_numeric', 'is_integer',

--- a/colour/utilities/data_structures.py
+++ b/colour/utilities/data_structures.py
@@ -456,9 +456,11 @@ class LazyCaseInsensitiveMapping(CaseInsensitiveMapping):
             Item value.
         """
 
+        import colour
+
         value = super(LazyCaseInsensitiveMapping, self).__getitem__(item)
 
-        if callable(value):
+        if callable(value) and hasattr(colour, '__disable_lazy_load__'):
             value = value()
             super(LazyCaseInsensitiveMapping, self).__setitem__(item, value)
 

--- a/colour/utilities/tests/test_common.py
+++ b/colour/utilities/tests/test_common.py
@@ -9,12 +9,12 @@ from collections import OrderedDict
 from functools import partial
 
 from colour.utilities import (
-    batch, multiprocessing_pool, is_iterable, is_string, is_numeric,
-    is_integer, is_sibling, filter_kwargs, filter_mapping, first_item,
-    get_domain_range_scale, set_domain_range_scale, domain_range_scale,
-    to_domain_1, to_domain_10, to_domain_100, to_domain_int, to_domain_degrees,
-    from_range_1, from_range_10, from_range_100, from_range_int,
-    from_range_degrees, validate_method)
+    CacheRegistry, batch, multiprocessing_pool, is_iterable, is_string,
+    is_numeric, is_integer, is_sibling, filter_kwargs, filter_mapping,
+    first_item, get_domain_range_scale, set_domain_range_scale,
+    domain_range_scale, to_domain_1, to_domain_10, to_domain_100,
+    to_domain_int, to_domain_degrees, from_range_1, from_range_10,
+    from_range_100, from_range_int, from_range_degrees, validate_method)
 
 __author__ = 'Colour Developers'
 __copyright__ = 'Copyright (C) 2013-2021 - Colour Developers'
@@ -32,6 +32,115 @@ __all__ = [
     'TestToDomainInt', 'TestFromRange1', 'TestFromRange10', 'TestFromRange100',
     'TestFromRangeDegrees', 'TestFromRangeInt'
 ]
+
+
+class TestCacheRegistry(unittest.TestCase):
+    """
+    Defines :class:`colour.utilities.common.CacheRegistry` class unit
+    tests methods.
+    """
+
+    @staticmethod
+    def _default_test_cache_registry():
+        """
+        Creates a default test cache registry.
+        """
+
+        cache_registry = CacheRegistry()
+        cache_a = cache_registry.register_cache('Cache A')
+        cache_a['Foo'] = 'Bar'
+        cache_b = cache_registry.register_cache('Cache B')
+        cache_b['John'] = 'Doe'
+        cache_b['Luke'] = 'Skywalker'
+
+        return cache_registry
+
+    def test_required_attributes(self):
+        """
+        Tests presence of required attributes.
+        """
+
+        required_attributes = ('registry', )
+
+        for attribute in required_attributes:
+            self.assertIn(attribute, dir(CacheRegistry))
+
+    def test_required_methods(self):
+        """
+        Tests presence of required methods.
+        """
+
+        required_methods = ('__init__', '__str__', 'register_cache',
+                            'unregister_cache', 'clear_cache',
+                            'clear_all_caches')
+
+        for method in required_methods:
+            self.assertIn(method, dir(CacheRegistry))
+
+    def test__str__(self):
+        """
+        Tests :class:`colour.utilities.common.CacheRegistry.__str__` method.
+        """
+
+        cache_registry = self._default_test_cache_registry()
+        self.assertEqual(
+            str(cache_registry),
+            "{'Cache A': '1 item(s)', 'Cache B': '2 item(s)'}")
+
+    def test_register_cache(self):
+        """
+        Tests :class:`colour.utilities.common.CacheRegistry.register_cache`
+        method.
+        """
+
+        cache_registry = CacheRegistry()
+        cache_a = cache_registry.register_cache('Cache A')
+        self.assertDictEqual(cache_registry.registry, {'Cache A': cache_a})
+        cache_b = cache_registry.register_cache('Cache B')
+        self.assertDictEqual(cache_registry.registry, {
+            'Cache A': cache_a,
+            'Cache B': cache_b
+        })
+
+    def test_unregister_cache(self):
+        """
+        Tests :class:`colour.utilities.common.CacheRegistry.unregister_cache`
+        method.
+        """
+
+        cache_registry = self._default_test_cache_registry()
+        cache_registry.unregister_cache('Cache A')
+        self.assertNotIn('Cache A', cache_registry.registry)
+        self.assertIn('Cache B', cache_registry.registry)
+
+    def test_clear_cache(self):
+        """
+        Tests :class:`colour.utilities.common.CacheRegistry.clear_cache`
+        method.
+        """
+
+        cache_registry = self._default_test_cache_registry()
+        cache_registry.clear_cache('Cache A')
+        self.assertDictEqual(cache_registry.registry, {
+            'Cache A': {},
+            'Cache B': {
+                'John': 'Doe',
+                'Luke': 'Skywalker'
+            }
+        })
+
+    def test_clear_all_caches(self):
+        """
+        Tests :class:`colour.utilities.common.CacheRegistry.clear_all_caches`
+        method.
+        """
+
+        cache_registry = self._default_test_cache_registry()
+        cache_registry.clear_all_caches()
+        self.assertDictEqual(cache_registry.registry, {
+            'Cache A': {},
+            'Cache B': {}
+        })
 
 
 class TestBatch(unittest.TestCase):

--- a/colour/volume/macadam_limits.py
+++ b/colour/volume/macadam_limits.py
@@ -11,6 +11,7 @@ from scipy.spatial import Delaunay
 
 from colour.models import xyY_to_XYZ
 from colour.volume import OPTIMAL_COLOUR_STIMULI_ILLUMINANTS
+from colour.utilities import CACHE_REGISTRY
 
 __author__ = 'Colour Developers'
 __copyright__ = 'Copyright (C) 2013-2021 - Colour Developers'
@@ -21,8 +22,13 @@ __status__ = 'Production'
 
 __all__ = ['is_within_macadam_limits']
 
-_CACHE_OPTIMAL_COLOUR_STIMULI_XYZ = {}
-_CACHE_OPTIMAL_COLOUR_STIMULI_XYZ_TRIANGULATIONS = {}
+_CACHE_OPTIMAL_COLOUR_STIMULI_XYZ = CACHE_REGISTRY.register_cache(
+    '{0}._CACHE_OPTIMAL_COLOUR_STIMULI_XYZ'.format(__name__))
+
+_CACHE_OPTIMAL_COLOUR_STIMULI_XYZ_TRIANGULATIONS = (
+    CACHE_REGISTRY.register_cache(
+        '{0}._CACHE_OPTIMAL_COLOUR_STIMULI_XYZ_TRIANGULATIONS'.format(
+            __name__)))
 
 
 def _XYZ_optimal_colour_stimuli(illuminant):

--- a/colour/volume/spectrum.py
+++ b/colour/volume/spectrum.py
@@ -27,7 +27,7 @@ from colour.colorimetry import (MSDS_CMFS_STANDARD_OBSERVER, SpectralShape,
                                 msds_to_XYZ, reshape_msds, sd_ones)
 from colour.constants import DEFAULT_FLOAT_DTYPE
 from colour.volume import is_within_mesh_volume
-from colour.utilities import zeros, validate_method
+from colour.utilities import CACHE_REGISTRY, zeros, validate_method
 
 __author__ = 'Colour Developers'
 __copyright__ = 'Copyright (C) 2013-2021 - Colour Developers'
@@ -49,8 +49,11 @@ interval of 5.
 SPECTRAL_SHAPE_OUTER_SURFACE_XYZ : SpectralShape
 """
 
-_CACHE_OUTER_SURFACE_XYZ = {}
-_CACHE_OUTER_SURFACE_XYZ_POINTS = {}
+_CACHE_OUTER_SURFACE_XYZ = CACHE_REGISTRY.register_cache(
+    '{0}._CACHE_OUTER_SURFACE_XYZ'.format(__name__))
+
+_CACHE_OUTER_SURFACE_XYZ_POINTS = CACHE_REGISTRY.register_cache(
+    '{0}._CACHE_OUTER_SURFACE_XYZ_POINTS'.format(__name__))
 
 
 def generate_pulse_waves(bins, pulse_order='Bins', filter_jagged_pulses=False):

--- a/colour/volume/spectrum.py
+++ b/colour/volume/spectrum.py
@@ -313,6 +313,7 @@ def XYZ_outer_surface(cmfs=None,
     """
 
     if cmfs is None:
+        # pylint: disable=E1102
         cmfs = reshape_msds(
             MSDS_CMFS_STANDARD_OBSERVER['CIE 1931 2 Degree Standard Observer'],
             SPECTRAL_SHAPE_OUTER_SURFACE_XYZ)
@@ -395,6 +396,7 @@ def is_within_visible_spectrum(XYZ,
     """
 
     if cmfs is None:
+        # pylint: disable=E1102
         cmfs = reshape_msds(
             MSDS_CMFS_STANDARD_OBSERVER['CIE 1931 2 Degree Standard Observer'],
             SPECTRAL_SHAPE_OUTER_SURFACE_XYZ)

--- a/colour/volume/tests/test_spectrum.py
+++ b/colour/volume/tests/test_spectrum.py
@@ -132,6 +132,7 @@ class TestXYZOuterSurface(unittest.TestCase):
         cmfs = MSDS_CMFS_STANDARD_OBSERVER[
             'CIE 1931 2 Degree Standard Observer']
 
+        # pylint: disable=E1102
         np.testing.assert_array_almost_equal(
             XYZ_outer_surface(reshape_msds(cmfs, shape)),
             np.array([

--- a/colour/volume/tests/test_spectrum.py
+++ b/colour/volume/tests/test_spectrum.py
@@ -7,8 +7,9 @@ import numpy as np
 import unittest
 from itertools import permutations
 
-from colour.colorimetry import (SPECTRAL_SHAPE_DEFAULT, SpectralShape,
-                                MSDS_CMFS_STANDARD_OBSERVER)
+from colour.colorimetry import (MSDS_CMFS_STANDARD_OBSERVER,
+                                SPECTRAL_SHAPE_DEFAULT, SpectralShape,
+                                reshape_msds)
 from colour.volume import (generate_pulse_waves, XYZ_outer_surface,
                            is_within_visible_spectrum)
 from colour.utilities import ignore_numpy_errors
@@ -132,7 +133,7 @@ class TestXYZOuterSurface(unittest.TestCase):
             'CIE 1931 2 Degree Standard Observer']
 
         np.testing.assert_array_almost_equal(
-            XYZ_outer_surface(cmfs.copy().align(shape)),
+            XYZ_outer_surface(reshape_msds(cmfs, shape)),
             np.array([
                 [0.00000000e+00, 0.00000000e+00, 0.00000000e+00],
                 [9.63613812e-05, 2.90567768e-06, 4.49612264e-04],

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -28,6 +28,39 @@ runtime:
     :func:`colour.utilities.show_warning` definition and thus providing
     complete traceback from the point where the warning occurred.
 
+Caching
+-------
+
+**Colour** uses various internal caches to improve speed and prevent redundant
+processes, notably for spectral related computations.
+
+The internal caches are managed with the `colour.utilities.CACHE_REGISTRY`
+cache registry object:
+
+.. code-block:: python
+
+    import colour
+
+    print(colour.utilities.CACHE_REGISTRY)
+
+.. code-block:: text
+
+    {'colour.colorimetry.spectrum._CACHE_RESHAPED_SDS_AND_MSDS': '0 item(s)',
+     'colour.colorimetry.tristimulus_values._CACHE_LAGRANGE_INTERPOLATING_COEFFICIENTS': '0 '
+                                                                                         'item(s)',
+     'colour.colorimetry.tristimulus_values._CACHE_SD_TO_XYZ': '0 item(s)',
+     'colour.colorimetry.tristimulus_values._CACHE_TRISTIMULUS_WEIGHTING_FACTORS': '0 '
+                                                                                   'item(s)',
+     'colour.quality.cfi2017._CACHE_TCS_CIE2017': '0 item(s)',
+     'colour.volume.macadam_limits._CACHE_OPTIMAL_COLOUR_STIMULI_XYZ': '0 item(s)',
+     'colour.volume.macadam_limits._CACHE_OPTIMAL_COLOUR_STIMULI_XYZ_TRIANGULATIONS': '0 '
+                                                                                      'item(s)',
+     'colour.volume.spectrum._CACHE_OUTER_SURFACE_XYZ': '0 item(s)',
+     'colour.volume.spectrum._CACHE_OUTER_SURFACE_XYZ_POINTS': '0 item(s)'}
+
+See `colour.utilities.CacheRegistry` class documentation for more information
+on how to manage the cache registry.
+
 Using Colour without Scipy
 --------------------------
 

--- a/docs/colour.colorimetry.rst
+++ b/docs/colour.colorimetry.rst
@@ -24,6 +24,20 @@ Spectral Data Structure
     SPECTRAL_SHAPE_ASTME308
     SPECTRAL_SHAPE_DEFAULT
 
+**Ancillary Objects**
+
+``colour.colorimetry``
+
+.. currentmodule:: colour.colorimetry
+
+.. autosummary::
+    :toctree: generated/
+
+    sds_and_msds_to_sds
+    sds_and_msds_to_msds
+    reshape_sd
+    reshape_msds
+
 Spectral Data Generation
 ------------------------
 
@@ -59,13 +73,11 @@ Spectral Data Generation
 
     blackbody_spectral_radiance
     daylight_locus_function
-
     sd_gaussian_normal
     sd_gaussian_fwhm
     sd_single_led_Ohno2005
     sd_multi_leds_Ohno2005
-    sds_and_msds_to_sds
-    sds_and_msds_to_msds
+
 
 **Aliases**
 

--- a/docs/colour.utilities.rst
+++ b/docs/colour.utilities.rst
@@ -24,7 +24,16 @@ Common
 
 .. autosummary::
     :toctree: generated/
+    :template: class.rst
 
+    CacheRegistry
+
+.. currentmodule:: colour.utilities
+
+.. autosummary::
+    :toctree: generated/
+
+    CACHE_REGISTRY
     handle_numpy_errors
     ignore_numpy_errors
     raise_numpy_errors


### PR DESCRIPTION
We have a few caches now in *Colour* but no API to manage them. This is even more relevant with #840. With that in mind I added a small API to manage the caches. It is available via the `colour.utilities.CACHE_REGISTRY` attribute, an instance of  `colour.utilities.CacheRegistry`.

```python
>>> cache_registry = CacheRegistry()
>>> cache_a = cache_registry.register_cache('Cache A')
>>> cache_a['Foo'] = 'Bar'
>>> cache_b = cache_registry.register_cache('Cache B')
>>> cache_b['John'] = 'Doe'
>>> cache_b['Luke'] = 'Skywalker'
>>> print(cache_registry)
{'Cache A': '1 item(s)', 'Cache B': '2 item(s)'}
>>> cache_registry.clear_cache('Cache A')
>>> print(cache_registry)
{'Cache A': '0 item(s)', 'Cache B': '2 item(s)'}
>>> cache_registry.unregister_cache('Cache B')
>>> print(cache_registry)
{'Cache A': '0 item(s)'}
>>> print(cache_b)
{}
```