### PR TITLE
PR: Add "Munsell Renotation System" reference illuminant in the data header.

### DIFF
--- a/colour/notation/datasets/munsell/real.py
+++ b/colour/notation/datasets/munsell/real.py
@@ -6,6 +6,9 @@ Defines the *Munsell Renotation System* *Real* datasets. Those are *real*,
 within MacAdam limits *Munsell* colours only. They are the colours listed in
 the original 1943 renotation article *(Newhall, Nickerson, & Judd, 1943)*.
 
+Chromaticities assume Illuminant C, approximately 6700K, 
+as neutral origin for both the hue and chroma loci. 
+
 Notes
 -----
 -   The Munsell Renotation data commonly available within the all.dat,


### PR DESCRIPTION
<!--
Thank you for taking the time to create this pull request. If it is the first
time you are contributing to a colour-science repository, a contributing guide
is available to guide the process: https://www.colour-science.org/contributing/.
-->

# Summary

Quick addition in docstring, since I had to research this information myself, about the illuminant of the Munsell dataset renotation.

# Preflight

<!-- Please mark any checkboxes that do not apply to this pull request as [N/A]. -->

**Code Style and Quality**

- [ ] Unit tests have been implemented and passed.
- [ ] Mypy static checking has been run and passed.
- [ ] Pre-commit hooks have been run and passed.
- [ ] New transformations have been added to the *Automatic Colour Conversion Graph*.
- [ ] New transformations have been exported to the relevant namespaces, e.g. `colour`, `colour.models`.

<!-- The unit tests can be invoked with `poetry run invoke tests` -->
<!-- Mypy can be started with `dmypy run -- --show-error-codes --warn-unused-ignores --warn-redundant-casts --install-types --non-interactive -p colour` -->

**Documentation**

- [ ] New features are documented along with examples if relevant.
- [ ] The documentation is [Sphinx](https://www.sphinx-doc.org/en/master/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant.

<!--
Thank you again!
-->
