### PR TITLE
PR: Refactor "Otsu (2018)" classes.

### DIFF
--- a/colour/examples/recovery/examples_otsu2018.py
+++ b/colour/examples/recovery/examples_otsu2018.py
@@ -31,7 +31,7 @@ reflectances = [
     for reflectance in colour.SDS_COLOURCHECKERS['ColorChecker N Ohta']
     .values()
 ]
-node_tree = colour.recovery.NodeTree_Otsu2018(reflectances)
+node_tree = colour.recovery.Tree_Otsu2018(reflectances)
 node_tree.optimise()
 dataset = node_tree.to_dataset()
 print(colour.recovery.XYZ_to_sd_Otsu2018(XYZ, dataset=dataset))

--- a/colour/recovery/__init__.py
+++ b/colour/recovery/__init__.py
@@ -19,6 +19,11 @@ References
     doi:10.1080/10867651.1999.10487511
 """
 
+import sys
+
+from colour.utilities.deprecation import ModuleAPI, build_API_changes
+from colour.utilities.documentation import is_documentation_building
+
 from colour.utilities import (CaseInsensitiveMapping, as_float_array,
                               filter_kwargs, validate_method)
 
@@ -29,8 +34,9 @@ from .jakob2019 import (sd_Jakob2019, find_coefficients_Jakob2019,
 from .mallett2019 import (spectral_primary_decomposition_Mallett2019,
                           RGB_to_sd_Mallett2019)
 from .meng2015 import XYZ_to_sd_Meng2015
-from .otsu2018 import Dataset_Otsu2018, NodeTree_Otsu2018, XYZ_to_sd_Otsu2018
+from .otsu2018 import Dataset_Otsu2018, Tree_Otsu2018, XYZ_to_sd_Otsu2018
 from .smits1999 import RGB_to_sd_Smits1999
+
 __all__ = []
 __all__ += datasets.__all__
 __all__ += [
@@ -41,7 +47,7 @@ __all__ += [
     'spectral_primary_decomposition_Mallett2019', 'RGB_to_sd_Mallett2019'
 ]
 __all__ += ['XYZ_to_sd_Meng2015']
-__all__ += ['Dataset_Otsu2018', 'NodeTree_Otsu2018', 'XYZ_to_sd_Otsu2018']
+__all__ += ['Dataset_Otsu2018', 'Tree_Otsu2018', 'XYZ_to_sd_Otsu2018']
 __all__ += ['RGB_to_sd_Smits1999']
 
 XYZ_TO_SD_METHODS = CaseInsensitiveMapping({
@@ -473,3 +479,31 @@ def XYZ_to_sd(XYZ, method='Meng 2015', **kwargs):
 
 
 __all__ += ['XYZ_TO_SD_METHODS', 'XYZ_to_sd']
+
+
+# ----------------------------------------------------------------------------#
+# ---                API Changes and Deprecation Management                ---#
+# ----------------------------------------------------------------------------#
+class recovery(ModuleAPI):
+    def __getattr__(self, attribute):
+        return super(recovery, self).__getattr__(attribute)
+
+
+# v0.4.0
+API_CHANGES = {
+    'ObjectRenamed': [[
+        'colour.recovery.NodeTree_Otsu2018',
+        'colour.recovery.Tree_Otsu2018',
+    ], ]
+}
+"""
+Defines the *colour.recovery* sub-package API changes.
+
+API_CHANGES : dict
+"""
+
+if not is_documentation_building():
+    sys.modules['colour.recovery'] = recovery(sys.modules['colour.recovery'],
+                                              build_API_changes(API_CHANGES))
+
+    del ModuleAPI, is_documentation_building, build_API_changes, sys

--- a/colour/recovery/tests/test_otsu2018.py
+++ b/colour/recovery/tests/test_otsu2018.py
@@ -10,13 +10,14 @@ import tempfile
 import unittest
 
 from colour.characterisation import SDS_COLOURCHECKERS
-from colour.colorimetry import (handle_spectral_arguments, reshape_sd,
-                                sd_to_XYZ)
+from colour.colorimetry import (handle_spectral_arguments, reshape_msds,
+                                reshape_sd, sd_to_XYZ, sds_and_msds_to_msds)
 from colour.difference import delta_E_CIE1976
 from colour.models import XYZ_to_Lab, XYZ_to_xy
 from colour.recovery import (XYZ_to_sd_Otsu2018, SPECTRAL_SHAPE_OTSU2018,
-                             Dataset_Otsu2018, NodeTree_Otsu2018)
-from colour.recovery.otsu2018 import DATASET_REFERENCE_OTSU2018, Data, Node
+                             Dataset_Otsu2018, Tree_Otsu2018)
+from colour.recovery.otsu2018 import (
+    DATASET_REFERENCE_OTSU2018, Data_Otsu2018, Node_Otsu2018, PartitionAxis)
 from colour.utilities import domain_range_scale, metric_mse
 
 __author__ = 'Colour Developers'
@@ -27,8 +28,8 @@ __email__ = 'colour-developers@colour-science.org'
 __status__ = 'Production'
 
 __all__ = [
-    'TestDataset_Otsu2018', 'TestXYZ_to_sd_Otsu2018', 'TestData', 'TestNode',
-    'TestNodeTree_Otsu2018'
+    'TestDataset_Otsu2018', 'TestXYZ_to_sd_Otsu2018', 'TestData_Otsu2018',
+    'TestNode_Otsu2018', 'TestTree_Otsu2018'
 ]
 
 
@@ -229,70 +230,9 @@ class TestXYZ_to_sd_Otsu2018(unittest.TestCase):
                     decimal=7)
 
 
-class TestData(unittest.TestCase):
+class TestData_Otsu2018(unittest.TestCase):
     """
-    Defines :class:`colour.recovery.otsu2018.Data` definition unit tests
-    methods.
-    """
-
-    def test_required_attributes(self):
-        """
-        Tests presence of required attributes.
-        """
-
-        required_attributes = ('tree', 'reflectances', 'reflectances',
-                               'basis_functions', 'mean')
-
-        for attribute in required_attributes:
-            self.assertIn(attribute, dir(Data))
-
-    def test_required_methods(self):
-        """
-        Tests presence of required methods.
-        """
-
-        required_methods = ('__init__', '__str__', '__len__', 'PCA',
-                            'reconstruct', 'reconstruction_error', 'origin',
-                            'partition')
-
-        for method in required_methods:
-            self.assertIn(method, dir(Data))
-
-
-class TestNode(unittest.TestCase):
-    """
-    Defines :class:`colour.recovery.otsu2018.Node` definition unit tests
-    methods.
-    """
-
-    def test_required_attributes(self):
-        """
-        Tests presence of required attributes.
-        """
-
-        required_attributes = ('id', 'tree', 'data', 'children', 'leaves',
-                               'partition_axis')
-
-        for attribute in required_attributes:
-            self.assertIn(attribute, dir(Node))
-
-    def test_required_methods(self):
-        """
-        Tests presence of required methods.
-        """
-
-        required_methods = ('__init__', '__str__', '__len__', 'is_leaf',
-                            'split', 'find_best_partition',
-                            'leaf_reconstruction_error',
-                            'branch_reconstruction_error')
-
-        for method in required_methods:
-            self.assertIn(method, dir(Node))
-
-
-class TestNodeTree_Otsu2018(unittest.TestCase):
-    """
-    Defines :class:`colour.recovery.otsu2018.NodeTree_Otsu2018` definition unit
+    Defines :class:`colour.recovery.otsu2018.Data_Otsu2018` definition unit
     tests methods.
     """
 
@@ -304,6 +244,365 @@ class TestNodeTree_Otsu2018(unittest.TestCase):
         self._shape = SPECTRAL_SHAPE_OTSU2018
         self._cmfs, self._sd_D65 = handle_spectral_arguments(
             shape_default=self._shape)
+
+        self._reflectances = np.transpose(
+            reshape_msds(
+                sds_and_msds_to_msds(
+                    SDS_COLOURCHECKERS['ColorChecker N Ohta'].values()),
+                self._shape).values)
+
+        self._data = Data_Otsu2018(self._reflectances, self._cmfs,
+                                   self._sd_D65)
+
+    def test_required_attributes(self):
+        """
+        Tests presence of required attributes.
+        """
+
+        required_attributes = ('reflectances', 'cmfs', 'illuminant',
+                               'basis_functions', 'mean')
+
+        for attribute in required_attributes:
+            self.assertIn(attribute, dir(Data_Otsu2018))
+
+    def test_required_methods(self):
+        """
+        Tests presence of required methods.
+        """
+
+        required_methods = ('__init__', '__str__', '__len__', 'origin',
+                            'partition', 'PCA', 'reconstruct',
+                            'reconstruction_error')
+
+        for method in required_methods:
+            self.assertIn(method, dir(Data_Otsu2018))
+
+    def test_reflectances(self):
+        """
+        Tests :attr:`colour.recovery.otsu2018.Data_Otsu2018.reflectances`
+        property.
+        """
+
+        self.assertIs(self._data.reflectances, self._reflectances)
+
+    def test_cmfs(self):
+        """
+        Tests :attr:`colour.recovery.otsu2018.Data_Otsu2018.cmfs` property.
+        """
+
+        self.assertIs(self._data.cmfs, self._cmfs)
+
+    def test_illuminant(self):
+        """
+        Tests :attr:`colour.recovery.otsu2018.Data_Otsu2018.illuminant`
+        property.
+        """
+
+        self.assertIs(self._data.illuminant, self._sd_D65)
+
+    def test_basis_functions(self):
+        """
+        Tests :attr:`colour.recovery.otsu2018.Data_Otsu2018.basis_functions`
+        property.
+        """
+
+        data = Data_Otsu2018(self._reflectances, self._cmfs, self._sd_D65)
+
+        self.assertIsNone(data.basis_functions)
+
+        data.PCA()
+
+        self.assertTupleEqual(data.basis_functions.shape, (3, 36))
+
+    def test_mean(self):
+        """
+        Tests :attr:`colour.recovery.otsu2018.Data_Otsu2018.mean` property.
+        """
+
+        data = Data_Otsu2018(self._reflectances, self._cmfs, self._sd_D65)
+
+        self.assertIsNone(data.mean)
+
+        data.PCA()
+
+        self.assertTupleEqual(data.mean.shape, (36, ))
+
+    def test__str__(self):
+        """
+        Tests :func:`colour.recovery.otsu2018.Data_Otsu2018.__str__` method.
+        """
+
+        self.assertEqual(str(self._data), 'Data_Otsu2018(24 Reflectances)')
+
+    def test__len__(self):
+        """
+        Tests :func:`colour.recovery.otsu2018.Data_Otsu2018.__len__` method.
+        """
+
+        self.assertEqual(len(self._data), 24)
+
+    def test_origin(self):
+        """
+        Tests :func:`colour.recovery.otsu2018.Data_Otsu2018.origin` method.
+        """
+
+        self.assertAlmostEqual(
+            self._data.origin(4, 1), 0.255284008578559, places=7)
+
+    def test_partition(self):
+        """
+        Tests :func:`colour.recovery.otsu2018.Data_Otsu2018.partition` method.
+        """
+
+        partition = self._data.partition(PartitionAxis(4, 1))
+
+        self.assertEqual(len(partition), 2)
+
+    def test_PCA(self):
+        """
+        Tests :func:`colour.recovery.otsu2018.Data_Otsu2018.PCA` method.
+        """
+
+        data = Data_Otsu2018(self._reflectances, self._cmfs, self._sd_D65)
+
+        data.PCA()
+
+        np.testing.assert_almost_equal(
+            data.basis_functions,
+            np.array([
+                [
+                    0.04391241, 0.08560996, 0.15556120, 0.20826672, 0.22981218,
+                    0.23117641, 0.22718022, 0.21742869, 0.19854261, 0.16868383,
+                    0.12020268, 0.05958463, -0.01015508, -0.08775193,
+                    -0.16957532, -0.23186776, -0.26516404, -0.27409402,
+                    -0.27856619, -0.27685075, -0.25597708, -0.21331000,
+                    -0.15372029, -0.08746878, -0.02744494, 0.01725581,
+                    0.04756055, 0.07184639, 0.09090063, 0.10317253, 0.10830387,
+                    0.10872694, 0.10645999, 0.10766424, 0.11170078, 0.11620896
+                ],
+                [
+                    0.03137588, 0.06204234, 0.11364884, 0.17579436, 0.20914074,
+                    0.22152351, 0.23120105, 0.24039823, 0.24730359, 0.25195045,
+                    0.25237533, 0.24672212, 0.23538236, 0.22094141, 0.20389065,
+                    0.18356599, 0.15952882, 0.13567812, 0.11401807, 0.09178015,
+                    0.06539517, 0.03173809, -0.00658524, -0.04710763,
+                    -0.08379987, -0.11074555, -0.12606191, -0.13630094,
+                    -0.13988107, -0.14193361, -0.14671866, -0.15164795,
+                    -0.15772737, -0.16328073, -0.16588768, -0.16947164
+                ],
+                [
+                    -0.01360289, -0.02375832, -0.04262545, -0.07345243,
+                    -0.09081235, -0.09227928, -0.08922710, -0.08626299,
+                    -0.08584571, -0.08843734, -0.09475094, -0.10376740,
+                    -0.11331399, -0.12109706, -0.12678070, -0.13401030,
+                    -0.14417036, -0.15408359, -0.16265529, -0.17079814,
+                    -0.17972656, -0.19005983, -0.20053986, -0.21017531,
+                    -0.21808806, -0.22347400, -0.22650876, -0.22895376,
+                    -0.22982598, -0.23001787, -0.23036398, -0.22917409,
+                    -0.22684271, -0.22387883, -0.22065773, -0.21821049
+                ],
+            ]),
+            decimal=7)
+
+        np.testing.assert_almost_equal(
+            data.mean,
+            np.array([
+                0.08795833, 0.12050000, 0.16787500, 0.20675000, 0.22329167,
+                0.22837500, 0.23229167, 0.23579167, 0.23658333, 0.23779167,
+                0.23866667, 0.23975000, 0.24345833, 0.25054167, 0.25791667,
+                0.26150000, 0.26437500, 0.26566667, 0.26475000, 0.26554167,
+                0.27137500, 0.28279167, 0.29529167, 0.31070833, 0.32575000,
+                0.33829167, 0.34675000, 0.35554167, 0.36295833, 0.37004167,
+                0.37854167, 0.38675000, 0.39587500, 0.40266667, 0.40683333,
+                0.41287500
+            ]),
+            decimal=7)
+
+    def test_reconstruct(self):
+        """
+        Tests :func:`colour.recovery.otsu2018.Data_Otsu2018.reconstruct`
+        method.
+        """
+
+        data = Data_Otsu2018(self._reflectances, self._cmfs, self._sd_D65)
+
+        data.PCA()
+
+        np.testing.assert_almost_equal(
+            data.reconstruct(np.array([
+                0.20654008,
+                0.12197225,
+                0.05136952,
+            ])).values,
+            np.array([
+                0.06899964, 0.08241919, 0.09768650, 0.08938555, 0.07872582,
+                0.07140930, 0.06385099, 0.05471747, 0.04281364, 0.03073280,
+                0.01761134, 0.00772535, 0.00379120, 0.00405617, 0.00595014,
+                0.01323536, 0.03229711, 0.05661531, 0.07763041, 0.10271461,
+                0.14276781, 0.20239859, 0.27288559, 0.35044541, 0.42170481,
+                0.47567859, 0.50910276, 0.53578140, 0.55251101, 0.56530032,
+                0.58029915, 0.59367723, 0.60830542, 0.62100871, 0.62881635,
+                0.63971254
+            ]),
+            decimal=7)
+
+    def test_reconstruction_error(self):
+        """
+        Tests :func:`colour.recovery.otsu2018.Data_Otsu2018.\
+reconstruction_error` method.
+        """
+
+        data = Data_Otsu2018(self._reflectances, self._cmfs, self._sd_D65)
+
+        self.assertAlmostEqual(
+            data.reconstruction_error(), 2.753352549148681, places=7)
+
+
+class TestNode_Otsu2018(unittest.TestCase):
+    """
+    Defines :class:`colour.recovery.otsu2018.Node_Otsu2018` definition unit
+    tests methods.
+    """
+
+    def setUp(self):
+        """
+        Initialises common tests attributes.
+        """
+
+        self._shape = SPECTRAL_SHAPE_OTSU2018
+        self._cmfs, self._sd_D65 = handle_spectral_arguments(
+            shape_default=self._shape)
+
+        self._reflectances = sds_and_msds_to_msds(
+            SDS_COLOURCHECKERS['ColorChecker N Ohta'].values())
+
+        self._tree = Tree_Otsu2018(self._reflectances)
+        self._tree.optimise()
+        for leaf in self._tree.leaves:
+            if len(leaf.parent.children) == 2:
+                self._node_a = leaf.parent
+                self._node_b, self._node_c = self._node_a.children
+                break
+
+        self._data_a = Data_Otsu2018(
+            np.transpose(reshape_msds(self._reflectances, self._shape).values),
+            self._cmfs, self._sd_D65)
+        self._data_b = self._node_b.data
+
+        self._partition_axis = self._node_a.partition_axis
+
+    def test_required_attributes(self):
+        """
+        Tests presence of required attributes.
+        """
+
+        required_attributes = ('partition_axis', 'row')
+
+        for attribute in required_attributes:
+            self.assertIn(attribute, dir(Node_Otsu2018))
+
+    def test_required_methods(self):
+        """
+        Tests presence of required methods.
+        """
+
+        required_methods = ('__init__', 'split', 'minimise',
+                            'leaf_reconstruction_error',
+                            'branch_reconstruction_error')
+
+        for method in required_methods:
+            self.assertIn(method, dir(Node_Otsu2018))
+
+    def test_partition_axis(self):
+        """
+        Tests :attr:`colour.recovery.otsu2018.Node_Otsu2018.partition_axis`
+        property.
+        """
+
+        self.assertIs(self._node_a.partition_axis, self._partition_axis)
+
+    def test_row(self):
+        """
+        Tests :attr:`colour.recovery.otsu2018.Node_Otsu2018.row` property.
+        """
+
+        self.assertListEqual(self._node_a.row, [
+            self._partition_axis.direction,
+            self._partition_axis.origin,
+            self._node_b,
+            self._node_c,
+        ])
+
+    def test_split(self):
+        """
+        Tests :func:`colour.recovery.otsu2018.None.split` method.
+        """
+
+        node_a = Node_Otsu2018(self._tree, None)
+        node_b = Node_Otsu2018(self._tree, self._data_a)
+        node_c = Node_Otsu2018(self._tree, self._data_a)
+        node_a.split([node_b, node_c], PartitionAxis(12, 0))
+
+        self.assertEqual(len(node_a.children), 2)
+
+    def test_minimise(self):
+        """
+        Tests :func:`colour.recovery.otsu2018.None.minimise` method.
+        """
+
+        node = Node_Otsu2018(data=self._data_a)
+        partition, axis, partition_error = node.minimise(3)
+
+        self.assertTupleEqual((len(partition[0].data), len(partition[1].data)),
+                              (10, 14))
+        self.assertAlmostEqual(axis.origin, 0.324111380117147, places=7)
+        self.assertAlmostEqual(partition_error, 2.0402980027, places=7)
+
+    def test_leaf_reconstruction_error(self):
+        """
+        Tests :func:`colour.recovery.otsu2018.None.leaf_reconstruction_error`
+        method.
+        """
+
+        self.assertAlmostEqual(
+            self._node_b.leaf_reconstruction_error(),
+            1.145340908277367e-29,
+            places=7)
+
+    def test_branch_reconstruction_error(self):
+        """
+        Tests :func:`colour.recovery.otsu2018.None.branch_reconstruction_error`
+        method.
+        """
+
+        self.assertAlmostEqual(
+            self._node_a.branch_reconstruction_error(),
+            3.900015991807948e-25,
+            places=7)
+
+
+class TestTree_Otsu2018(unittest.TestCase):
+    """
+    Defines :class:`colour.recovery.otsu2018.Tree_Otsu2018` definition unit
+    tests methods.
+    """
+
+    def setUp(self):
+        """
+        Initialises common tests attributes.
+        """
+
+        self._shape = SPECTRAL_SHAPE_OTSU2018
+        self._cmfs, self._sd_D65 = handle_spectral_arguments(
+            shape_default=self._shape)
+
+        self._reflectances = sds_and_msds_to_msds(
+            list(SDS_COLOURCHECKERS['ColorChecker N Ohta'].values()) +
+            list(SDS_COLOURCHECKERS['BabelColor Average'].values()))
+
+        self._tree = Tree_Otsu2018(self._reflectances, self._cmfs,
+                                   self._sd_D65)
+
         self._XYZ_D65 = sd_to_XYZ(self._sd_D65)
         self._xy_D65 = XYZ_to_xy(self._XYZ_D65)
 
@@ -321,11 +620,10 @@ class TestNodeTree_Otsu2018(unittest.TestCase):
         Tests presence of required attributes.
         """
 
-        required_attributes = ('reflectances', 'cmfs', 'illuminant',
-                               'minimum_cluster_size')
+        required_attributes = ('reflectances', 'cmfs', 'illuminant')
 
         for attribute in required_attributes:
-            self.assertIn(attribute, dir(NodeTree_Otsu2018))
+            self.assertIn(attribute, dir(Tree_Otsu2018))
 
     def test_required_methods(self):
         """
@@ -335,22 +633,46 @@ class TestNodeTree_Otsu2018(unittest.TestCase):
         required_methods = ('__init__', '__str__', 'optimise', 'to_dataset')
 
         for method in required_methods:
-            self.assertIn(method, dir(NodeTree_Otsu2018))
+            self.assertIn(method, dir(Tree_Otsu2018))
 
-    def test_NodeTree_Otsu2018_and_Dataset_Otsu2018(self):
+    def test_reflectances(self):
         """
-        Tests :class:`colour.recovery.otsu2018.NodeTree_Otsu2018` dataset
+        Tests :attr:`colour.recovery.otsu2018.Tree_Otsu2018.reflectances`
+        property.
+        """
+
+        np.testing.assert_almost_equal(
+            self._tree.reflectances,
+            np.transpose(
+                reshape_msds(
+                    sds_and_msds_to_msds(self._reflectances),
+                    self._shape).values),
+            decimal=7)
+
+    def test_cmfs(self):
+        """
+        Tests :attr:`colour.recovery.otsu2018.Tree_Otsu2018.cmfs` property.
+        """
+
+        self.assertIs(self._tree.cmfs, self._cmfs)
+
+    def test_illuminant(self):
+        """
+        Tests :attr:`colour.recovery.otsu2018.Tree_Otsu2018.illuminant`
+        property.
+        """
+
+        self.assertIs(self._tree.illuminant, self._sd_D65)
+
+    def test_Tree_Otsu2018(self):
+        """
+        Tests :class:`colour.recovery.otsu2018.Tree_Otsu2018` dataset
         generation and :class:`colour.recovery.otsu2018.Dataset_Otsu2018`
         input and output. The generated dataset is also tested for
         reconstruction errors.
         """
 
-        reflectances = []
-        for colourchecker in ['ColorChecker N Ohta', 'BabelColor Average']:
-            for sd in SDS_COLOURCHECKERS[colourchecker].values():
-                reflectances.append(reshape_sd(sd, self._shape).values)
-
-        node_tree = NodeTree_Otsu2018(reflectances, self._cmfs, self._sd_D65)
+        node_tree = Tree_Otsu2018(self._reflectances, self._cmfs, self._sd_D65)
         node_tree.optimise(iterations=5)
 
         path = os.path.join(self._temporary_directory, 'Test_Otsu2018.npz')

--- a/colour/utilities/__init__.py
+++ b/colour/utilities/__init__.py
@@ -3,7 +3,7 @@
 import sys
 
 from .data_structures import (Lookup, Structure, CaseInsensitiveMapping,
-                              LazyCaseInsensitiveMapping)
+                              LazyCaseInsensitiveMapping, Node)
 from .common import (
     CacheRegistry, CACHE_REGISTRY, handle_numpy_errors, ignore_numpy_errors,
     raise_numpy_errors, print_numpy_errors, warn_numpy_errors,
@@ -37,7 +37,7 @@ from colour.utilities.documentation import is_documentation_building
 
 __all__ = [
     'Lookup', 'Structure', 'CaseInsensitiveMapping',
-    'LazyCaseInsensitiveMapping'
+    'LazyCaseInsensitiveMapping', 'Node'
 ]
 __all__ += [
     'CacheRegistry', 'CACHE_REGISTRY', 'handle_numpy_errors',

--- a/colour/utilities/tests/test_data_structures.py
+++ b/colour/utilities/tests/test_data_structures.py
@@ -9,7 +9,7 @@ import pickle
 import unittest
 
 from colour.utilities import (Structure, Lookup, CaseInsensitiveMapping,
-                              LazyCaseInsensitiveMapping)
+                              LazyCaseInsensitiveMapping, Node)
 
 __author__ = 'Colour Developers'
 __copyright__ = 'Copyright (C) 2013-2021 - Colour Developers'
@@ -20,7 +20,7 @@ __status__ = 'Production'
 
 __all__ = [
     'TestStructure', 'TestLookup', 'TestCaseInsensitiveMapping',
-    'TestLazyCaseInsensitiveMapping'
+    'TestLazyCaseInsensitiveMapping', 'TestNode'
 ]
 
 
@@ -376,6 +376,188 @@ LazyCaseInsensitiveMapping.__getitem__` method.
         self.assertEqual(mapping['Jane'], 'Doe')
 
         self.assertEqual(mapping['jane'], 'Doe')
+
+
+class TestNode(unittest.TestCase):
+    """
+    Defines :class:`colour.utilities.data_structures.Node` class unit tests
+    methods.
+    """
+
+    def setUp(self):
+        """
+        Initialises common tests attributes.
+        """
+
+        self._data = {'John': 'Doe'}
+
+        self._node_a = Node('Node A', data=self._data)
+        self._node_b = Node('Node B', self._node_a)
+        self._node_c = Node('Node C', self._node_a)
+        self._node_d = Node('Node D', self._node_b)
+        self._node_e = Node('Node E', self._node_b)
+        self._node_f = Node('Node F', self._node_d)
+        self._node_g = Node('Node G', self._node_f)
+        self._node_h = Node('Node H', self._node_g)
+
+        self._tree = self._node_a
+
+    def test_required_attributes(self):
+        """
+        Tests presence of required attributes.
+        """
+
+        required_attributes = ('name', 'parent', 'children', 'id', 'root',
+                               'leaves', 'siblings', 'data')
+
+        for attribute in required_attributes:
+            self.assertIn(attribute, dir(Node))
+
+    def test_required_methods(self):
+        """
+        Tests presence of required methods.
+        """
+
+        required_methods = ('__new__', '__init__', '__str__', '__len__',
+                            'is_root', 'is_inner', 'is_leaf', 'walk', 'render')
+
+        for method in required_methods:
+            self.assertIn(method, dir(Node))
+
+    def test_name(self):
+        """
+        Tests :attr:`colour.utilities.data_structures.Node.name` property.
+        """
+
+        self.assertEqual(self._tree.name, 'Node A')
+        self.assertIn('Node#', Node().name)
+
+    def test_parent(self):
+        """
+        Tests :attr:`colour.utilities.data_structures.Node.parent` property.
+        """
+
+        self.assertIs(self._node_b.parent, self._node_a)
+        self.assertIs(self._node_h.parent, self._node_g)
+
+    def test_children(self):
+        """
+        Tests :attr:`colour.utilities.data_structures.Node.children` property.
+        """
+
+        self.assertListEqual(self._node_a.children,
+                             [self._node_b, self._node_c])
+
+    def test_id(self):
+        """
+        Tests :attr:`colour.utilities.data_structures.Node.id` property.
+        """
+
+        self.assertIsInstance(self._node_a.id, int)
+
+    def test_root(self):
+        """
+        Tests :attr:`colour.utilities.data_structures.Node.root` property.
+        """
+
+        self.assertIs(self._node_a.root, self._node_a)
+        self.assertIs(self._node_f.root, self._node_a)
+        self.assertIs(self._node_g.root, self._node_a)
+        self.assertIs(self._node_h.root, self._node_a)
+
+    def test_leaves(self):
+        """
+        Tests :attr:`colour.utilities.data_structures.Node.leaves` property.
+        """
+
+        self.assertListEqual(list(self._node_h.leaves), [self._node_h])
+
+        self.assertListEqual(
+            list(self._node_a.leaves),
+            [self._node_h, self._node_e, self._node_c])
+
+    def test_siblings(self):
+        """
+        Tests :attr:`colour.utilities.data_structures.Node.siblings` property.
+        """
+
+        self.assertListEqual(list(self._node_b.siblings), [self._node_c])
+
+    def test_data(self):
+        """
+        Tests :attr:`colour.utilities.data_structures.Node.data` property.
+        """
+
+        self.assertIs(self._node_a.data, self._data)
+
+    def test__str__(self):
+        """
+        Tests :attr:`colour.utilities.data_structures.Node.__str__` method.
+        """
+
+        self.assertIn('Node#', str(self._node_a))
+        self.assertIn("{'John': 'Doe'})", str(self._node_a))
+
+    def test__len__(self):
+        """
+        Tests :attr:`colour.utilities.data_structures.Node.__len__` method.
+        """
+
+        self.assertEqual(len(self._node_a), 7)
+
+    def test_is_root(self):
+        """
+        Tests :attr:`colour.utilities.data_structures.Node.is_root` method.
+        """
+
+        self.assertTrue(self._node_a.is_root())
+        self.assertFalse(self._node_b.is_root())
+        self.assertFalse(self._node_c.is_root())
+        self.assertFalse(self._node_h.is_root())
+
+    def test_is_inner(self):
+        """
+        Tests :attr:`colour.utilities.data_structures.Node.is_inner` method.
+        """
+
+        self.assertFalse(self._node_a.is_inner())
+        self.assertTrue(self._node_b.is_inner())
+        self.assertFalse(self._node_c.is_inner())
+        self.assertFalse(self._node_h.is_inner())
+
+    def test_is_leaf(self):
+        """
+        Tests :attr:`colour.utilities.data_structures.Node.is_leaf` method.
+        """
+
+        self.assertFalse(self._node_a.is_leaf())
+        self.assertFalse(self._node_b.is_leaf())
+        self.assertTrue(self._node_c.is_leaf())
+        self.assertTrue(self._node_h.is_leaf())
+
+    def test_walk(self):
+        """
+        Tests :attr:`colour.utilities.data_structures.Node.walk` method.
+        """
+
+        self.assertListEqual(
+            list(self._node_a.walk()), [
+                self._node_b, self._node_d, self._node_f, self._node_g,
+                self._node_h, self._node_e, self._node_c
+            ])
+
+        self.assertListEqual(
+            list(self._node_h.walk(ascendants=True)), [
+                self._node_g, self._node_f, self._node_d, self._node_b,
+                self._node_a
+            ])
+
+    def test_render(self):
+        """
+        Tests :attr:`colour.utilities.data_structures.Node.render` method.
+        """
+
+        self.assertIsInstance(self._node_a.render(), str)
 
 
 if __name__ == '__main__':

--- a/docs/colour.recovery.rst
+++ b/docs/colour.recovery.rst
@@ -100,7 +100,7 @@ Otsu, Yamamoto and Hachisuka (2018)
     :toctree: generated/
 
     Dataset_Otsu2018
-    NodeTree_Otsu2018
+    Tree_Otsu2018
 
 Smits (1999)
 ------------

--- a/docs/colour.utilities.rst
+++ b/docs/colour.utilities.rst
@@ -132,6 +132,7 @@ Data Structures
     CaseInsensitiveMapping
     LazyCaseInsensitiveMapping
     Lookup
+    Node
     Structure
 
 Verbose


### PR DESCRIPTION
As I was improving coverage in *Otsu (2018)* and implemented unit tests, I started to simplify the various interfaces and started to be bothered by the lack of clean separation between the _Data_, _Node_ and _Tree_ classes. To improve the implementation, I added a new `colour.utilities.Node` class that is inherited by `colour.recovery.otsu2018.Node_Otsu2018` class. The colorimetric computations capabilities have all been moved to the `colour.recovery.otsu2018.Data_Otsu2018` class, the name is not ideal since the class is not purely about data but lacking of better, this is, for now, the way.

I shaved a lot of fat and kept only the minimal set of attributes and methods.