### PR TITLE
PR: Use "np.expm1" in "colour.colorimetry.planck_law" definition.

### DIFF
--- a/colour/colorimetry/blackbody.py
+++ b/colour/colorimetry/blackbody.py
@@ -106,9 +106,7 @@ def planck_law(
     l = as_float_array(wavelength)  # noqa
     t = as_float_array(temperature)
 
-    p = ((c1 * n ** -2 * l ** -5) / np.pi) * (
-        np.exp(c2 / (n * l * t)) - 1
-    ) ** -1
+    p = ((c1 * n ** -2 * l ** -5) / np.pi) * (np.expm1(c2 / (n * l * t))) ** -1
 
     return p
 


### PR DESCRIPTION
This PR cherry-picks https://github.com/colour-science/colour/pull/926/commits/f6350d99405cc8dabe7cf76150928623b5cc7af4 from @ntessore to bypass the develop merge in #926.