### PR TITLE
Feature/tm2714 bandwidth fixes

### DIFF
--- a/colour/io/tm2714.py
+++ b/colour/io/tm2714.py
@@ -953,7 +953,9 @@ class SpectralDistribution_IESTM2714(SpectralDistribution):
                     Element_Specification_IESTM2714(
                         "BandwidthFWHM",
                         "bandwidth_FWHM",
-                        read_conversion=as_float_scalar,
+                        read_conversion=(
+                            lambda x: None if x == "None" else as_float_scalar(x)
+                        ),
                     ),
                     Element_Specification_IESTM2714(
                         "BandwidthCorrected",
@@ -962,7 +964,7 @@ class SpectralDistribution_IESTM2714(SpectralDistribution):
                             lambda x: True if x == "true" else False
                         ),
                         write_conversion=(
-                            lambda x: "true" if x is True else "False"
+                            lambda x: "true" if x is True else "false"
                         ),
                     ),
                 ),

--- a/colour/io/tm2714.py
+++ b/colour/io/tm2714.py
@@ -954,7 +954,9 @@ class SpectralDistribution_IESTM2714(SpectralDistribution):
                         "BandwidthFWHM",
                         "bandwidth_FWHM",
                         read_conversion=(
-                            lambda x: None if x == "None" else as_float_scalar(x)
+                            lambda x: None
+                            if x == "None"
+                            else as_float_scalar(x)
                         ),
                     ),
                     Element_Specification_IESTM2714(


### PR DESCRIPTION
<!--
Thank you for taking the time to create this pull request. If it is the first
time you are contributing to a colour-science repository, a contributing guide
is available to guide the process: https://www.colour-science.org/contributing/.
-->

# Summary

This fixes two suboptimalities with colour/io/tm2714.py's SpectralDistribution_IESTM2714 class: the existing code crashes reading a .spdx file with a value of None for BandwidthFWHM, and the existing code is inconsistent in its case when writing out BandwidthCorrected - it writes true and False instead of true and false.

# Preflight

<!-- Please mark any checkboxes that do not apply to this pull request as [N/A]. -->

**Code Style and Quality**

- [ N/A ] Unit tests have been implemented and passed.
- [ N/A ] Mypy static checking has been run and passed.
- [ X ] Pre-commit hooks have been run and passed.
- [ N/A ] New transformations have been added to the *Automatic Colour Conversion Graph*.
- [ N/A ] New transformations have been exported to the relevant namespaces, e.g. `colour`, `colour.models`.

<!-- The unit tests can be invoked with `poetry run invoke tests` -->
<!-- Mypy can be started with `dmypy run -- --show-error-codes --warn-unused-ignores --warn-redundant-casts --install-types --non-interactive -p colour` -->

**Documentation**

- [ N/A ] New features are documented along with examples if relevant.
- [ N/A ] The documentation is [Sphinx](https://www.sphinx-doc.org/en/master/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant.

<!--
Thank you again!
-->
