### PR TITLE
Feature/tjd test improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ docs/_static/Tutorial_*.png
 docs/generated
 poetry.lock
 references
+
+.vscode/

--- a/colour/plotting/conftest.py
+++ b/colour/plotting/conftest.py
@@ -1,0 +1,29 @@
+"""
+Plotting - Tests
+================
+Configures pytest to use the AGG headless backend. This allows the plotting
+unittests to run without creating windows in IDEs such as VSCode.
+"""
+import pytest
+import matplotlib
+
+__author__ = "Colour Developers"
+__copyright__ = "Copyright 2013 Colour Developers"
+__license__ = "New BSD License - https://opensource.org/licenses/BSD-3-Clause"
+__maintainer__ = "Colour Developers"
+__email__ = "colour-developers@colour-science.org"
+__status__ = "Production"
+
+
+@pytest.fixture(autouse=True, scope="session")
+def mplHeadlessBackend() -> None:
+    """
+    Configure matplotlib for headless testing.
+
+    pytest Fixture automatically applied to any tests in this package or any
+    subpackages at the beginning of the pytest session.
+    """
+    curBackend = matplotlib.get_backend()
+    matplotlib.use("AGG")
+    yield
+    matplotlib.use(curBackend)

--- a/colour/plotting/conftest.py
+++ b/colour/plotting/conftest.py
@@ -4,6 +4,7 @@ Plotting - Tests
 Configures pytest to use the AGG headless backend. This allows the plotting
 unittests to run without creating windows in IDEs such as VSCode.
 """
+from typing import Generator
 import pytest
 import matplotlib
 
@@ -16,7 +17,7 @@ __status__ = "Production"
 
 
 @pytest.fixture(autouse=True, scope="session")
-def mplHeadlessBackend() -> None:
+def mplHeadlessBackend() -> Generator[None, None, None]:
     """
     Configure matplotlib for headless testing.
 

--- a/colour/volume/tests/test_spectrum.py
+++ b/colour/volume/tests/test_spectrum.py
@@ -3,7 +3,7 @@
 
 import numpy as np
 import unittest
-from itertools import permutations
+from itertools import product
 
 from colour.colorimetry import (
     MSDS_CMFS,
@@ -243,9 +243,9 @@ class TestIsWithinVisibleSpectrum(unittest.TestCase):
         """
 
         cases = [-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan]
-        cases = set(permutations(cases * 3, r=3))
-        for case in cases:
-            is_within_visible_spectrum(case)
+        cases = set(product(cases, repeat=3)) - {(0, 0, 0)}
+        isVisible = is_within_visible_spectrum(list(cases))
+        assert all(~isVisible)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ sphinx = { version = ">= 4, < 5", optional = true }  # Development dependency.
 sphinxcontrib-bibtex = { version = "*", optional = true }  # Development dependency.
 toml = { version = "*", optional = true }  # Development dependency.
 twine = { version = "*", optional = true }  # Development dependency.
+pytest-xdist = { version = "^2.5.0", optional = true } #Development dependency.
 
 [tool.poetry.dev-dependencies]
 biblib-simple = "*"
@@ -157,6 +158,9 @@ ignore_missing_imports = true
 [tool.pydocstyle]
 convention = "numpy"
 add-ignore = "D104,D200,D202,D205,D301,D400"
+
+[tool.pytest.ini_options]
+addopts = "-n auto --durations=5"
 
 [build-system]
 requires = [ "poetry_core>=1.0.0" ]

--- a/tasks.py
+++ b/tasks.py
@@ -245,12 +245,11 @@ def tests(ctx: Context):
 
     message_box('Running "Pytest"...')
     ctx.run(
-        "py.test "
+        "pytest "
         "--disable-warnings "
         "--doctest-modules "
         f"--ignore={PYTHON_PACKAGE_NAME}/examples "
-        f"{PYTHON_PACKAGE_NAME}",
-        env={"MPLBACKEND": "AGG"},
+        f"{PYTHON_PACKAGE_NAME}"
     )
 
 


### PR DESCRIPTION
# Summary

This is a first contribution PR mainly to practice the branching, PR, testing, and general development tools of colour-science. It contains some minor changes to the testing infrastructure. It also improves the developer experience using vscode. 

* The tasks.py uses `pytest` instead of `pytest` (deprecated). 
* `matplotlib` is configured into headless mode with a pytest fixture instead of an environment variable (improves usability of vscode testing tools).
* The testing task lists the 5 longest duration tests (good to be mindful)
* One extremely long running test has been reduced from 4 minutes to a few seconds (MBP2020 4-core i5)
* Test run on multiple workers by default with pytest-xdist

# Preflight

**Code Style and Quality**

- [x] Unit tests have been implemented and passed.
- [x] Mypy static checking has been run and passed.
- [x] Pre-commit hooks have been run and passed.
- [N/A] New transformations have been added to the *Automatic Colour Conversion Graph*.
- [N/A] New transformations have been exported to the relevant namespaces, e.g. `colour`, `colour.models`.

**Documentation**

- [x] New features are documented along with examples if relevant.
- [ ] The documentation is [Sphinx](https://www.sphinx-doc.org/en/master/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant.

<!--
Thank you again!
-->
