### PR TITLE
PR: Add __eq__, __ne__, and __hash__ methods for "colour.io.tm2714.Header_IESTM2714" class.

### DIFF
--- a/colour/io/tests/test_tm2714.py
+++ b/colour/io/tests/test_tm2714.py
@@ -3,13 +3,13 @@ Defines the unit tests for the :mod:`colour.io.tm2714` module.
 """
 
 from __future__ import annotations
-from copy import deepcopy
 
 import numpy as np
 import os
 import shutil
 import unittest
 import tempfile
+from copy import deepcopy
 
 from colour.colorimetry import SpectralDistribution
 from colour.hints import Dict, List, Optional, Tuple, Union, cast
@@ -173,7 +173,7 @@ class TestIES_TM2714_Header(unittest.TestCase):
 
     def test__eq__(self):
         """
-        Tests :meth:`colour.io.tm2714.Header_IESTM2714.__eq__ method.
+        Tests :meth:`colour.io.tm2714.Header_IESTM2714.__eq__` method.
         """
 
         h0 = Header_IESTM2714(manufacturer='a', catalog_number='b', description='c',
@@ -187,7 +187,7 @@ class TestIES_TM2714_Header(unittest.TestCase):
 
     def test__ne__(self):
         """
-        Tests :meth:`colour.io.tm2714.Header_IESTM2714.__ne__ method.
+        Tests :meth:`colour.io.tm2714.Header_IESTM2714.__ne__` method.
         """
 
         h0 = Header_IESTM2714(manufacturer='a', catalog_number='b', description='c',
@@ -204,7 +204,7 @@ class TestIES_TM2714_Header(unittest.TestCase):
 
     def test__hash__(self):
         """
-        Tests :meth:`colour.io.tm2714.Header_IESTM2714.__hash__ method.
+        Tests :meth:`colour.io.tm2714.Header_IESTM2714.__hash__` method.
         """
 
         h0 = Header_IESTM2714(manufacturer='a', catalog_number='b', description='c',

--- a/colour/io/tests/test_tm2714.py
+++ b/colour/io/tests/test_tm2714.py
@@ -3,6 +3,7 @@ Defines the unit tests for the :mod:`colour.io.tm2714` module.
 """
 
 from __future__ import annotations
+from copy import deepcopy
 
 import numpy as np
 import os
@@ -170,6 +171,43 @@ class TestIES_TM2714_Header(unittest.TestCase):
         for attribute in required_attributes:
             self.assertIn(attribute, dir(Header_IESTM2714))
 
+    def test__eq__(self):
+        """
+        Tests :meth:`colour.io.tm2714.Header_IESTM2714.__eq__ method.
+        """
+
+        h0 = Header_IESTM2714(manufacturer='a', catalog_number='b', description='c', document_creator='d',
+                              unique_identifier='e', measurement_equipment='f', laboratory='g', report_number='h',
+                              report_date='i', document_creation_date='j', comments='k')
+
+        h1 = deepcopy(h0)
+        self.assertEqual(h0, h1)
+
+    def test__ne__(self):
+        """
+        Tests :meth:`colour.io.tm2714.Header_IESTM2714.__ne__ method.
+        """
+
+        h0 = Header_IESTM2714(manufacturer='a', catalog_number='b', description='c', document_creator='d',
+                              unique_identifier='e', measurement_equipment='f', laboratory='g', report_number='h',
+                              report_date='i', document_creation_date='j', comments='k')
+        h1 = deepcopy(h0)
+
+        h1.manufacturer = 'aa'
+        self.assertNotEqual(h0, h1)
+        h1.manufacturer = 'a'
+        self.assertEqual(h0, h1)
+
+    def test__hash__(self):
+        """
+        Tests :meth:`colour.io.tm2714.Header_IESTM2714.__hash__ method.
+        """
+
+        h0 = Header_IESTM2714(manufacturer='a', catalog_number='b', description='c', document_creator='d',
+                              unique_identifier='e', measurement_equipment='f', laboratory='g', report_number='h',
+                              report_date='i', document_creation_date='j', comments='k')
+
+        self.assertIsInstance(hash(h0), int)
 
 class TestIES_TM2714_Sd(unittest.TestCase):
     """

--- a/colour/io/tests/test_tm2714.py
+++ b/colour/io/tests/test_tm2714.py
@@ -176,9 +176,11 @@ class TestIES_TM2714_Header(unittest.TestCase):
         Tests :meth:`colour.io.tm2714.Header_IESTM2714.__eq__ method.
         """
 
-        h0 = Header_IESTM2714(manufacturer='a', catalog_number='b', description='c', document_creator='d',
-                              unique_identifier='e', measurement_equipment='f', laboratory='g', report_number='h',
-                              report_date='i', document_creation_date='j', comments='k')
+        h0 = Header_IESTM2714(manufacturer='a', catalog_number='b', description='c',
+                              document_creator='d', unique_identifier='e',
+                              measurement_equipment='f', laboratory='g',
+                              report_number='h', report_date='i',
+                              document_creation_date='j', comments='k')
 
         h1 = deepcopy(h0)
         self.assertEqual(h0, h1)
@@ -188,9 +190,11 @@ class TestIES_TM2714_Header(unittest.TestCase):
         Tests :meth:`colour.io.tm2714.Header_IESTM2714.__ne__ method.
         """
 
-        h0 = Header_IESTM2714(manufacturer='a', catalog_number='b', description='c', document_creator='d',
-                              unique_identifier='e', measurement_equipment='f', laboratory='g', report_number='h',
-                              report_date='i', document_creation_date='j', comments='k')
+        h0 = Header_IESTM2714(manufacturer='a', catalog_number='b', description='c',
+                              document_creator='d', unique_identifier='e',
+                              measurement_equipment='f', laboratory='g',
+                              report_number='h', report_date='i',
+                              document_creation_date='j', comments='k')
         h1 = deepcopy(h0)
 
         h1.manufacturer = 'aa'
@@ -203,11 +207,14 @@ class TestIES_TM2714_Header(unittest.TestCase):
         Tests :meth:`colour.io.tm2714.Header_IESTM2714.__hash__ method.
         """
 
-        h0 = Header_IESTM2714(manufacturer='a', catalog_number='b', description='c', document_creator='d',
-                              unique_identifier='e', measurement_equipment='f', laboratory='g', report_number='h',
-                              report_date='i', document_creation_date='j', comments='k')
+        h0 = Header_IESTM2714(manufacturer='a', catalog_number='b', description='c',
+                              document_creator='d', unique_identifier='e',
+                              measurement_equipment='f', laboratory='g',
+                              report_number='h', report_date='i',
+                              document_creation_date='j', comments='k')
 
         self.assertIsInstance(hash(h0), int)
+
 
 class TestIES_TM2714_Sd(unittest.TestCase):
     """

--- a/colour/io/tm2714.py
+++ b/colour/io/tm2714.py
@@ -601,7 +601,7 @@ class Header_IESTM2714:
 
         self._comments = value
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: Any) -> Boolean:
         if isinstance(other, Header_IESTM2714):
             comps = [
                 self._manufacturer == other.manufacturer,
@@ -619,10 +619,10 @@ class Header_IESTM2714:
             return all(comps)
         return False
 
-    def __ne__(self, other: Any) -> bool:
+    def __ne__(self, other: Any) -> Boolean:
         return not (self == other)
 
-    def __hash__(self) -> int:
+    def __hash__(self) -> Integer:
         return hash((self._manufacturer, self._catalog_number, self._description,
                      self._document_creator, self._unique_identifier,
                      self._measurement_equipment, self._laboratory,

--- a/colour/io/tm2714.py
+++ b/colour/io/tm2714.py
@@ -28,6 +28,7 @@ from colour.hints import (
     Boolean,
     Callable,
     Floating,
+    Integer,
     Literal,
     Optional,
     cast,

--- a/colour/io/tm2714.py
+++ b/colour/io/tm2714.py
@@ -623,9 +623,11 @@ class Header_IESTM2714:
         return not self == other
 
     def __hash__(self):
-        return hash((self._manufacturer, self._catalog_number, self._description, self._document_creator,
-                     self._unique_identifier, self._measurement_equipment, self._laboratory,
-                     self._report_number, self._report_date, self._document_creation_date, self._comments))
+        return hash((self._manufacturer, self._catalog_number, self._description,
+                     self._document_creator, self._unique_identifier,
+                     self._measurement_equipment, self._laboratory,
+                     self._report_number, self._report_date,
+                     self._document_creation_date, self._comments))
 
 
 class SpectralDistribution_IESTM2714(SpectralDistribution):

--- a/colour/io/tm2714.py
+++ b/colour/io/tm2714.py
@@ -601,7 +601,7 @@ class Header_IESTM2714:
 
         self._comments = value
 
-    def __eq__(self, other):
+    def __eq__(self, other: Any) -> bool:
         if isinstance(other, Header_IESTM2714):
             comps = [
                 self._manufacturer == other.manufacturer,
@@ -619,10 +619,10 @@ class Header_IESTM2714:
             return all(comps)
         return False
 
-    def __ne__(self, other):
-        return not self == other
+    def __ne__(self, other: Any) -> bool:
+        return not (self == other)
 
-    def __hash__(self):
+    def __hash__(self) -> bool:
         return hash((self._manufacturer, self._catalog_number, self._description,
                      self._document_creator, self._unique_identifier,
                      self._measurement_equipment, self._laboratory,

--- a/colour/io/tm2714.py
+++ b/colour/io/tm2714.py
@@ -601,6 +601,32 @@ class Header_IESTM2714:
 
         self._comments = value
 
+    def __eq__(self, other):
+        if isinstance(other, Header_IESTM2714):
+            comps = [
+                self._manufacturer == other.manufacturer,
+                self._catalog_number == other.catalog_number,
+                self._description == other.description,
+                self._document_creator == other.document_creator,
+                self._unique_identifier == other.unique_identifier,
+                self._measurement_equipment == other.measurement_equipment,
+                self._laboratory == other.laboratory,
+                self._report_number == other.report_number,
+                self._report_date == other.report_date,
+                self._document_creation_date == other.document_creation_date,
+                self._comments == other.comments
+            ]
+            return all(comps)
+        return False
+
+    def __ne__(self, other):
+        return not self == other
+
+    def __hash__(self):
+        return hash((self._manufacturer, self._catalog_number, self._description, self._document_creator,
+                     self._unique_identifier, self._measurement_equipment, self._laboratory,
+                     self._report_number, self._report_date, self._document_creation_date, self._comments))
+
 
 class SpectralDistribution_IESTM2714(SpectralDistribution):
     """

--- a/colour/io/tm2714.py
+++ b/colour/io/tm2714.py
@@ -622,7 +622,7 @@ class Header_IESTM2714:
     def __ne__(self, other: Any) -> bool:
         return not (self == other)
 
-    def __hash__(self) -> bool:
+    def __hash__(self) -> int:
         return hash((self._manufacturer, self._catalog_number, self._description,
                      self._document_creator, self._unique_identifier,
                      self._measurement_equipment, self._laboratory,


### PR DESCRIPTION
Fairly straightforward, but: please consider whether it suffices to just compare the complete set of properties or whether the mapping attributes need also be compared.