### PR TITLE
PR: Add aliases for ITU-T H.273 video color metadata

### DIFF
--- a/colour/models/rgb/datasets/ebu_3213_e.py
+++ b/colour/models/rgb/datasets/ebu_3213_e.py
@@ -1,0 +1,64 @@
+"""
+EBU Tech. 3213-E Primaries and White Point
+==========================================
+
+Defines primaries and white point chromaticity coordinates from EBU Tech.
+3213-E (:cite:`EuropeanBroadcastingUnion3213E`).
+
+References
+----------
+-   :cite:`EuropeanBroadcastingUnion3213E` : European Broadcasting Union
+    Tech. 3213-E (1975), Standard for Chromaticity Tolerances For Studio
+    Monitors.
+    https://tech.ebu.ch/docs/tech/tech3213.pdf
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from colour.hints import NDArray
+from colour.models.rgb import normalised_primary_matrix
+
+__author__ = "Colour Developers"
+__copyright__ = "Copyright 2013 Colour Developers"
+__license__ = "New BSD License - https://opensource.org/licenses/BSD-3-Clause"
+__maintainer__ = "Colour Developers"
+__email__ = "colour-developers@colour-science.org"
+__status__ = "Production"
+
+__all__ = [
+    "PRIMARIES_EBU_3213_E",
+    "WHITEPOINT_NAME_EBU_3213_E",
+    "CCS_WHITEPOINT_EBU_3213_E",
+    "MATRIX_EBU_3213_E_RGB_TO_XYZ",
+    "MATRIX_XYZ_TO_EBU_3213_E_RGB",
+]
+
+PRIMARIES_EBU_3213_E: NDArray = np.array(
+    [
+        [0.64, 0.33],
+        [0.29, 0.60],
+        [0.15, 0.06],
+    ]
+)
+"""Colourspace primaries for EBU Tech. 3213-E, as defined in
+:cite:`EuropeanBroadcastingUnion3213E`."""
+
+WHITEPOINT_NAME_EBU_3213_E: str = "D65"
+"""Whitepoint name for EBU Tech. 3213-E, as defined in
+:cite:`EuropeanBroadcastingUnion3213E`."""
+
+CCS_WHITEPOINT_EBU_3213_E: NDArray = np.array([0.313, 0.329])
+"""Whitepoint chromaticity coordinates for EBU Tech. 3213-E, as defined in
+:cite:`EuropeanBroadcastingUnion3213E`."""
+
+MATRIX_EBU_3213_E_RGB_TO_XYZ: NDArray = normalised_primary_matrix(
+    PRIMARIES_EBU_3213_E, CCS_WHITEPOINT_EBU_3213_E
+)
+"""EBU Tech. 3213-E colourspace to *CIE XYZ* tristimulus values matrix."""
+
+MATRIX_XYZ_TO_EBU_3213_E_RGB: NDArray = np.linalg.inv(
+    MATRIX_EBU_3213_E_RGB_TO_XYZ
+)
+"""*CIE XYZ* tristimulus values to EBU Tech. 3213-E colourspace matrix."""

--- a/colour/models/rgb/datasets/itut_h_273.py
+++ b/colour/models/rgb/datasets/itut_h_273.py
@@ -1,0 +1,96 @@
+"""
+ITU-T H.273 video primaries and whitepoints
+===========================================
+
+Contains several primaries and whitepoints that are defined in ITU-T H.273
+(:cite:`ITU2021`) but don't belong in another specification or standard.
+
+References
+----------
+-   :cite:`ITU2021` : International Telecommunication Union. (2021). Recommendation
+    ITU-T H.273 - Coding-independent code points for video signal type identification.
+    https://www.itu.int/rec/T-REC-H.273-202107-I/en
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from colour.hints import NDArray
+from colour.models.rgb import normalised_primary_matrix
+
+__author__ = "Colour Developers"
+__copyright__ = "Copyright 2013 Colour Developers"
+__license__ = "New BSD License - https://opensource.org/licenses/BSD-3-Clause"
+__maintainer__ = "Colour Developers"
+__email__ = "colour-developers@colour-science.org"
+__status__ = "Production"
+
+__all__ = [
+    "PRIMARIES_FILM_C",
+    "WHITEPOINT_NAME_FILM_C",
+    "CCS_WHITEPOINT_FILM_C",
+    "MATRIX_FILM_C_RGB_TO_XYZ",
+    "MATRIX_XYZ_TO_FILM_C_RGB",
+    "PRIMARIES_ITUT_H273_22",
+    "WHITEPOINT_NAME_ITUT_H273_22",
+    "CCS_WHITEPOINT_ITUT_H273_22",
+    "MATRIX_ITUT_H273_22_RGB_TO_XYZ",
+    "MATRIX_XYZ_TO_ITUT_H273_22_RGB",
+]
+
+PRIMARIES_FILM_C: NDArray = np.array(
+    [
+        [0.681, 0.319],
+        [0.243, 0.692],
+        [0.145, 0.049],
+    ]
+)
+"""Colourspace primaries for "colour filters using illuminant C", as defined in
+:cite:`ITU2021`."""
+
+WHITEPOINT_NAME_FILM_C: str = "C"
+"""Whitepoint name for "colour filters using illuminant C", as defined in
+:cite:`ITU2021`."""
+
+# Note: ITU-T H.273 defines white point C as [0.310, 0.316], while colour
+# has a slightly higher precision.
+CCS_WHITEPOINT_FILM_C: NDArray = np.array([0.310, 0.316])
+"""Whitepoint chromaticity coordinates for "colour filters using illuminant C", as
+defined in :cite:`ITU2021`."""
+
+MATRIX_FILM_C_RGB_TO_XYZ: NDArray = normalised_primary_matrix(
+    PRIMARIES_FILM_C, CCS_WHITEPOINT_FILM_C
+)
+"""'Colour filters using Illuminant C' colourspace to *CIE XYZ* tristimulus values
+matrix."""
+
+MATRIX_XYZ_TO_FILM_C_RGB: NDArray = np.linalg.inv(MATRIX_FILM_C_RGB_TO_XYZ)
+"""*CIE XYZ* tristimulus values to 'Colour filters using Illuminant C' colourspace
+matrix."""
+
+PRIMARIES_ITUT_H273_22: NDArray = np.array(
+    [
+        [0.630, 0.340],
+        [0.295, 0.605],
+        [0.155, 0.077],
+    ]
+)
+"""Colourspace primaries for ColourPrimaries number 22 defined in :cite:`ITU2021`."""
+
+WHITEPOINT_NAME_ITUT_H273_22: str = "D65"
+"""Whitepoint name for ColourPrimaries number 22 defined in :cite:`ITU2021`."""
+
+CCS_WHITEPOINT_ITUT_H273_22: NDArray = np.array([0.3127, 0.3290])
+"""Whitepoint chromaticity coordinates for ColourPrimaries number 22, as defined in
+:cite:`ITU2021`."""
+
+MATRIX_ITUT_H273_22_RGB_TO_XYZ: NDArray = normalised_primary_matrix(
+    PRIMARIES_ITUT_H273_22, CCS_WHITEPOINT_ITUT_H273_22
+)
+"""ITU-T H.273 ColourPrimaries number 22 to *CIE XYZ* tristimulus values matrix."""
+
+MATRIX_XYZ_TO_ITUT_H273_22_RGB: NDArray = np.linalg.inv(
+    MATRIX_ITUT_H273_22_RGB_TO_XYZ
+)
+"""*CIE XYZ* tristimulus values to ITU-T H.273 ColourPrimaries number 22 matrix."""

--- a/colour/models/rgb/transfer_functions/__init__.py
+++ b/colour/models/rgb/transfer_functions/__init__.py
@@ -59,7 +59,15 @@ from .itur_bt_601 import oetf_BT601, oetf_inverse_BT601
 from .itur_bt_709 import oetf_BT709, oetf_inverse_BT709
 from .itur_bt_1886 import eotf_inverse_BT1886, eotf_BT1886
 from .itur_bt_2020 import oetf_BT2020, oetf_inverse_BT2020
+from .itur_bt_1361 import oetf_BT1361_extended
 from .st_2084 import eotf_inverse_ST2084, eotf_ST2084
+from .st_428 import eotf_inverse_ST428_1
+from .itut_h_273 import (
+    oetf_linear,
+    oetf_log,
+    oetf_log_sqrt,
+)
+from .iec_61966_2 import oetf_iec_61966_2_unbounded
 from .itur_bt_2100 import (
     oetf_BT2100_PQ,
     oetf_inverse_BT2100_PQ,
@@ -307,6 +315,20 @@ __all__ += [
 __all__ += [
     "eotf_inverse_sRGB",
     "eotf_sRGB",
+]
+__all__ += [
+    "oetf_linear",
+    "oetf_log",
+    "oetf_log_sqrt",
+]
+__all__ += [
+    "oetf_iec_61966_2_unbounded",
+]
+__all__ += [
+    "eotf_inverse_ST428_1",
+]
+__all__ += [
+    "oetf_BT1361_extended",
 ]
 __all__ += [
     "log_encoding_ViperLog",

--- a/colour/models/rgb/transfer_functions/iec_61966_2.py
+++ b/colour/models/rgb/transfer_functions/iec_61966_2.py
@@ -1,0 +1,84 @@
+"""
+IEC 61966-2
+===========
+
+Define transfer functions from *IEC 61966-2* (sRGB, sYCC, xvYCC).
+
+Note that this function uses the definition from :cite:`ITU2021` since IEC
+61966-2 is not publicly accessible.
+
+References
+----------
+-   :cite:`ITU2021` : International Telecommunication Union. (2021).
+    Recommendation ITU-T H.273 - Coding-independent code points for video
+    signal type identification.
+    https://www.itu.int/rec/T-REC-H.273-202107-I/en
+"""
+
+import numpy as np
+
+from colour.models.rgb.transfer_functions.srgb import eotf_inverse_sRGB
+
+from colour.utilities import (
+    as_float,
+    from_range_1,
+    to_domain_1,
+)
+
+
+def oetf_iec_61966_2_unbounded(Lc):
+    """
+    Define the unbounded opto-electronic transfer functions (OETF) for *IEC 61966-2*
+    family of transfer functions (*2-1 sRGB*, *2-1 sYCC*, *2-4 xvYCC*).
+
+    Parameters
+    ----------
+    Lc
+        Scene *Luminance* :math:`Lc`.
+
+    Returns
+    -------
+    :class:`numpy.floating` or :class:`numpy.ndarray`
+        Corresponding electrical signal :math:`V`.
+
+    Notes
+    -----
+    Usage in :cite:`ITU2021` is as follows:
+
+    - For IEC 61966-2-1 sRGB (MatrixCoefficients=0), function is only defined
+      for Lc in [0-1] range.
+
+    - For IEC 61966-2-1 sYCC (MatrixCoefficients=5) and IEC 61966-2-4 xvYCC,
+      function is defined for any real-valued Lc.
+
+    +------------+-----------------------+---------------+
+    | **Domain** | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``Lc``     | [-inf, inf]           | [-inf, inf]   |
+    +------------+-----------------------+---------------+
+
+    +------------+-----------------------+---------------+
+    | **Range**  | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``V``      | [-inf, inf]           | [-inf, inf]   |
+    +------------+-----------------------+---------------+
+
+    References
+    ----------
+    -   :cite:`ITU2021`
+
+    Examples
+    --------
+    >>> oetf_iec_61966_2_unbounded(0.18)  # doctest: +ELLIPSIS
+    0.4613561295004...
+    """
+
+    Lc = to_domain_1(Lc)
+
+    V = np.where(
+        Lc >= 0,
+        eotf_inverse_sRGB(Lc),
+        -eotf_inverse_sRGB(-Lc),
+    )
+
+    return as_float(from_range_1(V))

--- a/colour/models/rgb/transfer_functions/iec_61966_2.py
+++ b/colour/models/rgb/transfer_functions/iec_61966_2.py
@@ -18,6 +18,7 @@ References
 import numpy as np
 
 from colour.models.rgb.transfer_functions.srgb import eotf_inverse_sRGB
+from colour.models.rgb.transfer_functions.srgb import eotf_sRGB
 
 from colour.utilities import (
     as_float,
@@ -71,6 +72,8 @@ def oetf_iec_61966_2_unbounded(Lc):
     --------
     >>> oetf_iec_61966_2_unbounded(0.18)  # doctest: +ELLIPSIS
     0.4613561295004...
+    >>> oetf_iec_61966_2_unbounded(-0.18)  # doctest: +ELLIPSIS
+    -0.4613561295004...
     """
 
     Lc = to_domain_1(Lc)
@@ -82,3 +85,64 @@ def oetf_iec_61966_2_unbounded(Lc):
     )
 
     return as_float(from_range_1(V))
+
+
+def oetf_inverse_iec_61966_2_unbounded(V):
+    """
+    Define the unbounded inverse-opto-electronic transfer functions (OETF) for
+    *IEC 61966-2* family of transfer functions (*2-1 sRGB*, *2-1 sYCC*, *2-4
+    xvYCC*).
+
+    Parameters
+    ----------
+    V
+        Electrical signal :math:`V`.
+
+    Returns
+    -------
+    :class:`numpy.floating` or :class:`numpy.ndarray`
+        Corresponding scene luminance :math:`Lc`.
+
+    Notes
+    -----
+    Usage in :cite:`ITU2021` is as follows:
+
+    - For IEC 61966-2-1 sRGB (MatrixCoefficients=0), function is only defined
+      for Lc in [0-1] range.
+
+    - For IEC 61966-2-1 sYCC (MatrixCoefficients=5) and IEC 61966-2-4 xvYCC,
+      function is defined for any real-valued Lc.
+
+    +------------+-----------------------+---------------+
+    | **Range**  | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``V``      | [-inf, inf]           | [-inf, inf]   |
+    +------------+-----------------------+---------------+
+
+    +------------+-----------------------+---------------+
+    | **Domain** | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``Lc``     | [-inf, inf]           | [-inf, inf]   |
+    +------------+-----------------------+---------------+
+
+    References
+    ----------
+    -   :cite:`ITU2021`
+
+    Examples
+    --------
+    >>> oetf_inverse_iec_61966_2_unbounded(0.461356129500)  # doctest: +ELLIPSIS
+    0.1799999999...
+    >>> oetf_inverse_iec_61966_2_unbounded(-0.461356129500)  # doctest: +ELLIPSIS
+    -0.1799999999...
+    """
+
+    V = to_domain_1(V)
+
+    Lc = np.where(
+        V >= 0,
+        eotf_sRGB(V),
+        -eotf_sRGB(-V),
+    )
+
+    return as_float(from_range_1(Lc))

--- a/colour/models/rgb/transfer_functions/itur_bt_1361.py
+++ b/colour/models/rgb/transfer_functions/itur_bt_1361.py
@@ -21,9 +21,23 @@ from colour.utilities import (
     as_float,
 )
 
+__author__ = "Colour Developers"
+__copyright__ = "Copyright 2013 Colour Developers"
+__license__ = "New BSD License - https://opensource.org/licenses/BSD-3-Clause"
+__maintainer__ = "Colour Developers"
+__email__ = "colour-developers@colour-science.org"
+__status__ = "Production"
+
+__all__ = [
+    "oetf_BT1361_extended",
+    "oetf_inverse_BT1361_extended",
+]
+
 
 L_LINEAR_THRESHOLD_POSITIVE = 0.018
 L_LINEAR_THRESHOLD_NEGATIVE = -0.0045
+EP_LINEAR_THRESHOLD_POSITIVE = 4.500 * L_LINEAR_THRESHOLD_POSITIVE
+EP_LINEAR_THRESHOLD_NEGATIVE = 4.500 * L_LINEAR_THRESHOLD_NEGATIVE
 
 
 def oetf_BT1361_extended(L):
@@ -91,3 +105,70 @@ def oetf_BT1361_extended(L):
     )
 
     return as_float(Ep)
+
+
+def oetf_inverse_BT1361_extended(Ep):
+    """
+    Define the inverse-opto-electronic transfer functions (OETF) for *ITU-R
+    BT.1361* extended color gamut.
+
+    Parameters
+    ----------
+    Ep
+        Non-linear primary signal :math:`E'`.
+
+    Returns
+    -------
+    :class:`numpy.floating` or :class:`numpy.ndarray`
+        Corresponding scene *Luminance* :math:`L`.
+
+    Notes
+    -----
+    +------------+-----------------------+-------------------+
+    | **Range**  | **Scale - Reference** | **Scale - 1**     |
+    +============+=======================+===================+
+    | ``Ep'``    | [-0.25, 1.152...]     | [-0.25, 1.152...] |
+    +------------+-----------------------+-------------------+
+
+    +------------+-----------------------+---------------+
+    | **Domain** | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``L``      | [-0.25, 1.33]         | [-0.25, 1.33] |
+    +------------+-----------------------+---------------+
+
+
+    References
+    ----------
+    :cite:`InternationalTelecommunicationUnion1998`
+
+    Examples
+    --------
+    >>> oetf_inverse_BT1361_extended(0.4090077288641)  # doctest: +ELLIPSIS
+    0.1799999...
+    >>> oetf_inverse_BT1361_extended(-0.25)  # doctest: +ELLIPSIS
+    -0.25
+    >>> oetf_inverse_BT1361_extended(1.1504846663972)  # doctest: +ELLIPSIS
+    1.3299999...
+    """
+
+    Ep = as_float_array(Ep)
+
+    L = np.where(
+        Ep >= 0,
+        np.where(
+            Ep >= EP_LINEAR_THRESHOLD_POSITIVE,
+            # L in [0.018, 1.33] range
+            spow((Ep + 0.099)/1.099, 1/0.45),
+            # L in [0, 0.018] range
+            Ep / 4.500,
+        ),
+        np.where(
+            Ep <= EP_LINEAR_THRESHOLD_NEGATIVE,
+            # L in [-0.25, -0.0045] range
+            -spow((-4*Ep + 0.099)/1.099, 1/0.45)/4,
+            # L in [-0.0045, 0] range
+            Ep / 4.500,
+        ),
+    )
+
+    return as_float(L)

--- a/colour/models/rgb/transfer_functions/itur_bt_1361.py
+++ b/colour/models/rgb/transfer_functions/itur_bt_1361.py
@@ -97,8 +97,7 @@ def oetf_BT1361_extended(L):
         np.where(
             L <= L_LINEAR_THRESHOLD_NEGATIVE,
             # L in [-0.25, -0.0045] range
-            -(1.099 * spow(-4 * L, 0.45) - 0.099)
-            / 4,
+            -(1.099 * spow(-4 * L, 0.45) - 0.099) / 4,
             # L in [-0.0045, 0] range
             4.500 * L,
         ),
@@ -158,14 +157,14 @@ def oetf_inverse_BT1361_extended(Ep):
         np.where(
             Ep >= EP_LINEAR_THRESHOLD_POSITIVE,
             # L in [0.018, 1.33] range
-            spow((Ep + 0.099)/1.099, 1/0.45),
+            spow((Ep + 0.099) / 1.099, 1 / 0.45),
             # L in [0, 0.018] range
             Ep / 4.500,
         ),
         np.where(
             Ep <= EP_LINEAR_THRESHOLD_NEGATIVE,
             # L in [-0.25, -0.0045] range
-            -spow((-4*Ep + 0.099)/1.099, 1/0.45)/4,
+            -spow((-4 * Ep + 0.099) / 1.099, 1 / 0.45) / 4,
             # L in [-0.0045, 0] range
             Ep / 4.500,
         ),

--- a/colour/models/rgb/transfer_functions/itur_bt_1361.py
+++ b/colour/models/rgb/transfer_functions/itur_bt_1361.py
@@ -1,0 +1,81 @@
+"""
+ITU-R BT.1361
+=============
+
+Define transfer functions from *ITU-R BT.1361*.
+
+References
+----------
+-   :cite:`InternationalTelecommunicationUnion1998` : International
+    Telecommunication Union. (1998). Recommendation ITU-R BT.1361 -
+    Worldwide unified colorimetry and related characteristics of
+    future television and imaging systems
+    https://www.itu.int/dms_pubrec/itu-r/rec/bt/\
+R-REC-BT.1361-0-199802-W!!PDF-E.pdf
+"""
+import numpy as np
+
+from colour.algebra import spow
+from colour.utilities import (
+    as_float_array,
+    as_float,
+)
+
+
+def oetf_BT1361_extended(L):
+    """
+    Define the opto-electronic transfer functions (OETF) for *ITU-R BT.1361* extended
+    color gamut.
+
+    Parameters
+    ----------
+    L
+        Scene *Luminance* :math:`L`.
+
+    Returns
+    -------
+    :class:`numpy.floating` or :class:`numpy.ndarray`
+        Corresponding non-linear primary signal :math:`V`.
+
+    Notes
+    -----
+    +------------+-----------------------+---------------+
+    | **Domain** | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``L``      | [-0.25, 1.33]         | [-0.25, 1.33] |
+    +------------+-----------------------+---------------+
+
+    +------------+-----------------------+---------------+
+    | **Range**  | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``E``      | [-1, -1]              | [-1, 1]       |
+    +------------+-----------------------+---------------+
+
+    References
+    ----------
+    :cite:`InternationalTelecommunicationUnion1998`
+
+    Examples
+    --------
+    >>> oetf_BT1361_extended(0.18)  # doctest: +ELLIPSIS
+    0.4090077288641...
+    """
+
+    L = as_float_array(L)
+
+    E = np.where(
+        L >= 0,
+        np.where(
+            L >= 0.018,
+            1.099 * spow(L, 0.45) - 0.099,  # [0.018, 1.33] range
+            4.500 * L,  # [0, 0.018] range
+        ),
+        np.where(
+            L <= -0.0045,
+            4.500 * L,  # [-0.0045, 0] range
+            -(spow(1.099 * (-4 * L), 0.45) - 0.099)
+            / 4,  # [-0.25, -0.0045] range
+        ),
+    )
+
+    return as_float(E)

--- a/colour/models/rgb/transfer_functions/itur_bt_1361.py
+++ b/colour/models/rgb/transfer_functions/itur_bt_1361.py
@@ -22,6 +22,10 @@ from colour.utilities import (
 )
 
 
+L_LINEAR_THRESHOLD_POSITIVE = 0.018
+L_LINEAR_THRESHOLD_NEGATIVE = -0.0045
+
+
 def oetf_BT1361_extended(L):
     """
     Define the opto-electronic transfer functions (OETF) for *ITU-R BT.1361* extended
@@ -35,7 +39,7 @@ def oetf_BT1361_extended(L):
     Returns
     -------
     :class:`numpy.floating` or :class:`numpy.ndarray`
-        Corresponding non-linear primary signal :math:`V`.
+        Corresponding non-linear primary signal :math:`E'`.
 
     Notes
     -----
@@ -45,11 +49,11 @@ def oetf_BT1361_extended(L):
     | ``L``      | [-0.25, 1.33]         | [-0.25, 1.33] |
     +------------+-----------------------+---------------+
 
-    +------------+-----------------------+---------------+
-    | **Range**  | **Scale - Reference** | **Scale - 1** |
-    +============+=======================+===============+
-    | ``E``      | [-1, -1]              | [-1, 1]       |
-    +------------+-----------------------+---------------+
+    +------------+-----------------------+-------------------+
+    | **Range**  | **Scale - Reference** | **Scale - 1**     |
+    +============+=======================+===================+
+    | ``Ep'``    | [-0.25, 1.152...]     | [-0.25, 1.152...] |
+    +------------+-----------------------+-------------------+
 
     References
     ----------
@@ -59,23 +63,31 @@ def oetf_BT1361_extended(L):
     --------
     >>> oetf_BT1361_extended(0.18)  # doctest: +ELLIPSIS
     0.4090077288641...
+    >>> oetf_BT1361_extended(-0.25)  # doctest: +ELLIPSIS
+    -0.25
+    >>> oetf_BT1361_extended(1.33)  # doctest: +ELLIPSIS
+    1.1504846663972...
     """
 
     L = as_float_array(L)
 
-    E = np.where(
+    Ep = np.where(
         L >= 0,
         np.where(
-            L >= 0.018,
-            1.099 * spow(L, 0.45) - 0.099,  # [0.018, 1.33] range
-            4.500 * L,  # [0, 0.018] range
+            L >= L_LINEAR_THRESHOLD_POSITIVE,
+            # L in [0.018, 1.33] range
+            1.099 * spow(L, 0.45) - 0.099,
+            # L in [0, 0.018] range
+            4.500 * L,
         ),
         np.where(
-            L <= -0.0045,
-            4.500 * L,  # [-0.0045, 0] range
-            -(spow(1.099 * (-4 * L), 0.45) - 0.099)
-            / 4,  # [-0.25, -0.0045] range
+            L <= L_LINEAR_THRESHOLD_NEGATIVE,
+            # L in [-0.25, -0.0045] range
+            -(1.099 * spow(-4 * L, 0.45) - 0.099)
+            / 4,
+            # L in [-0.0045, 0] range
+            4.500 * L,
         ),
     )
 
-    return as_float(E)
+    return as_float(Ep)

--- a/colour/models/rgb/transfer_functions/itut_h_273.py
+++ b/colour/models/rgb/transfer_functions/itut_h_273.py
@@ -1,0 +1,183 @@
+"""
+ITU-T H.273 video transfer functions
+====================================
+
+Contains several transfer functions that are defined in ITU-T H.273
+(:cite:`ITU2021`) but don't belong in another specification or standard.
+
+References
+----------
+-   :cite:`ITU2021` : International Telecommunication Union. (2021). Recommendation
+    ITU-T H.273 - Coding-independent code points for video signal type identification.
+    https://www.itu.int/rec/T-REC-H.273-202107-I/en
+"""
+
+import numpy as np
+
+from colour.utilities import (
+    as_float,
+    from_range_1,
+    to_domain_1,
+)
+
+__author__ = "Colour Developers"
+__copyright__ = "Copyright 2013 Colour Developers"
+__license__ = "New BSD License - https://opensource.org/licenses/BSD-3-Clause"
+__maintainer__ = "Colour Developers"
+__email__ = "colour-developers@colour-science.org"
+__status__ = "Production"
+
+__all__ = [
+    "oetf_linear",
+    "oetf_log",
+    "oetf_log_sqrt",
+]
+
+
+def oetf_linear(Lc):
+    """
+    Linear opto-electronic transfer function (OETF) defined in ITU-T H.273.
+
+    Parameters
+    ----------
+    Lc
+        Scene *Luminance* :math:`Lc`.
+
+    Returns
+    -------
+    :class:`numpy.floating` or :class:`numpy.ndarray`
+        Corresponding electrical signal :math:`V`.
+
+    Notes
+    -----
+    +------------+-----------------------+---------------+
+    | **Domain** | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``Lc``     | [0, 1]                | [0, 1]        |
+    +------------+-----------------------+---------------+
+
+    +------------+-----------------------+---------------+
+    | **Range**  | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``V``      | [0, 1]                | [0, 1]        |
+    +------------+-----------------------+---------------+
+
+    References
+    ----------
+    :cite:`ITU2021`
+
+    Examples
+    --------
+    >>> oetf_linear(0.18)  # doctest: +ELLIPSIS
+    0.17999999...
+    """
+
+    Lc = to_domain_1(Lc)
+
+    V = Lc
+
+    return as_float(from_range_1(V))
+
+
+def oetf_log(Lc):
+    """
+    Define the opto-electronic transfer functions (OETF) for Logarithmic
+    encoding (100:1 range) defined in ITU-T H.273.
+
+    Parameters
+    ----------
+    Lc
+        Scene *Luminance* :math:`Lc`.
+
+    Returns
+    -------
+    :class:`numpy.floating` or :class:`numpy.ndarray`
+        Corresponding electrical signal :math:`V`.
+
+    Notes
+    -----
+    +------------+-----------------------+---------------+
+    | **Domain** | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``Lc``     | [0, 1]                | [0, 1]        |
+    +------------+-----------------------+---------------+
+
+    +------------+-----------------------+---------------+
+    | **Range**  | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``V``      | [0, 1]                | [0, 1]        |
+    +------------+-----------------------+---------------+
+
+    References
+    ----------
+    :cite:`ITU2021`
+
+    Examples
+    --------
+    >>> oetf_log(0.18)  # doctest: +ELLIPSIS
+    0.6276362525516...
+    """
+
+    Lc = to_domain_1(Lc)
+
+    V = np.where(
+        Lc >= 0.01,
+        # Lc in [0.01, 1] range
+        1.0 + np.log10(Lc) / 2.0,
+        # Lc in [0, 0.01] range
+        0.0,
+    )
+
+    return as_float(from_range_1(V))
+
+
+def oetf_log_sqrt(Lc):
+    """
+    Define the opto-electronic transfer functions (OETF) for Logarithmic
+    encoding (100*Sqrt(10):1 range) defined in ITU-T H.273.
+
+    Parameters
+    ----------
+    Lc
+        Scene *Luminance* :math:`Lc`.
+
+    Returns
+    -------
+    :class:`numpy.floating` or :class:`numpy.ndarray`
+        Corresponding electrical signal :math:`V`.
+
+    Notes
+    -----
+    +------------+-----------------------+---------------+
+    | **Domain** | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``Lc``     | [0, 1]                | [0, 1]        |
+    +------------+-----------------------+---------------+
+
+    +------------+-----------------------+---------------+
+    | **Range**  | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``V``      | [0, 1]                | [0, 1]        |
+    +------------+-----------------------+---------------+
+
+    References
+    ----------
+    :cite:`ITU2021`
+
+    Examples
+    --------
+    >>> oetf_log_sqrt(0.18)  # doctest: +ELLIPSIS
+    0.702109002041...
+    """
+
+    Lc = to_domain_1(Lc)
+
+    V = np.where(
+        Lc >= np.sqrt(10) / 1000,
+        # Lc in [0.01, 1] range
+        1.0 + np.log10(Lc) / 2.5,
+        # Lc in [0, 0.01] range
+        0.0,
+    )
+
+    return as_float(from_range_1(V))

--- a/colour/models/rgb/transfer_functions/itut_h_273.py
+++ b/colour/models/rgb/transfer_functions/itut_h_273.py
@@ -14,6 +14,7 @@ References
 
 import numpy as np
 
+from colour.algebra import spow
 from colour.utilities import (
     as_float,
     from_range_1,
@@ -31,6 +32,9 @@ __all__ = [
     "oetf_linear",
     "oetf_log",
     "oetf_log_sqrt",
+    "oetf_inverse_linear",
+    "oetf_inverse_log",
+    "oetf_inverse_log_sqrt",
 ]
 
 
@@ -79,6 +83,52 @@ def oetf_linear(Lc):
     return as_float(from_range_1(V))
 
 
+def oetf_inverse_linear(V):
+    """
+    Linear inverse-opto-electronic transfer function (OETF) defined in ITU-T
+    H.273.
+
+    Parameters
+    ----------
+    V
+        Electrical signal :math:`V`.
+
+    Returns
+    -------
+    :class:`numpy.floating` or :class:`numpy.ndarray`
+        Corresponding scene *Luminance* :math:`Lc`.
+
+    Notes
+    -----
+    +------------+-----------------------+---------------+
+    | **Range**  | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``V``      | [0, 1]                | [0, 1]        |
+    +------------+-----------------------+---------------+
+
+    +------------+-----------------------+---------------+
+    | **Domain** | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``Lc``     | [0, 1]                | [0, 1]        |
+    +------------+-----------------------+---------------+
+
+    References
+    ----------
+    :cite:`ITU2021`
+
+    Examples
+    --------
+    >>> oetf_inverse_linear(0.18)  # doctest: +ELLIPSIS
+    0.17999999...
+    """
+
+    V = to_domain_1(V)
+
+    Lc = V
+
+    return as_float(from_range_1(Lc))
+
+
 def oetf_log(Lc):
     """
     Define the opto-electronic transfer functions (OETF) for Logarithmic
@@ -116,6 +166,12 @@ def oetf_log(Lc):
     --------
     >>> oetf_log(0.18)  # doctest: +ELLIPSIS
     0.6276362525516...
+    >>> oetf_log(0.01)  # doctest: +ELLIPSIS
+    0.0
+    >>> oetf_log(0.001)  # doctest: +ELLIPSIS
+    0.0
+    >>> oetf_log(1.0)  # doctest: +ELLIPSIS
+    1.0
     """
 
     Lc = to_domain_1(Lc)
@@ -129,6 +185,62 @@ def oetf_log(Lc):
     )
 
     return as_float(from_range_1(V))
+
+
+def oetf_inverse_log(V):
+    """
+    Define the inverse-opto-electronic transfer functions (OETF) for
+    Logarithmic encoding (100:1 range) defined in ITU-T H.273.
+
+    Parameters
+    ----------
+    V
+        Electrical signal :math:`V`.
+
+    Returns
+    -------
+    :class:`numpy.floating` or :class:`numpy.ndarray`
+        Corresponding scene *Luminance* :math:`Lc`.
+
+    Notes
+    -----
+    +------------+-----------------------+---------------+
+    | **Range**  | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``V``      | [0, 1]                | [0, 1]        |
+    +------------+-----------------------+---------------+
+
+    +------------+-----------------------+---------------+
+    | **Domain** | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``Lc``     | [0, 1]                | [0, 1]        |
+    +------------+-----------------------+---------------+
+
+    References
+    ----------
+    :cite:`ITU2021`
+
+    Examples
+    --------
+    >>> oetf_inverse_log(0.6276362525516)  # doctest: +ELLIPSIS
+    0.17999999...
+    >>> oetf_inverse_log(0.0)  # doctest: +ELLIPSIS
+    0.01
+    >>> oetf_inverse_log(1.0)  # doctest: +ELLIPSIS
+    1.0
+    """
+
+    V = to_domain_1(V)
+
+    Lc = np.where(
+        V >= 0.0,
+        # Lc in [0.01, 1] range
+        spow(10, (V-1.0)*2.0),
+        # Lc in [0, 0.01] range
+        0.01,
+    )
+
+    return as_float(from_range_1(Lc))
 
 
 def oetf_log_sqrt(Lc):
@@ -168,16 +280,78 @@ def oetf_log_sqrt(Lc):
     --------
     >>> oetf_log_sqrt(0.18)  # doctest: +ELLIPSIS
     0.702109002041...
+    >>> oetf_log_sqrt(0.003162277660168)  # doctest: +ELLIPSIS
+    0.0
+    >>> oetf_log_sqrt(0.0001)  # doctest: +ELLIPSIS
+    0.0
+    >>> oetf_log_sqrt(1.0)  # doctest: +ELLIPSIS
+    1.0
     """
 
     Lc = to_domain_1(Lc)
 
     V = np.where(
         Lc >= np.sqrt(10) / 1000,
-        # Lc in [0.01, 1] range
+        # Lc in [sqrt(10)/1000, 1] range
         1.0 + np.log10(Lc) / 2.5,
-        # Lc in [0, 0.01] range
+        # Lc in [0, sqrt(10)/1000] range
         0.0,
     )
 
     return as_float(from_range_1(V))
+
+
+def oetf_inverse_log_sqrt(V):
+    """
+    Define the inverse-opto-electronic transfer functions (OETF) for
+    Logarithmic encoding (100*Sqrt(10):1 range) defined in ITU-T H.273.
+
+    Parameters
+    ----------
+    V
+        Electrical signal :math:`V`.
+
+    Returns
+    -------
+    :class:`numpy.floating` or :class:`numpy.ndarray`
+        Corresponding scene *Luminance* :math:`Lc`.
+
+    Notes
+    -----
+    +------------+-----------------------+---------------+
+    | **Range**  | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``V``      | [0, 1]                | [0, 1]        |
+    +------------+-----------------------+---------------+
+
+    +------------+-----------------------+---------------+
+    | **Domain** | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``Lc``     | [0, 1]                | [0, 1]        |
+    +------------+-----------------------+---------------+
+
+    References
+    ----------
+    :cite:`ITU2021`
+
+    Examples
+    --------
+    >>> oetf_inverse_log_sqrt(0.702109002041)  # doctest: +ELLIPSIS
+    0.1799999999...
+    >>> oetf_inverse_log_sqrt(0.0)  # doctest: +ELLIPSIS
+    0.00316227766...
+    >>> oetf_inverse_log_sqrt(1.0)  # doctest: +ELLIPSIS
+    1.0
+    """
+
+    V = to_domain_1(V)
+
+    Lc = np.where(
+        V >= 0.0,
+        # Lc in [sqrt(10)/1000, 1] range
+        spow(10, (V-1.0)*2.5),
+        # Lc in [0, sqrt(10)/1000] range
+        np.sqrt(10) / 1000,
+    )
+
+    return as_float(from_range_1(Lc))

--- a/colour/models/rgb/transfer_functions/itut_h_273.py
+++ b/colour/models/rgb/transfer_functions/itut_h_273.py
@@ -235,7 +235,7 @@ def oetf_inverse_log(V):
     Lc = np.where(
         V >= 0.0,
         # Lc in [0.01, 1] range
-        spow(10, (V-1.0)*2.0),
+        spow(10, (V - 1.0) * 2.0),
         # Lc in [0, 0.01] range
         0.01,
     )
@@ -349,7 +349,7 @@ def oetf_inverse_log_sqrt(V):
     Lc = np.where(
         V >= 0.0,
         # Lc in [sqrt(10)/1000, 1] range
-        spow(10, (V-1.0)*2.5),
+        spow(10, (V - 1.0) * 2.5),
         # Lc in [0, sqrt(10)/1000] range
         np.sqrt(10) / 1000,
     )

--- a/colour/models/rgb/transfer_functions/st_428.py
+++ b/colour/models/rgb/transfer_functions/st_428.py
@@ -1,0 +1,68 @@
+"""
+SMPTE ST 428-1 (2019)
+=====================
+
+Defines *SMPTE ST 428-1 (2019)* inverse electro-optical transfer function (EOTF).
+
+Note that this function uses the definition from :cite:`ITU2021` since SMPTE ST
+428-1 is not publicly accessible.
+
+References
+----------
+-   :cite:`ITU2021` : International Telecommunication Union. (2021).
+    Recommendation ITU-T H.273 - Coding-independent code points for video
+    signal type identification.
+    https://www.itu.int/rec/T-REC-H.273-202107-I/en
+"""
+
+from colour.algebra import spow
+from colour.utilities import (
+    as_float,
+    from_range_1,
+    to_domain_1,
+)
+
+
+def eotf_inverse_ST428_1(Lo):
+    """
+    Define the *SMPTE ST 428-1 (2019)* inverse electro-optical transfer function (EOTF).
+
+    Parameters
+    ----------
+    Lo
+        Output display *Luminance* :math:`Lo` of the image.
+
+    Returns
+    -------
+    :class:`numpy.floating` or :class:`numpy.ndarray`
+        Corresponding electrical signal :math:`V`.
+
+    Notes
+    -----
+    +------------+-----------------------+---------------+
+    | **Domain** | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``L``      | [0, 1]                | [0, 1]        |
+    +------------+-----------------------+---------------+
+
+    +------------+-----------------------+---------------+
+    | **Range**  | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``V``      | [0, 1]                | [0, 1]        |
+    +------------+-----------------------+---------------+
+
+    References
+    ----------
+    -   :cite:`ITU2021`
+
+    Examples
+    --------
+    >>> eotf_inverse_ST428_1(0.18)  # doctest: +ELLIPSIS
+    0.5000483377172...
+    """
+
+    Lo = to_domain_1(Lo)
+
+    V = spow(48 * Lo / 52.37, 1 / 2.6)
+
+    return as_float(from_range_1(V))

--- a/colour/models/rgb/transfer_functions/st_428.py
+++ b/colour/models/rgb/transfer_functions/st_428.py
@@ -22,6 +22,63 @@ from colour.utilities import (
     to_domain_1,
 )
 
+__author__ = "Colour Developers"
+__copyright__ = "Copyright 2013 Colour Developers"
+__license__ = "New BSD License - https://opensource.org/licenses/BSD-3-Clause"
+__maintainer__ = "Colour Developers"
+__email__ = "colour-developers@colour-science.org"
+__status__ = "Production"
+
+__all__ = [
+    "eotf_ST428_1",
+    "eotf_inverse_ST428_1",
+]
+
+
+def eotf_ST428_1(V):
+    """
+    Define the *SMPTE ST 428-1 (2019)* electro-optical transfer function (EOTF).
+
+    Parameters
+    ----------
+    V
+        Electrical signal :math:`V`.
+
+    Returns
+    -------
+    :class:`numpy.floating` or :class:`numpy.ndarray`
+        Corresponding output display *Luminance* :math:`Lo` of the image.
+
+    Notes
+    -----
+    +------------+-----------------------+---------------+
+    | **Range**  | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``V``      | [0, 1]                | [0, 1]        |
+    +------------+-----------------------+---------------+
+
+    +------------+-----------------------+---------------+
+    | **Domain** | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``Lo``     | [0, 1]                | [0, 1]        |
+    +------------+-----------------------+---------------+
+
+    References
+    ----------
+    -   :cite:`ITU2021`
+
+    Examples
+    --------
+    >>> eotf_ST428_1(0.5000483377172)  # doctest: +ELLIPSIS
+    0.179999999...
+    """
+
+    V = to_domain_1(V)
+
+    Lo = 52.37 * spow(V, 2.6) / 48
+
+    return as_float(from_range_1(Lo))
+
 
 def eotf_inverse_ST428_1(Lo):
     """
@@ -42,7 +99,7 @@ def eotf_inverse_ST428_1(Lo):
     +------------+-----------------------+---------------+
     | **Domain** | **Scale - Reference** | **Scale - 1** |
     +============+=======================+===============+
-    | ``L``      | [0, 1]                | [0, 1]        |
+    | ``Lo``     | [0, 1]                | [0, 1]        |
     +------------+-----------------------+---------------+
 
     +------------+-----------------------+---------------+

--- a/colour/models/rgb/video.py
+++ b/colour/models/rgb/video.py
@@ -1,0 +1,664 @@
+"""
+ITU-T H.273 video colour metadata
+=================================
+
+Defines aliases to a set of standard colour primaries, transfer functions and
+YUV to RGB matrix coefficients used in video metadata.
+
+These metadata were historically defined in ISO/IEC 23001-8 (:cite:`ISO2013`) then
+superseded and duplicated by other standards (among others: :cite:`ISO2020`,
+:cite:`ISO2021`, :cite:`ITU2021`). They are widely in use to define color-related
+properties in video encoding and decoding software libraries, including ffmpeg.
+
+References
+----------
+-   :cite:`ITU2021` : International Telecommunication Union. (2021).
+    Recommendation ITU-T H.273 - Coding-independent code points for video
+    signal type identification.
+    https://www.itu.int/rec/T-REC-H.273-202107-I/en
+-   :cite:`ISO2013` : International Organization for Standardization. (2013).
+    INTERNATIONAL STANDARD ISO/IEC 23001-8:2013 - Information technology - MPEG
+    systems technologies - Part 8: Coding-independent code points, §7.1 "Colour
+    primaries"
+-   :cite:`ISO2021` : International Organization for Standardization. (2021).
+    INTERNATIONAL STANDARD ISO/IEC 23091-2:2021 - Information technology -
+    Coding-independent code points - Part 2: Video, §8.1 "Colour primaries"
+-   :cite:`ISO2020` : International Organization for Standardization. (2020).
+    INTERNATIONAL STANDARD ISO/IEC 14496-10:2020 - Information technology -
+    Coding of audio-visual objects - Part 10: Advanced video coding"
+"""
+
+import functools
+import enum
+
+import numpy as np
+
+import colour
+
+import colour.models.rgb.datasets.itut_h_273
+from colour.models.rgb.transfer_functions.gamma import gamma_function
+from colour.models.rgb.transfer_functions.itur_bt_709 import oetf_BT709
+from colour.models.rgb.transfer_functions.itur_bt_1886 import eotf_BT1886
+from colour.models.rgb.transfer_functions.itur_bt_2020 import oetf_BT2020
+from colour.models.rgb.transfer_functions.itur_bt_1361 import (
+    oetf_BT1361_extended,
+)
+from colour.models.rgb.transfer_functions.itur_bt_2100 import oetf_BT2100_HLG
+from colour.models.rgb.transfer_functions.st_428 import eotf_inverse_ST428_1
+from colour.models.rgb.transfer_functions.st_2084 import eotf_inverse_ST2084
+from colour.models.rgb.transfer_functions.iec_61966_2 import (
+    oetf_iec_61966_2_unbounded,
+)
+from colour.models.rgb.transfer_functions.itur_bt_601 import oetf_BT601
+from colour.models.rgb.transfer_functions.smpte_240m import oetf_SMPTE240M
+from colour.models.rgb.transfer_functions.itut_h_273 import (
+    oetf_linear,
+    oetf_log,
+    oetf_log_sqrt,
+)
+
+__all__ = [
+    "CCS_WHITEPOINTS_ISO14496_10",
+    "CCS_WHITEPOINTS_ISO23001_8",
+    "CCS_WHITEPOINTS_ISO23091_2",
+    "CCS_WHITEPOINTS_ITU_T_H273",
+    "ColourPrimaries_ISO14496_10",
+    "ColourPrimaries_ISO23001_8",
+    "ColourPrimaries_ISO23091_2",
+    "ColourPrimaries_ITU_T_H273",
+    "MATRICES_ISO14496_10_RGB_TO_XYZ",
+    "MATRICES_ISO23001_8_RGB_TO_XYZ",
+    "MATRICES_ISO23091_2_RGB_TO_XYZ",
+    "MATRICES_ITU_T_H273_RGB_TO_XYZ",
+    "MATRICES_XYZ_TO_ISO14496_10_RGB",
+    "MATRICES_XYZ_TO_ISO23001_8_RGB",
+    "MATRICES_XYZ_TO_ISO23091_2_RGB",
+    "MATRICES_XYZ_TO_ITU_T_H273_RGB",
+    "MatrixCoefficients_ISO14496_10",
+    "MatrixCoefficients_ISO23001_8",
+    "MatrixCoefficients_ISO23091_2",
+    "MatrixCoefficients_ITU_T_H273",
+    "PRIMARIES_ISO14496_10",
+    "PRIMARIES_ISO23001_8",
+    "PRIMARIES_ISO23091_2",
+    "PRIMARIES_ITU_T_H273",
+    "TRANSFER_FUNCTIONS_ISO14496_10",
+    "TRANSFER_FUNCTIONS_ISO23001_8",
+    "TRANSFER_FUNCTIONS_ISO23091_2",
+    "TRANSFER_FUNCTIONS_ITU_T_H273",
+    "TransferCharacteristics_ISO14496_10",
+    "TransferCharacteristics_ISO23001_8",
+    "TransferCharacteristics_ISO23091_2",
+    "TransferCharacteristics_ITU_T_H273",
+    "WEIGHTS_YCBCR_ISO14496_10",
+    "WEIGHTS_YCBCR_ISO23001_8",
+    "WEIGHTS_YCBCR_ISO23091_2",
+    "WEIGHTS_YCBCR_ITU_T_H273",
+    "WHITEPOINTS_NAMES_ISO14496_10",
+    "WHITEPOINTS_NAMES_ISO23001_8",
+    "WHITEPOINTS_NAMES_ISO23091_2",
+    "WHITEPOINTS_NAMES_ITU_T_H273",
+    "eotf_BT1886",
+    "eotf_inverse_ST2084",
+    "eotf_inverse_ST428_1",
+    "eotf_inverse_gamma22",
+    "eotf_inverse_gamma28",
+    "oetf_BT1361_extended",
+    "oetf_BT2020_10bit",
+    "oetf_BT2020_12bit",
+    "oetf_BT2100_HLG",
+    "oetf_BT601",
+    "oetf_BT709",
+    "oetf_SMPTE240M",
+    "oetf_iec_61966_2_1",
+    "oetf_iec_61966_2_4",
+    "oetf_linear",
+    "oetf_log",
+    "oetf_log_sqrt",
+]
+
+oetf_BT2020_12bit = functools.partial(oetf_BT2020, is_12_bits_system=True)
+oetf_BT2020_10bit = functools.partial(oetf_BT2020, is_12_bits_system=False)
+eotf_inverse_gamma22 = functools.partial(gamma_function, exponent=1 / 2.2)
+eotf_inverse_gamma28 = functools.partial(gamma_function, exponent=1 / 2.8)
+oetf_iec_61966_2_4 = oetf_iec_61966_2_unbounded
+oetf_iec_61966_2_1 = oetf_iec_61966_2_unbounded
+
+
+@enum.unique
+class ColourPrimaries_ITU_T_H273(enum.IntEnum):
+    """ColourPrimaries tags as defined in ITU-T H.273 § 8.1.
+
+    The enumeration members use  the same names as ffmpeg `AVCOL_PRI_*` constants.
+    """
+
+    BT709 = 1  # also ITU-R BT1361 / IEC 61966-2-4 / SMPTE RP177 Annex B
+    BT470M = 4  # also FCC Title 47 Code of Federal Regulations 73.682 (a)(20)
+
+    # also ITU-R BT601-6 625 / ITU-R BT1358 625 / ITU-R BT1700 625 PAL & SECAM
+    BT470BG = 5
+
+    SMPTE170M = (
+        6  # also ITU-R BT601-6 525 / ITU-R BT1358 525 / ITU-R BT1700 NTSC
+    )
+    SMPTE240M = 7  # functionally identical to above
+    FILM = 8  # colour filters using Illuminant C
+    BT2020 = 9  # ITU-R BT2020
+    SMPTE428 = 10  # SMPTE ST 428-1 (CIE 1931 XYZ)
+    SMPTE431 = 11  # SMPTE ST 431-2 (2011) / DCI P3
+    SMPTE432 = 12  # SMPTE ST 432-1 (2010) / P3 D65 / Display P3
+
+    # Note: This corresponds to "AVCOL_PRI_EBU3213" in ffmpeg, but neither ITU-T
+    # H.273:2021 nor ISO/IEC 23091-2:2021 contain the same values as EBU Tech. 3213, nor
+    # do they refer to it directly (ColourPrimaries=22 contains the remark "No
+    # corresponding industry specification identified" in both cases).
+    #
+    # Since both ISO/IEC 23001-8:2013 and 14497-10:2020 do refer to EBU Tech 3213-E
+    # (1975) but contain the same primaries and whitepoint as the 2021 revisions, this
+    # is likely a error in the initial standards that was later discovered and
+    # corrected.
+    UNKNOWN22 = 22
+
+
+@enum.unique
+class TransferCharacteristics_ITU_T_H273(enum.IntEnum):
+    """TransferCharacteristics tags as defined in ITU-T H.273 § 8.2.
+
+    The enumeration members use the same names as ffmpeg `AVCOL_TRC_*` constants.
+    """
+
+    BT709 = 1  # also ITU-R BT1361
+    GAMMA22 = 4  # also ITU-R BT470M / ITU-R BT1700 625 PAL & SECAM
+    GAMMA28 = 5  # also ITU-R BT470BG
+
+    # also ITU-R BT601-6 525 or 625 / ITU-R BT1358 525 or 625 / ITU-R BT1700 NTSC
+    SMPTE170M = 6
+
+    SMPTE240M = 7
+    LINEAR = 8  # "Linear transfer characteristics"
+    LOG = 9  # "Logarithmic transfer characteristic (100:1 range)"
+
+    # "Logarithmic transfer characteristic (100 * Sqrt(10) : 1 range)"
+    LOG_SQRT = 10
+
+    IEC61966_2_4 = 11  # IEC 61966-2-4
+    BT1361_ECG = 12  # ITU-R BT1361 Extended Colour Gamut
+    IEC61966_2_1 = 13  # IEC 61966-2-1 (sRGB or sYCC)
+    BT2020_10 = 14  # ITU-R BT2020 for 10-bit system
+    BT2020_12 = 15  # ITU-R BT2020 for 12-bit system
+    SMPTE2084 = 16  # SMPTE ST 2084 for 10-, 12-, 14- and 16-bit systems
+    SMPTE428 = 17  # SMPTE ST 428-1
+    ARIB_STD_B67 = 18  # ARIB STD-B67, known as "Hybrid log-gamma"
+
+
+@enum.unique
+class MatrixCoefficients_ITU_T_H273(enum.IntEnum):
+    """MatrixCoefficients tags as defined in ITU-T H.273 § 8.3
+
+    The enumeration members use the same names as ffmpeg `AVCOL_SPC_*` constants.
+    """
+
+    RGB = 0  # order of coefficients is actually GBR, also IEC 61966-2-1 (sRGB)
+    BT709 = (
+        1  # also ITU-R BT1361 / IEC 61966-2-4 xvYCC709 / SMPTE RP177 Annex B
+    )
+    FCC = 4  # FCC Title 47 Code of Federal Regulations 73.682 (a)(20)
+
+    # also ITU-R BT601-6 625 / ITU-R BT1358 625 / ITU-R BT1700 625 PAL & SECAM
+    # / IEC 61966-2-4 xvYCC601
+    BT470BG = 5
+
+    SMPTE170M = (
+        6  # also ITU-R BT601-6 525 / ITU-R BT1358 525 / ITU-R BT1700 NTSC
+    )
+    SMPTE240M = 7  # functionally identical to above
+    YCGCO = 8  # Used by Dirac / VC-2 and H.264 FRext, see ITU-T SG16
+    BT2020_NCL = 9  # ITU-R BT2020 non-constant luminance system
+    BT2020_CL = 10  # ITU-R BT2020 constant luminance system
+    SMPTE2085 = 11  # SMPTE 2085, Y'D'zD'x
+    CHROMA_DERIVED_NCL = (
+        12  # Chromaticity-derived non-constant luminance system
+    )
+    CHROMA_DERIVED_CL = 13  # Chromaticity-derived constant luminance system
+    ICTCP = 14  # ITU-R BT.2100-0, ICtCp
+
+
+PRIMARIES_ITU_T_H273 = {
+    # 0: Reserved for future use
+    # 1: ITU-R BT.709-5, IEC 61966-2-1 sRGB or sYCC, IEC 61966-2-4, SMPTE RP177 Annex B
+    ColourPrimaries_ITU_T_H273.BT709: (
+        colour.models.rgb.datasets.itur_bt_709.PRIMARIES_BT709
+    ),
+    # 2: Unspecified
+    # 3: Reserved for future use
+    # 4: ITU-R BT.470-6 System M
+    ColourPrimaries_ITU_T_H273.BT470M: (
+        colour.models.rgb.datasets.itur_bt_470.PRIMARIES_BT470_525
+    ),
+    # 5: ITU-R BT.470-6 Systems BG, ITU-R BT.601-6 625
+    ColourPrimaries_ITU_T_H273.BT470BG: (
+        colour.models.rgb.datasets.itur_bt_470.PRIMARIES_BT470_625
+    ),
+    # 6: SMPTE 170M, ITU-R BT.601-6 525 (same as 7)
+    ColourPrimaries_ITU_T_H273.SMPTE170M: (
+        colour.models.rgb.datasets.smpte_240m.PRIMARIES_SMPTE_240M
+    ),
+    # 7: SMPTE 240M (same as 6)
+    ColourPrimaries_ITU_T_H273.SMPTE240M: (
+        colour.models.rgb.datasets.smpte_240m.PRIMARIES_SMPTE_240M
+    ),
+    # 8: Generic film (colour filters using Illuminant C)
+    ColourPrimaries_ITU_T_H273.FILM: (
+        colour.models.rgb.datasets.itut_h_273.PRIMARIES_FILM_C
+    ),
+    # 9: ITU-R BT.2020
+    ColourPrimaries_ITU_T_H273.BT2020: (
+        colour.models.rgb.datasets.itur_bt_2020.PRIMARIES_BT2020
+    ),
+    # 10: SMPTE ST 428-1 (DCDM, CIE 1931 XYZ as in ISO 11664-1)
+    ColourPrimaries_ITU_T_H273.SMPTE428: (
+        colour.models.rgb.datasets.dcdm_xyz.PRIMARIES_DCDM_XYZ
+    ),
+    # 11: SMPTE RP 431-2 (2011)
+    ColourPrimaries_ITU_T_H273.SMPTE431: (
+        colour.models.rgb.datasets.dci_p3.PRIMARIES_DCI_P3
+    ),
+    # 12: SMPTE EG 432-1 (2010)
+    ColourPrimaries_ITU_T_H273.SMPTE432: (
+        colour.models.rgb.datasets.p3_d65.PRIMARIES_P3_D65
+    ),
+    # 13-21: Reserved for future use
+    # 22: No corresponding industry specification
+    ColourPrimaries_ITU_T_H273.UNKNOWN22: (
+        colour.models.rgb.datasets.itut_h_273.PRIMARIES_ITUT_H273_22
+    ),
+    # 23-255: Reserved for future use
+}
+"""ColourPrimaries tag to colour primaries mapping defined in ITU-T H.273 §
+8.1"""
+
+
+CCS_WHITEPOINTS_ITU_T_H273 = {
+    # 0: Reserved for future use
+    # 1: ITU-R BT.709-5, IEC 61966-2-1 sRGB or sYCC, IEC 61966-2-4, SMPTE RP177 Annex B
+    ColourPrimaries_ITU_T_H273.BT709: (
+        colour.models.rgb.datasets.itur_bt_709.CCS_WHITEPOINT_BT709
+    ),
+    # 2: Unspecified
+    # 3: Reserved for future use
+    # 4: ITU-R BT.470-6 System M
+    ColourPrimaries_ITU_T_H273.BT470M: (
+        # Note: ITU-T H.273 defines white point C as [0.310, 0.316], while this
+        # has a slightly higher precision.
+        colour.models.rgb.datasets.itur_bt_470.CCS_WHITEPOINT_BT470_525
+    ),
+    # 5: ITU-R BT.470-6 Systems BG, ITU-R BT.601-6 625
+    ColourPrimaries_ITU_T_H273.BT470BG: (
+        colour.models.rgb.datasets.itur_bt_470.CCS_WHITEPOINT_BT470_625
+    ),
+    # 6: SMPTE 170M, ITU-R BT.601-6 525 (same as 7)
+    ColourPrimaries_ITU_T_H273.SMPTE170M: (
+        colour.models.rgb.datasets.smpte_240m.CCS_WHITEPOINT_SMPTE_240M
+    ),
+    # 7: SMPTE 240M (same as 6)
+    ColourPrimaries_ITU_T_H273.SMPTE240M: (
+        colour.models.rgb.datasets.smpte_240m.CCS_WHITEPOINT_SMPTE_240M
+    ),
+    # 8: Generic film (colour filters using Illuminant C)
+    ColourPrimaries_ITU_T_H273.FILM: (
+        colour.models.rgb.datasets.itut_h_273.CCS_WHITEPOINT_FILM_C
+    ),
+    # 9: ITU-R BT.2020
+    ColourPrimaries_ITU_T_H273.BT2020: (
+        colour.models.rgb.datasets.itur_bt_2020.CCS_WHITEPOINT_BT2020
+    ),
+    # 10: SMPTE ST 428-1 (DCDM, CIE 1931 XYZ as in ISO 11664-1)
+    ColourPrimaries_ITU_T_H273.SMPTE428: (
+        colour.models.rgb.datasets.dcdm_xyz.CCS_WHITEPOINT_DCDM_XYZ
+    ),
+    # 11: SMPTE RP 431-2 (2011)
+    ColourPrimaries_ITU_T_H273.SMPTE431: (
+        colour.models.rgb.datasets.dci_p3.CCS_WHITEPOINT_DCI_P3
+    ),
+    # 12: SMPTE EG 432-1 (2010)
+    ColourPrimaries_ITU_T_H273.SMPTE432: (
+        colour.models.rgb.datasets.p3_d65.CCS_WHITEPOINT_P3_D65
+    ),
+    # 13-21: Reserved for future use
+    # 22: No corresponding industry specification
+    ColourPrimaries_ITU_T_H273.UNKNOWN22: (
+        colour.models.rgb.datasets.itut_h_273.CCS_WHITEPOINT_ITUT_H273_22
+    ),
+    # 23-255: Reserved for future use
+}
+"""ColourPrimaries tag to whitepoint chromaticity coordinates mapping defined
+in ITU-T H.273 § 8.1"""
+
+
+WHITEPOINTS_NAMES_ITU_T_H273 = {
+    # 0: Reserved for future use
+    # 1: ITU-R BT.709-5, IEC 61966-2-1 sRGB or sYCC, IEC 61966-2-4, SMPTE RP177 Annex B
+    ColourPrimaries_ITU_T_H273.BT709: (
+        colour.models.rgb.datasets.itur_bt_709.WHITEPOINT_NAME_BT709
+    ),
+    # 2: Unspecified
+    # 3: Reserved for future use
+    # 4: ITU-R BT.470-6 System M
+    ColourPrimaries_ITU_T_H273.BT470M: (
+        colour.models.rgb.datasets.itur_bt_470.WHITEPOINT_NAME_BT470_525
+    ),
+    # 5: ITU-R BT.470-6 Systems BG, ITU-R BT.601-6 625
+    ColourPrimaries_ITU_T_H273.BT470BG: (
+        colour.models.rgb.datasets.itur_bt_470.WHITEPOINT_NAME_BT470_625
+    ),
+    # 6: SMPTE 170M, ITU-R BT.601-6 525 (same as 7)
+    ColourPrimaries_ITU_T_H273.SMPTE170M: (
+        colour.models.rgb.datasets.smpte_240m.WHITEPOINT_NAME_SMPTE_240M
+    ),
+    # 7: SMPTE 240M (same as 6)
+    ColourPrimaries_ITU_T_H273.SMPTE240M: (
+        colour.models.rgb.datasets.smpte_240m.WHITEPOINT_NAME_SMPTE_240M
+    ),
+    # 8: Generic film (colour filters using Illuminant C)
+    ColourPrimaries_ITU_T_H273.FILM: (
+        colour.models.rgb.datasets.itut_h_273.WHITEPOINT_NAME_FILM_C
+    ),
+    # 9: ITU-R BT.2020
+    ColourPrimaries_ITU_T_H273.BT2020: (
+        colour.models.rgb.datasets.itur_bt_2020.WHITEPOINT_NAME_BT2020
+    ),
+    # 10: SMPTE ST 428-1 (DCDM, CIE 1931 XYZ as in ISO 11664-1)
+    ColourPrimaries_ITU_T_H273.SMPTE428: (
+        colour.models.rgb.datasets.dcdm_xyz.WHITEPOINT_NAME_DCDM_XYZ
+    ),
+    # 11: SMPTE RP 431-2 (2011)
+    ColourPrimaries_ITU_T_H273.SMPTE431: (
+        colour.models.rgb.datasets.dci_p3.WHITEPOINT_NAME_DCI_P3
+    ),
+    # 12: SMPTE EG 432-1 (2010)
+    ColourPrimaries_ITU_T_H273.SMPTE432: (
+        colour.models.rgb.datasets.p3_d65.WHITEPOINT_NAME_P3_D65
+    ),
+    # 13-21: Reserved for future use
+    # 22: No corresponding industry specification
+    ColourPrimaries_ITU_T_H273.UNKNOWN22: (
+        colour.models.rgb.datasets.itut_h_273.WHITEPOINT_NAME_ITUT_H273_22
+    ),
+    # 23-255: Reserved for future use
+}
+"""ColourPrimaries tag to whitepoint names mapping defined in ITU-T H.273 §
+8.1"""
+
+
+MATRICES_ITU_T_H273_RGB_TO_XYZ = {
+    # 0: Reserved for future use
+    # 1: ITU-R BT.709-5, IEC 61966-2-1 sRGB or sYCC, IEC 61966-2-4, SMPTE RP177 Annex B
+    ColourPrimaries_ITU_T_H273.BT709: (
+        colour.models.rgb.datasets.itur_bt_709.MATRIX_BT709_TO_XYZ
+    ),
+    # 2: Unspecified
+    # 3: Reserved for future use
+    # 4: ITU-R BT.470-6 System M
+    ColourPrimaries_ITU_T_H273.BT470M: (
+        colour.models.rgb.datasets.itur_bt_470.MATRIX_BT470_525_TO_XYZ
+    ),
+    # 5: ITU-R BT.470-6 Systems BG, ITU-R BT.601-6 625
+    ColourPrimaries_ITU_T_H273.BT470BG: (
+        colour.models.rgb.datasets.itur_bt_470.MATRIX_BT470_625_TO_XYZ
+    ),
+    # 6: SMPTE 170M, ITU-R BT.601-6 525 (same as 7)
+    ColourPrimaries_ITU_T_H273.SMPTE170M: (
+        colour.models.rgb.datasets.smpte_240m.MATRIX_SMPTE_240M_TO_XYZ
+    ),
+    # 7: SMPTE 240M (same as 6)
+    ColourPrimaries_ITU_T_H273.SMPTE240M: (
+        colour.models.rgb.datasets.smpte_240m.MATRIX_SMPTE_240M_TO_XYZ
+    ),
+    # 8: Generic film (colour filters using Illuminant C)
+    ColourPrimaries_ITU_T_H273.FILM: (
+        colour.models.rgb.datasets.itut_h_273.MATRIX_FILM_C_RGB_TO_XYZ
+    ),
+    # 9: ITU-R BT.2020
+    ColourPrimaries_ITU_T_H273.BT2020: (
+        colour.models.rgb.datasets.itur_bt_2020.MATRIX_BT2020_TO_XYZ
+    ),
+    # 10: SMPTE ST 428-1 (DCDM, CIE 1931 XYZ as in ISO 11664-1)
+    ColourPrimaries_ITU_T_H273.SMPTE428: (
+        colour.models.rgb.datasets.dcdm_xyz.MATRIX_DCDM_XYZ_TO_XYZ
+    ),
+    # 11: SMPTE RP 431-2 (2011)
+    ColourPrimaries_ITU_T_H273.SMPTE431: (
+        colour.models.rgb.datasets.dci_p3.MATRIX_DCI_P3_TO_XYZ
+    ),
+    # 12: SMPTE EG 432-1 (2010)
+    ColourPrimaries_ITU_T_H273.SMPTE432: (
+        colour.models.rgb.datasets.p3_d65.MATRIX_P3_D65_TO_XYZ
+    ),
+    # 13-21: Reserved for future use
+    # 22: No corresponding industry specification
+    ColourPrimaries_ITU_T_H273.UNKNOWN22: (
+        colour.models.rgb.datasets.itut_h_273.MATRIX_ITUT_H273_22_RGB_TO_XYZ
+    ),
+    # 23-255: Reserved for future use
+}
+"""ColourPrimaries tag to RGB to XYZ matrices determined from primaries and
+whitepoints defined in ITU-T H.273 § 8.1"""
+
+
+MATRICES_XYZ_TO_ITU_T_H273_RGB = {
+    # 0: Reserved for future use
+    # 1: ITU-R BT.709-5, IEC 61966-2-1 sRGB or sYCC, IEC 61966-2-4, SMPTE RP177 Annex B
+    ColourPrimaries_ITU_T_H273.BT709: (
+        colour.models.rgb.datasets.itur_bt_709.MATRIX_XYZ_TO_BT709
+    ),
+    # 2: Unspecified
+    # 3: Reserved for future use
+    # 4: ITU-R BT.470-6 System M
+    ColourPrimaries_ITU_T_H273.BT470M: (
+        colour.models.rgb.datasets.itur_bt_470.MATRIX_XYZ_TO_BT470_525
+    ),
+    # 5: ITU-R BT.470-6 Systems BG, ITU-R BT.601-6 625
+    ColourPrimaries_ITU_T_H273.BT470BG: (
+        colour.models.rgb.datasets.itur_bt_470.MATRIX_XYZ_TO_BT470_625
+    ),
+    # 6: SMPTE 170M, ITU-R BT.601-6 525 (same as 7)
+    ColourPrimaries_ITU_T_H273.SMPTE170M: (
+        colour.models.rgb.datasets.smpte_240m.MATRIX_XYZ_TO_SMPTE_240M
+    ),
+    # 7: SMPTE 240M (same as 6)
+    ColourPrimaries_ITU_T_H273.SMPTE240M: (
+        colour.models.rgb.datasets.smpte_240m.MATRIX_XYZ_TO_SMPTE_240M
+    ),
+    # 8: Generic film (colour filters using Illuminant C)
+    ColourPrimaries_ITU_T_H273.FILM: (
+        colour.models.rgb.datasets.itut_h_273.MATRIX_XYZ_TO_FILM_C_RGB
+    ),
+    # 9: ITU-R BT.2020
+    ColourPrimaries_ITU_T_H273.BT2020: (
+        colour.models.rgb.datasets.itur_bt_2020.MATRIX_XYZ_TO_BT2020
+    ),
+    # 10: SMPTE ST 428-1 (DCDM, CIE 1931 XYZ as in ISO 11664-1)
+    ColourPrimaries_ITU_T_H273.SMPTE428: (
+        colour.models.rgb.datasets.dcdm_xyz.MATRIX_XYZ_TO_DCDM_XYZ
+    ),
+    # 11: SMPTE RP 431-2 (2011)
+    ColourPrimaries_ITU_T_H273.SMPTE431: (
+        colour.models.rgb.datasets.dci_p3.MATRIX_XYZ_TO_DCI_P3
+    ),
+    # 12: SMPTE EG 432-1 (2010)
+    ColourPrimaries_ITU_T_H273.SMPTE432: (
+        colour.models.rgb.datasets.p3_d65.MATRIX_XYZ_TO_P3_D65
+    ),
+    # 13-21: Reserved for future use
+    # 22: No corresponding industry specification
+    ColourPrimaries_ITU_T_H273.UNKNOWN22: (
+        colour.models.rgb.datasets.itut_h_273.MATRIX_XYZ_TO_ITUT_H273_22_RGB
+    ),
+    # 23-255: Reserved for future use
+}
+"""ColourPrimaries tag to XYZ to RGB matrices determined from primaries and
+whitepoints defined in ITU-T H.273 § 8.1"""
+
+
+TRANSFER_FUNCTIONS_ITU_T_H273 = {
+    # 0: Reserved for future use
+    # 1: ITU-R BT.709
+    TransferCharacteristics_ITU_T_H273.BT709: oetf_BT709,
+    # 2: Unspecified
+    # 3: Reserved for future use
+    # 4: Gamma 2.2 (also ITU-R BT470M / ITU-R BT1700 625 PAL & SECAM) (this is
+    # an inverse-EOTF)
+    TransferCharacteristics_ITU_T_H273.GAMMA22: eotf_inverse_gamma22,
+    # 5: Gamma 2.8 (also ITU-R BT470BG) (this is an inverse-EOTF)
+    TransferCharacteristics_ITU_T_H273.GAMMA28: eotf_inverse_gamma28,
+    # 6: SMPTE 170M (also ITU-R BT601-6 525 or 625 / ITU-R BT1358 525 or 625 /
+    # ITU-R BT1700 NTSC)
+    TransferCharacteristics_ITU_T_H273.SMPTE170M: oetf_BT601,
+    # 7: SMPTE 240M
+    TransferCharacteristics_ITU_T_H273.SMPTE240M: oetf_SMPTE240M,
+    # 8: Linear transfer characteristics (this is an OETF)
+    TransferCharacteristics_ITU_T_H273.LINEAR: oetf_linear,
+    # 9: Logarithmic transfer characteristic (100:1 range)
+    TransferCharacteristics_ITU_T_H273.LOG: oetf_log,
+    # 10: Logarithmic transfer characteristic (100 * Sqrt(10) : 1 range)
+    TransferCharacteristics_ITU_T_H273.LOG_SQRT: oetf_log_sqrt,
+    # 11: IEC 61966-2-4
+    TransferCharacteristics_ITU_T_H273.IEC61966_2_4: oetf_iec_61966_2_4,
+    # 12: ITU-R BT1361 Extended Colour Gamut
+    TransferCharacteristics_ITU_T_H273.BT1361_ECG: oetf_BT1361_extended,
+    # 13: IEC 61966-2-1 (sRGB or sYCC)
+    TransferCharacteristics_ITU_T_H273.IEC61966_2_1: oetf_iec_61966_2_1,
+    # 14: ITU-R BT2020 for 10-bit system
+    TransferCharacteristics_ITU_T_H273.BT2020_10: oetf_BT2020_10bit,
+    # 15: ITU-R BT2020 for 12-bit system
+    TransferCharacteristics_ITU_T_H273.BT2020_12: oetf_BT2020_12bit,
+    # 16: SMPTE ST 2084 (PQ, Perceptual Quantizer) for 10-, 12-, 14- and 16-bit systems
+    TransferCharacteristics_ITU_T_H273.SMPTE2084: eotf_inverse_ST2084,
+    # 17: SMPTE ST 428-1
+    TransferCharacteristics_ITU_T_H273.SMPTE428: eotf_inverse_ST428_1,
+    # 18: ARIB STD B67, also ITU-R BT.2100 HLG (Hybrid Log-Gamma), in [0-1] range
+    TransferCharacteristics_ITU_T_H273.ARIB_STD_B67: oetf_BT2100_HLG,
+}
+"""Mapping from TransferCharacteristics tag to transfer functions defined in
+ITU-T H.273 § 8.2
+
+Note that the standard contains both OETFs or inverse-EOTFs."""
+
+
+WEIGHTS_YCBCR_ITU_T_H273 = {}
+"""K_R and K_B coefficients for YCbCr conversion defined in ITU-T H.273 §8.3
+
+Notes
+-----
+
+Several values of MatrixCoefficients don't directly correspond to K_R and
+K_B values but instead have separate equations, which are not included in
+this mapping:
+
+- MatrixCoefficients_ITU_T_H273.YCGCO
+- MatrixCoefficients_ITU_T_H273.SMPTE2085
+- MatrixCoefficients_ITU_T_H273.CHROMA_DERIVED_NCL
+- MatrixCoefficients_ITU_T_H273.CHROMA_DERIVED_CL
+- MatrixCoefficients_ITU_T_H273.ICTCP
+"""
+
+WEIGHTS_YCBCR_ITU_T_H273[MatrixCoefficients_ITU_T_H273.RGB] = np.array(
+    [1.0, 1.0]
+)
+WEIGHTS_YCBCR_ITU_T_H273[
+    MatrixCoefficients_ITU_T_H273.BT709
+] = colour.models.rgb.ycbcr.WEIGHTS_YCBCR["ITU-R BT.709"]
+WEIGHTS_YCBCR_ITU_T_H273[MatrixCoefficients_ITU_T_H273.FCC] = np.array(
+    [0.30, 0.11]
+)
+WEIGHTS_YCBCR_ITU_T_H273[
+    MatrixCoefficients_ITU_T_H273.BT470BG
+] = colour.models.rgb.ycbcr.WEIGHTS_YCBCR["ITU-R BT.601"]
+WEIGHTS_YCBCR_ITU_T_H273[
+    MatrixCoefficients_ITU_T_H273.SMPTE170M
+] = colour.models.rgb.ycbcr.WEIGHTS_YCBCR["ITU-R BT.601"]
+# Note: The precision is different from WEIGHTS_YCBCR["ITU-R SMPTE-240M"]
+WEIGHTS_YCBCR_ITU_T_H273[MatrixCoefficients_ITU_T_H273.SMPTE240M] = np.array(
+    [0.212, 0.087]
+)
+WEIGHTS_YCBCR_ITU_T_H273[
+    MatrixCoefficients_ITU_T_H273.BT2020_NCL
+] = colour.models.rgb.ycbcr.WEIGHTS_YCBCR["ITU-R BT.2020"]
+WEIGHTS_YCBCR_ITU_T_H273[
+    MatrixCoefficients_ITU_T_H273.BT2020_CL
+] = colour.models.rgb.ycbcr.WEIGHTS_YCBCR["ITU-R BT.2020"]
+
+
+# Aliases for ISO/IEC 23091-2:2021. Verified to be functionally identical to ITU-T H.273
+# for the values defined here.
+ColourPrimaries_ISO23091_2 = ColourPrimaries_ITU_T_H273
+TransferCharacteristics_ISO23091_2 = TransferCharacteristics_ITU_T_H273
+MatrixCoefficients_ISO23091_2 = MatrixCoefficients_ITU_T_H273
+PRIMARIES_ISO23091_2 = PRIMARIES_ITU_T_H273
+WHITEPOINTS_NAMES_ISO23091_2 = WHITEPOINTS_NAMES_ITU_T_H273
+CCS_WHITEPOINTS_ISO23091_2 = CCS_WHITEPOINTS_ITU_T_H273
+MATRICES_ISO23091_2_RGB_TO_XYZ = MATRICES_ITU_T_H273_RGB_TO_XYZ
+MATRICES_XYZ_TO_ISO23091_2_RGB = MATRICES_XYZ_TO_ITU_T_H273_RGB
+TRANSFER_FUNCTIONS_ISO23091_2 = TRANSFER_FUNCTIONS_ITU_T_H273
+WEIGHTS_YCBCR_ISO23091_2 = WEIGHTS_YCBCR_ITU_T_H273
+
+
+@enum.unique
+class ColourPrimaries_ISO23001_8(enum.IntEnum):
+    """ColourPrimaries tags as defined in ISO/IEC 23001-8:2013 § 7.1.
+
+    The enumeration members use  the same names as ffmpeg `AVCOL_PRI_*` constants.
+    """
+
+    BT709 = 1  # also ITU-R BT1361 / IEC 61966-2-4 / SMPTE RP177 Annex B
+    BT470M = 4  # also FCC Title 47 Code of Federal Regulations 73.682 (a)(20)
+
+    # also ITU-R BT601-6 625 / ITU-R BT1358 625 / ITU-R BT1700 625 PAL & SECAM
+    BT470BG = 5
+
+    SMPTE170M = (
+        6  # also ITU-R BT601-6 525 / ITU-R BT1358 525 / ITU-R BT1700 NTSC
+    )
+    SMPTE240M = 7  # functionally identical to above
+    FILM = 8  # colour filters using Illuminant C
+    BT2020 = 9  # ITU-R BT2020
+    SMPTE428 = 10  # SMPTE ST 428-1 (CIE 1931 XYZ)
+    SMPTE431 = 11  # SMPTE ST 431-2 (2011) / DCI P3
+    SMPTE432 = 12  # SMPTE ST 432-1 (2010) / P3 D65 / Display P3
+
+    # Note: This corresponds to "AVCOL_PRI_EBU3213" in ffmpeg, but neither ITU-T
+    # H.273:2021 nor ISO/IEC 23091-2:2021 contain the same values as EBU Tech. 3213, nor
+    # do they refer to it directly (ColourPrimaries=22 contains the remark "No
+    # corresponding industry specification identified" in both cases).
+    #
+    # Since both ISO/IEC 23001-8:2013 and 14497-10:2020 do refer to EBU Tech 3213-E
+    # (1975) but contain the same primaries and whitepoint as the 2021 revisions, this
+    # is likely a error in the initial standards that was later discovered and
+    # corrected.
+    EBU3213 = 22
+
+
+# Aliases for ISO/IEC 23001-8:2013. Verified to be functionally identical to ITU-T H.273
+# for the values defined here, except for the remark regarding EBU Tech. 3213-E.
+TransferCharacteristics_ISO23001_8 = TransferCharacteristics_ITU_T_H273
+MatrixCoefficients_ISO23001_8 = MatrixCoefficients_ITU_T_H273
+PRIMARIES_ISO23001_8 = PRIMARIES_ITU_T_H273
+WHITEPOINTS_NAMES_ISO23001_8 = WHITEPOINTS_NAMES_ITU_T_H273
+CCS_WHITEPOINTS_ISO23001_8 = CCS_WHITEPOINTS_ITU_T_H273
+MATRICES_ISO23001_8_RGB_TO_XYZ = MATRICES_ITU_T_H273_RGB_TO_XYZ
+MATRICES_XYZ_TO_ISO23001_8_RGB = MATRICES_XYZ_TO_ITU_T_H273_RGB
+TRANSFER_FUNCTIONS_ISO23001_8 = TRANSFER_FUNCTIONS_ITU_T_H273
+WEIGHTS_YCBCR_ISO23001_8 = WEIGHTS_YCBCR_ITU_T_H273
+
+# Aliases for ISO/IEC 14496-10:2020. Verified to be functionally identical to ITU-T
+# H.273 for the values defined here, except for the remark regarding EBU Tech. 3213-E.
+ColourPrimaries_ISO14496_10 = ColourPrimaries_ISO23001_8
+TransferCharacteristics_ISO14496_10 = TransferCharacteristics_ITU_T_H273
+MatrixCoefficients_ISO14496_10 = MatrixCoefficients_ITU_T_H273
+PRIMARIES_ISO14496_10 = PRIMARIES_ITU_T_H273
+WHITEPOINTS_NAMES_ISO14496_10 = WHITEPOINTS_NAMES_ITU_T_H273
+CCS_WHITEPOINTS_ISO14496_10 = CCS_WHITEPOINTS_ITU_T_H273
+MATRICES_ISO14496_10_RGB_TO_XYZ = MATRICES_ITU_T_H273_RGB_TO_XYZ
+MATRICES_XYZ_TO_ISO14496_10_RGB = MATRICES_XYZ_TO_ITU_T_H273_RGB
+TRANSFER_FUNCTIONS_ISO14496_10 = TRANSFER_FUNCTIONS_ITU_T_H273
+WEIGHTS_YCBCR_ISO14496_10 = WEIGHTS_YCBCR_ITU_T_H273


### PR DESCRIPTION
<!--
Thank you for taking the time to create this pull request. If it is the first
time you are contributing to a colour-science repository, a contributing guide
is available to guide the process: https://www.colour-science.org/contributing/.
-->

# Summary

This implements what's discussed in #982.

I tried to stick as close to the original ISO standard as possible, but there are a few caveats:

- Some sets of primaries/whitepionts as well as transfer functions were not already present in colour ; I implemented them here based on the ISO standard in this module and added the necessary references.
- The ISO standard is not very clear on the values of alpha, beta and gamma for ITU-R BT.1361, so I chose instead to implement the OETF based on that standard.
- I'm not very certain of how I should implement EOTFs/OETFs when the range is not [0-1] (e.g. BT.1361, which has an extended range). Is there any consensus on that? How is it usually documented?
- I linked the RGB <-> XYZ matrices from the original module in colour even though they are not defined explicitly in the ISO standard, just because it makes things more consistent with how the original modules in `colour.models.rgb.datasets` work. Let me know if this is not needed.

# Preflight

**Personal todo**
- [x] Verify that ISO 23001-8:2013 aligns with ISO 23091-2
- [x] Verify that ISO 23001-8:2013 aligns with ITU-T H.273
- [x] Verify that ISO [14496-10:2020](https://standards.iso.org/ittf/PubliclyAvailableStandards/index.html) aligns with the rest
- [x] Finish updating the doctests/examples
- [x] Finish adding typing hints

**Code Style and Quality**

- [x] Unit tests have been implemented and passed.
- [x] Mypy static checking has been run and passed.
- [x] Pre-commit hooks have been run and passed.
- [ ] New transformations have been added to the *Automatic Colour Conversion Graph*.
- [x] New transformations have been exported to the relevant namespaces, e.g. `colour`, `colour.models`.

<!-- The unit tests can be invoked with `poetry run invoke tests` -->
<!-- Mypy can be started with `dmypy run -- --show-error-codes --warn-unused-ignores --warn-redundant-casts --install-types --non-interactive -p colour` -->

**Documentation**

- [x] New features are documented along with examples if relevant.
- [x] The documentation is [Sphinx](https://www.sphinx-doc.org/en/master/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant.

<!--
Thank you again!
-->
