### PR TITLE
PR: Implement support for "OpenColorIO" processor.

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -40,20 +40,20 @@ jobs:
     - name: Install Poetry
       run: |
         curl -L https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py -o get-poetry.py
-        python get-poetry.py --version 1.0.10
+        python get-poetry.py
         echo "$HOME/.poetry/bin" >> $GITHUB_PATH
       shell: bash
     - name: Install Package Dependencies (macOS & Ubuntu)
       if: matrix.os == 'macOS-latest' || matrix.os == 'ubuntu-18.04'
       run: |
-        python3 -m pip install --upgrade pip
+        poetry run python -m pip install --upgrade pip
         poetry install --extras "graphviz optional plotting"
         poetry run python -c "import imageio;imageio.plugins.freeimage.download()"
       shell: bash
     - name: Install Package Dependencies (Windows)
       if: matrix.os == 'windows-latest'
       run: |
-        python3 -m pip install --upgrade pip
+        poetry run python -m pip install --upgrade pip
         poetry install --extras "optional plotting"
         poetry run python -c "import imageio;imageio.plugins.freeimage.download()"
       shell: bash

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -46,12 +46,14 @@ jobs:
     - name: Install Package Dependencies (macOS & Ubuntu)
       if: matrix.os == 'macOS-latest' || matrix.os == 'ubuntu-18.04'
       run: |
+        python3 -m pip install --upgrade pip
         poetry install --extras "graphviz optional plotting"
         poetry run python -c "import imageio;imageio.plugins.freeimage.download()"
       shell: bash
     - name: Install Package Dependencies (Windows)
       if: matrix.os == 'windows-latest'
       run: |
+        python3 -m pip install --upgrade pip
         poetry install --extras "optional plotting"
         poetry run python -c "import imageio;imageio.plugins.freeimage.download()"
       shell: bash

--- a/colour/io/__init__.py
+++ b/colour/io/__init__.py
@@ -7,6 +7,7 @@ from .image import read_image_OpenImageIO, write_image_OpenImageIO
 from .image import read_image_Imageio, write_image_Imageio
 from .image import READ_IMAGE_METHODS, WRITE_IMAGE_METHODS
 from .image import read_image, write_image
+from .ocio import process_image_OpenColorIO
 from .tabular import (read_spectral_data_from_csv_file, read_sds_from_csv_file,
                       write_sds_to_csv_file)
 from .tm2714 import SpectralDistribution_IESTM2714
@@ -21,6 +22,7 @@ __all__ += ['read_image_OpenImageIO', 'write_image_OpenImageIO']
 __all__ += ['read_image_Imageio', 'write_image_Imageio']
 __all__ += ['READ_IMAGE_METHODS', 'WRITE_IMAGE_METHODS']
 __all__ += ['read_image', 'write_image']
+__all__ += ['process_image_OpenColorIO']
 __all__ += [
     'read_spectral_data_from_csv_file', 'read_sds_from_csv_file',
     'write_sds_to_csv_file'

--- a/colour/io/ocio.py
+++ b/colour/io/ocio.py
@@ -39,7 +39,9 @@ def process_image_OpenColorIO(a, *args, **kwargs):
         See https://opencolorio.readthedocs.io/en/latest/api/config.html for
         more information.
     config : unicode, optional
-        *OpenColorIO* config to use for processing.
+        *OpenColorIO* config to use for processing. If not defined, the
+        *OpenColorIO* set defined by the ``$OCIO`` environment variable is
+        used.
 
     Returns
     -------

--- a/colour/io/ocio.py
+++ b/colour/io/ocio.py
@@ -40,8 +40,6 @@ def process_image_OpenColorIO(a, *args, **kwargs):
         more information.
     config : unicode, optional
         *OpenColorIO* config to use for processing.
-    use_cpu : bool, optional
-        Whether to use the *CPU* or *GPU* processor.
 
     Returns
     -------
@@ -89,8 +87,6 @@ def process_image_OpenColorIO(a, *args, **kwargs):
 
     import PyOpenColorIO as ocio
 
-    use_cpu = kwargs.get('use_cpu', True)
-
     config = kwargs.get('config')
     config = (ocio.Config.CreateFromEnv()
               if config is None else ocio.Config.CreateFromFile(config))
@@ -98,10 +94,7 @@ def process_image_OpenColorIO(a, *args, **kwargs):
     a = np.atleast_3d(as_float_array(a, dtype=np.float32))
     height, width, channels = a.shape
 
-    processor = config.getProcessor(*args)
-
-    processor = (processor.getDefaultCPUProcessor()
-                 if use_cpu else processor.getDefaultGPUProcessor())
+    processor = config.getProcessor(*args).getDefaultCPUProcessor()
 
     image_desc = ocio.PackedImageDesc(a, width, height, channels)
 

--- a/colour/io/tests/resources/config-aces-reference.ocio.yaml
+++ b/colour/io/tests/resources/config-aces-reference.ocio.yaml
@@ -1,0 +1,587 @@
+ocio_profile_version: 2.1
+
+environment:
+  {}
+search_path: ""
+strictparsing: true
+luma: [0.2126, 0.7152, 0.0722]
+description: |
+  The "Academy Color Encoding System" (ACES) "Reference Config".
+
+  This "OpenColorIO" config is a strict and quasi-analytical implementation of "aces-dev" and is designed as a reference for software developers. It is not a replacement for the previous "ACES" configs nor the "ACES Studio Config".
+
+  Generated with "OpenColorIO-Config-ACES" v0.1.1-5-g48ca436 on the 2021/07/17 at 15:31.
+
+roles:
+  aces_interchange: ACES - ACES2065-1
+  cie_xyz_d65_interchange: CIE-XYZ-D65
+  color_timing: ACES - ACEScct
+  compositing_log: ACES - ACEScct
+  data: Utility - Raw
+  default: ACES - ACES2065-1
+  reference: ACES - ACES2065-1
+  rendering: ACES - ACEScg
+  scene_linear: ACES - ACEScg
+
+file_rules:
+  - !<Rule> {name: Default, colorspace: ACES - ACES2065-1}
+
+shared_views:
+  - !<View> {name: Output - SDR Video - ACES 1.0, view_transform: Output - SDR Video - ACES 1.0, display_colorspace: <USE_DISPLAY_NAME>}
+  - !<View> {name: Output - SDR Video (D60 sim on D65) - ACES 1.0, view_transform: Output - SDR Video (D60 sim on D65) - ACES 1.0, display_colorspace: <USE_DISPLAY_NAME>}
+  - !<View> {name: Output - SDR Video (P3 lim) - ACES 1.1, view_transform: Output - SDR Video (P3 lim) - ACES 1.1, display_colorspace: <USE_DISPLAY_NAME>}
+  - !<View> {name: Output - SDR Video (Rec.709 lim) - ACES 1.1, view_transform: Output - SDR Video (Rec.709 lim) - ACES 1.1, display_colorspace: <USE_DISPLAY_NAME>}
+  - !<View> {name: Output - HDR Video (1000 nits & Rec.2020 lim) - ACES 1.1, view_transform: Output - HDR Video (1000 nits & Rec.2020 lim) - ACES 1.1, display_colorspace: <USE_DISPLAY_NAME>}
+  - !<View> {name: Output - HDR Video (2000 nits & Rec.2020 lim) - ACES 1.1, view_transform: Output - HDR Video (2000 nits & Rec.2020 lim) - ACES 1.1, display_colorspace: <USE_DISPLAY_NAME>}
+  - !<View> {name: Output - HDR Video (4000 nits & Rec.2020 lim) - ACES 1.1, view_transform: Output - HDR Video (4000 nits & Rec.2020 lim) - ACES 1.1, display_colorspace: <USE_DISPLAY_NAME>}
+  - !<View> {name: Output - HDR Video (1000 nits & P3 lim) - ACES 1.1, view_transform: Output - HDR Video (1000 nits & P3 lim) - ACES 1.1, display_colorspace: <USE_DISPLAY_NAME>}
+  - !<View> {name: Output - HDR Video (2000 nits & P3 lim) - ACES 1.1, view_transform: Output - HDR Video (2000 nits & P3 lim) - ACES 1.1, display_colorspace: <USE_DISPLAY_NAME>}
+  - !<View> {name: Output - HDR Video (4000 nits & P3 lim) - ACES 1.1, view_transform: Output - HDR Video (4000 nits & P3 lim) - ACES 1.1, display_colorspace: <USE_DISPLAY_NAME>}
+  - !<View> {name: Output - SDR Cinema - ACES 1.0, view_transform: Output - SDR Cinema - ACES 1.0, display_colorspace: <USE_DISPLAY_NAME>}
+  - !<View> {name: Output - SDR Cinema (D60 sim on D65) - ACES 1.1, view_transform: Output - SDR Cinema (D60 sim on D65) - ACES 1.1, display_colorspace: <USE_DISPLAY_NAME>}
+  - !<View> {name: Output - SDR Cinema (Rec.709 lim) - ACES 1.1, view_transform: Output - SDR Cinema (Rec.709 lim) - ACES 1.1, display_colorspace: <USE_DISPLAY_NAME>}
+  - !<View> {name: Output - SDR Cinema (D60 sim on DCI) - ACES 1.0, view_transform: Output - SDR Cinema (D60 sim on DCI) - ACES 1.0, display_colorspace: <USE_DISPLAY_NAME>}
+  - !<View> {name: Output - SDR Cinema (D65 sim on DCI) - ACES 1.1, view_transform: Output - SDR Cinema (D65 sim on DCI) - ACES 1.1, display_colorspace: <USE_DISPLAY_NAME>}
+  - !<View> {name: Output - HDR Cinema (108 nits & P3 lim) - ACES 1.1, view_transform: Output - HDR Cinema (108 nits & P3 lim) - ACES 1.1, display_colorspace: <USE_DISPLAY_NAME>}
+  - !<View> {name: Un-tone-mapped, view_transform: Un-tone-mapped, display_colorspace: <USE_DISPLAY_NAME>}
+
+displays:
+  Display - sRGB:
+    - !<View> {name: Raw, colorspace: Utility - Raw}
+    - !<Views> [Output - SDR Video - ACES 1.0, Output - SDR Video (D60 sim on D65) - ACES 1.0, Un-tone-mapped]
+  Display - Rec.1886 / Rec.709 Video:
+    - !<View> {name: Raw, colorspace: Utility - Raw}
+    - !<Views> [Output - SDR Video - ACES 1.0, Output - SDR Video (D60 sim on D65) - ACES 1.0, Un-tone-mapped]
+  Display - Rec.1886 / Rec.2020 Video:
+    - !<View> {name: Raw, colorspace: Utility - Raw}
+    - !<Views> [Output - SDR Video - ACES 1.0, Output - SDR Video (P3 lim) - ACES 1.1, Output - SDR Video (Rec.709 lim) - ACES 1.1, Un-tone-mapped]
+  Display - Rec.2100-HLG:
+    - !<View> {name: Raw, colorspace: Utility - Raw}
+    - !<Views> [Output - HDR Video (1000 nits & Rec.2020 lim) - ACES 1.1, Un-tone-mapped]
+  Display - Rec.2100-PQ:
+    - !<View> {name: Raw, colorspace: Utility - Raw}
+    - !<Views> [Output - HDR Video (1000 nits & Rec.2020 lim) - ACES 1.1, Output - HDR Video (2000 nits & Rec.2020 lim) - ACES 1.1, Output - HDR Video (4000 nits & Rec.2020 lim) - ACES 1.1, Un-tone-mapped]
+  Display - ST2084-P3-D65:
+    - !<View> {name: Raw, colorspace: Utility - Raw}
+    - !<Views> [Output - HDR Video (1000 nits & P3 lim) - ACES 1.1, Output - HDR Video (2000 nits & P3 lim) - ACES 1.1, Output - HDR Video (4000 nits & P3 lim) - ACES 1.1, Output - HDR Cinema (108 nits & P3 lim) - ACES 1.1, Un-tone-mapped]
+  Display - P3-D60:
+    - !<View> {name: Raw, colorspace: Utility - Raw}
+    - !<Views> [Output - SDR Cinema - ACES 1.0, Un-tone-mapped]
+  Display - P3-D65:
+    - !<View> {name: Raw, colorspace: Utility - Raw}
+    - !<Views> [Output - SDR Cinema - ACES 1.0, Output - SDR Cinema (D60 sim on D65) - ACES 1.1, Output - SDR Cinema (Rec.709 lim) - ACES 1.1, Un-tone-mapped]
+  Display - P3-DCI:
+    - !<View> {name: Raw, colorspace: Utility - Raw}
+    - !<Views> [Output - SDR Cinema (D60 sim on DCI) - ACES 1.0, Output - SDR Cinema (D65 sim on DCI) - ACES 1.1, Un-tone-mapped]
+
+active_displays: [Display - sRGB, Display - Rec.1886 / Rec.709 Video, Display - Rec.1886 / Rec.2020 Video, Display - Rec.2100-HLG, Display - Rec.2100-PQ, Display - ST2084-P3-D65, Display - P3-D60, Display - P3-D65, Display - P3-DCI]
+active_views: [Output - SDR Video - ACES 1.0, Output - SDR Video (D60 sim on D65) - ACES 1.0, Output - SDR Video (P3 lim) - ACES 1.1, Output - SDR Video (Rec.709 lim) - ACES 1.1, Output - HDR Video (1000 nits & Rec.2020 lim) - ACES 1.1, Output - HDR Video (2000 nits & Rec.2020 lim) - ACES 1.1, Output - HDR Video (4000 nits & Rec.2020 lim) - ACES 1.1, Output - HDR Video (1000 nits & P3 lim) - ACES 1.1, Output - HDR Video (2000 nits & P3 lim) - ACES 1.1, Output - HDR Video (4000 nits & P3 lim) - ACES 1.1, Output - SDR Cinema - ACES 1.0, Output - SDR Cinema (D60 sim on D65) - ACES 1.1, Output - SDR Cinema (Rec.709 lim) - ACES 1.1, Output - SDR Cinema (D60 sim on DCI) - ACES 1.0, Output - SDR Cinema (D65 sim on DCI) - ACES 1.1, Output - HDR Cinema (108 nits & P3 lim) - ACES 1.1, Raw]
+inactive_colorspaces: [CIE-XYZ-D65]
+
+looks:
+  - !<Look>
+    name: LMT - Blue Light Artifact Fix
+    process_space: ACES - ACES2065-1
+    description: |
+      LMT for desaturating blue hues to reduce clipping artifacts
+
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:LMT.Academy.BlueLightArtifactFix.a1.1.0
+    transform: !<BuiltinTransform> {style: ACES-LMT - BLUE_LIGHT_ARTIFACT_FIX}
+
+  - !<Look>
+    name: LMT - ACES 1.3 Reference Gamut Compression
+    process_space: ACES - ACES2065-1
+    description: |
+      LMT (applied in ACES2065-1) to compress scene-referred values from common cameras into the AP1 gamut
+
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:LMT.Academy.GamutCompress.a1.3.0
+    transform: !<BuiltinTransform> {style: ACES-LMT - ACES 1.3 Reference Gamut Compression}
+
+
+default_view_transform: Un-tone-mapped
+
+view_transforms:
+  - !<ViewTransform>
+    name: Output - SDR Video - ACES 1.0
+    description: |
+      Component of ACES Output Transforms for SDR D65 video
+
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ODT.Academy.RGBmonitor_100nits_dim.a1.0.3
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec2020_100nits_dim.a1.0.3
+    from_scene_reference: !<BuiltinTransform> {style: ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - SDR-VIDEO_1.0}
+
+  - !<ViewTransform>
+    name: Output - SDR Video (D60 sim on D65) - ACES 1.0
+    description: |
+      Component of ACES Output Transforms for SDR D65 video simulating D60 white
+
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.3
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_D60sim_100nits_dim.a1.0.3
+    from_scene_reference: !<BuiltinTransform> {style: ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - SDR-VIDEO-D60sim-D65_1.0}
+
+  - !<ViewTransform>
+    name: Output - SDR Video (P3 lim) - ACES 1.1
+    description: |
+      Component of ACES Output Transforms for SDR D65 video
+
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec2020_P3D65limited_100nits_dim.a1.1.0
+    from_scene_reference: !<BuiltinTransform> {style: ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - SDR-VIDEO-P3lim_1.1}
+
+  - !<ViewTransform>
+    name: Output - SDR Video (Rec.709 lim) - ACES 1.1
+    description: |
+      Component of ACES Output Transforms for SDR D65 video
+
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec2020_Rec709limited_100nits_dim.a1.1.0
+    from_scene_reference: !<BuiltinTransform> {style: ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - SDR-VIDEO-REC709lim_1.1}
+
+  - !<ViewTransform>
+    name: Output - HDR Video (1000 nits & Rec.2020 lim) - ACES 1.1
+    description: |
+      Component of ACES Output Transforms for 1000 nit HDR D65 video
+
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:RRTODT.Academy.Rec2020_1000nits_15nits_HLG.a1.1.0
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:RRTODT.Academy.Rec2020_1000nits_15nits_ST2084.a1.1.0
+    from_scene_reference: !<BuiltinTransform> {style: ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - HDR-VIDEO-1000nit-15nit-REC2020lim_1.1}
+
+  - !<ViewTransform>
+    name: Output - HDR Video (2000 nits & Rec.2020 lim) - ACES 1.1
+    description: |
+      Component of ACES Output Transforms for 2000 nit HDR D65 video
+
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:RRTODT.Academy.Rec2020_2000nits_15nits_ST2084.a1.1.0
+    from_scene_reference: !<BuiltinTransform> {style: ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - HDR-VIDEO-2000nit-15nit-REC2020lim_1.1}
+
+  - !<ViewTransform>
+    name: Output - HDR Video (4000 nits & Rec.2020 lim) - ACES 1.1
+    description: |
+      Component of ACES Output Transforms for 4000 nit HDR D65 video
+
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:RRTODT.Academy.Rec2020_4000nits_15nits_ST2084.a1.1.0
+    from_scene_reference: !<BuiltinTransform> {style: ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - HDR-VIDEO-4000nit-15nit-REC2020lim_1.1}
+
+  - !<ViewTransform>
+    name: Output - HDR Video (1000 nits & P3 lim) - ACES 1.1
+    description: |
+      Component of ACES Output Transforms for 1000 nit HDR D65 video
+
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:RRTODT.Academy.P3D65_1000nits_15nits_ST2084.a1.1.0
+    from_scene_reference: !<BuiltinTransform> {style: ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - HDR-VIDEO-1000nit-15nit-P3lim_1.1}
+
+  - !<ViewTransform>
+    name: Output - HDR Video (2000 nits & P3 lim) - ACES 1.1
+    description: |
+      Component of ACES Output Transforms for 2000 nit HDR D65 video
+
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:RRTODT.Academy.P3D65_2000nits_15nits_ST2084.a1.1.0
+    from_scene_reference: !<BuiltinTransform> {style: ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - HDR-VIDEO-2000nit-15nit-P3lim_1.1}
+
+  - !<ViewTransform>
+    name: Output - HDR Video (4000 nits & P3 lim) - ACES 1.1
+    description: |
+      Component of ACES Output Transforms for 4000 nit HDR D65 video
+
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:RRTODT.Academy.P3D65_4000nits_15nits_ST2084.a1.1.0
+    from_scene_reference: !<BuiltinTransform> {style: ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - HDR-VIDEO-4000nit-15nit-P3lim_1.1}
+
+  - !<ViewTransform>
+    name: Output - SDR Cinema - ACES 1.0
+    description: |
+      Component of ACES Output Transforms for SDR cinema
+
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ODT.Academy.P3D60_48nits.a1.0.3
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ODT.Academy.P3D65_48nits.a1.1.0
+    from_scene_reference: !<BuiltinTransform> {style: ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - SDR-CINEMA_1.0}
+
+  - !<ViewTransform>
+    name: Output - SDR Cinema (D60 sim on D65) - ACES 1.1
+    description: |
+      Component of ACES Output Transforms for SDR D65 cinema simulating D60 white
+
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ODT.Academy.P3D65_D60sim_48nits.a1.1.0
+    from_scene_reference: !<BuiltinTransform> {style: ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - SDR-CINEMA-D60sim-D65_1.1}
+
+  - !<ViewTransform>
+    name: Output - SDR Cinema (Rec.709 lim) - ACES 1.1
+    description: |
+      Component of ACES Output Transforms for SDR cinema
+
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ODT.Academy.P3D65_Rec709limited_48nits.a1.1.0
+    from_scene_reference: !<BuiltinTransform> {style: ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - SDR-CINEMA-REC709lim_1.1}
+
+  - !<ViewTransform>
+    name: Output - SDR Cinema (D60 sim on DCI) - ACES 1.0
+    description: |
+      Component of ACES Output Transforms for SDR DCI cinema simulating D60 white
+
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ODT.Academy.P3DCI_48nits.a1.0.3
+    from_scene_reference: !<BuiltinTransform> {style: ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - SDR-CINEMA-D60sim-DCI_1.0}
+
+  - !<ViewTransform>
+    name: Output - SDR Cinema (D65 sim on DCI) - ACES 1.1
+    description: |
+      Component of ACES Output Transforms for SDR DCI cinema simulating D65 white
+
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ODT.Academy.P3DCI_D65sim_48nits.a1.1.0
+    from_scene_reference: !<BuiltinTransform> {style: ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - SDR-CINEMA-D65sim-DCI_1.1}
+
+  - !<ViewTransform>
+    name: Output - HDR Cinema (108 nits & P3 lim) - ACES 1.1
+    description: |
+      Component of ACES Output Transforms for 108 nit HDR D65 cinema
+
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:RRTODT.Academy.P3D65_108nits_7point2nits_ST2084.a1.1.0
+    from_scene_reference: !<BuiltinTransform> {style: ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - HDR-CINEMA-108nit-7.2nit-P3lim_1.1}
+
+  - !<ViewTransform>
+    name: Un-tone-mapped
+    from_scene_reference: !<BuiltinTransform> {style: UTILITY - ACES-AP0_to_CIE-XYZ-D65_BFD}
+
+display_colorspaces:
+  - !<ColorSpace>
+    name: CIE-XYZ-D65
+    family: ""
+    equalitygroup: ""
+    bitdepth: 32f
+    description: The "CIE XYZ (D65)" display connection colorspace.
+    isdata: false
+    allocation: uniform
+
+  - !<ColorSpace>
+    name: Display - sRGB
+    family: Display
+    equalitygroup: ""
+    bitdepth: 32f
+    description: Convert CIE XYZ (D65 white) to sRGB (piecewise EOTF)
+    isdata: false
+    categories: [file-io]
+    encoding: sdr-video
+    allocation: uniform
+    from_display_reference: !<BuiltinTransform> {style: DISPLAY - CIE-XYZ-D65_to_sRGB}
+
+  - !<ColorSpace>
+    name: Display - Rec.1886 / Rec.709 Video
+    family: Display
+    equalitygroup: ""
+    bitdepth: 32f
+    description: Convert CIE XYZ (D65 white) to Rec.1886/Rec.709 (HD video)
+    isdata: false
+    categories: [file-io]
+    encoding: sdr-video
+    allocation: uniform
+    from_display_reference: !<BuiltinTransform> {style: DISPLAY - CIE-XYZ-D65_to_REC.1886-REC.709}
+
+  - !<ColorSpace>
+    name: Display - Rec.1886 / Rec.2020 Video
+    family: Display
+    equalitygroup: ""
+    bitdepth: 32f
+    description: Convert CIE XYZ (D65 white) to Rec.1886/Rec.2020 (UHD video)
+    isdata: false
+    categories: [file-io]
+    encoding: sdr-video
+    allocation: uniform
+    from_display_reference: !<BuiltinTransform> {style: DISPLAY - CIE-XYZ-D65_to_REC.1886-REC.2020}
+
+  - !<ColorSpace>
+    name: Display - Rec.2100-HLG
+    family: Display
+    equalitygroup: ""
+    bitdepth: 32f
+    description: Convert CIE XYZ (D65 white) to Rec.2100-HLG, 1000 nit
+    isdata: false
+    categories: [file-io]
+    encoding: hdr-video
+    allocation: uniform
+    from_display_reference: !<BuiltinTransform> {style: DISPLAY - CIE-XYZ-D65_to_REC.2100-HLG-1000nit}
+
+  - !<ColorSpace>
+    name: Display - Rec.2100-PQ
+    family: Display
+    equalitygroup: ""
+    bitdepth: 32f
+    description: Convert CIE XYZ (D65 white) to Rec.2100-PQ
+    isdata: false
+    categories: [file-io]
+    encoding: hdr-video
+    allocation: uniform
+    from_display_reference: !<BuiltinTransform> {style: DISPLAY - CIE-XYZ-D65_to_REC.2100-PQ}
+
+  - !<ColorSpace>
+    name: Display - ST2084-P3-D65
+    family: Display
+    equalitygroup: ""
+    bitdepth: 32f
+    description: Convert CIE XYZ (D65 white) to ST-2084 (PQ), P3-D65 primaries
+    isdata: false
+    categories: [file-io]
+    encoding: sdr-video
+    allocation: uniform
+    from_display_reference: !<BuiltinTransform> {style: DISPLAY - CIE-XYZ-D65_to_ST2084-P3-D65}
+
+  - !<ColorSpace>
+    name: Display - P3-D60
+    family: Display
+    equalitygroup: ""
+    bitdepth: 32f
+    description: Convert CIE XYZ (D65 white) to Gamma 2.6, P3-D60 (Bradford adaptation)
+    isdata: false
+    categories: [file-io]
+    encoding: sdr-video
+    allocation: uniform
+    from_display_reference: !<BuiltinTransform> {style: DISPLAY - CIE-XYZ-D65_to_G2.6-P3-D60-BFD}
+
+  - !<ColorSpace>
+    name: Display - P3-D65
+    family: Display
+    equalitygroup: ""
+    bitdepth: 32f
+    description: Convert CIE XYZ (D65 white) to Gamma 2.6, P3-D65
+    isdata: false
+    categories: [file-io]
+    encoding: sdr-video
+    allocation: uniform
+    from_display_reference: !<BuiltinTransform> {style: DISPLAY - CIE-XYZ-D65_to_G2.6-P3-D65}
+
+  - !<ColorSpace>
+    name: Display - P3-DCI
+    family: Display
+    equalitygroup: ""
+    bitdepth: 32f
+    description: Convert CIE XYZ (D65 white) to Gamma 2.6, P3-DCI (DCI white with Bradford adaptation)
+    isdata: false
+    categories: [file-io]
+    encoding: sdr-video
+    allocation: uniform
+    from_display_reference: !<BuiltinTransform> {style: DISPLAY - CIE-XYZ-D65_to_G2.6-P3-DCI-BFD}
+
+colorspaces:
+  - !<ColorSpace>
+    name: ACES - ACES2065-1
+    family: ACES
+    equalitygroup: ""
+    bitdepth: 32f
+    description: The "Academy Color Encoding System" reference colorspace.
+    isdata: false
+    encoding: scene-linear
+    allocation: uniform
+
+  - !<ColorSpace>
+    name: Utility - Raw
+    family: Utility
+    equalitygroup: ""
+    bitdepth: 32f
+    description: The utility "Raw" colorspace.
+    isdata: true
+    allocation: uniform
+
+  - !<ColorSpace>
+    name: ACES - ACEScc
+    family: ACES
+    equalitygroup: ""
+    bitdepth: 32f
+    description: |
+      Convert ACEScc to ACES2065-1
+
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScc_to_ACES.a1.0.3
+    isdata: false
+    categories: [file-io]
+    encoding: log
+    allocation: uniform
+    to_scene_reference: !<BuiltinTransform> {style: ACEScc_to_ACES2065-1}
+
+  - !<ColorSpace>
+    name: ACES - ACEScct
+    family: ACES
+    equalitygroup: ""
+    bitdepth: 32f
+    description: |
+      Convert ACEScct to ACES2065-1
+
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScct_to_ACES.a1.0.3
+    isdata: false
+    categories: [file-io, working-space]
+    encoding: log
+    allocation: uniform
+    to_scene_reference: !<BuiltinTransform> {style: ACEScct_to_ACES2065-1}
+
+  - !<ColorSpace>
+    name: ACES - ACEScg
+    family: ACES
+    equalitygroup: ""
+    bitdepth: 32f
+    description: |
+      Convert ACEScg to ACES2065-1
+
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScg_to_ACES.a1.0.3
+    isdata: false
+    categories: [file-io, working-space]
+    encoding: scene-linear
+    allocation: uniform
+    to_scene_reference: !<BuiltinTransform> {style: ACEScg_to_ACES2065-1}
+
+  - !<ColorSpace>
+    name: ACES - ADX10
+    family: ACES
+    equalitygroup: ""
+    bitdepth: 32f
+    description: |
+      Convert ADX10 to ACES2065-1
+
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ADX10_to_ACES.a1.0.3
+    isdata: false
+    categories: [file-io]
+    encoding: log
+    allocation: uniform
+    to_scene_reference: !<BuiltinTransform> {style: ADX10_to_ACES2065-1}
+
+  - !<ColorSpace>
+    name: ACES - ADX16
+    family: ACES
+    equalitygroup: ""
+    bitdepth: 32f
+    description: |
+      Convert ADX16 to ACES2065-1
+
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ADX16_to_ACES.a1.0.3
+    isdata: false
+    categories: [file-io]
+    encoding: log
+    allocation: uniform
+    to_scene_reference: !<BuiltinTransform> {style: ADX16_to_ACES2065-1}
+
+  - !<ColorSpace>
+    name: Input - Canon - CLog2 CGamut
+    family: Input/Canon
+    equalitygroup: ""
+    bitdepth: 32f
+    description: |
+      Convert Canon Log 2 Cinema Gamut to ACES2065-1
+
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.CLog2_CGamut_to_ACES.a1.1.0
+    isdata: false
+    categories: [file-io]
+    encoding: log
+    allocation: uniform
+    to_scene_reference: !<BuiltinTransform> {style: CANON_CLOG2-CGAMUT_to_ACES2065-1}
+
+  - !<ColorSpace>
+    name: Input - Canon - CLog3 CGamut
+    family: Input/Canon
+    equalitygroup: ""
+    bitdepth: 32f
+    description: |
+      Convert Canon Log 3 Cinema Gamut to ACES2065-1
+
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.CLog3_CGamut_to_ACES.a1.1.0
+    isdata: false
+    categories: [file-io]
+    encoding: log
+    allocation: uniform
+    to_scene_reference: !<BuiltinTransform> {style: CANON_CLOG3-CGAMUT_to_ACES2065-1}
+
+  - !<ColorSpace>
+    name: Input - RED - Log3G10 RWG
+    family: Input/RED
+    equalitygroup: ""
+    bitdepth: 32f
+    description: |
+      Convert RED Log3G10 RED Wide Gamut to ACES2065-1
+
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.Log3G10_RWG_to_ACES.a1.1.0
+    isdata: false
+    categories: [file-io]
+    encoding: log
+    allocation: uniform
+    to_scene_reference: !<BuiltinTransform> {style: RED_LOG3G10-RWG_to_ACES2065-1}
+
+  - !<ColorSpace>
+    name: Input - ARRI - LogC EI800 AWG
+    family: Input/ARRI
+    equalitygroup: ""
+    bitdepth: 32f
+    description: |
+      Convert ARRI ALEXA LogC (EI800) ALEXA Wide Gamut to ACES2065-1
+
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.LogC_EI800_AWG_to_ACES.a1.1.0
+    isdata: false
+    categories: [file-io]
+    encoding: log
+    allocation: uniform
+    to_scene_reference: !<BuiltinTransform> {style: ARRI_ALEXA-LOGC-EI800-AWG_to_ACES2065-1}
+
+  - !<ColorSpace>
+    name: Input - Sony - SLog3 SGamut3
+    family: Input/Sony
+    equalitygroup: ""
+    bitdepth: 32f
+    description: |
+      Convert Sony S-Log3 S-Gamut3 to ACES2065-1
+
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.SLog3_SGamut3_to_ACES.a1.1.0
+    isdata: false
+    categories: [file-io]
+    encoding: log
+    allocation: uniform
+    to_scene_reference: !<BuiltinTransform> {style: SONY_SLOG3-SGAMUT3_to_ACES2065-1}
+
+  - !<ColorSpace>
+    name: Input - Sony - SLog3 SGamut3Cine
+    family: Input/Sony
+    equalitygroup: ""
+    bitdepth: 32f
+    description: |
+      Convert Sony S-Log3 S-Gamut3.Cine to ACES2065-1
+
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.SLog3_SGamut3Cine_to_ACES.a1.1.0
+    isdata: false
+    categories: [file-io]
+    encoding: log
+    allocation: uniform
+    to_scene_reference: !<BuiltinTransform> {style: SONY_SLOG3-SGAMUT3.CINE_to_ACES2065-1}
+
+  - !<ColorSpace>
+    name: Input - Sony - SLog3 Venice SGamut3
+    family: Input/Sony
+    equalitygroup: ""
+    bitdepth: 32f
+    description: |
+      Convert Sony S-Log3 S-Gamut3 for the Venice camera to ACES2065-1
+
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.SLog3_Venice_SGamut3_to_ACES.a1.1.0
+    isdata: false
+    categories: [file-io]
+    encoding: log
+    allocation: uniform
+    to_scene_reference: !<BuiltinTransform> {style: SONY_SLOG3-SGAMUT3-VENICE_to_ACES2065-1}
+
+  - !<ColorSpace>
+    name: Input - Sony - SLog3 Venice SGamut3Cine
+    family: Input/Sony
+    equalitygroup: ""
+    bitdepth: 32f
+    description: |
+      Convert Sony S-Log3 S-Gamut3.Cine for the Venice camera to ACES2065-1
+
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.SLog3_Venice_SGamut3Cine_to_ACES.a1.1.0
+    isdata: false
+    categories: [file-io]
+    encoding: log
+    allocation: uniform
+    to_scene_reference: !<BuiltinTransform> {style: SONY_SLOG3-SGAMUT3.CINE-VENICE_to_ACES2065-1}
+
+  - !<ColorSpace>
+    name: Input - Panasonic - VLog VGamut
+    family: Input/Panasonic
+    equalitygroup: ""
+    bitdepth: 32f
+    description: |
+      Convert Panasonic Varicam V-Log V-Gamut to ACES2065-1
+
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.VLog_VGamut_to_ACES.a1.1.0
+    isdata: false
+    categories: [file-io]
+    encoding: log
+    allocation: uniform
+    to_scene_reference: !<BuiltinTransform> {style: PANASONIC_VLOG-VGAMUT_to_ACES2065-1}

--- a/colour/io/tests/test_ocio.py
+++ b/colour/io/tests/test_ocio.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+"""
+Defines the unit tests for the :mod:`colour.io.ocio` module.
+"""
+
+import numpy as np
+import os
+import unittest
+
+from colour.io import process_image_OpenColorIO
+from colour.utilities import full
+
+__author__ = 'Colour Developers'
+__copyright__ = 'Copyright (C) 2013-2021 - Colour Developers'
+__license__ = 'New BSD License - https://opensource.org/licenses/BSD-3-Clause'
+__maintainer__ = 'Colour Developers'
+__email__ = 'colour-developers@colour-science.org'
+__status__ = 'Production'
+
+__all__ = ['RESOURCES_DIRECTORY', 'TestProcessImageOpenColorIO']
+
+RESOURCES_DIRECTORY = os.path.join(os.path.dirname(__file__), 'resources')
+
+
+class TestProcessImageOpenColorIO(unittest.TestCase):
+    """
+    Defines :func:`colour.io.ocio.process_image_OpenColorIO` definition unit
+    tests methods.
+    """
+
+    def test_process_image_OpenColorIO(self):
+        """
+        Tests :func:`colour.io.ocio.process_image_OpenColorIO` definition.
+        """
+
+        import PyOpenColorIO as ocio
+
+        config = os.path.join(RESOURCES_DIRECTORY,
+                              'config-aces-reference.ocio.yaml')
+
+        a = full([4, 2, 3], 0.18)
+
+        np.testing.assert_almost_equal(
+            process_image_OpenColorIO(
+                a, 'ACES - ACES2065-1', 'ACES - ACEScct', config=config),
+            np.array([
+                [[0.41358781, 0.41358781, 0.41358781],
+                 [0.41358781, 0.41358781, 0.41358781]],
+                [[0.41358781, 0.41358781, 0.41358781],
+                 [0.41358781, 0.41358781, 0.41358781]],
+                [[0.41358781, 0.41358781, 0.41358781],
+                 [0.41358781, 0.41358781, 0.41358781]],
+                [[0.41358781, 0.41358781, 0.41358781],
+                 [0.41358781, 0.41358781, 0.41358781]],
+            ]),
+            decimal=7)
+
+        np.testing.assert_almost_equal(
+            process_image_OpenColorIO(
+                a,
+                'ACES - ACES2065-1',
+                'Display - sRGB',
+                'Output - SDR Video - ACES 1.0',
+                ocio.TRANSFORM_DIR_FORWARD,
+                config=config),
+            np.array([
+                [[0.35595229, 0.35595256, 0.35595250],
+                 [0.35595229, 0.35595256, 0.35595250]],
+                [[0.35595229, 0.35595256, 0.35595250],
+                 [0.35595229, 0.35595256, 0.35595250]],
+                [[0.35595229, 0.35595256, 0.35595250],
+                 [0.35595229, 0.35595256, 0.35595250]],
+                [[0.35595229, 0.35595256, 0.35595250],
+                 [0.35595229, 0.35595256, 0.35595250]],
+            ]),
+            decimal=7)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/colour/utilities/__init__.py
+++ b/colour/utilities/__init__.py
@@ -9,13 +9,13 @@ from .common import (
     raise_numpy_errors, print_numpy_errors, warn_numpy_errors,
     ignore_python_warnings, batch, disable_multiprocessing,
     multiprocessing_pool, is_matplotlib_installed, is_networkx_installed,
-    is_openimageio_installed, is_pandas_installed, is_tqdm_installed, required,
-    is_iterable, is_string, is_numeric, is_integer, is_sibling, filter_kwargs,
-    filter_mapping, first_item, get_domain_range_scale, set_domain_range_scale,
-    domain_range_scale, to_domain_1, to_domain_10, to_domain_100,
-    to_domain_degrees, to_domain_int, from_range_1, from_range_10,
-    from_range_100, from_range_degrees, from_range_int, copy_definition,
-    validate_method)
+    is_opencolorio_installed, is_openimageio_installed, is_pandas_installed,
+    is_tqdm_installed, required, is_iterable, is_string, is_numeric,
+    is_integer, is_sibling, filter_kwargs, filter_mapping, first_item,
+    get_domain_range_scale, set_domain_range_scale, domain_range_scale,
+    to_domain_1, to_domain_10, to_domain_100, to_domain_degrees, to_domain_int,
+    from_range_1, from_range_10, from_range_100, from_range_degrees,
+    from_range_int, copy_definition, validate_method)
 from .verbose import (
     ColourWarning, ColourUsageWarning, ColourRuntimeWarning, message_box,
     show_warning, warning, runtime_warning, usage_warning, filter_warnings,
@@ -45,14 +45,14 @@ __all__ += [
     'warn_numpy_errors', 'ignore_python_warnings', 'batch',
     'disable_multiprocessing', 'multiprocessing_pool',
     'is_matplotlib_installed', 'is_networkx_installed',
-    'is_openimageio_installed', 'is_pandas_installed', 'is_tqdm_installed',
-    'required', 'is_iterable', 'is_string', 'is_numeric', 'is_integer',
-    'is_sibling', 'filter_kwargs', 'filter_mapping', 'first_item',
-    'get_domain_range_scale', 'set_domain_range_scale', 'domain_range_scale',
-    'to_domain_1', 'to_domain_10', 'to_domain_100', 'to_domain_degrees',
-    'to_domain_int', 'from_range_1', 'from_range_10', 'from_range_100',
-    'from_range_degrees', 'from_range_int', 'copy_definition',
-    'validate_method'
+    'is_opencolorio_installed', 'is_openimageio_installed',
+    'is_pandas_installed', 'is_tqdm_installed', 'required', 'is_iterable',
+    'is_string', 'is_numeric', 'is_integer', 'is_sibling', 'filter_kwargs',
+    'filter_mapping', 'first_item', 'get_domain_range_scale',
+    'set_domain_range_scale', 'domain_range_scale', 'to_domain_1',
+    'to_domain_10', 'to_domain_100', 'to_domain_degrees', 'to_domain_int',
+    'from_range_1', 'from_range_10', 'from_range_100', 'from_range_degrees',
+    'from_range_int', 'copy_definition', 'validate_method'
 ]
 __all__ += [
     'ColourWarning', 'ColourUsageWarning', 'ColourRuntimeWarning',

--- a/colour/utilities/common.py
+++ b/colour/utilities/common.py
@@ -43,14 +43,14 @@ __all__ = [
     'warn_numpy_errors', 'ignore_python_warnings', 'batch',
     'disable_multiprocessing', 'multiprocessing_pool',
     'is_matplotlib_installed', 'is_networkx_installed',
-    'is_openimageio_installed', 'is_pandas_installed', 'is_tqdm_installed',
-    'required', 'is_iterable', 'is_string', 'is_numeric', 'is_integer',
-    'is_sibling', 'filter_kwargs', 'filter_mapping', 'first_item',
-    'get_domain_range_scale', 'set_domain_range_scale', 'domain_range_scale',
-    'to_domain_1', 'to_domain_10', 'to_domain_100', 'to_domain_degrees',
-    'to_domain_int', 'from_range_1', 'from_range_10', 'from_range_100',
-    'from_range_degrees', 'from_range_int', 'copy_definition',
-    'validate_method'
+    'is_opencolorio_installed', 'is_openimageio_installed',
+    'is_pandas_installed', 'is_tqdm_installed', 'required', 'is_iterable',
+    'is_string', 'is_numeric', 'is_integer', 'is_sibling', 'filter_kwargs',
+    'filter_mapping', 'first_item', 'get_domain_range_scale',
+    'set_domain_range_scale', 'domain_range_scale', 'to_domain_1',
+    'to_domain_10', 'to_domain_100', 'to_domain_degrees', 'to_domain_int',
+    'from_range_1', 'from_range_10', 'from_range_100', 'from_range_degrees',
+    'from_range_int', 'copy_definition', 'validate_method'
 ]
 
 
@@ -563,6 +563,42 @@ def is_networkx_installed(raise_exception=False):
         return False
 
 
+def is_opencolorio_installed(raise_exception=False):
+    """
+    Returns if *OpenColorIO* is installed and available.
+
+    Parameters
+    ----------
+    raise_exception : bool
+        Raise exception if *OpenColorIO* is unavailable.
+
+    Returns
+    -------
+    bool
+        Is *OpenColorIO* installed.
+
+    Raises
+    ------
+    ImportError
+        If *OpenColorIO* is not installed.
+    """
+
+    try:  # pragma: no cover
+        # pylint: disable=W0612
+        import PyOpenColorIO  # noqa
+
+        return True
+    except ImportError as error:  # pragma: no cover
+        if raise_exception:
+            raise ImportError(
+                ('"OpenColorIO" related API features are not available: '
+                 '"{0}".\nPlease refer to the installation guide for more '
+                 'information: '
+                 'https://www.colour-science.org/installation-guide/'
+                 ).format(error))
+        return False
+
+
 def is_openimageio_installed(raise_exception=False):
     """
     Returns if *OpenImageIO* is installed and available.
@@ -674,6 +710,7 @@ def is_tqdm_installed(raise_exception=False):
 _REQUIREMENTS_TO_CALLABLE = CaseInsensitiveMapping({
     'Matplotlib': is_matplotlib_installed,
     'NetworkX': is_networkx_installed,
+    'OpenColorIO': is_opencolorio_installed,
     'OpenImageIO': is_openimageio_installed,
     'Pandas': is_pandas_installed,
     'tqdm': is_tqdm_installed,
@@ -682,7 +719,8 @@ _REQUIREMENTS_TO_CALLABLE = CaseInsensitiveMapping({
 Mapping of requirements to their respective callables.
 
 _REQUIREMENTS_TO_CALLABLE : CaseInsensitiveMapping
-    **{'Matplotlib', 'NetworkX', 'OpenImageIO', 'Pandas', 'tqdm'}**
+    **{'Matplotlib', 'NetworkX', 'OpenColorIO', 'OpenImageIO', 'Pandas',
+    'tqdm'}**
 """
 
 
@@ -693,7 +731,8 @@ def required(*requirements):
     Other Parameters
     ----------------
     \\*requirements : list, optional
-        **{'Matplotlib', 'NetworkX', 'OpenImageIO', 'Pandas', 'tqdm'}**,
+        **{'Matplotlib', 'NetworkX', 'OpenColorIO', 'OpenImageIO', 'Pandas',
+        'tqdm'}**,
         Requirements to check whether they are satisfied.
 
     Returns

--- a/colour/utilities/verbose.py
+++ b/colour/utilities/verbose.py
@@ -625,7 +625,7 @@ def describe_environment(runtime_packages=True,
     if runtime_packages:
         for package in [
                 'imageio', 'matplotlib', 'networkx', 'numpy', 'pandas',
-                'pygraphviz', 'scipy', 'tqdm'
+                'pygraphviz', 'PyOpenColorIO', 'scipy', 'tqdm'
         ]:
             try:
                 namespace = __import__(package)

--- a/docs/colour.io.rst
+++ b/docs/colour.io.rst
@@ -34,6 +34,18 @@ Image Data
     read_image_Imageio
     write_image_Imageio
 
+OpenColorIO Processing
+----------------------
+
+``colour.io``
+
+.. currentmodule:: colour.io
+
+.. autosummary::
+    :toctree: generated/
+
+    process_image_OpenColorIO
+
 Look Up Table (LUT) Data
 ------------------------
 

--- a/docs/colour.utilities.rst
+++ b/docs/colour.utilities.rst
@@ -45,6 +45,7 @@ Common
     multiprocessing_pool
     is_matplotlib_installed
     is_networkx_installed
+    is_opencolorio_installed
     is_openimageio_installed
     is_pandas_installed
     is_tqdm_installed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ mock = { version = "*", optional = true }  # Development dependency.
 networkx = { version = "*", optional = true }
 nose = { version = "*", optional = true }  # Development dependency.
 numpy = { version = "*", optional = true }
+opencolorio = { version = "*", optional = true }
 pandas = { version = "*", optional = true }
 pre-commit = { version = "*", optional = true }  # Development dependency.
 pygraphviz = { version = "*", optional = true }
@@ -112,7 +113,7 @@ development = [
     "yapf"
 ]
 graphviz = [ "pygraphviz" ]
-optional = [ "networkx", "pandas", "tqdm" ]
+optional = [ "networkx", "opencolorio", "pandas", "tqdm" ]
 plotting = [ "matplotlib" ]
 read-the-docs = [
     "mock",


### PR DESCRIPTION
References #654.

The API is as follows:

```python
>>> config = os.path.join(os.path.dirname(__file__), 'tests', 'resources',  'config-aces-reference.ocio.yaml')
>>> a = full([4, 2, 3], 0.18)
>>> process_image_OpenColorIO(a, 'ACES - ACES2065-1', 'ACES - ACEScct', config=config)
array([[[ 0.4135878...,  0.4135878...,  0.4135878...],
        [ 0.4135878...,  0.4135878...,  0.4135878...]],

       [[ 0.4135878...,  0.4135878...,  0.4135878...],
        [ 0.4135878...,  0.4135878...,  0.4135878...]],

       [[ 0.4135878...,  0.4135878...,  0.4135878...],
        [ 0.4135878...,  0.4135878...,  0.4135878...]],

       [[ 0.4135878...,  0.4135878...,  0.4135878...],
        [ 0.4135878...,  0.4135878...,  0.4135878...]]], dtype=float32)
>>> process_image_OpenColorIO(a, 'ACES - ACES2065-1', 'Display - sRGB',  'Output - SDR Video - ACES 1.0', ocio.TRANSFORM_DIR_FORWARD, config=config)
array([[[ 0.3559523...,  0.3559525...,  0.3559525...],
        [ 0.3559523...,  0.3559525...,  0.3559525...]],

       [[ 0.3559523...,  0.3559525...,  0.3559525...],
        [ 0.3559523...,  0.3559525...,  0.3559525...]],

       [[ 0.3559523...,  0.3559525...,  0.3559525...],
        [ 0.3559523...,  0.3559525...,  0.3559525...]],

       [[ 0.3559523...,  0.3559525...,  0.3559525...],
        [ 0.3559523...,  0.3559525...,  0.3559525...]]], dtype=float32)
```

it is also possible to use the *OCIO* config from the environment.