### PR TITLE
PR: Revert (partially) "Implement support for "Hellwig, Stolitzka  and Fairchild (2022)" "Helmholtz–Kohlrausch" effect extension."

### DIFF
--- a/BIBLIOGRAPHY.bib
+++ b/BIBLIOGRAPHY.bib
@@ -1,3212 +1,3875 @@
-
-@article{Abebe2017,
-  title = {Perceptual {{Lightness Modeling}} for {{High-Dynamic-Range Imaging}}},
-  author = {Abebe, Mekides Assefa and Pouli, Tania and Larabi, Mohamed-Chaker and Reinhard, Erik},
-  year = {2017},
-  month = jul,
-  journal = {ACM Transactions on Applied Perception},
-  volume = {15},
-  number = {1},
-  pages = {1--19},
-  issn = {15443558},
-  doi = {10.1145/3086577},
-  abstract = {\textcopyright{} 2017 ACM. The human visual system (HVS) non-linearly processes light from the real world, allowing us to perceive detail over a wide range of illumination. Although models that describe this non-linearity are constructed based on psycho-visual experiments, they generally apply to a limited range of illumination and therefore may not fully explain the behavior of theHVS under more extreme illumination conditions. We propose a modified experimental protocol for measuring visual responses to emissive stimuli that do not require participant training, nor requiring the exclusion of non-expert participants. Furthermore, the protocol can be applied to stimuli covering an extended luminance range. Based on the outcome of our experiment, we propose a new model describing lightness response over an extended luminance range. The model can be integrated with existing color appearance models or perceptual color spaces. To demonstrate the effectiveness of our model in high dynamic range applications, we evaluate its suitability for dynamic range expansion relative to existing solutions.},
-  file = {/Users/kelsolaar/Zotero/storage/PVZGMBRZ/Abebe et al. - 2017 - Perceptual Lightness Modeling for High-Dynamic-Ran.pdf;/Users/kelsolaar/Zotero/storage/V33CXH9X/Abebe et al. - 2017 - Perceptual Lightness Modeling for High-Dynamic-Range Imaging.pdf}
-}
-
-@misc{AdobeSystems2005a,
-  title = {Adobe {{RGB}} (1998) {{Color Image Encoding}}},
-  author = {{Adobe Systems}},
-  year = {2005},
-  file = {/Users/kelsolaar/Zotero/storage/Y9MJZ34N/Adobe Systems - 2005 - Adobe RGB (1998) Color Image Encoding.pdf}
-}
-
-@misc{AdobeSystems2013,
-  title = {Adobe {{DNG Software Development Kit}} ({{SDK}}) - 1.3.0.0 - Dng\_sdk\_1\_3/Dng\_sdk/Source/Dng\_temperature.Cpp::Dng\_temperature::{{Set}}\_xy\_coord},
-  author = {{Adobe Systems}},
-  year = {2013}
-}
-
-@misc{AdobeSystems2013a,
-  title = {Adobe {{DNG Software Development Kit}} ({{SDK}}) - 1.3.0.0 - Dng\_sdk\_1\_3/Dng\_sdk/Source/Dng\_temperature.Cpp::Dng\_temperature::Xy\_coord},
-  author = {{Adobe Systems}},
-  year = {2013}
-}
-
-@misc{AdobeSystems2013b,
-  title = {Cube {{LUT Specification}}},
-  author = {{Adobe Systems}},
-  year = {2013},
-  keywords = {Iridas,look-up table,specification},
-  file = {/Users/kelsolaar/Zotero/storage/LLPBPADA/Adobe Systems - 2013 - Cube LUT Specification.pdf}
-}
-
 @misc{ANSI2003a,
-  title = {Specification of {{ROMM RGB}}},
-  author = {{ANSI}},
-  year = {2003},
-  pages = {1--2},
-  file = {/Users/kelsolaar/Zotero/storage/HKFYZ5YF/ANSI - 2003 - Specification of ROMM RGB.pdf}
+  title        = {Specification of {{ROMM RGB}}},
+  author       = {{ANSI}},
+  year         = 2003,
+  pages        = {1--2},
 }
-
 @book{ANSI2018,
-  title = {{{ANSI}}/{{IES TM-30-18}} - {{IES Method}} for {{Evaluating Light Source Color Rendition}}},
-  author = {{ANSI} and {IES Color Committee}},
-  year = {2018},
-  publisher = {{ANSI/IES}},
-  isbn = {978-0-87995-379-9},
-  file = {/Users/kelsolaar/Zotero/storage/GIU9NWLP/TM-30-18_tools_etc.zip;/Users/kelsolaar/Zotero/storage/JZHTHWRW/ANSI and IES Color Committee - ANSIIES TM-30-18 - IES Method for Evaluating Ligh.pdf}
+  title        = {{{ANSI}}/{{IES TM-30-18}} - {{IES Method}} for
+    {{Evaluating Light Source Color Rendition}}},
+  author       = {{ANSI} and {IES Color Committee}},
+  year         = 2018,
+  publisher    = {{ANSI/IES}},
+  isbn         = {978-0-87995-379-9},
 }
-
-@misc{AppleInc.2019,
-  title = {{{displayP3}}},
-  author = {{Apple Inc.}},
-  year = {2019},
-  howpublished = {https://developer.apple.com/documentation/coregraphics/cgcolorspace/1408916-displayp3}
-}
-
 @misc{ARRI2012a,
-  title = {{{ALEXA}} - {{Log C Curve}} - {{Usage}} in {{VFX}}},
-  author = {{ARRI}},
-  year = {2012},
-  file = {/Users/kelsolaar/Zotero/storage/JIDE329W/ARRI - 2012 - ALEXA - Log C Curve - Usage in VFX.pdf}
+  title        = {{{ALEXA}} - {{Log C Curve}} - {{Usage}} in {{VFX}}},
+  author       = {{ARRI}},
+  year         = 2012,
 }
-
-@misc{AssociationofRadioIndustriesandBusinesses2015a,
-  title = {Essential {{Parameter Values}} for the {{Extended Image Dynamic Range Television}} ({{EIDRTV}}) {{System}} for {{Programme Production}}},
-  author = {{Association of Radio Industries and Businesses}},
-  year = {2015},
-  file = {/Users/kelsolaar/Zotero/storage/UK6PZDJ4/Association of Radio Industries and Businesses - 2015 - Essential Parameter Values for the Extended Image Dynamic Range Television (EIDR.pdf}
-}
-
 @misc{ASTMInternational1989a,
-  title = {{{ASTM D1535-89}} - {{Standard Practice}} for {{Specifying Color}} by the {{Munsell System}}},
-  author = {{ASTM International}},
-  year = {1989},
-  pages = {1--29},
-  keywords = {color,D1535,Munsell,Munsell color order system,Munsell notation},
-  file = {/Users/kelsolaar/Zotero/storage/L25FKG5G/ASTM International - 1989 - ASTM D1535-89 - Standard Practice for Specifying Color by the Munsell System.pdf}
+  title        = {{{ASTM D1535-89}} - {{Standard Practice}} for
+    {{Specifying Color}} by the {{Munsell System}}},
+  author       = {{ASTM International}},
+  year         = 1989,
+  pages        = {1--29},
+  keywords     = {color,D1535,Munsell,Munsell color order
+    system,Munsell notation},
 }
-
 @misc{ASTMInternational2007,
-  title = {{{ASTM D2244-07}} - {{Standard Practice}} for {{Calculation}} of {{Color Tolerances}} and {{Color Differences}} from {{Instrumentally Measured Color Coordinates}}},
-  author = {{ASTM International}},
-  year = {2007},
-  volume = {i},
-  pages = {1--10},
-  doi = {10.1520/D2244-16},
-  file = {/Users/kelsolaar/Zotero/storage/XJCF7QV3/ASTM International - 2007 - ASTM D2244-07 - Standard Practice for Calculation of Color Tolerances and Color Differences from Instrumenta.pdf}
+  title        = {{{ASTM D2244-07}} - {{Standard Practice}} for
+    {{Calculation}} of {{Color Tolerances}} and {{Color Differences}}
+    from {{Instrumentally Measured Color Coordinates}}},
+  author       = {{ASTM International}},
+  year         = 2007,
+  volume       = {i},
+  pages        = {1--10},
+  doi          = {10.1520/D2244-16},
 }
-
 @misc{ASTMInternational2008a,
-  title = {{{ASTM D1535-08e1}} - {{Standard Practice}} for {{Specifying Color}} by the {{Munsell System}}},
-  author = {{ASTM International}},
-  year = {2008},
-  doi = {10.1520/D1535-08E01}
+  title        = {{{ASTM D1535-08e1}} - {{Standard Practice}} for
+    {{Specifying Color}} by the {{Munsell System}}},
+  author       = {{ASTM International}},
+  year         = 2008,
+  doi          = {10.1520/D1535-08E01},
 }
-
 @misc{ASTMInternational2011a,
-  title = {{{ASTM E2022-11}} - {{Standard Practice}} for {{Calculation}} of {{Weighting Factors}} for {{Tristimulus Integration}}},
-  author = {{ASTM International}},
-  year = {2011},
-  pages = {1--10},
-  doi = {10.1520/E2022-11},
-  abstract = {This standard is issued under the fixed designation E2022; the number immediately following the designation indicates the year of original adoption or, in the case of revision, the year of last revision. A number in parentheses indicates the year of last reapproval. A superscript epsilon) indicates an editorial change since the last revision or reapproval.},
-  file = {/Users/kelsolaar/Zotero/storage/YAYJ5HAI/ASTM International - 2011 - ASTM E2022-11 - Standard Practice for Calculation of Weighting Factors for Tristimulus Integration.pdf}
+  title        = {{{ASTM E2022-11}} - {{Standard Practice}} for
+    {{Calculation}} of {{Weighting Factors}} for {{Tristimulus
+    Integration}}},
+  author       = {{ASTM International}},
+  year         = 2011,
+  pages        = {1--10},
+  doi          = {10.1520/E2022-11},
+  abstract     = {This standard is issued under the fixed designation
+    E2022; the number immediately following the designation indicates
+    the year of original adoption or, in the case of revision, the
+    year of last revision. A number in parentheses indicates the year
+    of last reapproval. A superscript epsilon) indicates an editorial
+    change since the last revision or reapproval.},
 }
-
 @misc{ASTMInternational2015,
-  title = {{{ASTM E313-15e1}} - {{Standard Practice}} for {{Calculating Yellowness}} and {{Whiteness Indices}} from {{Instrumentally Measured Color Coordinates}}},
-  author = {{ASTM International}},
-  year = {2015},
-  doi = {10.1520/E0313-20},
-  file = {/Users/kelsolaar/Zotero/storage/WXZIPWTS/ASTM International - ASTM E313-15e1 - Standard Practice for Calculating.pdf}
+  title        = {{{ASTM E313-15e1}} - {{Standard Practice}} for
+    {{Calculating Yellowness}} and {{Whiteness Indices}} from
+    {{Instrumentally Measured Color Coordinates}}},
+  author       = {{ASTM International}},
+  year         = 2015,
+  doi          = {10.1520/E0313-20},
 }
-
 @misc{ASTMInternational2015b,
-  title = {{{ASTM E308-15}} - {{Standard Practice}} for {{Computing}} the {{Colors}} of {{Objects}} by {{Using}} the {{CIE System}}},
-  author = {{ASTM International}},
-  year = {2015},
-  pages = {1--47},
-  doi = {10.1520/E0308-15},
-  file = {/Users/kelsolaar/Zotero/storage/6NCHYYI5/ASTM International - 2015 - ASTM E308-15 - Standard Practice for Computing the Colors of Objects by Using the CIE System.pdf}
+  title        = {{{ASTM E308-15}} - {{Standard Practice}} for
+    {{Computing}} the {{Colors}} of {{Objects}} by {{Using}} the {{CIE
+    System}}},
+  author       = {{ASTM International}},
+  year         = 2015,
+  pages        = {1--47},
+  doi          = {10.1520/E0308-15},
 }
-
+@article{Abebe2017,
+  title        = {Perceptual {{Lightness Modeling}} for
+    {{High-Dynamic-Range Imaging}}},
+  author       = {Abebe, Mekides Assefa and Pouli, Tania and Larabi,
+    Mohamed-Chaker and Reinhard, Erik},
+  year         = 2017,
+  month        = jul,
+  journal      = {ACM Transactions on Applied Perception},
+  volume       = 15,
+  number       = 1,
+  pages        = {1--19},
+  issn         = 15443558,
+  doi          = {10.1145/3086577},
+  abstract     = {\textcopyright{} 2017 ACM. The human visual system
+    (HVS) non-linearly processes light from the real world, allowing
+    us to perceive detail over a wide range of illumination. Although
+    models that describe this non-linearity are constructed based on
+    psycho-visual experiments, they generally apply to a limited range
+    of illumination and therefore may not fully explain the behavior
+    of theHVS under more extreme illumination conditions. We propose a
+    modified experimental protocol for measuring visual responses to
+    emissive stimuli that do not require participant training, nor
+    requiring the exclusion of non-expert participants. Furthermore,
+    the protocol can be applied to stimuli covering an extended
+    luminance range. Based on the outcome of our experiment, we
+    propose a new model describing lightness response over an extended
+    luminance range. The model can be integrated with existing color
+    appearance models or perceptual color spaces. To demonstrate the
+    effectiveness of our model in high dynamic range applications, we
+    evaluate its suitability for dynamic range expansion relative to
+    existing solutions.},
+}
+@misc{AdobeSystems2005a,
+  title        = {Adobe {{RGB}} (1998) {{Color Image Encoding}}},
+  author       = {{Adobe Systems}},
+  year         = 2005,
+}
+@misc{AdobeSystems2013,
+  title        = {Adobe {{DNG Software Development Kit}} ({{SDK}}) -
+    1.3.0.0 -
+    Dng\_sdk\_1\_3/Dng\_sdk/Source/Dng\_temperature.Cpp::Dng\_temperature::{{Set}}\_xy\_coord},
+  author       = {{Adobe Systems}},
+  year         = 2013,
+}
+@misc{AdobeSystems2013a,
+  title        = {Adobe {{DNG Software Development Kit}} ({{SDK}}) -
+    1.3.0.0 -
+    Dng\_sdk\_1\_3/Dng\_sdk/Source/Dng\_temperature.Cpp::Dng\_temperature::Xy\_coord},
+  author       = {{Adobe Systems}},
+  year         = 2013,
+}
+@misc{AdobeSystems2013b,
+  title        = {Cube {{LUT Specification}}},
+  author       = {{Adobe Systems}},
+  year         = 2013,
+  keywords     = {Iridas,look-up table,specification},
+}
+@misc{AppleInc.2019,
+  title        = {{{displayP3}}},
+  author       = {{Apple Inc.}},
+  year         = 2019,
+  howpublished = {https://developer.apple.com/documentation/coregraphics/cgcolorspace/1408916-displayp3},
+}
+@misc{AssociationofRadioIndustriesandBusinesses2015a,
+  title        = {Essential {{Parameter Values}} for the {{Extended
+    Image Dynamic Range Television}} ({{EIDRTV}}) {{System}} for
+    {{Programme Production}}},
+  author       = {{Association of Radio Industries and Businesses}},
+  year         = 2015,
+}
 @misc{BabelColor2012b,
-  title = {The {{ColorChecker}} (since 1976!)},
-  author = {{BabelColor}},
-  year = {2012},
-  howpublished = {http://www.babelcolor.com/main\_level/ColorChecker.htm}
+  title        = {The {{ColorChecker}} (since 1976!)},
+  author       = {{BabelColor}},
+  year         = 2012,
+  howpublished = {http://www.babelcolor.com/main\_level/ColorChecker.htm},
 }
-
 @misc{BabelColor2012c,
-  title = {{{ColorChecker RGB}} and Spectra},
-  author = {{BabelColor}},
-  year = {2012},
-  file = {/Users/kelsolaar/Zotero/storage/BASARME2/BabelColor - 2012 - ColorChecker RGB and spectra.xls}
+  title        = {{{ColorChecker RGB}} and Spectra},
+  author       = {{BabelColor}},
+  year         = 2012,
 }
-
 @book{Barten1999,
-  title = {Contrast {{Sensitivity}} of the {{Human Eye}} and {{Its Effects}} on {{Image Quality}}},
-  author = {Barten, Peter G.},
-  year = {1999},
-  month = dec,
-  number = {1999},
-  publisher = {{SPIE}},
-  issn = {10924388},
-  doi = {10.1117/3.353254},
-  isbn = {978-0-8194-7849-8},
-  pmid = {18723593},
-  file = {/Users/kelsolaar/Zotero/storage/A35HIELA/Barten - 1999 - Contrast Sensitivity of the Human Eye and Its Effects on Image Quality.pdf}
+  title        = {Contrast {{Sensitivity}} of the {{Human Eye}} and
+    {{Its Effects}} on {{Image Quality}}},
+  author       = {Barten, Peter G.},
+  year         = 1999,
+  month        = dec,
+  number       = 1999,
+  publisher    = {{SPIE}},
+  issn         = 10924388,
+  doi          = {10.1117/3.353254},
+  isbn         = {978-0-8194-7849-8},
+  pmid         = 18723593,
 }
-
 @inproceedings{Barten2003,
-  title = {Formula for the Contrast Sensitivity of the Human Eye},
-  booktitle = {Proceedings of {{SPIE}}},
-  author = {Barten, Peter G. J.},
-  editor = {Miyake, Yoichi and Rasmussen, D. Rene},
-  year = {2003},
-  month = dec,
-  volume = {5294},
-  pages = {231--238},
-  issn = {0277786X},
-  doi = {10.1117/12.537476},
-  abstract = {The contrast sensitivity of the human eye and its dependence on luminance and display size is described on the basis of internal noise in the visual system. With the addition of a global description of the optical MTF of the eye, a complete physical model is presented for the spatial contrast sensitivity function. Calculation results obtained with this model are compared with measurements published in literature.},
-  isbn = {0-8194-3496-5},
-  keywords = {contrast sensitivity,csf,human eye,orientation angle,standard observer,surround luminance}
+  title        = {Formula for the Contrast Sensitivity of the Human
+    Eye},
+  booktitle    = {Proceedings of {{SPIE}}},
+  author       = {Barten, Peter G. J.},
+  editor       = {Miyake, Yoichi and Rasmussen, D. Rene},
+  year         = 2003,
+  month        = dec,
+  volume       = 5294,
+  pages        = {231--238},
+  issn         = {0277786X},
+  doi          = {10.1117/12.537476},
+  abstract     = {The contrast sensitivity of the human eye and its
+    dependence on luminance and display size is described on the basis
+    of internal noise in the visual system. With the addition of a
+    global description of the optical MTF of the eye, a complete
+    physical model is presented for the spatial contrast sensitivity
+    function. Calculation results obtained with this model are
+    compared with measurements published in literature.},
+  isbn         = {0-8194-3496-5},
+  keywords     = {contrast sensitivity,csf,human eye,orientation
+    angle,standard observer,surround luminance},
 }
-
 @article{Bianco2010a,
-  title = {Two New von {{Kries}} Based Chromatic Adaptation Transforms Found by Numerical Optimization},
-  author = {Bianco, S. and Schettini, R.},
-  year = {2010},
-  month = jun,
-  journal = {Color Research \& Application},
-  volume = {35},
-  number = {3},
-  pages = {184--192},
-  issn = {03612317},
-  doi = {10.1002/col.20573},
-  file = {/Users/kelsolaar/Zotero/storage/9MT6YK3T/Bianco, Schettini - 2010 - Two new von Kries based chromatic adaptation transforms found by numerical optimization.pdf}
+  title        = {Two New von {{Kries}} Based Chromatic Adaptation
+    Transforms Found by Numerical Optimization},
+  author       = {Bianco, S. and Schettini, R.},
+  year         = 2010,
+  month        = jun,
+  journal      = {Color Research \& Application},
+  volume       = 35,
+  number       = 3,
+  pages        = {184--192},
+  issn         = 03612317,
+  doi          = {10.1002/col.20573},
 }
-
 @misc{BlackmagicDesign2020,
-  title = {{{DaVinci Wide Gamut}} - {{DaVinci Resolve Studio}} 17 {{Public Beta}} 1},
-  author = {{Blackmagic Design}},
-  year = {2020},
-  month = nov
+  title        = {{{DaVinci Wide Gamut}} - {{DaVinci Resolve Studio}}
+    17 {{Public Beta}} 1},
+  author       = {{Blackmagic Design}},
+  year         = 2020,
+  month        = nov,
 }
-
 @misc{BlackmagicDesign2020a,
-  title = {Wide {{Gamut Intermediate DaVinci Resolve}}},
-  author = {{Blackmagic Design}},
-  year = {2020},
-  file = {/Users/kelsolaar/Zotero/storage/QRUMYRLW/Blackmagic Design - 2020 - Wide Gamut Intermediate DaVinci Resolve.pdf}
+  title        = {Wide {{Gamut Intermediate DaVinci Resolve}}},
+  author       = {{Blackmagic Design}},
+  year         = 2020,
 }
-
 @misc{BlackmagicDesign2021,
-  title = {Blackmagic {{Generation}} 5 {{Color Science}}},
-  author = {{Blackmagic Design}},
-  year = {2021},
-  file = {/Users/kelsolaar/Zotero/storage/UHWCNCMJ/Blackmagic Design - 2021 - Blackmagic Generation 5 Color Science.pdf}
+  title        = {Blackmagic {{Generation}} 5 {{Color Science}}},
+  author       = {{Blackmagic Design}},
+  year         = 2021,
 }
-
 @article{Bodhaine1999a,
-  title = {On {{Rayleigh Optical Depth Calculations}}},
-  author = {Bodhaine, Barry A. and Wood, Norman B. and Dutton, Ellsworth G. and Slusser, James R.},
-  year = {1999},
-  month = nov,
-  journal = {Journal of Atmospheric and Oceanic Technology},
-  volume = {16},
-  number = {11},
-  pages = {1854--1861},
-  issn = {0739-0572},
-  doi = {10.1175/1520-0426(1999)016<1854:ORODC>2.0.CO;2},
-  abstract = {Many different techniques are used for the calculation of Rayleigh optical depth in the atmosphere. In some cases differences among these techniques can be important, especially in the UV region of the spectrum and under clean atmospheric conditions. The authors recommend that the calculation of Rayleigh optical depth be approached by going back to the first principles of Rayleigh scattering theory rather than the variety of curve- fitting techniques currently in use. A survey of the literature was conducted in order to determine the latest values of the physical constants necessary and to review the methods available for the calculation of Rayleigh optical depth. The recommended approach requires the accurate calculation of the refractive index of air based on the latest published measurements. Calculations estimating Rayleigh optical depth should be done as accurately as possible because the inaccuracies that arise can equal or even exceed other quantities being estimated, such as aerosol optical depth, particularly in the UV region of the spectrum. All of the calculations are simple enough to be done easily in a spreadsheet.},
-  file = {/Users/kelsolaar/Zotero/storage/GP3Y5RGW/Bodhaine et al. - 1999 - On Rayleigh Optical Depth Calculations.pdf}
+  title        = {On {{Rayleigh Optical Depth Calculations}}},
+  author       = {Bodhaine, Barry A. and Wood, Norman B. and Dutton,
+    Ellsworth G. and Slusser, James R.},
+  year         = 1999,
+  month        = nov,
+  journal      = {Journal of Atmospheric and Oceanic Technology},
+  volume       = 16,
+  number       = 11,
+  pages        = {1854--1861},
+  issn         = {0739-0572},
+  doi          = {10.1175/1520-0426(1999)016<1854:ORODC>2.0.CO;2},
+  abstract     = {Many different techniques are used for the
+    calculation of Rayleigh optical depth in the atmosphere. In some
+    cases differences among these techniques can be important,
+    especially in the UV region of the spectrum and under clean
+    atmospheric conditions. The authors recommend that the calculation
+    of Rayleigh optical depth be approached by going back to the first
+    principles of Rayleigh scattering theory rather than the variety
+    of curve- fitting techniques currently in use. A survey of the
+    literature was conducted in order to determine the latest values
+    of the physical constants necessary and to review the methods
+    available for the calculation of Rayleigh optical depth. The
+    recommended approach requires the accurate calculation of the
+    refractive index of air based on the latest published
+    measurements. Calculations estimating Rayleigh optical depth
+    should be done as accurately as possible because the inaccuracies
+    that arise can equal or even exceed other quantities being
+    estimated, such as aerosol optical depth, particularly in the UV
+    region of the spectrum. All of the calculations are simple enough
+    to be done easily in a spreadsheet.},
 }
-
 @misc{Borer2017a,
-  title = {Private {{Discussion}} with {{Mansencal}}, {{T}}. and {{Shaw}}, {{N}}.},
-  author = {Borer, Tim},
-  year = {2017}
+  title        = {Private {{Discussion}} with {{Mansencal}}, {{T}}.
+    and {{Shaw}}, {{N}}.},
+  author       = {Borer, Tim},
+  year         = 2017,
 }
-
 @misc{Bourkea,
-  title = {Intersection Point of Two Line Segments in 2 Dimensions},
-  author = {Bourke, Paul},
-  howpublished = {http://paulbourke.net/geometry/pointlineplane/}
+  title        = {Intersection Point of Two Line Segments in 2
+    Dimensions},
+  author       = {Bourke, Paul},
+  howpublished = {http://paulbourke.net/geometry/pointlineplane/},
 }
-
 @misc{Bourkeb,
-  title = {Trilinear {{Interpolation}}},
-  author = {Bourke, Paul},
-  howpublished = {http://paulbourke.net/miscellaneous/interpolation/}
+  title        = {Trilinear {{Interpolation}}},
+  author       = {Bourke, Paul},
+  howpublished = {http://paulbourke.net/miscellaneous/interpolation/},
 }
-
 @article{Breneman1987b,
-  title = {Corresponding Chromaticities for Different States of Adaptation to Complex Visual Fields},
-  author = {Breneman, Edwin J.},
-  year = {1987},
-  month = jun,
-  journal = {Journal of the Optical Society of America A},
-  volume = {4},
-  number = {6},
-  pages = {1115},
-  issn = {1084-7529},
-  doi = {10.1364/JOSAA.4.001115},
-  abstract = {While each of his or her two eyes was independently adapted to a different illuminant in viewing a complex visual field, each of a number of observers matched a series of test colors seen by one eye with a juxtaposed variable stimulus seen by the other eye. The 2 degrees test and matching stimuli were located centrally in the complex adapting field, which subtended an angle of 31 degrees X 24 degrees. In making the matches, the observer viewed the test and matching stimuli for a series of brief intervals (approximately 1 sec) while viewing the complex adapting field with normal eye movements. Nine experiments were performed with different pairs of illuminants and different illuminances ranging from that of an average living room to that of a scene illuminated with hazy sunlight. In three other experiments each of the observer's two eyes was adapted to a different illuminance of D55. The amount of adaptation was more nearly complete at high levels of illuminance than at low levels, and the proportional amount of adaptation was less for the "blue" receptors. When adaptation coefficients were determined from the actual adaptation differences (e.g., from corresponding tristimulus values for matching neutrals) rather than from the adapting illuminants, a linear von Kries transformation based on experimentally determined visual primaries gave corresponding chromaticities that were in good agreement with the results obtained in each of the chromatic-adaptation experiments, except at the lowest illuminances. The results of the experiments in which each eye was adapted to different levels of the same illuminant indicated again that adaptation to the different levels was incomplete, the proportional amount of adaptation being less at low illuminances and for the "blue" receptors. This caused a change in chromatic adaptation with the level of illuminance even when the chromaticities of the adapting lights were equal. The results of these experiments also indicated that higher purities are needed in order to produce the same absolute color appearances at low levels of illuminance.},
-  pmid = {3598755},
-  file = {/Users/kelsolaar/Zotero/storage/3PERLZ56/Breneman - 1987 - Corresponding chromaticities for different states of adaptation to complex visual fields(2).pdf;/Users/kelsolaar/Zotero/storage/Y6Z63Q67/Breneman - 1987 - Corresponding chromaticities for different states of adaptation to complex visual fields.pdf}
+  title        = {Corresponding Chromaticities for Different States of
+    Adaptation to Complex Visual Fields},
+  author       = {Breneman, Edwin J.},
+  year         = 1987,
+  month        = jun,
+  journal      = {Journal of the Optical Society of America A},
+  volume       = 4,
+  number       = 6,
+  pages        = 1115,
+  issn         = {1084-7529},
+  doi          = {10.1364/JOSAA.4.001115},
+  abstract     = {While each of his or her two eyes was independently
+    adapted to a different illuminant in viewing a complex visual
+    field, each of a number of observers matched a series of test
+    colors seen by one eye with a juxtaposed variable stimulus seen by
+    the other eye. The 2 degrees test and matching stimuli were
+    located centrally in the complex adapting field, which subtended
+    an angle of 31 degrees X 24 degrees. In making the matches, the
+    observer viewed the test and matching stimuli for a series of
+    brief intervals (approximately 1 sec) while viewing the complex
+    adapting field with normal eye movements. Nine experiments were
+    performed with different pairs of illuminants and different
+    illuminances ranging from that of an average living room to that
+    of a scene illuminated with hazy sunlight. In three other
+    experiments each of the observer's two eyes was adapted to a
+    different illuminance of D55. The amount of adaptation was more
+    nearly complete at high levels of illuminance than at low levels,
+    and the proportional amount of adaptation was less for the "blue"
+    receptors. When adaptation coefficients were determined from the
+    actual adaptation differences (e.g., from corresponding
+    tristimulus values for matching neutrals) rather than from the
+    adapting illuminants, a linear von Kries transformation based on
+    experimentally determined visual primaries gave corresponding
+    chromaticities that were in good agreement with the results
+    obtained in each of the chromatic-adaptation experiments, except
+    at the lowest illuminances. The results of the experiments in
+    which each eye was adapted to different levels of the same
+    illuminant indicated again that adaptation to the different levels
+    was incomplete, the proportional amount of adaptation being less
+    at low illuminances and for the "blue" receptors. This caused a
+    change in chromatic adaptation with the level of illuminance even
+    when the chromaticities of the adapting lights were equal. The
+    results of these experiments also indicated that higher purities
+    are needed in order to produce the same absolute color appearances
+    at low levels of illuminance.},
+  pmid         = 3598755,
 }
-
 @article{Brill2008a,
-  title = {Repairing Gamut Problems in {{CIECAM02}}: {{A}} Progress Report},
-  author = {Brill, Michael H. and Susstrunk, Sabine},
-  year = {2008},
-  month = oct,
-  journal = {Color Research \& Application},
-  volume = {33},
-  number = {5},
-  pages = {424--426},
-  issn = {03612317},
-  doi = {10.1002/col.20432},
-  abstract = {The color-appearance model CIECAM02 has several problems. which can result in mathematical instabilities, due to the position of the chromatic-adaptation primaries relative to the spectrum locus and to the presumed physiological cone primaries. To keep a corresponding (adapted) color within the positive gamut given by the chromatic adaptation primaries, the gamut must he within the cone primary octant. To contain adapted colors within the positive cone-primary octan, it suffices to truncate the action of adaptation at the boundary of that octant. Such modifications may be needed to avoid the mathematical problems in CIECAM02.},
-  keywords = {Chromatic adaptation,CIECAM02,Color appearance,Gamut,Model,Primary}
+  title        = {Repairing Gamut Problems in {{CIECAM02}}: {{A}}
+    Progress Report},
+  author       = {Brill, Michael H. and Susstrunk, Sabine},
+  year         = 2008,
+  month        = oct,
+  journal      = {Color Research \& Application},
+  volume       = 33,
+  number       = 5,
+  pages        = {424--426},
+  issn         = 03612317,
+  doi          = {10.1002/col.20432},
+  abstract     = {The color-appearance model CIECAM02 has several
+    problems. which can result in mathematical instabilities, due to
+    the position of the chromatic-adaptation primaries relative to the
+    spectrum locus and to the presumed physiological cone primaries.
+    To keep a corresponding (adapted) color within the positive gamut
+    given by the chromatic adaptation primaries, the gamut must he
+    within the cone primary octant. To contain adapted colors within
+    the positive cone-primary octan, it suffices to truncate the
+    action of adaptation at the boundary of that octant. Such
+    modifications may be needed to avoid the mathematical problems in
+    CIECAM02.},
+  keywords     = {Chromatic adaptation,CIECAM02,Color
+    appearance,Gamut,Model,Primary},
 }
-
 @misc{Broadbent2009a,
-  title = {Calculation from the {{Original Experimental Data}} of the {{Cie}} 1931 {{RGB Standard Observer Spectral Chromaticity Co-Ordinates}} and {{Color Matching Functions}}.},
-  author = {Broadbent, A. D.},
-  year = {2009},
-  journal = {Qu\'ebec, Canada: D\'epartement de g\'enie chimique, \ldots},
-  pages = {1--17},
-  abstract = {This paper describes all the steps in the calculations of the CIE 1931 RGB spectral chromaticity co-ordinates and color matching functions starting from the initial experimental data of W. D. Wright and J. Guild. Sufficient information is given to allow the reader to reproduce and verify the results obtained at each stage of the calculations and to critically analyze the procedures used. In some instances, the available literature only provides limited descriptions of the actual steps in the calculations and, in others, important data were not published. Nevertheless, it has been possible to more or less reproduce the entire sequence of calculations. All the tables of numerical data are given in the accompanying computer worksheet file CIE1931\_RGB.xls.},
+  title        = {Calculation from the {{Original Experimental Data}}
+    of the {{Cie}} 1931 {{RGB Standard Observer Spectral Chromaticity
+    Co-Ordinates}} and {{Color Matching Functions}}.},
+  author       = {Broadbent, A. D.},
+  year         = 2009,
+  journal      = {Qu\'ebec, Canada: D\'epartement de g\'enie chimique,
+    \ldots},
+  pages        = {1--17},
+  abstract     = {This paper describes all the steps in the
+    calculations of the CIE 1931 RGB spectral chromaticity
+    co-ordinates and color matching functions starting from the
+    initial experimental data of W. D. Wright and J. Guild. Sufficient
+    information is given to allow the reader to reproduce and verify
+    the results obtained at each stage of the calculations and to
+    critically analyze the procedures used. In some instances, the
+    available literature only provides limited descriptions of the
+    actual steps in the calculations and, in others, important data
+    were not published. Nevertheless, it has been possible to more or
+    less reproduce the entire sequence of calculations. All the tables
+    of numerical data are given in the accompanying computer worksheet
+    file CIE1931\_RGB.xls.},
   howpublished = {http://www.cis.rit.edu/mcsl/research/1931.php},
-  file = {/Users/kelsolaar/Zotero/storage/N5MAJMIE/Broadbent - 2009 - Calculation from the Original Experimental Data of the Cie 1931 RGB Standard Observer Spectral Chromaticity Co-Ordina.pdf}
 }
-
 @book{Burger2009b,
-  title = {Principles of {{Digital Image Processing}}},
-  author = {Burger, Wilhelm and Burge, Mark James},
-  year = {2009},
-  publisher = {{Springer London}},
-  address = {{London}},
-  doi = {10.1007/978-1-84800-195-4},
-  isbn = {978-1-84800-194-7}
+  title        = {Principles of {{Digital Image Processing}}},
+  author       = {Burger, Wilhelm and Burge, Mark James},
+  year         = 2009,
+  publisher    = {{Springer London}},
+  address      = {{London}},
+  doi          = {10.1007/978-1-84800-195-4},
+  isbn         = {978-1-84800-194-7},
 }
-
-@misc{Cabello2015,
-  title = {{{PlaneGeometry}}.Js},
-  author = {Cabello, Ricardo},
-  howpublished = {https://github.com/mrdoob/three.js/blob/dev/src/geometries/PlaneGeometry.js}
-}
-
-@misc{Canon2014a,
-  title = {{{EOS C500 Firmware Update}}},
-  author = {{Canon}},
-  year = {2014},
-  howpublished = {https://www.usa.canon.com/internet/portal/us/home/explore/product-showcases/cameras-and-lenses/cinema-eos-firmware/c500}
-}
-
-@misc{Canona,
-  title = {{{EOS C300 Mark II}} - {{EOS C300 Mark II Input Transform Version}} 2.0 (for {{Cinema Gamut}} / {{BT}}.2020)},
-  author = {{Canon}},
-  year = {2016},
-  howpublished = {https://www.usa.canon.com/internet/portal/us/home/support/details/cameras/cinema-eos/eos-c300-mark-ii}
-}
-
-@article{Cao2013,
-  title = {Comparison of the Performance of Inverse Transformation Methods from {{OSA-UCS}} to {{CIEXYZ}}},
-  author = {Cao, Renbo and Trussell, H Joel and Shamey, Renzo},
-  year = {2013},
-  month = aug,
-  journal = {Journal of the Optical Society of America A},
-  volume = {30},
-  number = {8},
-  pages = {1508},
-  issn = {1084-7529},
-  doi = {10.1364/JOSAA.30.001508},
-  abstract = {The Optical Society of America's Uniform Color Scales (OSA-UCS) is one of the color spaces that most closely approximate a "true" uniform color space. Different techniques have been used to convert OSA-UCS-based color specification parameters, L, j, and g, to the CIE tristimulus values, X, Y, and Z. However, none of these methods provides a direct method of inverting OSA-UCS to CIEXYZ values. Thus, numerical algorithms, such as the Newton-Raphson method, have been employed to obtain the transformations. The relative low accuracy and long computation time of this method makes it undesirable for practical applications. An artificial neural network (ANN) was employed to convert OSA-UCS to CIEXYZ. Its performance was compared with that of numerical methods. After optimization, ANN gave a better performance with a mean error (DeltaEXYZ) of 1.0x10(-4) and a conversion time of less than 1 s for 1891 samples.},
-  isbn = {1520-8532 (Electronic)\textbackslash r1084-7529 (Linking)},
-  pmid = {24323208},
-  file = {/Users/kelsolaar/Zotero/storage/NIFLE5ID/Cao, Trussell, Shamey - 2013 - Comparison of the performance of inverse transformation methods from OSA-UCS to CIEXYZ.pdf}
-}
-
-@techreport{Carter2018,
-  title = {{{CIE}} 015:2018 {{Colorimetry}}, 4th {{Edition}}},
-  author = {Carter, E.C. and Schanda, J.D. and Hirschler, R. and Jost, S. and Luo, M.R. and Melgosa, M. and Ohno, Y. and Pointer, M.R. and Rich, D.C. and Vienot, F. and Whitehead, L. and Wold, J.H.},
-  year = {2018},
-  month = oct,
-  address = {{Vienna}},
-  institution = {{International Commission on Illumination}},
-  doi = {10.25039/TR.015.2018},
-  isbn = {9783902842138},
-  file = {/Users/kelsolaar/Zotero/storage/YH47BDDY/Carter et al. - 2018 - CIE 0152018 Colorimetry, 4th Edition.pdf}
-}
-
-@misc{Castro2014a,
-  title = {Numpy: {{Fastest}} Way of Computing Diagonal for Each Row of a 2d Array},
-  author = {Castro, Saullo},
-  year = {2014},
-  howpublished = {http://stackoverflow.com/questions/26511401/numpy-fastest-way-of-computing-diagonal-for-each-row-of-a-2d-array/26517247\#26517247}
-}
-
-@article{Centore2012a,
-  title = {An Open-Source Inversion Algorithm for the {{Munsell}} Renotation},
-  author = {Centore, Paul},
-  year = {2012},
-  month = dec,
-  journal = {Color Research \& Application},
-  volume = {37},
-  number = {6},
-  pages = {455--464},
-  issn = {03612317},
-  doi = {10.1002/col.20715},
-  keywords = {algorithm,inverse renotation,munsell,open source,renotation},
-  file = {/Users/kelsolaar/Zotero/storage/QB5MY39J/Centore - 2012 - An open-source inversion algorithm for the Munsell renotation.pdf}
-}
-
-@misc{Centore2014k,
-  title = {{{MunsellAndKubelkaMunkToolboxApr2014}} - {{MunsellRenotationRoutines}}/{{MunsellHueToASTMHue}}.m},
-  author = {Centore, Paul},
-  year = {2014}
-}
-
-@misc{Centore2014l,
-  title = {{{MunsellAndKubelkaMunkToolboxApr2014}} - {{MunsellSystemRoutines}}/{{LinearVsRadialInterpOnRenotationOvoid}}.m},
-  author = {Centore, Paul},
-  year = {2014}
-}
-
-@misc{Centore2014m,
-  title = {{{MunsellAndKubelkaMunkToolboxApr2014}} - {{MunsellRenotationRoutines}}/{{MunsellToxyY}}.m},
-  author = {Centore, Paul},
-  year = {2014}
-}
-
-@misc{Centore2014n,
-  title = {{{MunsellAndKubelkaMunkToolboxApr2014}} - {{MunsellRenotationRoutines}}/{{FindHueOnRenotationOvoid}}.m},
-  author = {Centore, Paul},
-  year = {2014}
-}
-
-@misc{Centore2014o,
-  title = {{{MunsellAndKubelkaMunkToolboxApr2014}} - {{MunsellSystemRoutines}}/{{BoundingRenotationHues}}.m},
-  author = {Centore, Paul},
-  year = {2014}
-}
-
-@misc{Centore2014p,
-  title = {{{MunsellAndKubelkaMunkToolboxApr2014}} - {{MunsellRenotationRoutines}}/{{xyYtoMunsell}}.m},
-  author = {Centore, Paul},
-  year = {2014}
-}
-
-@misc{Centore2014q,
-  title = {{{MunsellAndKubelkaMunkToolboxApr2014}} - {{MunsellRenotationRoutines}}/{{MunsellToxyForIntegerMunsellValue}}.m},
-  author = {Centore, Paul},
-  year = {2014}
-}
-
-@misc{Centore2014r,
-  title = {{{MunsellAndKubelkaMunkToolboxApr2014}} - {{MunsellRenotationRoutines}}/{{MaxChromaForExtrapolatedRenotation}}.m},
-  author = {Centore, Paul},
-  year = {2014}
-}
-
-@misc{Centore2014s,
-  title = {{{MunsellAndKubelkaMunkToolboxApr2014}} - {{MunsellRenotationRoutines}}/{{MunsellHueToChromDiagHueAngle}}.m},
-  author = {Centore, Paul},
-  year = {2014}
-}
-
-@misc{Centore2014t,
-  title = {{{MunsellAndKubelkaMunkToolboxApr2014}} - {{MunsellRenotationRoutines}}/{{ChromDiagHueAngleToMunsellHue}}.m},
-  author = {Centore, Paul},
-  year = {2014}
-}
-
-@misc{Centore2014u,
-  title = {{{MunsellAndKubelkaMunkToolboxApr2014}} - {{GeneralRoutines}}/{{CIELABtoApproxMunsellSpec}}.m},
-  author = {Centore, Paul},
-  year = {2014}
-}
-
-@misc{Centorea,
-  title = {The {{Munsell}} and {{Kubelka-Munk Toolbox}}},
-  author = {Centore, Paul},
-  howpublished = {http://www.munsellcolourscienceforpainters.com/MunsellAndKubelkaMunkToolbox/MunsellAndKubelkaMunkToolbox.html}
-}
-
-@misc{Chamberlain2015,
-  title = {{{LUT}} Documentation (to Create from Another Program)},
-  author = {Chamberlain, Peter},
-  year = {2015},
-  howpublished = {https://forum.blackmagicdesign.com/viewtopic.php?f=21\&t=40284\#p232952}
-}
-
-@article{Cheung2004,
-  title = {A Comparative Study of the Characterisation of Colour Cameras by Means of Neural Networks and Polynomial Transforms},
-  author = {Cheung, Vien and Westland, Stephen and Connah, David and Ripamonti, Caterina},
-  year = {2004},
-  journal = {Coloration Technology},
-  volume = {120},
-  number = {1},
-  pages = {19--25},
-  issn = {14723581},
-  doi = {10.1111/j.1478-4408.2004.tb00201.x},
-  abstract = {The proliferation of low-cost colour imaging devices in the consumer market has led to a greater need to transfer images from one medium or device to another without loss of colour fidelity. A common solution is to characterise each device in terms of its CIE tristimulus values. In this paper two general techniques, artificial neural networks and polynomial transforms, are compared for their usefulness in characterising colour cameras. The neural and polynomial techniques are shown to give approximately similar performance once the parameters of the models are optimised. Since neural networks can be difficult and time-consuming to train, it is concluded that polynomial transforms offer the better alternative for camera characterisation.},
-  file = {/Users/kelsolaar/Zotero/storage/D4IVRZWP/Cheung et al. - 2004 - A comparative study of the characterisation of colour cameras by means of neural networks and polynomial transfor.pdf}
-}
-
-@misc{CIEce,
-  title = {{{CIE}} 15:2004 {{Tables Data}}},
-  author = {{CIE}},
-  year = {2004},
-  file = {/Users/kelsolaar/Zotero/storage/R95FLNMC/CIE - 2004 - CIE 152004 Tables Data.xls}
-}
-
-@misc{CIEcf,
-  title = {{{CIE Spectral Data}}},
-  author = {{CIE}},
-  file = {/Users/kelsolaar/Zotero/storage/SH9FS2YZ/CIE - Unknown - CIE Spectral Data.xls}
-}
-
 @book{CIEDivision12022,
-  title = {{{CIE}} 248:2022 {{The CIE}} 2016 {{Colour Appearance Model}} for {{Colour Management Systems}}: {{CIECAM16}}},
-  author = {{CIE Division 1} and {CIE Division 8}},
-  year = {2022},
-  publisher = {{Commission Internationale de l'Eclairage}},
-  isbn = {978-3-902842-94-7},
-  file = {/Users/kelsolaar/Zotero/storage/5LMUJ936/CIE Division 1Division 8 - 2022 - CIE 2482022 The CIE 2016 Colour Appearance Model .pdf}
+  title        = {{{CIE}} 248:2022 {{The CIE}} 2016 {{Colour
+    Appearance Model}} for {{Colour Management Systems}}: {{CIECAM16}}},
+  author       = {{CIE Division 1} and {CIE Division 8}},
+  year         = 2022,
+  publisher    = {{Commission Internationale de l'Eclairage}},
+  isbn         = {978-3-902842-94-7},
 }
-
 @book{CIETC1-321994b,
-  title = {{{CIE}} 109-1994 {{A Method}} of {{Predicting Corresponding Colours}} under {{Different Chromatic}} and {{Illuminance Adaptations}}},
-  author = {{CIE TC 1-32}},
-  year = {1994},
-  publisher = {{Commission Internationale de l'Eclairage}},
-  isbn = {978-3-900734-51-0},
-  file = {/Users/kelsolaar/Zotero/storage/MFXWLR4T/CIE TC 1-32 - 1994 - CIE 109-1994 A Method of Predicting Corresponding Colours under Different Chromatic and Illuminance Adaptations.pdf}
+  title        = {{{CIE}} 109-1994 {{A Method}} of {{Predicting
+    Corresponding Colours}} under {{Different Chromatic}} and
+    {{Illuminance Adaptations}}},
+  author       = {{CIE TC 1-32}},
+  year         = 1994,
+  publisher    = {{Commission Internationale de l'Eclairage}},
+  isbn         = {978-3-900734-51-0},
 }
-
 @book{CIETC1-362006a,
-  title = {{{CIE}} 170-1:2006 {{Fundamental Chromaticity Diagram}} with {{Physiological Axes}} - {{Part}} 1},
-  author = {{CIE TC 1-36}},
-  year = {2006},
-  publisher = {{Commission Internationale de l'Eclairage}},
-  isbn = {978-3-901906-46-6},
-  file = {/Users/kelsolaar/Zotero/storage/8KV64XHT/CIE TC 1-36 - 2006 - CIE 170-12006 Fundamental Chromaticity Diagram with Physiological Axes - Part 1.pdf}
+  title        = {{{CIE}} 170-1:2006 {{Fundamental Chromaticity
+    Diagram}} with {{Physiological Axes}} - {{Part}} 1},
+  author       = {{CIE TC 1-36}},
+  year         = 2006,
+  publisher    = {{Commission Internationale de l'Eclairage}},
+  isbn         = {978-3-901906-46-6},
 }
-
 @incollection{CIETC1-382005e,
-  title = {9. {{INTERPOLATION}}},
-  booktitle = {{{CIE}} 167:2005 {{Recommended Practice}} for {{Tabulating Spectral Data}} for {{Use}} in {{Colour Computations}}},
-  author = {{CIE TC 1-38}},
-  year = {2005},
-  pages = {14--19},
-  isbn = {978-3-901906-41-1}
+  title        = {9. {{INTERPOLATION}}},
+  booktitle    = {{{CIE}} 167:2005 {{Recommended Practice}} for
+    {{Tabulating Spectral Data}} for {{Use}} in {{Colour
+    Computations}}},
+  author       = {{CIE TC 1-38}},
+  year         = 2005,
+  pages        = {14--19},
+  isbn         = {978-3-901906-41-1},
 }
-
 @incollection{CIETC1-382005f,
-  title = {9.2.4 {{Method}} of Interpolation for Uniformly Spaced Independent Variable},
-  booktitle = {{{CIE}} 167:2005 {{Recommended Practice}} for {{Tabulating Spectral Data}} for {{Use}} in {{Colour Computations}}},
-  author = {{CIE TC 1-38}},
-  year = {2005},
-  pages = {1--27},
-  isbn = {978-3-901906-41-1}
+  title        = {9.2.4 {{Method}} of Interpolation for Uniformly
+    Spaced Independent Variable},
+  booktitle    = {{{CIE}} 167:2005 {{Recommended Practice}} for
+    {{Tabulating Spectral Data}} for {{Use}} in {{Colour
+    Computations}}},
+  author       = {{CIE TC 1-38}},
+  year         = 2005,
+  pages        = {1--27},
+  isbn         = {978-3-901906-41-1},
 }
-
 @incollection{CIETC1-382005g,
-  title = {{{EXTRAPOLATION}}},
-  booktitle = {{{CIE}} 167:2005 {{Recommended Practice}} for {{Tabulating Spectral Data}} for {{Use}} in {{Colour Computations}}},
-  author = {{CIE TC 1-38}},
-  year = {2005},
-  pages = {19--20},
-  isbn = {978-3-901906-41-1}
+  title        = {{{EXTRAPOLATION}}},
+  booktitle    = {{{CIE}} 167:2005 {{Recommended Practice}} for
+    {{Tabulating Spectral Data}} for {{Use}} in {{Colour
+    Computations}}},
+  author       = {{CIE TC 1-38}},
+  year         = 2005,
+  pages        = {19--20},
+  isbn         = {978-3-901906-41-1},
 }
-
 @incollection{CIETC1-382005h,
-  title = {Table {{V}}. {{Values}} of the c-Coefficients of {{Equ}}.s 6 and 7.},
-  booktitle = {{{CIE}} 167:2005 {{Recommended Practice}} for {{Tabulating Spectral Data}} for {{Use}} in {{Colour Computations}}},
-  author = {{CIE TC 1-38}},
-  year = {2005},
-  pages = {19},
-  isbn = {978-3-901906-41-1}
+  title        = {Table {{V}}. {{Values}} of the c-Coefficients of
+    {{Equ}}.s 6 and 7.},
+  booktitle    = {{{CIE}} 167:2005 {{Recommended Practice}} for
+    {{Tabulating Spectral Data}} for {{Use}} in {{Colour
+    Computations}}},
+  author       = {{CIE TC 1-38}},
+  year         = 2005,
+  pages        = 19,
+  isbn         = {978-3-901906-41-1},
 }
-
 @incollection{CIETC1-482004,
-  title = {{{EXPLANATORY COMMENTS}} - 5},
-  booktitle = {{{CIE}} 015:2004 {{Colorimetry}}, 3rd {{Edition}}},
-  author = {{CIE TC 1-48}},
-  year = {2004},
-  pages = {68--68},
-  isbn = {978-3-901906-33-6}
+  title        = {{{EXPLANATORY COMMENTS}} - 5},
+  booktitle    = {{{CIE}} 015:2004 {{Colorimetry}}, 3rd {{Edition}}},
+  author       = {{CIE TC 1-48}},
+  year         = 2004,
+  pages        = {68--68},
+  isbn         = {978-3-901906-33-6},
 }
-
 @book{CIETC1-482004h,
-  title = {{{CIE}} 015:2004 {{Colorimetry}}, 3rd {{Edition}}},
-  author = {{CIE TC 1-48}},
-  year = {2004},
-  journal = {CIE 015:2004 Colorimetry, 3rd Edition},
-  publisher = {{Commission Internationale de l'Eclairage}},
-  isbn = {978-3-901906-33-6},
-  file = {/Users/kelsolaar/Zotero/storage/2RNVBZQX/CIE TC 1-48 - 2004 - CIE 0152004 Colorimetry, 3rd Edition.pdf}
+  title        = {{{CIE}} 015:2004 {{Colorimetry}}, 3rd {{Edition}}},
+  author       = {{CIE TC 1-48}},
+  year         = 2004,
+  journal      = {CIE 015:2004 Colorimetry, 3rd Edition},
+  publisher    = {{Commission Internationale de l'Eclairage}},
+  isbn         = {978-3-901906-33-6},
 }
-
 @incollection{CIETC1-482004i,
-  title = {{{APPENDIX E}}. {{INFORMATION ON THE USE OF PLANCK}}'{{S EQUATION FOR STANDARD AIR}}},
-  booktitle = {{{CIE}} 015:2004 {{Colorimetry}}, 3rd {{Edition}}},
-  author = {{CIE TC 1-48}},
-  year = {2004},
-  pages = {77--82},
-  isbn = {978-3-901906-33-6},
-  file = {/Users/kelsolaar/Zotero/storage/6J5GE7WN/CIE TC 1-48 - 2004 - APPENDIX E. INFORMATION ON THE USE OF PLANCK'S EQUATION FOR STANDARD AIR.pdf}
+  title        = {{{APPENDIX E}}. {{INFORMATION ON THE USE OF
+    PLANCK}}'{{S EQUATION FOR STANDARD AIR}}},
+  booktitle    = {{{CIE}} 015:2004 {{Colorimetry}}, 3rd {{Edition}}},
+  author       = {{CIE TC 1-48}},
+  year         = 2004,
+  pages        = {77--82},
+  isbn         = {978-3-901906-33-6},
 }
-
 @incollection{CIETC1-482004j,
-  title = {{{CIE}} 1976 Uniform Chromaticity Scale Diagram ({{UCS}} Diagram)},
-  booktitle = {{{CIE}} 015:2004 {{Colorimetry}}, 3rd {{Edition}}},
-  author = {{CIE TC 1-48}},
-  year = {2004},
-  pages = {24},
-  isbn = {978-3-901906-33-6}
+  title        = {{{CIE}} 1976 Uniform Chromaticity Scale Diagram
+    ({{UCS}} Diagram)},
+  booktitle    = {{{CIE}} 015:2004 {{Colorimetry}}, 3rd {{Edition}}},
+  author       = {{CIE TC 1-48}},
+  year         = 2004,
+  pages        = 24,
+  isbn         = {978-3-901906-33-6},
 }
-
 @incollection{CIETC1-482004k,
-  title = {The Evaluation of Whiteness},
-  booktitle = {{{CIE}} 015:2004 {{Colorimetry}}, 3rd {{Edition}}},
-  author = {{CIE TC 1-48}},
-  year = {2004},
-  pages = {24},
-  isbn = {978-3-901906-33-6}
+  title        = {The Evaluation of Whiteness},
+  booktitle    = {{{CIE}} 015:2004 {{Colorimetry}}, 3rd {{Edition}}},
+  author       = {{CIE TC 1-48}},
+  year         = 2004,
+  pages        = 24,
+  isbn         = {978-3-901906-33-6},
 }
-
 @incollection{CIETC1-482004l,
-  title = {Extrapolation},
-  booktitle = {{{CIE}} 015:2004 {{Colorimetry}}, 3rd {{Edition}}},
-  author = {{CIE TC 1-48}},
-  year = {2004},
-  pages = {24},
-  isbn = {978-3-901906-33-6}
+  title        = {Extrapolation},
+  booktitle    = {{{CIE}} 015:2004 {{Colorimetry}}, 3rd {{Edition}}},
+  author       = {{CIE TC 1-48}},
+  year         = 2004,
+  pages        = 24,
+  isbn         = {978-3-901906-33-6},
 }
-
 @incollection{CIETC1-482004m,
-  title = {{{CIE}} 1976 Uniform Colour Spaces},
-  booktitle = {{{CIE}} 015:2004 {{Colorimetry}}, 3rd {{Edition}}},
-  author = {{CIE TC 1-48}},
-  year = {2004},
-  pages = {24},
-  isbn = {978-3-901906-33-6}
+  title        = {{{CIE}} 1976 Uniform Colour Spaces},
+  booktitle    = {{{CIE}} 015:2004 {{Colorimetry}}, 3rd {{Edition}}},
+  author       = {{CIE TC 1-48}},
+  year         = 2004,
+  pages        = 24,
+  isbn         = {978-3-901906-33-6},
 }
-
 @incollection{CIETC1-482004n,
-  title = {3.1 {{Recommendations}} Concerning Standard Physical Data of Illuminants},
-  booktitle = {{{CIE}} 015:2004 {{Colorimetry}}, 3rd {{Edition}}},
-  author = {{CIE TC 1-48}},
-  year = {2004},
-  pages = {12--13},
-  isbn = {978-3-901906-33-6}
+  title        = {3.1 {{Recommendations}} Concerning Standard Physical
+    Data of Illuminants},
+  booktitle    = {{{CIE}} 015:2004 {{Colorimetry}}, 3rd {{Edition}}},
+  author       = {{CIE TC 1-48}},
+  year         = 2004,
+  pages        = {12--13},
+  isbn         = {978-3-901906-33-6},
 }
-
 @incollection{CIETC1-482004o,
-  title = {9.1 {{Dominant}} Wavelength and Purity},
-  booktitle = {{{CIE}} 015:2004 {{Colorimetry}}, 3rd {{Edition}}},
-  author = {{CIE TC 1-48}},
-  year = {2004},
-  pages = {32--33},
-  isbn = {978-3-901906-33-6}
+  title        = {9.1 {{Dominant}} Wavelength and Purity},
+  booktitle    = {{{CIE}} 015:2004 {{Colorimetry}}, 3rd {{Edition}}},
+  author       = {{CIE TC 1-48}},
+  year         = 2004,
+  pages        = {32--33},
+  isbn         = {978-3-901906-33-6},
 }
-
 @book{CIETC1-902017,
-  title = {{CIE 2017 colour fidelity index for accurate scientific use}},
-  author = {{CIE TC 1-90}},
-  year = {2017},
-  series = {{Technical report / CIE}},
-  number = {224},
-  publisher = {{CIE Central Bureau}},
-  address = {{Vienna}},
-  isbn = {978-3-902842-61-9},
-  langid = {eng fre ger},
-  annotation = {OCLC: 988568299},
-  file = {/Users/kelsolaar/Zotero/storage/HSG7SBTW/CIE TC 1-90 - 2017 - CIE 2017 colour fidelity index for accurate scient.pdf;/Users/kelsolaar/Zotero/storage/JQGCSM8S/933_TC1-90.zip}
+  title        = {{CIE 2017 colour fidelity index for accurate
+    scientific use}},
+  author       = {{CIE TC 1-90}},
+  year         = 2017,
+  series       = {{Technical report / CIE}},
+  number       = 224,
+  publisher    = {{CIE Central Bureau}},
+  address      = {{Vienna}},
+  isbn         = {978-3-902842-61-9},
+  langid       = {eng fre ger},
+  annotation   = {OCLC: 988568299},
 }
-
-@misc{Colblindora,
-  title = {Deuteranopia - {{Red-Green Color Blindness}}},
-  author = {{Colblindor}},
-  howpublished = {http://www.color-blindness.com/deuteranopia-red-green-color-blindness/}
+@misc{CIEce,
+  title        = {{{CIE}} 15:2004 {{Tables Data}}},
+  author       = {{CIE}},
+  year         = 2004,
 }
-
-@misc{Colblindorb,
-  title = {Protanopia - {{Red-Green Color Blindness}}},
-  author = {{Colblindor}},
-  howpublished = {http://www.color-blindness.com/protanopia-red-green-color-blindness/}
+@misc{CIEcf,
+  title        = {{{CIE Spectral Data}}},
+  author       = {{CIE}},
 }
-
-@misc{Colblindorc,
-  title = {Tritanopia - {{Blue-Yellow Color Blindness}}},
-  author = {{Colblindor}},
-  howpublished = {http://www.color-blindness.com/tritanopia-blue-yellow-color-blindness/}
-}
-
-@misc{Cottrella,
-  title = {The {{Russell RGB}} Working Color Space},
-  author = {Cottrell, Russell}
-}
-
-@article{Cowan2004,
-  title = {Contrast {{Sensitivity Experiment}} to {{Determine}} the {{Bit Depth}} for {{Digital Cinema}}},
-  author = {Cowan, Matthew and Kennel, Glenn and Maier, Thomas and Walker, Brad},
-  year = {2004},
-  month = sep,
-  journal = {SMPTE Motion Imaging Journal},
-  volume = {113},
-  number = {9},
-  pages = {281--292},
-  issn = {2160-2492},
-  doi = {10.5594/j11549},
-  abstract = {The SMPTE Color ad hoc group was formed in 2001 (under DC28.2) to investigate the colorimetric requirements for the Digital Cinema Distribution Master (DCDM). A draft specification on color image encoding was published in September 2002 that recommended the use of XYZ color space, a gamma 1/2.6 transfer function, and 12 bits per color. With the support of Digital Cinema Initiatives (DCI), a test was designed to verify these color image encoding parameters. This paper reports the results of the contrast sensitivity experiment, which showed that many of our observers could see a modulation corresponding to a one code value change with 10-bit encoding, but few observers would see a one-code value change with 12-bit encoding. This result matches the results of published contrast sensitivity experiments.},
-  file = {/Users/kelsolaar/Zotero/storage/72ZNEKRS/Cowan et al. - 2004 - Contrast Sensitivity Experiment to Determine the B.pdf;/Users/kelsolaar/Zotero/storage/QPYY7VA7/Cowan et al. - 2004 - Constant Sensitivity Experiment to Determine the Bit Depth for Digital Cinema.pdf;/Users/kelsolaar/Zotero/storage/5UAUS78N/7262492.html}
-}
-
-@article{Cui2002,
-  ids = {Cui2002a},
-  title = {Uniform Colour Spaces Based on the {{DIN99}} Colour-Difference Formula},
-  author = {Cui, G. and Luo, M. R. and Rigg, B. and Roesler, G. and Witt, K.},
-  year = {2002},
-  journal = {Color Research \& Application},
-  volume = {27},
-  number = {4},
-  pages = {282--290},
-  issn = {1520-6378},
-  doi = {10.1002/col.10066},
-  abstract = {Several colour-difference formulas such as CMC, CIE94, and CIEDE2000 have been developed by modifying CIELAB. These formulas give much better fits for experimental data based on small colour differences than does CIELAB. None of these has an associated uniform colour space (UCS). The need for a UCS is demonstrated by the widespread use of the a*b* diagram despite the lack of uniformity. This article describes the development of formulas, with the same basic structure as the DIN99 formula, that predict the experimental data sets better than do the CMC and CIE94 colour-difference formulas and only slightly worse than CIEDE2000 (which was optimized on the experimental data). However, these formulas all have an associated UCS. The spaces are similar in form to L*a*b*. \textcopyright{} 2002 Wiley Periodicals, Inc. Col Res Appl, 27, 282\textendash 290, 2002; Published online in Wiley InterScience (www.interscience.wiley.com). DOI 10.1002/col.10066},
-  copyright = {Copyright \textcopyright{} 2002 Wiley Periodicals, Inc.},
-  langid = {english},
-  keywords = {colour discrimination ellipses,colour-difference metrics,uniform colour space},
-  annotation = {\_eprint: https://onlinelibrary.wiley.com/doi/pdf/10.1002/col.10066},
-  file = {/Users/kelsolaar/Zotero/storage/VET934GU/Cui et al. - 2002 - Uniform colour spaces based on the DIN99 colour-di.pdf;/Users/kelsolaar/Zotero/storage/TKDLWCHN/col.html}
-}
-
 @misc{CVRLp,
-  title = {{{CIE}} (2012) 10-Deg {{XYZ}} "Physiologically-Relevant" Colour Matching Functions},
-  author = {{CVRL}},
-  howpublished = {http://www.cvrl.org/database/text/cienewxyz/cie2012xyz10.htm}
+  title        = {{{CIE}} (2012) 10-Deg {{XYZ}}
+    "Physiologically-Relevant" Colour Matching Functions},
+  author       = {{CVRL}},
+  howpublished = {http://www.cvrl.org/database/text/cienewxyz/cie2012xyz10.htm},
 }
-
 @misc{CVRLq,
-  title = {Luminous Efficiency},
-  author = {{CVRL}},
-  howpublished = {http://www.cvrl.org/lumindex.htm}
+  title        = {Luminous Efficiency},
+  author       = {{CVRL}},
+  howpublished = {http://www.cvrl.org/lumindex.htm},
 }
-
 @misc{CVRLr,
-  title = {New {{CIE XYZ}} Functions Transformed from the {{CIE}} (2006) {{LMS}} Functions},
-  author = {{CVRL}},
-  howpublished = {http://cvrl.ioo.ucl.ac.uk/ciexyzpr.htm}
+  title        = {New {{CIE XYZ}} Functions Transformed from the
+    {{CIE}} (2006) {{LMS}} Functions},
+  author       = {{CVRL}},
+  howpublished = {http://cvrl.ioo.ucl.ac.uk/ciexyzpr.htm},
 }
-
 @misc{CVRLs,
-  title = {Older {{CIE Standards}}},
-  author = {{CVRL}},
-  howpublished = {http://cvrl.ioo.ucl.ac.uk/cie.htm}
+  title        = {Older {{CIE Standards}}},
+  author       = {{CVRL}},
+  howpublished = {http://cvrl.ioo.ucl.ac.uk/cie.htm},
 }
-
 @misc{CVRLt,
-  title = {Stiles \& {{Burch}} Individual 10-Deg Colour Matching Data},
-  author = {{CVRL}},
-  howpublished = {http://www.cvrl.org/stilesburch10\_ind.htm}
+  title        = {Stiles \& {{Burch}} Individual 10-Deg Colour
+    Matching Data},
+  author       = {{CVRL}},
+  howpublished = {http://www.cvrl.org/stilesburch10\_ind.htm},
 }
-
 @misc{CVRLu,
-  title = {Cone {{Fundamentals}}},
-  author = {Stockman, Andrew and Sharpe, Lindsay T.},
-  year = {2000},
-  howpublished = {http://www.cvrl.org/cones.htm}
+  title        = {Cone {{Fundamentals}}},
+  author       = {Stockman, Andrew and Sharpe, Lindsay T.},
+  year         = 2000,
+  howpublished = {http://www.cvrl.org/cones.htm},
 }
-
 @misc{CVRLv,
-  title = {{{CIE}} (2012) 2-Deg {{XYZ}} "Physiologically-Relevant" Colour Matching Functions},
-  author = {{CVRL}},
-  howpublished = {http://www.cvrl.org/database/text/cienewxyz/cie2012xyz2.htm}
+  title        = {{{CIE}} (2012) 2-Deg {{XYZ}}
+    "Physiologically-Relevant" Colour Matching Functions},
+  author       = {{CVRL}},
+  howpublished = {http://www.cvrl.org/database/text/cienewxyz/cie2012xyz2.htm},
 }
-
 @misc{CVRLw,
-  title = {Stiles \& {{Burch}} Individual 2-Deg Colour Matching Data},
-  author = {{CVRL}},
-  howpublished = {http://www.cvrl.org/stilesburch2\_ind.htm}
+  title        = {Stiles \& {{Burch}} Individual 2-Deg Colour Matching
+    Data},
+  author       = {{CVRL}},
+  howpublished = {http://www.cvrl.org/stilesburch2\_ind.htm},
 }
-
-@article{Darrodi2015a,
-  title = {Reference Data Set for Camera Spectral Sensitivity Estimation},
-  author = {Darrodi, Maryam Mohammadzadeh and Finlayson, Graham and Goodman, Teresa and Mackiewicz, Michal},
-  year = {2015},
-  month = mar,
-  journal = {Journal of the Optical Society of America A},
-  volume = {32},
-  number = {3},
-  pages = {381},
-  issn = {1084-7529},
-  doi = {10.1364/JOSAA.32.000381},
-  file = {/Users/kelsolaar/Zotero/storage/5YWZ3D5W/Darrodi et al. - 2015 - Reference data set for camera spectral sensitivity estimation.pdf}
+@misc{Cabello2015,
+  title        = {{{PlaneGeometry}}.Js},
+  author       = {Cabello, Ricardo},
+  howpublished = {https://github.com/mrdoob/three.js/blob/dev/src/geometries/PlaneGeometry.js},
 }
-
-@article{David2015,
-  title = {Development of the {{IES}} Method for Evaluating the Color Rendition of Light Sources},
-  author = {David, Aurelien and Fini, Paul T. and Houser, Kevin W. and Ohno, Yoshi and Royer, Michael P. and Smet, Kevin A. G. and Wei, Minchen and Whitehead, Lorne},
-  year = {2015},
-  month = jun,
-  journal = {Optics Express},
-  volume = {23},
-  number = {12},
-  pages = {15888},
-  issn = {1094-4087},
-  doi = {10.1364/OE.23.015888},
-  abstract = {We have developed a two-measure system for evaluating light sources' color rendition that builds upon conceptual progress of numerous researchers over the last two decades. The system quantifies the color fidelity and color gamut (change in object chroma) of a light source in comparison to a reference illuminant. The calculations are based on a newly developed set of reflectance data from real samples uniformly distributed in color space (thereby fairly representing all colors) and in wavelength space (thereby precluding artificial optimization of the color rendition scores by spectral engineering). The color fidelity score Rf is an improved version of the CIE color rendering index. The color gamut score Rg is an improved version of the Gamut Area Index. In combination, they provide two complementary assessments to guide the optimization of future light sources. This method summarizes the findings of the Color Metric Task Group of the Illuminating Engineering Society of North America (IES). It is adopted in the upcoming IES TM-30-2015, and is proposed for consideration with the International Commission on Illumination (CIE).},
-  langid = {english},
-  file = {/Users/kelsolaar/Zotero/storage/68IR97V4/David et al. - 2015 - Development of the IES method for evaluating the c.pdf;/Users/kelsolaar/Zotero/storage/VK4HT79Q/David et al. - 2015 - Development of the IES method for evaluating the color rendition of light sources.pdf}
+@misc{Canon2014a,
+  title        = {{{EOS C500 Firmware Update}}},
+  author       = {{Canon}},
+  year         = 2014,
+  howpublished = {https://www.usa.canon.com/internet/portal/us/home/explore/product-showcases/cameras-and-lenses/cinema-eos-firmware/c500},
 }
-
-@article{Davis2010a,
-  title = {Color Quality Scale},
-  author = {Davis, Wendy and Ohno, Yoshiro},
-  year = {2010},
-  month = mar,
-  journal = {Optical Engineering},
-  volume = {49},
-  number = {3},
-  pages = {033602},
-  issn = {0091-3286},
-  doi = {10.1117/1.3360335},
-  abstract = {The color rendering index (CRI) has been shown to have deficiencies when applied to white light-emitting-diode\textendash based sources. Furthermore, evidence suggests that the restricted scope of the CRI unnecessarily penalizes some light sources with desirable color qualities. To solve the problems of the CRI and include other dimensions of color quality, the color quality scale (CQS) has been developed. Although the CQS uses many of elements of the CRI, there are a number of fundamental differences. Like the CRI, the CQS is a test-samples method that compares the appearance of a set of reflective samples when illuminated by the test lamp to their appearance under a reference illuminant. The CQS uses a larger set of reflective samples, all of high chroma, and combines the color differences of the samples with a root mean square. Additionally, the CQS does not penalize light sources for causing increases in the chroma of object colors but does penalize sources with smaller rendered color gamut areas. The scale of the CQS is converted to span 0-100, and the uniform object color space and chromatic adaptation transform used in the calculations are updated. Supplementary scales have also been developed for expert users.},
-  isbn = {0091-3286},
-  file = {/Users/kelsolaar/Zotero/storage/W3SHRJ84/Davis and Ohno - 2010 - Color quality scale.pdf}
+@misc{Canona,
+  title        = {{{EOS C300 Mark II}} - {{EOS C300 Mark II Input
+    Transform Version}} 2.0 (for {{Cinema Gamut}} / {{BT}}.2020)},
+  author       = {{Canon}},
+  year         = 2016,
+  howpublished = {https://www.usa.canon.com/internet/portal/us/home/support/details/cameras/cinema-eos/eos-c300-mark-ii},
 }
-
-@misc{DigitalCinemaInitiatives2007b,
-  title = {Digital {{Cinema System Specification}} - {{Version}} 1.1},
-  author = {{Digital Cinema Initiatives}},
-  year = {2007},
-  file = {/Users/kelsolaar/Zotero/storage/WSI7QRSL/Digital Cinema Initiatives - 2007 - Digital Cinema System Specification - Version 1.1.pdf}
+@article{Cao2013,
+  title        = {Comparison of the Performance of Inverse
+    Transformation Methods from {{OSA-UCS}} to {{CIEXYZ}}},
+  author       = {Cao, Renbo and Trussell, H Joel and Shamey, Renzo},
+  year         = 2013,
+  month        = aug,
+  journal      = {Journal of the Optical Society of America A},
+  volume       = 30,
+  number       = 8,
+  pages        = 1508,
+  issn         = {1084-7529},
+  doi          = {10.1364/JOSAA.30.001508},
+  abstract     = {The Optical Society of America's Uniform Color
+    Scales (OSA-UCS) is one of the color spaces that most closely
+    approximate a "true" uniform color space. Different techniques
+    have been used to convert OSA-UCS-based color specification
+    parameters, L, j, and g, to the CIE tristimulus values, X, Y, and
+    Z. However, none of these methods provides a direct method of
+    inverting OSA-UCS to CIEXYZ values. Thus, numerical algorithms,
+    such as the Newton-Raphson method, have been employed to obtain
+    the transformations. The relative low accuracy and long
+    computation time of this method makes it undesirable for practical
+    applications. An artificial neural network (ANN) was employed to
+    convert OSA-UCS to CIEXYZ. Its performance was compared with that
+    of numerical methods. After optimization, ANN gave a better
+    performance with a mean error (DeltaEXYZ) of 1.0x10(-4) and a
+    conversion time of less than 1 s for 1891 samples.},
+  isbn         = {1520-8532 (Electronic)\textbackslash r1084-7529
+    (Linking)},
+  pmid         = 24323208,
 }
-
-@misc{DjangoSoftwareFoundation2022,
-  title = {Slugify},
-  author = {{Django Software Foundation}},
-  year = {2022}
+@techreport{Carter2018,
+  title        = {{{CIE}} 015:2018 {{Colorimetry}}, 4th {{Edition}}},
+  author       = {Carter, E.C. and Schanda, J.D. and Hirschler, R. and
+    Jost, S. and Luo, M.R. and Melgosa, M. and Ohno, Y. and Pointer,
+    M.R. and Rich, D.C. and Vienot, F. and Whitehead, L. and Wold,
+    J.H.},
+  year         = 2018,
+  month        = oct,
+  address      = {{Vienna}},
+  institution  = {{International Commission on Illumination}},
+  doi          = {10.25039/TR.015.2018},
+  isbn         = 9783902842138,
 }
-
+@misc{Castro2014a,
+  title        = {Numpy: {{Fastest}} Way of Computing Diagonal for
+    Each Row of a 2d Array},
+  author       = {Castro, Saullo},
+  year         = 2014,
+  howpublished = {http://stackoverflow.com/questions/26511401/numpy-fastest-way-of-computing-diagonal-for-each-row-of-a-2d-array/26517247\#26517247},
+}
+@article{Centore2012a,
+  title        = {An Open-Source Inversion Algorithm for the
+    {{Munsell}} Renotation},
+  author       = {Centore, Paul},
+  year         = 2012,
+  month        = dec,
+  journal      = {Color Research \& Application},
+  volume       = 37,
+  number       = 6,
+  pages        = {455--464},
+  issn         = 03612317,
+  doi          = {10.1002/col.20715},
+  keywords     = {algorithm,inverse renotation,munsell,open
+    source,renotation},
+}
+@misc{Centore2014k,
+  title        = {{{MunsellAndKubelkaMunkToolboxApr2014}} -
+    {{MunsellRenotationRoutines}}/{{MunsellHueToASTMHue}}.m},
+  author       = {Centore, Paul},
+  year         = 2014,
+}
+@misc{Centore2014l,
+  title        = {{{MunsellAndKubelkaMunkToolboxApr2014}} -
+    {{MunsellSystemRoutines}}/{{LinearVsRadialInterpOnRenotationOvoid}}.m},
+  author       = {Centore, Paul},
+  year         = 2014,
+}
+@misc{Centore2014m,
+  title        = {{{MunsellAndKubelkaMunkToolboxApr2014}} -
+    {{MunsellRenotationRoutines}}/{{MunsellToxyY}}.m},
+  author       = {Centore, Paul},
+  year         = 2014,
+}
+@misc{Centore2014n,
+  title        = {{{MunsellAndKubelkaMunkToolboxApr2014}} -
+    {{MunsellRenotationRoutines}}/{{FindHueOnRenotationOvoid}}.m},
+  author       = {Centore, Paul},
+  year         = 2014,
+}
+@misc{Centore2014o,
+  title        = {{{MunsellAndKubelkaMunkToolboxApr2014}} -
+    {{MunsellSystemRoutines}}/{{BoundingRenotationHues}}.m},
+  author       = {Centore, Paul},
+  year         = 2014,
+}
+@misc{Centore2014p,
+  title        = {{{MunsellAndKubelkaMunkToolboxApr2014}} -
+    {{MunsellRenotationRoutines}}/{{xyYtoMunsell}}.m},
+  author       = {Centore, Paul},
+  year         = 2014,
+}
+@misc{Centore2014q,
+  title        = {{{MunsellAndKubelkaMunkToolboxApr2014}} -
+    {{MunsellRenotationRoutines}}/{{MunsellToxyForIntegerMunsellValue}}.m},
+  author       = {Centore, Paul},
+  year         = 2014,
+}
+@misc{Centore2014r,
+  title        = {{{MunsellAndKubelkaMunkToolboxApr2014}} -
+    {{MunsellRenotationRoutines}}/{{MaxChromaForExtrapolatedRenotation}}.m},
+  author       = {Centore, Paul},
+  year         = 2014,
+}
+@misc{Centore2014s,
+  title        = {{{MunsellAndKubelkaMunkToolboxApr2014}} -
+    {{MunsellRenotationRoutines}}/{{MunsellHueToChromDiagHueAngle}}.m},
+  author       = {Centore, Paul},
+  year         = 2014,
+}
+@misc{Centore2014t,
+  title        = {{{MunsellAndKubelkaMunkToolboxApr2014}} -
+    {{MunsellRenotationRoutines}}/{{ChromDiagHueAngleToMunsellHue}}.m},
+  author       = {Centore, Paul},
+  year         = 2014,
+}
+@misc{Centore2014u,
+  title        = {{{MunsellAndKubelkaMunkToolboxApr2014}} -
+    {{GeneralRoutines}}/{{CIELABtoApproxMunsellSpec}}.m},
+  author       = {Centore, Paul},
+  year         = 2014,
+}
+@misc{Centorea,
+  title        = {The {{Munsell}} and {{Kubelka-Munk Toolbox}}},
+  author       = {Centore, Paul},
+  howpublished = {http://www.munsellcolourscienceforpainters.com/MunsellAndKubelkaMunkToolbox/MunsellAndKubelkaMunkToolbox.html},
+}
+@misc{Chamberlain2015,
+  title        = {{{LUT}} Documentation (to Create from Another
+    Program)},
+  author       = {Chamberlain, Peter},
+  year         = 2015,
+  howpublished = {https://forum.blackmagicdesign.com/viewtopic.php?f=21\&t=40284\#p232952},
+}
+@article{Cheung2004,
+  title        = {A Comparative Study of the Characterisation of
+    Colour Cameras by Means of Neural Networks and Polynomial
+    Transforms},
+  author       = {Cheung, Vien and Westland, Stephen and Connah, David
+    and Ripamonti, Caterina},
+  year         = 2004,
+  journal      = {Coloration Technology},
+  volume       = 120,
+  number       = 1,
+  pages        = {19--25},
+  issn         = 14723581,
+  doi          = {10.1111/j.1478-4408.2004.tb00201.x},
+  abstract     = {The proliferation of low-cost colour imaging devices
+    in the consumer market has led to a greater need to transfer
+    images from one medium or device to another without loss of colour
+    fidelity. A common solution is to characterise each device in
+    terms of its CIE tristimulus values. In this paper two general
+    techniques, artificial neural networks and polynomial transforms,
+    are compared for their usefulness in characterising colour
+    cameras. The neural and polynomial techniques are shown to give
+    approximately similar performance once the parameters of the
+    models are optimised. Since neural networks can be difficult and
+    time-consuming to train, it is concluded that polynomial
+    transforms offer the better alternative for camera
+    characterisation.},
+}
+@misc{Colblindora,
+  title        = {Deuteranopia - {{Red-Green Color Blindness}}},
+  author       = {{Colblindor}},
+  howpublished = {http://www.color-blindness.com/deuteranopia-red-green-color-blindness/},
+}
+@misc{Colblindorb,
+  title        = {Protanopia - {{Red-Green Color Blindness}}},
+  author       = {{Colblindor}},
+  howpublished = {http://www.color-blindness.com/protanopia-red-green-color-blindness/},
+}
+@misc{Colblindorc,
+  title        = {Tritanopia - {{Blue-Yellow Color Blindness}}},
+  author       = {{Colblindor}},
+  howpublished = {http://www.color-blindness.com/tritanopia-blue-yellow-color-blindness/},
+}
+@misc{Cottrella,
+  title        = {The {{Russell RGB}} Working Color Space},
+  author       = {Cottrell, Russell},
+}
+@article{Cowan2004,
+  title        = {Contrast {{Sensitivity Experiment}} to {{Determine}}
+    the {{Bit Depth}} for {{Digital Cinema}}},
+  author       = {Cowan, Matthew and Kennel, Glenn and Maier, Thomas
+    and Walker, Brad},
+  year         = 2004,
+  month        = sep,
+  journal      = {SMPTE Motion Imaging Journal},
+  volume       = 113,
+  number       = 9,
+  pages        = {281--292},
+  issn         = {2160-2492},
+  doi          = {10.5594/j11549},
+  abstract     = {The SMPTE Color ad hoc group was formed in 2001
+    (under DC28.2) to investigate the colorimetric requirements for
+    the Digital Cinema Distribution Master (DCDM). A draft
+    specification on color image encoding was published in September
+    2002 that recommended the use of XYZ color space, a gamma 1/2.6
+    transfer function, and 12 bits per color. With the support of
+    Digital Cinema Initiatives (DCI), a test was designed to verify
+    these color image encoding parameters. This paper reports the
+    results of the contrast sensitivity experiment, which showed that
+    many of our observers could see a modulation corresponding to a
+    one code value change with 10-bit encoding, but few observers
+    would see a one-code value change with 12-bit encoding. This
+    result matches the results of published contrast sensitivity
+    experiments.},
+}
+@article{Cui2002,
+  ids          = {Cui2002a},
+  title        = {Uniform Colour Spaces Based on the {{DIN99}}
+    Colour-Difference Formula},
+  author       = {Cui, G. and Luo, M. R. and Rigg, B. and Roesler, G.
+    and Witt, K.},
+  year         = 2002,
+  journal      = {Color Research \& Application},
+  volume       = 27,
+  number       = 4,
+  pages        = {282--290},
+  issn         = {1520-6378},
+  doi          = {10.1002/col.10066},
+  abstract     = {Several colour-difference formulas such as CMC,
+    CIE94, and CIEDE2000 have been developed by modifying CIELAB.
+    These formulas give much better fits for experimental data based
+    on small colour differences than does CIELAB. None of these has an
+    associated uniform colour space (UCS). The need for a UCS is
+    demonstrated by the widespread use of the a*b* diagram despite the
+    lack of uniformity. This article describes the development of
+    formulas, with the same basic structure as the DIN99 formula, that
+    predict the experimental data sets better than do the CMC and
+    CIE94 colour-difference formulas and only slightly worse than
+    CIEDE2000 (which was optimized on the experimental data). However,
+    these formulas all have an associated UCS. The spaces are similar
+    in form to L*a*b*. \textcopyright{} 2002 Wiley Periodicals, Inc.
+    Col Res Appl, 27, 282\textendash 290, 2002; Published online in
+    Wiley InterScience (www.interscience.wiley.com). DOI
+    10.1002/col.10066},
+  copyright    = {Copyright \textcopyright{} 2002 Wiley Periodicals,
+    Inc.},
+  langid       = {english},
+  keywords     = {colour discrimination ellipses,colour-difference
+    metrics,uniform colour space},
+  annotation   = {\_eprint:
+    https://onlinelibrary.wiley.com/doi/pdf/10.1002/col.10066},
+}
 @misc{DJI2017,
-  title = {White {{Paper}} on {{D-Log}} and {{D-Gamut}} of {{DJI Cinema Color System}}},
-  author = {{Dji}},
-  year = {2017},
-  pages = {1--5},
-  file = {/Users/kelsolaar/Zotero/storage/KHLE47UN/Dji - 2017 - White Paper on D-Log and D-Gamut of DJI Cinema Color System.pdf}
+  title        = {White {{Paper}} on {{D-Log}} and {{D-Gamut}} of
+    {{DJI Cinema Color System}}},
+  author       = {{Dji}},
+  year         = 2017,
+  pages        = {1--5},
 }
-
+@article{Darrodi2015a,
+  title        = {Reference Data Set for Camera Spectral Sensitivity
+    Estimation},
+  author       = {Darrodi, Maryam Mohammadzadeh and Finlayson, Graham
+    and Goodman, Teresa and Mackiewicz, Michal},
+  year         = 2015,
+  month        = mar,
+  journal      = {Journal of the Optical Society of America A},
+  volume       = 32,
+  number       = 3,
+  pages        = 381,
+  issn         = {1084-7529},
+  doi          = {10.1364/JOSAA.32.000381},
+}
+@article{David2015,
+  title        = {Development of the {{IES}} Method for Evaluating the
+    Color Rendition of Light Sources},
+  author       = {David, Aurelien and Fini, Paul T. and Houser, Kevin
+    W. and Ohno, Yoshi and Royer, Michael P. and Smet, Kevin A. G. and
+    Wei, Minchen and Whitehead, Lorne},
+  year         = 2015,
+  month        = jun,
+  journal      = {Optics Express},
+  volume       = 23,
+  number       = 12,
+  pages        = 15888,
+  issn         = {1094-4087},
+  doi          = {10.1364/OE.23.015888},
+  abstract     = {We have developed a two-measure system for
+    evaluating light sources' color rendition that builds upon
+    conceptual progress of numerous researchers over the last two
+    decades. The system quantifies the color fidelity and color gamut
+    (change in object chroma) of a light source in comparison to a
+    reference illuminant. The calculations are based on a newly
+    developed set of reflectance data from real samples uniformly
+    distributed in color space (thereby fairly representing all
+    colors) and in wavelength space (thereby precluding artificial
+    optimization of the color rendition scores by spectral
+    engineering). The color fidelity score Rf is an improved version
+    of the CIE color rendering index. The color gamut score Rg is an
+    improved version of the Gamut Area Index. In combination, they
+    provide two complementary assessments to guide the optimization of
+    future light sources. This method summarizes the findings of the
+    Color Metric Task Group of the Illuminating Engineering Society of
+    North America (IES). It is adopted in the upcoming IES TM-30-2015,
+    and is proposed for consideration with the International
+    Commission on Illumination (CIE).},
+  langid       = {english},
+}
+@article{Davis2010a,
+  title        = {Color Quality Scale},
+  author       = {Davis, Wendy and Ohno, Yoshiro},
+  year         = 2010,
+  month        = mar,
+  journal      = {Optical Engineering},
+  volume       = 49,
+  number       = 3,
+  pages        = 033602,
+  issn         = {0091-3286},
+  doi          = {10.1117/1.3360335},
+  abstract     = {The color rendering index (CRI) has been shown to
+    have deficiencies when applied to white
+    light-emitting-diode\textendash based sources. Furthermore,
+    evidence suggests that the restricted scope of the CRI
+    unnecessarily penalizes some light sources with desirable color
+    qualities. To solve the problems of the CRI and include other
+    dimensions of color quality, the color quality scale (CQS) has
+    been developed. Although the CQS uses many of elements of the CRI,
+    there are a number of fundamental differences. Like the CRI, the
+    CQS is a test-samples method that compares the appearance of a set
+    of reflective samples when illuminated by the test lamp to their
+    appearance under a reference illuminant. The CQS uses a larger set
+    of reflective samples, all of high chroma, and combines the color
+    differences of the samples with a root mean square. Additionally,
+    the CQS does not penalize light sources for causing increases in
+    the chroma of object colors but does penalize sources with smaller
+    rendered color gamut areas. The scale of the CQS is converted to
+    span 0-100, and the uniform object color space and chromatic
+    adaptation transform used in the calculations are updated.
+    Supplementary scales have also been developed for expert users.},
+  isbn         = {0091-3286},
+}
+@misc{DigitalCinemaInitiatives2007b,
+  title        = {Digital {{Cinema System Specification}} -
+    {{Version}} 1.1},
+  author       = {{Digital Cinema Initiatives}},
+  year         = 2007,
+}
+@misc{DjangoSoftwareFoundation2022,
+  title        = {Slugify},
+  author       = {{Django Software Foundation}},
+  year         = 2022,
+}
 @misc{Dolby2016a,
-  title = {{{WHAT IS ICTCP}}? - {{INTRODUCTION}}},
-  author = {{Dolby}},
-  year = {2016},
-  file = {/Users/kelsolaar/Zotero/storage/TNDLN3NF/Dolby - 2016 - WHAT IS ICTCP - INTRODUCTION.pdf}
+  title        = {{{WHAT IS ICTCP}}? - {{INTRODUCTION}}},
+  author       = {{Dolby}},
+  year         = 2016,
 }
-
 @misc{Dyer2017,
-  title = {{{RAW}} to {{ACES}}},
-  author = {Dyer, Scott and Forsythe, Alexander and Irons, Jonathon and Mansencal, Thomas and Zhu, Miaoqi},
-  year = {2017}
+  title        = {{{RAW}} to {{ACES}}},
+  author       = {Dyer, Scott and Forsythe, Alexander and Irons,
+    Jonathon and Mansencal, Thomas and Zhu, Miaoqi},
+  year         = 2017,
 }
-
 @misc{EasyRGBh,
-  title = {{{RGB}} --{$>$} {{CMY}}},
-  author = {{EasyRGB}},
-  howpublished = {http://www.easyrgb.com/index.php?X=MATH\&H=11\#text11}
+  title        = {{{RGB}} --{$>$} {{CMY}}},
+  author       = {{EasyRGB}},
+  howpublished = {http://www.easyrgb.com/index.php?X=MATH\&H=11\#text11},
 }
-
 @misc{EasyRGBi,
-  title = {{{CMY}} --{$>$} {{RGB}}},
-  author = {{EasyRGB}},
-  howpublished = {http://www.easyrgb.com/index.php?X=MATH\&H=12\#text12}
+  title        = {{{CMY}} --{$>$} {{RGB}}},
+  author       = {{EasyRGB}},
+  howpublished = {http://www.easyrgb.com/index.php?X=MATH\&H=12\#text12},
 }
-
 @misc{EasyRGBj,
-  title = {{{RGB}} --{$>$} {{HSV}}},
-  author = {{EasyRGB}},
-  howpublished = {http://www.easyrgb.com/index.php?X=MATH\&H=20\#text20}
+  title        = {{{RGB}} --{$>$} {{HSV}}},
+  author       = {{EasyRGB}},
+  howpublished = {http://www.easyrgb.com/index.php?X=MATH\&H=20\#text20},
 }
-
 @misc{EasyRGBk,
-  title = {{{HSL}} --{$>$} {{RGB}}},
-  author = {{EasyRGB}},
-  howpublished = {http://www.easyrgb.com/index.php?X=MATH\&H=19\#text19}
+  title        = {{{HSL}} --{$>$} {{RGB}}},
+  author       = {{EasyRGB}},
+  howpublished = {http://www.easyrgb.com/index.php?X=MATH\&H=19\#text19},
 }
-
 @misc{EasyRGBl,
-  title = {{{RGB}} --{$>$} {{HSL}}},
-  author = {{EasyRGB}},
-  howpublished = {http://www.easyrgb.com/index.php?X=MATH\&H=18\#text18}
+  title        = {{{RGB}} --{$>$} {{HSL}}},
+  author       = {{EasyRGB}},
+  howpublished = {http://www.easyrgb.com/index.php?X=MATH\&H=18\#text18},
 }
-
 @misc{EasyRGBm,
-  title = {{{CMYK}} --{$>$} {{CMY}}},
-  author = {{EasyRGB}},
-  howpublished = {http://www.easyrgb.com/index.php?X=MATH\&H=14\#text14}
+  title        = {{{CMYK}} --{$>$} {{CMY}}},
+  author       = {{EasyRGB}},
+  howpublished = {http://www.easyrgb.com/index.php?X=MATH\&H=14\#text14},
 }
-
 @misc{EasyRGBn,
-  title = {{{HSV}} --{$>$} {{RGB}}},
-  author = {{EasyRGB}},
-  howpublished = {http://www.easyrgb.com/index.php?X=MATH\&H=21\#text21}
+  title        = {{{HSV}} --{$>$} {{RGB}}},
+  author       = {{EasyRGB}},
+  howpublished = {http://www.easyrgb.com/index.php?X=MATH\&H=21\#text21},
 }
-
 @misc{EasyRGBo,
-  title = {{{CMY}} --{$>$} {{CMYK}}},
-  author = {{EasyRGB}},
-  howpublished = {http://www.easyrgb.com/index.php?X=MATH\&H=13\#text13}
+  title        = {{{CMY}} --{$>$} {{CMYK}}},
+  author       = {{EasyRGB}},
+  howpublished = {http://www.easyrgb.com/index.php?X=MATH\&H=13\#text13},
 }
-
 @inproceedings{Ebner1998,
-  title = {Finding Constant Hue Surfaces in Color Space},
-  booktitle = {Proc. {{SPIE}} 3300, {{Color Imaging}}: {{Device-Independent Color}}, {{Color Hardcopy}}, and {{Graphic Arts III}}, (2 {{January}} 1998)},
-  author = {Ebner, Fritz and Fairchild, Mark D.},
-  editor = {Beretta, Giordano B. and Eschbach, Reiner},
-  year = {1998},
-  month = jan,
-  pages = {107--117},
-  doi = {10.1117/12.298269},
-  file = {/Users/kelsolaar/Zotero/storage/BGF9VVJF/Ebner, Fairchild - 1998 - Finding constant hue surfaces in color space.pdf}
+  title        = {Finding Constant Hue Surfaces in Color Space},
+  booktitle    = {Proc. {{SPIE}} 3300, {{Color Imaging}}:
+    {{Device-Independent Color}}, {{Color Hardcopy}}, and {{Graphic
+    Arts III}}, (2 {{January}} 1998)},
+  author       = {Ebner, Fritz and Fairchild, Mark D.},
+  editor       = {Beretta, Giordano B. and Eschbach, Reiner},
+  year         = 1998,
+  month        = jan,
+  pages        = {107--117},
+  doi          = {10.1117/12.298269},
 }
-
 @misc{Erdema,
-  title = {Fast {{Line Segment Intersection}}},
-  author = {Erdem, U. Murat},
-  howpublished = {http://www.mathworks.com/matlabcentral/fileexchange/27205-fast-line-segment-intersection}
+  title        = {Fast {{Line Segment Intersection}}},
+  author       = {Erdem, U. Murat},
+  howpublished = {http://www.mathworks.com/matlabcentral/fileexchange/27205-fast-line-segment-intersection},
 }
-
 @misc{Erdogana,
-  title = {How to {{Calculate Luminosity}}, {{Dominant Wavelength}}, and {{Excitation Purity}}},
-  author = {Erdogan, Turan},
-  pages = {7},
-  abstract = {There are many different systems for analyzing and representing the color of an object perceived by a human observer. For the purposes of unambiguously specifying the color an observer sees when looking through an optical filter at a well-defined light source, we have found the CIE Color Specification System to be the most accurate (for a simple and clear description, see [1]). In this article we briefly describe the method to calculate the three main parameters that fully specify color in this system: luminosity, dominant wavelength, and excitation purity. These terms specifically refer to the definitions in the CIE system given below, but they have analogies in many other systems. A set of more general terms often used to qualitatively describe color are: brightness, hue, and saturation (analogous to luminosity, dominant wavelength, and excitation purity, respectively). These terms (and others) are often used interchangeably. Here we will adhere to the official terms assigned to the CIE system to avoid any ambiguity.},
-  file = {/Users/kelsolaar/Zotero/storage/SMPXUKKN/Erdogan - Unknown - How to Calculate Luminosity, Dominant Wavelength, and Excitation Purity.pdf}
+  title        = {How to {{Calculate Luminosity}}, {{Dominant
+    Wavelength}}, and {{Excitation Purity}}},
+  author       = {Erdogan, Turan},
+  pages        = 7,
+  abstract     = {There are many different systems for analyzing and
+    representing the color of an object perceived by a human observer.
+    For the purposes of unambiguously specifying the color an observer
+    sees when looking through an optical filter at a well-defined
+    light source, we have found the CIE Color Specification System to
+    be the most accurate (for a simple and clear description, see
+    [1]). In this article we briefly describe the method to calculate
+    the three main parameters that fully specify color in this system:
+    luminosity, dominant wavelength, and excitation purity. These
+    terms specifically refer to the definitions in the CIE system
+    given below, but they have analogies in many other systems. A set
+    of more general terms often used to qualitatively describe color
+    are: brightness, hue, and saturation (analogous to luminosity,
+    dominant wavelength, and excitation purity, respectively). These
+    terms (and others) are often used interchangeably. Here we will
+    adhere to the official terms assigned to the CIE system to avoid
+    any ambiguity.},
 }
-
 @misc{EuropeanBroadcastingUnion1975,
-  title = {{{EBU Tech}} 3213 - {{EBU Standard}} for {{Chromaticity Tolerances}} for {{Studio Monitors}}},
-  author = {{European Broadcasting Union}},
-  year = {1975},
-  month = aug
+  title        = {{{EBU Tech}} 3213 - {{EBU Standard}} for
+    {{Chromaticity Tolerances}} for {{Studio Monitors}}},
+  author       = {{European Broadcasting Union}},
+  year         = 1975,
+  month        = aug,
 }
-
 @misc{EuropeanColorInitiative2002a,
-  title = {{{ECI RGB}} V2},
-  author = {{European Color Initiative}},
-  year = {2002}
+  title        = {{{ECI RGB}} V2},
+  author       = {{European Color Initiative}},
+  year         = 2002,
 }
-
-@article{Fairchild1991a,
-  title = {Formulation and Testing of an Incomplete-Chromatic-Adaptation Model},
-  author = {Fairchild, Mark D.},
-  year = {1991},
-  month = aug,
-  journal = {Color Research \& Application},
-  volume = {16},
-  number = {4},
-  pages = {243--250},
-  issn = {03612317},
-  doi = {10.1002/col.5080160406},
-  abstract = {A mathematical model of chromatic adaptation for calculating corresponding colors across changes of illumination based on the Hunt color appearance model is formulated and tested. This model consists of a modified von Kries transform that accounts for incomplete levels of adaptation. The model predicts that adaptation will be less complete as the saturation of the adapting stimulus increases and more complete as the luminance of the adapting stimulus increases. An experiment is described in which achromatic appearance is measured for various adapting conditions. The model is tested with these experimental results as well as results from another study and found to be significantly better at predicting corresponding colors than other proposed models.},
-  file = {/Users/kelsolaar/Zotero/storage/TU58D87I/Fairchild - 1991 - Formulation and testing of an incomplete-chromatic-adaptation model.pdf}
-}
-
-@article{Fairchild1996a,
-  title = {Refinement of the {{RLAB}} Color Space},
-  author = {Fairchild, Mark D.},
-  year = {1996},
-  month = oct,
-  journal = {Color Research \& Application},
-  volume = {21},
-  number = {5},
-  pages = {338--346},
-  issn = {0361-2317},
-  doi = {10.1002/(SICI)1520-6378(199610)21:5<338::AID-COL3>3.0.CO;2-Z},
-  abstract = {The prediction of color appearance using the RLAB color space has been tested for a variety of viewing conditions and stimulus types. These tests have shown that RLAB performs well for complex stimuli and not-so-well for simple stimuli. This article reviews the various psychophysical results, interprets their differences, and describes evolutionary enhancements to the RLAB model that simplify it and improve its performance. (C) 1996 John Wiley \& Sons, Inc.},
-  keywords = {color appearance,color spaces,color-appearance models},
-  file = {/Users/kelsolaar/Zotero/storage/4GFPCJDY/Fairchild - 1996 - Refinement of the RLAB color space.pdf}
-}
-
-@misc{Fairchild1998b,
-  title = {Colorimetric {{Characterization}} of {{The Apple Studio Display}} (Flat Panel {{LCD}})},
-  author = {Fairchild, M. and Wyble, D.},
-  year = {1998},
-  pages = {22},
-  abstract = {The colorimetric characterization of a flat-panel LCD monitor, the Apple Studio Display, using traditional CRT characterization techniques was evaluated. The results showed that the display performed up to the manufacturer's specifications in terms of luminance and contrast. However, the traditional CRT gain-offset-gamma (GOG) model for characterization was inadequate and a model with one-dimensional lookup tables followed by a 3x3 matrix was developed. The LUT model performed excellently with average CIE94 color differences between measured and predicted colors of approximately 1.0.},
-  file = {/Users/kelsolaar/Zotero/storage/IZFF4EKD/Fairchild, Wyble - 1998 - Colorimetric Characterization of The Apple Studio Display (flat panel LCD).pdf}
-}
-
-@incollection{Fairchild2004c,
-  title = {{{CIECAM02}}},
-  booktitle = {Color {{Appearance Models}}},
-  author = {Fairchild, Mark D.},
-  year = {2004},
-  edition = {Second},
-  pages = {289--301},
-  publisher = {{Wiley}},
-  isbn = {978-0-470-01216-1},
-  file = {/Users/kelsolaar/Zotero/storage/J8NW5I3Q/Fairchild - 2004 - CIECAM02.pdf}
-}
-
-@inproceedings{Fairchild2010,
-  title = {Hdr-{{CIELAB}} and Hdr-{{IPT}}: {{Simple Models}} for {{Describing}} the {{Color}} of {{High-Dynamic-Range}} and {{Wide-Color-Gamut Images}}},
-  booktitle = {Proc. of {{Color}} and {{Imaging Conference}}},
-  author = {Fairchild, Mark D. and Wyble, David R.},
-  year = {2010},
-  pages = {322--326},
-  issn = {21669635},
-  isbn = {978-1-62993-215-6},
-  keywords = {Copyright 2010 Society for Imaging Science and Tec},
-  file = {/Users/kelsolaar/Zotero/storage/JDMMH2D7/Fairchild, Wyble - 2010 - hdr-CIELAB and hdr-IPT Simple Models for Describing the Color of High-Dynamic-Range and Wide-Color-Gamut Image.pdf}
-}
-
-@inproceedings{Fairchild2011,
-  title = {Brightness, Lightness, and Specifying Color in High-Dynamic-Range Scenes and Images},
-  booktitle = {Proc. {{SPIE}} 7867, {{Image Quality}} and {{System Performance VIII}}},
-  author = {Fairchild, Mark D and Chen, Ping-hsu},
-  editor = {Farnand, Susan P. and Gaykema, Frans},
-  year = {2011},
-  month = jan,
-  pages = {78670O},
-  doi = {10.1117/12.872075},
-  keywords = {color appearance,color differences,color spaces,hdr,image quality,lightness},
-  file = {/Users/kelsolaar/Zotero/storage/TF57G2HW/Fairchild, Chen - 2011 - Brightness, lightness, and specifying color in high-dynamic-range scenes and images.pdf}
-}
-
-@incollection{Fairchild2013ba,
-  title = {The {{Nayatani}} et al. {{Model}}},
-  booktitle = {Color {{Appearance Models}}},
-  author = {Fairchild, Mark D.},
-  year = {2013},
-  edition = {Third},
-  pages = {4810--5085},
-  publisher = {{Wiley}},
-  isbn = {B00DAYO8E2}
-}
-
-@incollection{Fairchild2013s,
-  title = {{{FAIRCHILD}}'{{S}} 1990 {{MODEL}}},
-  booktitle = {Color {{Appearance Models}}},
-  author = {Fairchild, Mark D.},
-  year = {2013},
-  edition = {Third},
-  pages = {4418--4495},
-  publisher = {{Wiley}},
-  isbn = {B00DAYO8E2}
-}
-
-@incollection{Fairchild2013t,
-  title = {Chromatic {{Adaptation Models}}},
-  booktitle = {Color {{Appearance Models}}},
-  author = {Fairchild, Mark D.},
-  year = {2013},
-  edition = {Third},
-  pages = {4179--4252},
-  publisher = {{Wiley}},
-  isbn = {B00DAYO8E2}
-}
-
-@incollection{Fairchild2013u,
-  title = {The {{Hunt Model}}},
-  booktitle = {Color {{Appearance Models}}},
-  author = {Fairchild, Mark D.},
-  year = {2013},
-  edition = {Third},
-  pages = {5094--5556},
-  publisher = {{Wiley}},
-  isbn = {B00DAYO8E2}
-}
-
-@incollection{Fairchild2013v,
-  title = {{{ATD Model}}},
-  booktitle = {Color {{Appearance Models}}},
-  author = {Fairchild, Mark D.},
-  year = {2013},
-  edition = {Third},
-  pages = {5852--5991},
-  publisher = {{Wiley}},
-  isbn = {B00DAYO8E2}
-}
-
-@incollection{Fairchild2013w,
-  title = {The {{RLAB Model}}},
-  booktitle = {Color {{Appearance Models}}},
-  author = {Fairchild, Mark D.},
-  year = {2013},
-  edition = {Third},
-  pages = {5563--5824},
-  publisher = {{Wiley}},
-  isbn = {B00DAYO8E2}
-}
-
-@incollection{Fairchild2013x,
-  title = {{{LLAB Model}}},
-  booktitle = {Color {{Appearance Models}}},
-  author = {Fairchild, Mark D.},
-  year = {2013},
-  edition = {Third},
-  pages = {6025--6178},
-  publisher = {{Wiley}},
-  isbn = {B00DAYO8E2}
-}
-
-@incollection{Fairchild2013y,
-  title = {{{IPT Colourspace}}},
-  booktitle = {Color {{Appearance Models}}},
-  author = {Fairchild, Mark D.},
-  year = {2013},
-  edition = {Third},
-  pages = {6197--6223},
-  publisher = {{Wiley}},
-  isbn = {B00DAYO8E2}
-}
-
-@misc{Fairchild2022,
-  title = {Private {{Discussion}} with {{Mansencal}}, {{T}}.},
-  author = {Fairchild, Mark D and Hellwig, Luke},
-  year = {2022}
-}
-
-@misc{Fairchildb,
-  title = {Fairchild {{YSh}}},
-  author = {Fairchild, Mark D.}
-}
-
-@article{Fairman1985b,
-  title = {The Calculation of Weight Factors for Tristimulus Integration},
-  author = {Fairman, Hugh S.},
-  year = {1985},
-  journal = {Color Research \& Application},
-  volume = {10},
-  number = {4},
-  pages = {199--203},
-  issn = {03612317},
-  doi = {10.1002/col.5080100407},
-  file = {/Users/kelsolaar/Zotero/storage/E3XHFRKF/Fairman - 1985 - The calculation of weight factors for tristimulus integration.pdf}
-}
-
-@article{Fairman1997,
-  title = {How the {{CIE}} 1931 Color-Matching Functions Were Derived from {{Wright-Guild}} Data},
-  author = {Fairman, Hugh S. and Brill, Michael H. and Hemmendinger, Henry},
-  year = {1997},
-  month = feb,
-  journal = {Color Research \& Application},
-  volume = {22},
-  number = {1},
-  pages = {11--23},
-  issn = {0361-2317},
-  doi = {10.1002/(SICI)1520-6378(199702)22:1<11::AID-COL4>3.0.CO;2-7},
-  abstract = {Page 1. How the CIE 1931 Color-Matching Functions Were Derived from Wright-Guild Data Hugh S. Fairman, 1 Michael H. Brill, 2 Henry Hemmendinger 3},
-  keywords = {alychne,chromaticity diagram,cie,cie 1931 system,color-matching,colorimetry,cus,guild data,mation,primary colors,spectrum lo-,transfor-,wright},
-  file = {/Users/kelsolaar/Zotero/storage/8USALHXY/Fairman, Brill, Hemmendinger - 1997 - How the CIE 1931 color-matching functions were derived from Wright-Guild data.pdf}
-}
-
 @misc{FFmpegDevelopers2022,
-  title = {{{FFmpeg}}::{{AVColorPrimaries}}},
-  author = {{FFmpeg Developers}},
-  year = {2022},
-  month = aug
+  title        = {{{FFmpeg}}::{{AVColorPrimaries}}},
+  author       = {{FFmpeg Developers}},
+  year         = 2022,
+  month        = aug,
 }
-
 @misc{FFmpegDevelopers2022a,
-  title = {{{FFmpeg}}::{{AVColorTransferCharacteristic}}},
-  author = {{FFmpeg Developers}},
-  year = {2022},
-  month = aug
+  title        = {{{FFmpeg}}::{{AVColorTransferCharacteristic}}},
+  author       = {{FFmpeg Developers}},
+  year         = 2022,
+  month        = aug,
 }
-
 @misc{FFmpegDevelopers2022b,
-  title = {{{FFmpeg}}::{{AVColorSpace}}},
-  author = {{FFmpeg Developers}},
-  year = {2022},
-  month = aug
+  title        = {{{FFmpeg}}::{{AVColorSpace}}},
+  author       = {{FFmpeg Developers}},
+  year         = 2022,
+  month        = aug,
 }
-
+@article{Fairchild1991a,
+  title        = {Formulation and Testing of an
+    Incomplete-Chromatic-Adaptation Model},
+  author       = {Fairchild, Mark D.},
+  year         = 1991,
+  month        = aug,
+  journal      = {Color Research \& Application},
+  volume       = 16,
+  number       = 4,
+  pages        = {243--250},
+  issn         = 03612317,
+  doi          = {10.1002/col.5080160406},
+  abstract     = {A mathematical model of chromatic adaptation for
+    calculating corresponding colors across changes of illumination
+    based on the Hunt color appearance model is formulated and tested.
+    This model consists of a modified von Kries transform that
+    accounts for incomplete levels of adaptation. The model predicts
+    that adaptation will be less complete as the saturation of the
+    adapting stimulus increases and more complete as the luminance of
+    the adapting stimulus increases. An experiment is described in
+    which achromatic appearance is measured for various adapting
+    conditions. The model is tested with these experimental results as
+    well as results from another study and found to be significantly
+    better at predicting corresponding colors than other proposed
+    models.},
+}
+@article{Fairchild1996a,
+  title        = {Refinement of the {{RLAB}} Color Space},
+  author       = {Fairchild, Mark D.},
+  year         = 1996,
+  month        = oct,
+  journal      = {Color Research \& Application},
+  volume       = 21,
+  number       = 5,
+  pages        = {338--346},
+  issn         = {0361-2317},
+  doi          = {10.1002/(SICI)1520-6378(199610)21:5<338::AID-COL3>3.0.CO;2-Z},
+  abstract     = {The prediction of color appearance using the RLAB
+    color space has been tested for a variety of viewing conditions
+    and stimulus types. These tests have shown that RLAB performs well
+    for complex stimuli and not-so-well for simple stimuli. This
+    article reviews the various psychophysical results, interprets
+    their differences, and describes evolutionary enhancements to the
+    RLAB model that simplify it and improve its performance. (C) 1996
+    John Wiley \& Sons, Inc.},
+  keywords     = {color appearance,color spaces,color-appearance
+    models},
+}
+@misc{Fairchild1998b,
+  title        = {Colorimetric {{Characterization}} of {{The Apple
+    Studio Display}} (Flat Panel {{LCD}})},
+  author       = {Fairchild, M. and Wyble, D.},
+  year         = 1998,
+  pages        = 22,
+  abstract     = {The colorimetric characterization of a flat-panel
+    LCD monitor, the Apple Studio Display, using traditional CRT
+    characterization techniques was evaluated. The results showed that
+    the display performed up to the manufacturer's specifications in
+    terms of luminance and contrast. However, the traditional CRT
+    gain-offset-gamma (GOG) model for characterization was inadequate
+    and a model with one-dimensional lookup tables followed by a 3x3
+    matrix was developed. The LUT model performed excellently with
+    average CIE94 color differences between measured and predicted
+    colors of approximately 1.0.},
+}
+@incollection{Fairchild2004c,
+  title        = {{{CIECAM02}}},
+  booktitle    = {Color {{Appearance Models}}},
+  author       = {Fairchild, Mark D.},
+  year         = 2004,
+  edition      = {Second},
+  pages        = {289--301},
+  publisher    = {{Wiley}},
+  isbn         = {978-0-470-01216-1},
+}
+@inproceedings{Fairchild2010,
+  title        = {Hdr-{{CIELAB}} and Hdr-{{IPT}}: {{Simple Models}}
+    for {{Describing}} the {{Color}} of {{High-Dynamic-Range}} and
+    {{Wide-Color-Gamut Images}}},
+  booktitle    = {Proc. of {{Color}} and {{Imaging Conference}}},
+  author       = {Fairchild, Mark D. and Wyble, David R.},
+  year         = 2010,
+  pages        = {322--326},
+  issn         = 21669635,
+  isbn         = {978-1-62993-215-6},
+  keywords     = {Copyright 2010 Society for Imaging Science and Tec},
+}
+@inproceedings{Fairchild2011,
+  title        = {Brightness, Lightness, and Specifying Color in
+    High-Dynamic-Range Scenes and Images},
+  booktitle    = {Proc. {{SPIE}} 7867, {{Image Quality}} and {{System
+    Performance VIII}}},
+  author       = {Fairchild, Mark D and Chen, Ping-hsu},
+  editor       = {Farnand, Susan P. and Gaykema, Frans},
+  year         = 2011,
+  month        = jan,
+  pages        = {78670O},
+  doi          = {10.1117/12.872075},
+  keywords     = {color appearance,color differences,color
+    spaces,hdr,image quality,lightness},
+}
+@incollection{Fairchild2013ba,
+  title        = {The {{Nayatani}} et al. {{Model}}},
+  booktitle    = {Color {{Appearance Models}}},
+  author       = {Fairchild, Mark D.},
+  year         = 2013,
+  edition      = {Third},
+  pages        = {4810--5085},
+  publisher    = {{Wiley}},
+  isbn         = {B00DAYO8E2},
+}
+@incollection{Fairchild2013s,
+  title        = {{{FAIRCHILD}}'{{S}} 1990 {{MODEL}}},
+  booktitle    = {Color {{Appearance Models}}},
+  author       = {Fairchild, Mark D.},
+  year         = 2013,
+  edition      = {Third},
+  pages        = {4418--4495},
+  publisher    = {{Wiley}},
+  isbn         = {B00DAYO8E2},
+}
+@incollection{Fairchild2013t,
+  title        = {Chromatic {{Adaptation Models}}},
+  booktitle    = {Color {{Appearance Models}}},
+  author       = {Fairchild, Mark D.},
+  year         = 2013,
+  edition      = {Third},
+  pages        = {4179--4252},
+  publisher    = {{Wiley}},
+  isbn         = {B00DAYO8E2},
+}
+@incollection{Fairchild2013u,
+  title        = {The {{Hunt Model}}},
+  booktitle    = {Color {{Appearance Models}}},
+  author       = {Fairchild, Mark D.},
+  year         = 2013,
+  edition      = {Third},
+  pages        = {5094--5556},
+  publisher    = {{Wiley}},
+  isbn         = {B00DAYO8E2},
+}
+@incollection{Fairchild2013v,
+  title        = {{{ATD Model}}},
+  booktitle    = {Color {{Appearance Models}}},
+  author       = {Fairchild, Mark D.},
+  year         = 2013,
+  edition      = {Third},
+  pages        = {5852--5991},
+  publisher    = {{Wiley}},
+  isbn         = {B00DAYO8E2},
+}
+@incollection{Fairchild2013w,
+  title        = {The {{RLAB Model}}},
+  booktitle    = {Color {{Appearance Models}}},
+  author       = {Fairchild, Mark D.},
+  year         = 2013,
+  edition      = {Third},
+  pages        = {5563--5824},
+  publisher    = {{Wiley}},
+  isbn         = {B00DAYO8E2},
+}
+@incollection{Fairchild2013x,
+  title        = {{{LLAB Model}}},
+  booktitle    = {Color {{Appearance Models}}},
+  author       = {Fairchild, Mark D.},
+  year         = 2013,
+  edition      = {Third},
+  pages        = {6025--6178},
+  publisher    = {{Wiley}},
+  isbn         = {B00DAYO8E2},
+}
+@incollection{Fairchild2013y,
+  title        = {{{IPT Colourspace}}},
+  booktitle    = {Color {{Appearance Models}}},
+  author       = {Fairchild, Mark D.},
+  year         = 2013,
+  edition      = {Third},
+  pages        = {6197--6223},
+  publisher    = {{Wiley}},
+  isbn         = {B00DAYO8E2},
+}
+@misc{Fairchild2022,
+  title        = {Private {{Discussion}} with {{Mansencal}}, {{T}}.},
+  author       = {Fairchild, Mark D and Hellwig, Luke},
+  year         = 2022,
+}
+@misc{Fairchildb,
+  title        = {Fairchild {{YSh}}},
+  author       = {Fairchild, Mark D.},
+}
+@article{Fairman1985b,
+  title        = {The Calculation of Weight Factors for Tristimulus
+    Integration},
+  author       = {Fairman, Hugh S.},
+  year         = 1985,
+  journal      = {Color Research \& Application},
+  volume       = 10,
+  number       = 4,
+  pages        = {199--203},
+  issn         = 03612317,
+  doi          = {10.1002/col.5080100407},
+}
+@article{Fairman1997,
+  title        = {How the {{CIE}} 1931 Color-Matching Functions Were
+    Derived from {{Wright-Guild}} Data},
+  author       = {Fairman, Hugh S. and Brill, Michael H. and
+    Hemmendinger, Henry},
+  year         = 1997,
+  month        = feb,
+  journal      = {Color Research \& Application},
+  volume       = 22,
+  number       = 1,
+  pages        = {11--23},
+  issn         = {0361-2317},
+  doi          = {10.1002/(SICI)1520-6378(199702)22:1<11::AID-COL4>3.0.CO;2-7},
+  abstract     = {Page 1. How the CIE 1931 Color-Matching Functions
+    Were Derived from Wright-Guild Data Hugh S. Fairman, 1 Michael H.
+    Brill, 2 Henry Hemmendinger 3},
+  keywords     = {alychne,chromaticity diagram,cie,cie 1931
+    system,color-matching,colorimetry,cus,guild data,mation,primary
+    colors,spectrum lo-,transfor-,wright},
+}
 @misc{FiLMiCInc2017,
-  title = {{{FiLMiC Pro}} - {{User Manual}} v6 - {{Revision}} 1},
-  author = {{FiLMiC Inc}},
-  year = {2017},
-  pages = {1--46},
-  file = {/Users/kelsolaar/Zotero/storage/SCXMQ6YV/FiLMiC Inc - 2017 - FiLMiC Pro - User Manual v6 - Revision 1.pdf}
+  title        = {{{FiLMiC Pro}} - {{User Manual}} v6 - {{Revision}} 1},
+  author       = {{FiLMiC Inc}},
+  year         = 2017,
+  pages        = {1--46},
 }
-
 @article{Finlayson2015,
-  title = {Color {{Correction Using Root-Polynomial Regression}}},
-  author = {Finlayson, Graham D. and MacKiewicz, Michal and Hurlbert, Anya},
-  year = {2015},
-  month = may,
-  journal = {IEEE Transactions on Image Processing},
-  volume = {24},
-  number = {5},
-  pages = {1460--1470},
-  issn = {10577149},
-  doi = {10.1109/TIP.2015.2405336},
-  abstract = {Cameras record three color responses (RGB) which are device dependent. Camera coordinates are mapped to a standard color space, such as XYZ\textemdash useful for color measurement\textemdash by amapping function, e.g., the simple 3\texttimes 3 linear transform (usually derived through regression). This mapping, which we will refer to as linear color correction (LCC), has been demonstrated to work well in the number of studies. However, it can map RGBs to XYZs with high error. The advantage of the LCC is that it is independent of camera exposure. An alternative and potentially more powerful method for color correction is polynomial color correction (PCC). Here, the R, G,and B values at a pixel are extended by the polynomial terms. For a given calibration training set PCC can significantly reduce the colorimetric error. However, the PCC fit depends on exposure, i.e., as exposure changes the vector of polynomial components is altered in a nonlinear way which results in hue and saturation shifts. This paper proposes a new polynomial-type regression loosely related to the idea of fractional polynomials which we call root-PCC (RPCC). Our idea is to take each term in a polynomial expansion and take its kth root of each k-degree term. It is easy to show terms defined in this way scale with exposure. RPCC is a simple (low complexity) extension of LCC. The experiments presented in this paper demonstrate that RPCC enhances color correction performance on real and synthetic data.},
-  isbn = {1057-7149 VO - 24},
-  keywords = {camera characterization,Color correction,polynomial regression},
-  file = {/Users/kelsolaar/Zotero/storage/XD9AMJPE/Finlayson, MacKiewicz, Hurlbert - 2015 - Color Correction Using Root-Polynomial Regression.pdf}
+  title        = {Color {{Correction Using Root-Polynomial
+    Regression}}},
+  author       = {Finlayson, Graham D. and MacKiewicz, Michal and
+    Hurlbert, Anya},
+  year         = 2015,
+  month        = may,
+  journal      = {IEEE Transactions on Image Processing},
+  volume       = 24,
+  number       = 5,
+  pages        = {1460--1470},
+  issn         = 10577149,
+  doi          = {10.1109/TIP.2015.2405336},
+  abstract     = {Cameras record three color responses (RGB) which are
+    device dependent. Camera coordinates are mapped to a standard
+    color space, such as XYZ\textemdash useful for color
+    measurement\textemdash by amapping function, e.g., the simple
+    3\texttimes 3 linear transform (usually derived through
+    regression). This mapping, which we will refer to as linear color
+    correction (LCC), has been demonstrated to work well in the number
+    of studies. However, it can map RGBs to XYZs with high error. The
+    advantage of the LCC is that it is independent of camera exposure.
+    An alternative and potentially more powerful method for color
+    correction is polynomial color correction (PCC). Here, the R,
+    G,and B values at a pixel are extended by the polynomial terms.
+    For a given calibration training set PCC can significantly reduce
+    the colorimetric error. However, the PCC fit depends on exposure,
+    i.e., as exposure changes the vector of polynomial components is
+    altered in a nonlinear way which results in hue and saturation
+    shifts. This paper proposes a new polynomial-type regression
+    loosely related to the idea of fractional polynomials which we
+    call root-PCC (RPCC). Our idea is to take each term in a
+    polynomial expansion and take its kth root of each k-degree term.
+    It is easy to show terms defined in this way scale with exposure.
+    RPCC is a simple (low complexity) extension of LCC. The
+    experiments presented in this paper demonstrate that RPCC enhances
+    color correction performance on real and synthetic data.},
+  isbn         = {1057-7149 VO - 24},
+  keywords     = {camera characterization,Color correction,polynomial
+    regression},
 }
-
 @misc{Forsythe2018,
-  title = {Private {{Discussion}} with {{Mansencal}}, {{T}}},
-  author = {Forsythe, Alex},
-  year = {2018}
+  title        = {Private {{Discussion}} with {{Mansencal}}, {{T}}},
+  author       = {Forsythe, Alex},
+  year         = 2018,
 }
-
 @misc{Frohlich2017,
-  title = {Encoding High Dynamic Range and Wide Color Gamut Imagery},
-  author = {Fr{\"o}hlich, Jan},
-  year = {2017},
-  publisher = {{Universit\"at Stuttgart}},
-  abstract = {In dieser Dissertation wird ein szenischer Bewegtbilddatensatz mit erweitertem Dynamikumfang (High Dynamic Range, HDR) und gro\ss em Farbumfang (Wide Color Gamut, WCG) eingef\"uhrt und es werden Modelle zur Kodierung von HDR und WCG Bildern vorgestellt. Die objektive und visuelle Evaluation neuer HDR und WCG Bildverarbeitungsalgorithmen, Kompressionsverfahren und Bildwiedergabeger\"ate erfordert einen Referenzdatensatz hoher Qualit\"at. Daher wird ein neuer HDR- und WCG-Video-Datensatz mit einem Dynamikumfang von bis zu 18 fotografischen Blenden eingef\"uhrt. Er enth\"alt inszenierte und dokumentarische Szenen. Die einzelnen Szenen sind konzipiert um eine Herausforderung f\"ur Tone Mapping Operatoren, Gamut Mapping Algorithmen, Kompressionscodecs und HDR und WCG Bildanzeigeger\"ate darzustellen. Die Szenen sind mit professionellem Licht, Maske und Filmausstattung aufgenommen. Um einen cinematischen Bildeindruck zu erhalten, werden digitale Filmkameras mit `Super-35 mm' Sensorgr\"o\ss e verwendet. Der zus\"atzliche Informationsgehalt von HDR- und WCG-Videosignalen erfordert im Vergleich zu Signalen mit herk\"ommlichem Dynamikumfang eine neue und effizientere Signalkodierung. Ein Farbraum f\"ur HDR und WCG Video sollte nicht nur effizient quantisieren, sondern wegen der unterschiedlichen Monitoreigenschaften auf der Empf\"angerseite auch f\"ur die Dynamik- und Farbumfangsanpassung geeignet sein. Bisher wurden Methoden f\"ur die Quantisierung von HDR Luminanzsignalen vorgeschlagen. Es fehlt jedoch noch ein entsprechendes Modell f\"ur Farbdifferenzsignale. Es werden daher zwei neue Farbr\"aume eingef\"uhrt, die sich sowohl f\"ur die effiziente Kodierung von HDR und WCG Signalen als auch f\"ur die Dynamik- und Farbumfangsanpassung eignen. Diese Farbr\"aume werden mit existierenden HDR und WCG Farbsignalkodierungen des aktuellen Stands der Technik verglichen. Die vorgestellten Kodierungsschemata erlauben es, HDR- und WCG-Video mittels drei Farbkan\"alen mit 12 Bits tonaler Aufl\"osung zu quantisieren, ohne dass Quantisierungsartefakte sichtbar werden. W\"ahrend die Speicherung und \"Ubertragung von HDR und WCG Video mit 12-Bit Farbtiefe pro Kanal angestrebt wird, unterst\"utzen aktuell verbreitete Dateiformate, Videoschnittstellen und Kompressionscodecs oft nur niedrigere Bittiefen. Um diese existierende Infrastruktur f\"ur die HDR Video\"ubertragung und -speicherung nutzen zu k\"onnen, wird ein neues bildinhaltsabh\"angiges Quantisierungsschema eingef\"uhrt. Diese Quantisierungsmethode nutzt Bildeigenschaften wie Rauschen und Textur um die ben\"otigte tonale Aufl\"osung f\"ur die visuell verlustlose Quantisierung zu sch\"atzen. Die vorgestellte Methode erlaubt es HDR Video mit einer Bittiefe von 10 Bits ohne sichtbare Unterschiede zum Original zu quantisieren und kommt mit weniger Rechenkraft im Vergleich zu aktuellen HDR Bilddifferenzmetriken aus.},
-  collaborator = {Universit{\"a}t Stuttgart and Universit{\"a}t Stuttgart},
-  langid = {english},
-  keywords = {004},
-  file = {/Users/kelsolaar/Zotero/storage/A73FYINJ/Fröhlich - 2017 - Encoding high dynamic range and wide color gamut i.pdf}
+  title        = {Encoding High Dynamic Range and Wide Color Gamut
+    Imagery},
+  author       = {Fr{\"o}hlich, Jan},
+  year         = 2017,
+  publisher    = {{Universit\"at Stuttgart}},
+  abstract     = {In dieser Dissertation wird ein szenischer
+    Bewegtbilddatensatz mit erweitertem Dynamikumfang (High Dynamic
+    Range, HDR) und gro\ss em Farbumfang (Wide Color Gamut, WCG)
+    eingef\"uhrt und es werden Modelle zur Kodierung von HDR und WCG
+    Bildern vorgestellt. Die objektive und visuelle Evaluation neuer
+    HDR und WCG Bildverarbeitungsalgorithmen, Kompressionsverfahren
+    und Bildwiedergabeger\"ate erfordert einen Referenzdatensatz hoher
+    Qualit\"at. Daher wird ein neuer HDR- und WCG-Video-Datensatz mit
+    einem Dynamikumfang von bis zu 18 fotografischen Blenden
+    eingef\"uhrt. Er enth\"alt inszenierte und dokumentarische Szenen.
+    Die einzelnen Szenen sind konzipiert um eine Herausforderung f\"ur
+    Tone Mapping Operatoren, Gamut Mapping Algorithmen,
+    Kompressionscodecs und HDR und WCG Bildanzeigeger\"ate
+    darzustellen. Die Szenen sind mit professionellem Licht, Maske und
+    Filmausstattung aufgenommen. Um einen cinematischen Bildeindruck
+    zu erhalten, werden digitale Filmkameras mit `Super-35 mm'
+    Sensorgr\"o\ss e verwendet. Der zus\"atzliche Informationsgehalt
+    von HDR- und WCG-Videosignalen erfordert im Vergleich zu Signalen
+    mit herk\"ommlichem Dynamikumfang eine neue und effizientere
+    Signalkodierung. Ein Farbraum f\"ur HDR und WCG Video sollte nicht
+    nur effizient quantisieren, sondern wegen der unterschiedlichen
+    Monitoreigenschaften auf der Empf\"angerseite auch f\"ur die
+    Dynamik- und Farbumfangsanpassung geeignet sein. Bisher wurden
+    Methoden f\"ur die Quantisierung von HDR Luminanzsignalen
+    vorgeschlagen. Es fehlt jedoch noch ein entsprechendes Modell
+    f\"ur Farbdifferenzsignale. Es werden daher zwei neue Farbr\"aume
+    eingef\"uhrt, die sich sowohl f\"ur die effiziente Kodierung von
+    HDR und WCG Signalen als auch f\"ur die Dynamik- und
+    Farbumfangsanpassung eignen. Diese Farbr\"aume werden mit
+    existierenden HDR und WCG Farbsignalkodierungen des aktuellen
+    Stands der Technik verglichen. Die vorgestellten
+    Kodierungsschemata erlauben es, HDR- und WCG-Video mittels drei
+    Farbkan\"alen mit 12 Bits tonaler Aufl\"osung zu quantisieren,
+    ohne dass Quantisierungsartefakte sichtbar werden. W\"ahrend die
+    Speicherung und \"Ubertragung von HDR und WCG Video mit 12-Bit
+    Farbtiefe pro Kanal angestrebt wird, unterst\"utzen aktuell
+    verbreitete Dateiformate, Videoschnittstellen und
+    Kompressionscodecs oft nur niedrigere Bittiefen. Um diese
+    existierende Infrastruktur f\"ur die HDR Video\"ubertragung und
+    -speicherung nutzen zu k\"onnen, wird ein neues
+    bildinhaltsabh\"angiges Quantisierungsschema eingef\"uhrt. Diese
+    Quantisierungsmethode nutzt Bildeigenschaften wie Rauschen und
+    Textur um die ben\"otigte tonale Aufl\"osung f\"ur die visuell
+    verlustlose Quantisierung zu sch\"atzen. Die vorgestellte Methode
+    erlaubt es HDR Video mit einer Bittiefe von 10 Bits ohne sichtbare
+    Unterschiede zum Original zu quantisieren und kommt mit weniger
+    Rechenkraft im Vergleich zu aktuellen HDR Bilddifferenzmetriken
+    aus.},
+  collaborator = {Universit{\"a}t Stuttgart and Universit{\"a}t
+    Stuttgart},
+  langid       = {english},
+  keywords     = 004,
 }
-
 @misc{Fujifilm2016,
-  title = {F-{{Log Data Sheet Ver}}.1.0},
-  author = {{Fujifilm}},
-  year = {2016},
-  pages = {1--4},
-  file = {/Users/kelsolaar/Zotero/storage/VWE47E88/Fujifilm - 2016 - F-Log Data Sheet Ver.1.0.pdf}
+  title        = {F-{{Log Data Sheet Ver}}.1.0},
+  author       = {{Fujifilm}},
+  year         = 2016,
+  pages        = {1--4},
 }
-
 @misc{Gaggioni,
-  title = {S-{{Log}}: {{A}} New {{LUT}} for Digital Production Mastering and Interchange Applications},
-  author = {Gaggioni, Hugo and Dhanendra, Patel and Yamashita, Jin and Kawada, N. and Endo, K. and Clark, Curtis},
-  volume = {709},
-  pages = {1--13},
-  file = {/Users/kelsolaar/Zotero/storage/MBGPUINB/Gaggioni et al. - Unknown - S-Log A new LUT for digital production mastering and interchange applications.pdf}
+  title        = {S-{{Log}}: {{A}} New {{LUT}} for Digital Production
+    Mastering and Interchange Applications},
+  author       = {Gaggioni, Hugo and Dhanendra, Patel and Yamashita,
+    Jin and Kawada, N. and Endo, K. and Clark, Curtis},
+  volume       = 709,
+  pages        = {1--13},
 }
-
 @article{Garcia2007,
-  title = {Measurement of the Relationship between Perceived and Computed Color Differences},
-  author = {Garc{\'i}a, Pedro A. and Huertas, Rafael and Melgosa, Manuel and Cui, Guihua},
-  year = {2007},
-  month = jul,
-  journal = {Journal of the Optical Society of America A},
-  volume = {24},
-  number = {7},
-  pages = {1823},
-  issn = {1084-7529, 1520-8532},
-  doi = {10.1364/JOSAA.24.001823},
-  langid = {english},
-  file = {/Users/kelsolaar/Zotero/storage/YKA34UYC/García et al. - 2007 - Measurement of the relationship between perceived .pdf}
+  title        = {Measurement of the Relationship between Perceived
+    and Computed Color Differences},
+  author       = {Garc{\'i}a, Pedro A. and Huertas, Rafael and
+    Melgosa, Manuel and Cui, Guihua},
+  year         = 2007,
+  month        = jul,
+  journal      = {Journal of the Optical Society of America A},
+  volume       = 24,
+  number       = 7,
+  pages        = 1823,
+  issn         = {1084-7529, 1520-8532},
+  doi          = {10.1364/JOSAA.24.001823},
+  langid       = {english},
 }
-
 @article{Glasser1958a,
-  title = {Cube-{{Root Color Coordinate System}}},
-  author = {Glasser, L. G. and McKinney, A. H. and Reilly, C. D. and Schnelle, P. D.},
-  year = {1958},
-  month = oct,
-  journal = {Journal of the Optical Society of America},
-  volume = {48},
-  number = {10},
-  pages = {736},
-  publisher = {{OSA}},
-  issn = {0030-3941},
-  doi = {10.1364/JOSA.48.000736},
-  abstract = {A visually uniform color coordinate system, based upon simple mathematical formulas, is described. This system resembles the Adams chromatic-value system but replaces the quintic-parabola function with a cube-root function. For colors having reflectances greater than 0.5\% the color spacing obtained agrees with Munsell spacing as closely as the modified Adams system. At lower reflectances an expanded color spacing over that of the Munsell system is provided. The cube-root equations can be solved directly for color coordinate differences in terms of simple functions of the difference in colorimeter readings or tristimulus values. The computation of color coordinates in this system is simpler and requires less computational precision than other visually uniform color coordinate systems. A simple slide rule for computing color differences in cube-root color coordinates is described. A modification of the cube-root color coordinate system which provides nearly perfect representation of the spacing of Munsell colors is described, and the appropriateness of the assumptions required to obtain this behavior is discussed.},
-  file = {/Users/kelsolaar/Zotero/storage/S2ZDGDIB/Glasser et al. - 1958 - Cube-Root Color Coordinate System.pdf}
+  title        = {Cube-{{Root Color Coordinate System}}},
+  author       = {Glasser, L. G. and McKinney, A. H. and Reilly, C. D.
+    and Schnelle, P. D.},
+  year         = 1958,
+  month        = oct,
+  journal      = {Journal of the Optical Society of America},
+  volume       = 48,
+  number       = 10,
+  pages        = 736,
+  publisher    = {{OSA}},
+  issn         = {0030-3941},
+  doi          = {10.1364/JOSA.48.000736},
+  abstract     = {A visually uniform color coordinate system, based
+    upon simple mathematical formulas, is described. This system
+    resembles the Adams chromatic-value system but replaces the
+    quintic-parabola function with a cube-root function. For colors
+    having reflectances greater than 0.5\% the color spacing obtained
+    agrees with Munsell spacing as closely as the modified Adams
+    system. At lower reflectances an expanded color spacing over that
+    of the Munsell system is provided. The cube-root equations can be
+    solved directly for color coordinate differences in terms of
+    simple functions of the difference in colorimeter readings or
+    tristimulus values. The computation of color coordinates in this
+    system is simpler and requires less computational precision than
+    other visually uniform color coordinate systems. A simple slide
+    rule for computing color differences in cube-root color
+    coordinates is described. A modification of the cube-root color
+    coordinate system which provides nearly perfect representation of
+    the spacing of Munsell colors is described, and the
+    appropriateness of the assumptions required to obtain this
+    behavior is discussed.},
 }
-
 @misc{GoPro2016a,
-  title = {Gopro.Py},
-  author = {{GoPro} and Duiker, Haarm-Pieter and Mansencal, Thomas},
-  year = {2016},
-  howpublished = {https://github.com/hpd/OpenColorIO-Configs/blob/master/aces\_1.0.3/python/aces\_ocio/colorspaces/gopro.py}
+  title        = {Gopro.Py},
+  author       = {{GoPro} and Duiker, Haarm-Pieter and Mansencal,
+    Thomas},
+  year         = 2016,
+  howpublished = {https://github.com/hpd/OpenColorIO-Configs/blob/master/aces\_1.0.3/python/aces\_ocio/colorspaces/gopro.py},
 }
-
 @inproceedings{Guth1995a,
-  title = {Further Applications of the {{ATD}} Model for Color Vision},
-  booktitle = {Proc. {{SPIE}} 2414, {{Device-Independent Color Imaging II}}},
-  author = {Guth, S. Lee},
-  editor = {Walowit, Eric},
-  year = {1995},
-  month = apr,
-  volume = {2414},
-  pages = {12--26},
-  doi = {10.1117/12.206546},
-  abstract = {Previous and recent revisions of the ATD model for color perception\textbackslash nand visual adaption are incorporated into the version that is fully\textbackslash ndescribed in this paper.},
-  keywords = {chromatic adaptation,color appearances,color discriminations,color models},
-  file = {/Users/kelsolaar/Zotero/storage/S5JW9NGB/Guth - 1995 - Further applications of the ATD model for color vision.pdf}
+  title        = {Further Applications of the {{ATD}} Model for Color
+    Vision},
+  booktitle    = {Proc. {{SPIE}} 2414, {{Device-Independent Color
+    Imaging II}}},
+  author       = {Guth, S. Lee},
+  editor       = {Walowit, Eric},
+  year         = 1995,
+  month        = apr,
+  volume       = 2414,
+  pages        = {12--26},
+  doi          = {10.1117/12.206546},
+  abstract     = {Previous and recent revisions of the ATD model for
+    color perception\textbackslash nand visual adaption are
+    incorporated into the version that is fully\textbackslash
+    ndescribed in this paper.},
+  keywords     = {chromatic adaptation,color appearances,color
+    discriminations,color models},
 }
-
 @misc{Halir1998,
-  title = {Numerically {{Stable Direct Least Squares Fitting Of Ellipses}}},
-  author = {Halir, Radim and Flusser, Jan},
-  year = {1998},
-  pages = {1--8},
-  doi = {10.1.1.1.7559},
-  keywords = {eigenvectors,ellipses,fitting,least squares},
-  file = {/Users/kelsolaar/Zotero/storage/I6SPZ3D9/Halir, Flusser - 1998 - Numerically Stable Direct Least Squares Fitting Of Ellipses.pdf}
+  title        = {Numerically {{Stable Direct Least Squares Fitting Of
+    Ellipses}}},
+  author       = {Halir, Radim and Flusser, Jan},
+  year         = 1998,
+  pages        = {1--8},
+  doi          = {10.1.1.1.7559},
+  keywords     = {eigenvectors,ellipses,fitting,least squares},
 }
-
 @inproceedings{Hanbury2003,
-  title = {A {{3D-Polar Coordinate Colour Representation Well Adapted}} to {{Image Analysis}}},
-  booktitle = {Image {{Analysis}}},
-  author = {Hanbury, Allan},
-  editor = {Bigun, Josef and Gustavsson, Tomas},
-  year = {2003},
-  pages = {804--811},
-  publisher = {{Springer Berlin Heidelberg}},
-  address = {{Berlin, Heidelberg}},
-  abstract = {Representations of the RGB space in terms of 3D-polar coordinates (hue, saturation and brightness) are often used in image analysis. The literature describes a large number of similar coordinate systems (HLS, HSV, etc.). We show that the reason for the existence of so many systems is a poor definition of the saturation coordinate which makes it dependent on the brightness function used, and hence poorly suited to image analysis applications. An improved saturation measurement which (1) always has small values for achromatic colours and (2) is independent of the brightness function is derived.},
-  isbn = {978-3-540-45103-7}
+  title        = {A {{3D-Polar Coordinate Colour Representation Well
+    Adapted}} to {{Image Analysis}}},
+  booktitle    = {Image {{Analysis}}},
+  author       = {Hanbury, Allan},
+  editor       = {Bigun, Josef and Gustavsson, Tomas},
+  year         = 2003,
+  pages        = {804--811},
+  publisher    = {{Springer Berlin Heidelberg}},
+  address      = {{Berlin, Heidelberg}},
+  abstract     = {Representations of the RGB space in terms of
+    3D-polar coordinates (hue, saturation and brightness) are often
+    used in image analysis. The literature describes a large number of
+    similar coordinate systems (HLS, HSV, etc.). We show that the
+    reason for the existence of so many systems is a poor definition
+    of the saturation coordinate which makes it dependent on the
+    brightness function used, and hence poorly suited to image
+    analysis applications. An improved saturation measurement which
+    (1) always has small values for achromatic colours and (2) is
+    independent of the brightness function is derived.},
+  isbn         = {978-3-540-45103-7},
 }
-
 @article{Hellwig2020,
-  title = {Using {{Gaussian Spectra}} to {{Derive}} a {{Hue-linear Color Space}}},
-  author = {Hellwig, Luke and Fairchild, Mark D.},
-  year = {2020},
-  journal = {Journal of Perceptual Imaging},
-  issn = {2575-8144},
-  doi = {10.2352/J.Percept.Imaging.2020.3.2.020401},
-  abstract = {A new color space, I G P G T G, was developed. I G P G T G uses the same structure as IPT, an established hue-uniform color space utilized in gamut mapping applications. While IPT was fit to visual data on the perceived hue, I G P G T G was optimized based on evidence linking the peak wavelength of Gaussian-shaped light spectra to their perceived hues. The performance of I G P G T G on perceived hue data was compared to the performance of other established color spaces. Additionally, an experiment was run to directly compare the hue linearity of I G P G T G with those of other color spaces by using Case V of Thurstone's law of comparative judgment to generate hue-linearity scales. I G P G T G performed well in this experiment but poorly on extant visual data. The mixed results indicate that it is possible to derive a moderately hue-linear color space without visual data.},
-  langid = {english},
-  file = {/Users/kelsolaar/Zotero/storage/GFC3TX4B/Hellwig and Fairchild - 2020 - Using Gaussian Spectra to Derive a Hue-linear Colo.pdf}
+  title        = {Using {{Gaussian Spectra}} to {{Derive}} a
+    {{Hue-linear Color Space}}},
+  author       = {Hellwig, Luke and Fairchild, Mark D.},
+  year         = 2020,
+  journal      = {Journal of Perceptual Imaging},
+  issn         = {2575-8144},
+  doi          = {10.2352/J.Percept.Imaging.2020.3.2.020401},
+  abstract     = {A new color space, I G P G T G, was developed. I G P
+    G T G uses the same structure as IPT, an established hue-uniform
+    color space utilized in gamut mapping applications. While IPT was
+    fit to visual data on the perceived hue, I G P G T G was optimized
+    based on evidence linking the peak wavelength of Gaussian-shaped
+    light spectra to their perceived hues. The performance of I G P G
+    T G on perceived hue data was compared to the performance of other
+    established color spaces. Additionally, an experiment was run to
+    directly compare the hue linearity of I G P G T G with those of
+    other color spaces by using Case V of Thurstone's law of
+    comparative judgment to generate hue-linearity scales. I G P G T G
+    performed well in this experiment but poorly on extant visual
+    data. The mixed results indicate that it is possible to derive a
+    moderately hue-linear color space without visual data.},
+  langid       = {english},
 }
-
 @article{Hellwig2022,
-  title = {Brightness, Lightness, Colorfulness, and Chroma in {{{\textsc{CIECAM02}}}} and {{{\textsc{CAM16}}}}},
-  shorttitle = {Brightness, Lightness, Colorfulness, and Chroma In},
-  author = {Hellwig, Luke and Fairchild, Mark D.},
-  year = {2022},
-  month = mar,
-  journal = {Color Research \& Application},
-  pages = {col.22792},
-  issn = {0361-2317, 1520-6378},
-  doi = {10.1002/col.22792},
-  abstract = {In the CIECAM02 and CAM16 color appearance models, brightness is computed as a nonlinear function of lightness. This paper traces the history of that nonlinearity to its roots in the Hunt color appearance model. A new, more robust, linear relationship between lightness and brightness is proposed. This new formula also prompts the reevaluation of the CAM16 equations for chroma, colorfulness, and saturation. The new formulas for these perceptual attributes are tested on experimental data from the Munsell color order system and the LUTCHI color appearance dataset and are compared to the performance of the original CAM16 equations.},
-  langid = {english},
-  file = {/Users/kelsolaar/Zotero/storage/PF2MBQGV/Hellwig and Fairchild - 2022 - Brightness, lightness, colorfulness, and chroma in.pdf}
+  title        = {Brightness, Lightness, Colorfulness, and Chroma in
+    {{{\textsc{CIECAM02}}}} and {{{\textsc{CAM16}}}}},
+  shorttitle   = {Brightness, Lightness, Colorfulness, and Chroma In},
+  author       = {Hellwig, Luke and Fairchild, Mark D.},
+  year         = 2022,
+  month        = mar,
+  journal      = {Color Research \& Application},
+  pages        = {col.22792},
+  issn         = {0361-2317, 1520-6378},
+  doi          = {10.1002/col.22792},
+  abstract     = {In the CIECAM02 and CAM16 color appearance models,
+    brightness is computed as a nonlinear function of lightness. This
+    paper traces the history of that nonlinearity to its roots in the
+    Hunt color appearance model. A new, more robust, linear
+    relationship between lightness and brightness is proposed. This
+    new formula also prompts the reevaluation of the CAM16 equations
+    for chroma, colorfulness, and saturation. The new formulas for
+    these perceptual attributes are tested on experimental data from
+    the Munsell color order system and the LUTCHI color appearance
+    dataset and are compared to the performance of the original CAM16
+    equations.},
+  langid       = {english},
 }
-
-@article{Hellwig2022a,
-  title = {Extending {{CIECAM02}} and {{CAM16}} for the {{Helmholtz}}\textendash{{Kohlrausch}} Effect},
-  shorttitle = {Extending},
-  author = {Hellwig, Luke and Stolitzka, Dale and Fairchild, Mark D.},
-  year = {2022},
-  month = jun,
-  journal = {Color Research \& Application},
-  pages = {col.22793},
-  issn = {0361-2317, 1520-6378},
-  doi = {10.1002/col.22793},
-  langid = {english},
-  file = {/Users/kelsolaar/Zotero/storage/5P84N5BN/Hellwig et al. - 2022 - Extending C.pdf}
-}
-
 @article{Hernandez-Andres1999a,
-  title = {Calculating Correlated Color Temperatures across the Entire Gamut of Daylight and Skylight Chromaticities},
-  author = {{Hern{\'a}ndez-Andr{\'e}s}, Javier and Lee, Raymond L. and Romero, Javier},
-  year = {1999},
-  month = sep,
-  journal = {Applied Optics},
-  volume = {38},
-  number = {27},
-  pages = {5703},
-  publisher = {{Departamento de Optica, Facultad de Ciencias, Universidad de Granada, Granada 18071, Spain.}},
-  issn = {0003-6935},
-  doi = {10.1364/AO.38.005703},
-  abstract = {Natural outdoor illumination daily undergoes large changes in its correlated color temperature (CCT), yet existing equations for calculating CCT from chromaticity coordinates span only part of this range. To improve both the gamut and accuracy of these CCT calculations, we use chromaticities calculated from our measurements of nearly 7000 daylight and skylight spectra to test an equation that accurately maps CIE 1931 chromaticities x and y into CCT. We extend the work of McCamy [Color Res. Appl. 12, 285-287 (1992)] by using a chromaticity epicenter for CCT and the inverse slope of the line that connects it to x and y. With two epicenters for different CCT ranges, our simple equation is accurate across wide chromaticity and CCT ranges (3000-10(6) K) spanned by daylight and skylight.},
-  file = {/Users/kelsolaar/Zotero/storage/VIBV6GGX/Hernández-Andrés, Lee, Romero - 1999 - Calculating correlated color temperatures across the entire gamut of daylight and skylight chro.pdf}
+  title        = {Calculating Correlated Color Temperatures across the
+    Entire Gamut of Daylight and Skylight Chromaticities},
+  author       = {{Hern{\'a}ndez-Andr{\'e}s}, Javier and Lee, Raymond
+    L. and Romero, Javier},
+  year         = 1999,
+  month        = sep,
+  journal      = {Applied Optics},
+  volume       = 38,
+  number       = 27,
+  pages        = 5703,
+  publisher    = {{Departamento de Optica, Facultad de Ciencias,
+    Universidad de Granada, Granada 18071, Spain.}},
+  issn         = {0003-6935},
+  doi          = {10.1364/AO.38.005703},
+  abstract     = {Natural outdoor illumination daily undergoes large
+    changes in its correlated color temperature (CCT), yet existing
+    equations for calculating CCT from chromaticity coordinates span
+    only part of this range. To improve both the gamut and accuracy of
+    these CCT calculations, we use chromaticities calculated from our
+    measurements of nearly 7000 daylight and skylight spectra to test
+    an equation that accurately maps CIE 1931 chromaticities x and y
+    into CCT. We extend the work of McCamy [Color Res. Appl. 12,
+    285-287 (1992)] by using a chromaticity epicenter for CCT and the
+    inverse slope of the line that connects it to x and y. With two
+    epicenters for different CCT ranges, our simple equation is
+    accurate across wide chromaticity and CCT ranges (3000-10(6) K)
+    spanned by daylight and skylight.},
 }
-
 @misc{Hewlett-PackardDevelopmentCompany2009a,
-  title = {Understanding the {{HP DreamColor LP2480zx DCI-P3 Emulation Color Space}}},
-  author = {{Hewlett-Packard Development Company}},
-  year = {2009},
-  pages = {1--3},
-  file = {/Users/kelsolaar/Zotero/storage/UV8ZBEJ9/Hewlett-Packard Development Company - 2009 - Understanding the HP DreamColor LP2480zx DCI-P3 Emulation Color Space.pdf}
+  title        = {Understanding the {{HP DreamColor LP2480zx DCI-P3
+    Emulation Color Space}}},
+  author       = {{Hewlett-Packard Development Company}},
+  year         = 2009,
+  pages        = {1--3},
 }
-
 @misc{Holmesa,
-  title = {Ekta {{Space PS}} 5},
-  author = {Holmes, Joseph}
+  title        = {Ekta {{Space PS}} 5},
+  author       = {Holmes, Joseph},
 }
-
 @misc{Houston2015a,
-  title = {Private {{Discussion}} with {{Mansencal}}, {{T}}.},
-  author = {Houston, Jim},
-  year = {2015}
+  title        = {Private {{Discussion}} with {{Mansencal}}, {{T}}.},
+  author       = {Houston, Jim},
+  year         = 2015,
 }
-
 @article{Huang2015,
-  title = {Power Functions Improving the Performance of Color-Difference Formulas},
-  author = {Huang, Min and Cui, Guihua and Melgosa, Manuel and {S{\'a}nchez-Mara{\~n}{\'o}n}, Manuel and Li, Changjun and Luo, M. Ronnier and Liu, Haoxue},
-  year = {2015},
-  journal = {Optical Society of America},
-  volume = {23},
-  number = {1},
-  pages = {597--610},
-  issn = {1094-4087},
-  doi = {10.1364/OE.23.000597},
-  file = {/Users/kelsolaar/Zotero/storage/BC6AMLVG/Huang et al. - 2015 - Power functions improving the performance of color-difference formulas.pdf}
+  title        = {Power Functions Improving the Performance of
+    Color-Difference Formulas},
+  author       = {Huang, Min and Cui, Guihua and Melgosa, Manuel and
+    {S{\'a}nchez-Mara{\~n}{\'o}n}, Manuel and Li, Changjun and Luo, M.
+    Ronnier and Liu, Haoxue},
+  year         = 2015,
+  journal      = {Optical Society of America},
+  volume       = 23,
+  number       = 1,
+  pages        = {597--610},
+  issn         = {1094-4087},
+  doi          = {10.1364/OE.23.000597},
 }
-
 @article{Hung1995,
-  title = {Determination of Constant {{Hue Loci}} for a {{CRT}} Gamut and Their Predictions Using Color Appearance Spaces},
-  author = {Hung, Po-Chieh and Berns, Roy S.},
-  year = {1995},
-  month = oct,
-  journal = {Color Research \& Application},
-  volume = {20},
-  number = {5},
-  pages = {285--295},
-  issn = {03612317},
-  doi = {10.1002/col.5080200506},
-  keywords = {color appearance spaces,experiments to evaluate color space hue linearity,perceived hue},
-  file = {/Users/kelsolaar/Zotero/storage/7QNFRMUK/Hung, Berns - 1995 - Determination of constant Hue Loci for a CRT gamut and their predictions using color appearance spaces.pdf}
+  title        = {Determination of Constant {{Hue Loci}} for a {{CRT}}
+    Gamut and Their Predictions Using Color Appearance Spaces},
+  author       = {Hung, Po-Chieh and Berns, Roy S.},
+  year         = 1995,
+  month        = oct,
+  journal      = {Color Research \& Application},
+  volume       = 20,
+  number       = 5,
+  pages        = {285--295},
+  issn         = 03612317,
+  doi          = {10.1002/col.5080200506},
+  keywords     = {color appearance spaces,experiments to evaluate
+    color space hue linearity,perceived hue},
 }
-
 @book{Hunt2004b,
-  title = {The {{Reproduction}} of {{Colour}}},
-  author = {Hunt, R.W.G.},
-  year = {2004},
-  month = sep,
-  edition = {Sixth},
-  publisher = {{John Wiley \& Sons, Ltd}},
-  address = {{Chichester, UK}},
-  doi = {10.1002/0470024275},
-  isbn = {978-0-470-02427-0},
-  keywords = {calanus finmarchicus,egg production,gonad development,norwegian sea,phytoplankton},
-  file = {/Users/kelsolaar/Zotero/storage/DFM8FQZJ/Hunt - 2004 - The Reproduction of Colour.pdf}
+  title        = {The {{Reproduction}} of {{Colour}}},
+  author       = {Hunt, R.W.G.},
+  year         = 2004,
+  month        = sep,
+  edition      = {Sixth},
+  publisher    = {{John Wiley \& Sons, Ltd}},
+  address      = {{Chichester, UK}},
+  doi          = {10.1002/0470024275},
+  isbn         = {978-0-470-02427-0},
+  keywords     = {calanus finmarchicus,egg production,gonad
+    development,norwegian sea,phytoplankton},
 }
-
 @misc{HunterLab2008b,
-  title = {Hunter {{L}},a,b {{Color Scale}}},
-  author = {{HunterLab}},
-  year = {2008},
-  file = {/Users/kelsolaar/Zotero/storage/QCSVFR4Y/HunterLab - 2008 - Hunter L,a,b Color Scale.pdf}
+  title        = {Hunter {{L}},a,b {{Color Scale}}},
+  author       = {{HunterLab}},
+  year         = 2008,
 }
-
 @misc{HunterLab2008c,
-  title = {Illuminant {{Factors}} in {{Universal Software}} and {{EasyMatch Coatings}}},
-  author = {{HunterLab}},
-  year = {2008},
-  keywords = {ASTM illuminant},
-  file = {/Users/kelsolaar/Zotero/storage/69THKHD4/HunterLab - 2008 - Illuminant Factors in Universal Software and EasyMatch Coatings.pdf}
+  title        = {Illuminant {{Factors}} in {{Universal Software}} and
+    {{EasyMatch Coatings}}},
+  author       = {{HunterLab}},
+  year         = 2008,
+  keywords     = {ASTM illuminant},
 }
-
 @misc{HunterLab2012a,
-  title = {Hunter {{Rd}},a,b {{Color Scale}} - {{History}} and {{Application}}},
-  author = {{HunterLab}},
-  year = {2012},
-  keywords = {a rd,b rd,hunter rd,opponent color scale,rd a b,rdab},
-  file = {/Users/kelsolaar/Zotero/storage/IDWM4ZS7/HunterLab - 2012 - Hunter Rd,a,b Color Scale – History and Application.pdf}
+  title        = {Hunter {{Rd}},a,b {{Color Scale}} - {{History}} and
+    {{Application}}},
+  author       = {{HunterLab}},
+  year         = 2012,
+  keywords     = {a rd,b rd,hunter rd,opponent color scale,rd a b,rdab},
 }
-
 @misc{HutchColord,
-  title = {{{BestRGB}} (4 {{K}})},
-  author = {{HutchColor}}
+  title        = {{{BestRGB}} (4 {{K}})},
+  author       = {{HutchColor}},
 }
-
 @misc{HutchColore,
-  title = {{{XtremeRGB}} (4 {{K}})},
-  author = {{HutchColor}}
+  title        = {{{XtremeRGB}} (4 {{K}})},
+  author       = {{HutchColor}},
 }
-
 @misc{HutchColorf,
-  title = {{{MaxRGB}} (4 {{K}})},
-  author = {{HutchColor}}
+  title        = {{{MaxRGB}} (4 {{K}})},
+  author       = {{HutchColor}},
 }
-
 @misc{HutchColorg,
-  title = {{{DonRGB4}} (4 {{K}})},
-  author = {{HutchColor}}
+  title        = {{{DonRGB4}} (4 {{K}})},
+  author       = {{HutchColor}},
 }
-
 @book{IESComputerCommittee2014a,
-  title = {{{IES Standard Format}} for the {{Electronic Transfer}} of {{Spectral Data Electronic Transfer}} of {{Spectral Data}}},
-  author = {{IES Computer Committee} and {TM-27-14 Working Group}},
-  year = {2014},
-  publisher = {{Illuminating Engineering Society}},
-  isbn = {978-0-87995-295-2},
-  file = {/Users/kelsolaar/Zotero/storage/X8T6H9FS/IES Computer Committee, TM-27-14 Working Group - 2014 - IES Standard Format for the Electronic Transfer of Spectral Data Electronic Tran.pdf}
+  title        = {{{IES Standard Format}} for the {{Electronic
+    Transfer}} of {{Spectral Data Electronic Transfer}} of {{Spectral
+    Data}}},
+  author       = {{IES Computer Committee} and {TM-27-14 Working
+    Group}},
+  year         = 2014,
+  publisher    = {{Illuminating Engineering Society}},
+  isbn         = {978-0-87995-295-2},
 }
-
 @misc{InternationalColorConsortium2010,
-  title = {Specification {{ICC}}.1:2010 ({{Profile}} Version 4.3.0.0)},
-  author = {{International Color Consortium}},
-  year = {2010},
-  pages = {1--130},
-  file = {/Users/kelsolaar/Zotero/storage/HJPQMS5T/International Color Consortium - 2010 - Specification ICC.12010.pdf}
+  title        = {Specification {{ICC}}.1:2010 ({{Profile}} Version
+    4.3.0.0)},
+  author       = {{International Color Consortium}},
+  year         = 2010,
+  pages        = {1--130},
 }
-
 @misc{InternationalElectrotechnicalCommission1999a,
-  title = {{{IEC}} 61966-2-1:1999 - {{Multimedia}} Systems and Equipment - {{Colour}} Measurement and Management - {{Part}} 2-1: {{Colour}} Management - {{Default RGB}} Colour Space - {{sRGB}}},
-  author = {{International Electrotechnical Commission}},
-  year = {1999},
-  pages = {51},
-  file = {/Users/kelsolaar/Zotero/storage/CHHY5VTL/International Electrotechnical Commission - 1999 - IEC 61966-2-11999 - Multimedia systems and equipment - Colour measurement and managem.pdf}
+  title        = {{{IEC}} 61966-2-1:1999 - {{Multimedia}} Systems and
+    Equipment - {{Colour}} Measurement and Management - {{Part}} 2-1:
+    {{Colour}} Management - {{Default RGB}} Colour Space - {{sRGB}}},
+  author       = {{International Electrotechnical Commission}},
+  year         = 1999,
+  pages        = 51,
 }
-
 @misc{InternationalOrganizationforStandardization2002,
-  title = {{{INTERNATIONAL STANDARD ISO}} 7589-2002 - {{Photography}} - {{Illuminants}} for Sensitometry - {{Specifications}} for Daylight, Incandescent Tungsten and Printer},
-  author = {{International Organization for Standardization}},
-  year = {2002},
-  file = {/Users/kelsolaar/Zotero/storage/AP7R4ZUK/ISO - 2002 - INTERNATIONAL STANDARD 7589-2002 - Photography - Illuminants for sensitometry - Specifications for daylight, incandescent t.pdf}
+  title        = {{{INTERNATIONAL STANDARD ISO}} 7589-2002 -
+    {{Photography}} - {{Illuminants}} for Sensitometry -
+    {{Specifications}} for Daylight, Incandescent Tungsten and Printer},
+  author       = {{International Organization for Standardization}},
+  year         = 2002,
 }
-
 @misc{InternationalOrganizationforStandardization2012,
-  title = {{{INTERNATIONAL STANDARD ISO}} 17321-1 - {{Graphic}} Technology and Photography - {{Colour}} Characterisation of Digital Still Cameras ({{DSCs}}) - {{Part}} 1: {{Stimuli}}, Metrology and Test Procedures},
-  author = {{International Organization for Standardization}},
-  year = {2012},
-  file = {/Users/kelsolaar/Zotero/storage/2G448HML/tabula-ISO 17321-1-2012.zip;/Users/kelsolaar/Zotero/storage/5U9QAXM3/International Organization for Standardization - 2012 - INTERNATIONAL STANDARD ISO 17321-1 - Graphic techn.pdf}
+  title        = {{{INTERNATIONAL STANDARD ISO}} 17321-1 - {{Graphic}}
+    Technology and Photography - {{Colour}} Characterisation of
+    Digital Still Cameras ({{DSCs}}) - {{Part}} 1: {{Stimuli}},
+    Metrology and Test Procedures},
+  author       = {{International Organization for Standardization}},
+  year         = 2012,
 }
-
 @misc{InternationalOrganizationforStandardization2013,
-  title = {{{INTERNATIONAL STANDARD ISO}}/{{IEC}} 23001-8 - {{Information}} Technology - {{MPEG}} Systems Technologies - {{Part}} 8: {{Coding-independent}} Code Points},
-  author = {{International Organization for Standardization}},
-  year = {2013},
-  file = {/Users/kelsolaar/Zotero/storage/625YTALW/International Organization for Standardization - 2013 - INTERNATIONAL STANDARD ISOIEC 23001-8 - Informati.pdf}
+  title        = {{{INTERNATIONAL STANDARD ISO}}/{{IEC}} 23001-8 -
+    {{Information}} Technology - {{MPEG}} Systems Technologies -
+    {{Part}} 8: {{Coding-independent}} Code Points},
+  author       = {{International Organization for Standardization}},
+  year         = 2013,
 }
-
 @misc{InternationalOrganizationforStandardization2020,
-  title = {{{INTERNATIONAL STANDARD ISO}}/{{IEC}} 14496-10 - {{Information}} Technology - {{Coding}} of Audio-Visual Objects - {{Part}} 10: {{Advanced}} Video Coding},
-  author = {{International Organization for Standardization}},
-  year = {2020},
-  file = {/Users/kelsolaar/Zotero/storage/EWFPAHUM/International Organization for Standardization - 2020 - INTERNATIONAL STANDARD ISOIEC 14496-10 - Informat.pdf}
+  title        = {{{INTERNATIONAL STANDARD ISO}}/{{IEC}} 14496-10 -
+    {{Information}} Technology - {{Coding}} of Audio-Visual Objects -
+    {{Part}} 10: {{Advanced}} Video Coding},
+  author       = {{International Organization for Standardization}},
+  year         = 2020,
 }
-
 @misc{InternationalOrganizationforStandardization2021,
-  title = {{{INTERNATIONAL STANDARD ISO}}/{{IEC}} 23091-2 - {{Information}} Technology - {{Coding-}} Independent Code Points - {{Part}} 2: {{Video}}},
-  author = {{International Organization for Standardization}},
-  year = {2021},
-  file = {/Users/kelsolaar/Zotero/storage/L2F8CBGK/International Organization for Standardization - 2021 - INTERNATIONAL STANDARD ISOIEC 23091-2 - Informati.pdf}
+  title        = {{{INTERNATIONAL STANDARD ISO}}/{{IEC}} 23091-2 -
+    {{Information}} Technology - {{Coding-}} Independent Code Points -
+    {{Part}} 2: {{Video}}},
+  author       = {{International Organization for Standardization}},
+  year         = 2021,
 }
-
 @misc{InternationalTelecommunicationUnion1998,
-  title = {Recommendation {{ITU-R BT}}.1361 - {{Worldwide}} Unified Colorimetry and Related Characteristics of Future Television and Imaging Systems},
-  author = {{International Telecommunication Union}},
-  year = {1998},
-  pages = {1--32}
+  title        = {Recommendation {{ITU-R BT}}.1361 - {{Worldwide}}
+    Unified Colorimetry and Related Characteristics of Future
+    Television and Imaging Systems},
+  author       = {{International Telecommunication Union}},
+  year         = 1998,
+  pages        = {1--32},
 }
-
 @misc{InternationalTelecommunicationUnion1998a,
-  title = {Recommendation {{ITU-R BT}}.470-6 - {{CONVENTIONAL TELEVISION SYSTEMS}}},
-  author = {{International Telecommunication Union}},
-  year = {1998},
-  pages = {1--36},
-  file = {/Users/kelsolaar/Zotero/storage/3D28CU78/International Telecommunication Union - 1998 - Recommendation ITU-R BT.470-6 - CONVENTIONAL TELEVISION SYSTEMS.pdf}
+  title        = {Recommendation {{ITU-R BT}}.470-6 - {{CONVENTIONAL
+    TELEVISION SYSTEMS}}},
+  author       = {{International Telecommunication Union}},
+  year         = 1998,
+  pages        = {1--36},
 }
-
 @misc{InternationalTelecommunicationUnion2011e,
-  title = {Recommendation {{ITU-T T}}.871 - {{Information}} Technology - {{Digital}} Compression and Coding of Continuous-Tone Still Images: {{JPEG File Interchange Format}} ({{JFIF}})},
-  author = {{International Telecommunication Union}},
-  year = {2011},
-  file = {/Users/kelsolaar/Zotero/storage/82WBLIX8/International Telecommunication Union - 2011 - Recommendation ITU-T T.871 - Information technology – Digital compression and coding of.pdf}
+  title        = {Recommendation {{ITU-T T}}.871 - {{Information}}
+    Technology - {{Digital}} Compression and Coding of Continuous-Tone
+    Still Images: {{JPEG File Interchange Format}} ({{JFIF}})},
+  author       = {{International Telecommunication Union}},
+  year         = 2011,
 }
-
 @misc{InternationalTelecommunicationUnion2011f,
-  title = {Recommendation {{ITU-R BT}}.601-7 - {{Studio}} Encoding Parameters of Digital Television for Standard 4:3 and Wide-Screen 16:9 Aspect Ratios},
-  author = {{International Telecommunication Union}},
-  year = {2011},
-  file = {/Users/kelsolaar/Zotero/storage/B4D8LX8W/International Telecommunication Union - 2011 - Recommendation ITU-R BT.601-7 - Studio encoding parameters of digital television for stan.pdf}
+  title        = {Recommendation {{ITU-R BT}}.601-7 - {{Studio}}
+    Encoding Parameters of Digital Television for Standard 4:3 and
+    Wide-Screen 16:9 Aspect Ratios},
+  author       = {{International Telecommunication Union}},
+  year         = 2011,
 }
-
 @misc{InternationalTelecommunicationUnion2011h,
-  title = {Recommendation {{ITU-R BT}}.1886 - {{Reference}} Electro-Optical Transfer Function for Flat Panel Displays Used in {{HDTV}} Studio Production {{BT Series Broadcasting}} Service},
-  author = {{International Telecommunication Union}},
-  year = {2011},
-  file = {/Users/kelsolaar/Zotero/storage/D39N696V/International Telecommunication Union - 2011 - Recommendation ITU-R BT.1886 - Reference electro-optical transfer function for flat panel.pdf}
+  title        = {Recommendation {{ITU-R BT}}.1886 - {{Reference}}
+    Electro-Optical Transfer Function for Flat Panel Displays Used in
+    {{HDTV}} Studio Production {{BT Series Broadcasting}} Service},
+  author       = {{International Telecommunication Union}},
+  year         = 2011,
 }
-
 @misc{InternationalTelecommunicationUnion2015,
-  title = {Report {{ITU-R BT}}.2246-4 - {{The}} Present State of Ultra-High Definition Television {{BT Series Broadcasting}} Service},
-  author = {{International Telecommunication Union}},
-  year = {2015},
-  volume = {5},
-  pages = {1--92},
-  file = {/Users/kelsolaar/Zotero/storage/EGF7LGRS/International Telecommunication Union - 2015 - Report ITU-R BT.2246-4 - The present state of ultra-high definition television BT Series.pdf}
+  title        = {Report {{ITU-R BT}}.2246-4 - {{The}} Present State
+    of Ultra-High Definition Television {{BT Series Broadcasting}}
+    Service},
+  author       = {{International Telecommunication Union}},
+  year         = 2015,
+  volume       = 5,
+  pages        = {1--92},
 }
-
 @misc{InternationalTelecommunicationUnion2015h,
-  title = {Recommendation {{ITU-R BT}}.2020 - {{Parameter}} Values for Ultra-High Definition Television Systems for Production and International Programme Exchange},
-  author = {{International Telecommunication Union}},
-  year = {2015},
-  pages = {1--8},
-  abstract = {The role of the Radiocommunication Sector is to ensure the rational, equitable, efficient and economical use of the radio-frequency spectrum by all radiocommunication services, including satellite services, and carry out studies without limit of frequency range on the basis of which Recommendations are adopted. The regulatory and policy functions of the Radiocommunication Sector are performed by World and Regional Radiocommunication Conferences and Radiocommunication Assemblies supported by Study Groups},
-  file = {/Users/kelsolaar/Zotero/storage/XI25M4LV/International Telecommunication Union - 2015 - Recommendation ITU-R BT.2020 - Parameter values for ultra-high definition television syst.pdf}
+  title        = {Recommendation {{ITU-R BT}}.2020 - {{Parameter}}
+    Values for Ultra-High Definition Television Systems for Production
+    and International Programme Exchange},
+  author       = {{International Telecommunication Union}},
+  year         = 2015,
+  pages        = {1--8},
+  abstract     = {The role of the Radiocommunication Sector is to
+    ensure the rational, equitable, efficient and economical use of
+    the radio-frequency spectrum by all radiocommunication services,
+    including satellite services, and carry out studies without limit
+    of frequency range on the basis of which Recommendations are
+    adopted. The regulatory and policy functions of the
+    Radiocommunication Sector are performed by World and Regional
+    Radiocommunication Conferences and Radiocommunication Assemblies
+    supported by Study Groups},
 }
-
 @misc{InternationalTelecommunicationUnion2015i,
-  title = {Recommendation {{ITU-R BT}}.709-6 - {{Parameter}} Values for the {{HDTV}} Standards for Production and International Programme Exchange {{BT Series Broadcasting}} Service},
-  author = {{International Telecommunication Union}},
-  year = {2015},
-  pages = {1--32},
-  file = {/Users/kelsolaar/Zotero/storage/QRF7G7KP/International Telecommunication Union - 2015 - Recommendation ITU-R BT.709-6 - Parameter values for the HDTV standards for production an.pdf}
+  title        = {Recommendation {{ITU-R BT}}.709-6 - {{Parameter}}
+    Values for the {{HDTV}} Standards for Production and International
+    Programme Exchange {{BT Series Broadcasting}} Service},
+  author       = {{International Telecommunication Union}},
+  year         = 2015,
+  pages        = {1--32},
 }
-
 @misc{InternationalTelecommunicationUnion2017,
-  title = {Recommendation {{ITU-R BT}}.2100-1 - {{Image}} Parameter Values for High Dynamic Range Television for Use in Production and International Programme Exchange},
-  author = {{International Telecommunication Union}},
-  year = {2017},
-  file = {/Users/kelsolaar/Zotero/storage/WN4WGATP/International Telecommunication Union - 2017 - Recommendation ITU-R BT.2100-1 - Image parameter values for high dynamic range television.pdf}
+  title        = {Recommendation {{ITU-R BT}}.2100-1 - {{Image}}
+    Parameter Values for High Dynamic Range Television for Use in
+    Production and International Programme Exchange},
+  author       = {{International Telecommunication Union}},
+  year         = 2017,
 }
-
 @misc{InternationalTelecommunicationUnion2018,
-  title = {Recommendation {{ITU-R BT}}.2100-2 - {{Image}} Parameter Values for High Dynamic Range Television for Use in Production and International Programme Exchange},
-  author = {{International Telecommunication Union}},
-  year = {2018},
-  file = {/Users/kelsolaar/Zotero/storage/KUDHJGXI/International Telecommunication Union - 2018 - Recommendation ITU-R BT.2100-2 - Image parameter values for high dynamic range television.pdf}
+  title        = {Recommendation {{ITU-R BT}}.2100-2 - {{Image}}
+    Parameter Values for High Dynamic Range Television for Use in
+    Production and International Programme Exchange},
+  author       = {{International Telecommunication Union}},
+  year         = 2018,
 }
-
 @misc{InternationalTelecommunicationUnion2019,
-  title = {Recommendation {{ITU-R BT}}.2124-0 - {{Objective}} Metric for the Assessment of the Potential Visibility of Colour Differences in Television},
-  author = {{International Telecommunication Union}},
-  year = {2019},
-  pages = {1--36},
-  file = {/Users/kelsolaar/Zotero/storage/TZWUUUFT/International Telecommunication Union - 2019 - Recommendation ITU-R BT.2124-0 - Objective metric .pdf}
+  title        = {Recommendation {{ITU-R BT}}.2124-0 - {{Objective}}
+    Metric for the Assessment of the Potential Visibility of Colour
+    Differences in Television},
+  author       = {{International Telecommunication Union}},
+  year         = 2019,
+  pages        = {1--36},
 }
-
 @misc{InternationalTelecommunicationUnion2021,
-  title = {Recommendation {{ITU-T H}}.273 - {{Coding-independent}} Code Points for Video Signal Type Identification},
-  author = {{International Telecommunication Union}},
-  year = {2021},
-  file = {/Users/kelsolaar/Zotero/storage/3BXLP6V5/International Telecommunication Union - 2021 - Recommendation ITU-T H.273 - Coding-independent co.pdf}
+  title        = {Recommendation {{ITU-T H}}.273 -
+    {{Coding-independent}} Code Points for Video Signal Type
+    Identification},
+  author       = {{International Telecommunication Union}},
+  year         = 2021,
 }
-
 @article{Jakob2019,
-  ids = {Jakob},
-  title = {A {{Low}}-{{Dimensional Function Space}} for {{Efficient Spectral Upsampling}}},
-  author = {Jakob, Wenzel and Hanika, Johannes},
-  year = {2019},
-  month = may,
-  journal = {Computer Graphics Forum},
-  volume = {38},
-  number = {2},
-  pages = {147--155},
-  issn = {0167-7055, 1467-8659},
-  doi = {10.1111/cgf.13626},
-  langid = {english},
-  file = {/Users/kelsolaar/Zotero/storage/EWSYX4PR/Jakob, Hanika - Unknown - A Low-Dimensional Function Space for Efficient Spectral Upsampling.pdf}
+  ids          = {Jakob},
+  title        = {A {{Low}}-{{Dimensional Function Space}} for
+    {{Efficient Spectral Upsampling}}},
+  author       = {Jakob, Wenzel and Hanika, Johannes},
+  year         = 2019,
+  month        = may,
+  journal      = {Computer Graphics Forum},
+  volume       = 38,
+  number       = 2,
+  pages        = {147--155},
+  issn         = {0167-7055, 1467-8659},
+  doi          = {10.1111/cgf.13626},
+  langid       = {english},
 }
-
 @inproceedings{Jiang2013,
-  title = {What Is the Space of Spectral Sensitivity Functions for Digital Color Cameras?},
-  booktitle = {2013 {{IEEE Workshop}} on {{Applications}} of {{Computer Vision}} ({{WACV}})},
-  author = {Jiang, Jun and Liu, Dengyu and Gu, Jinwei and Susstrunk, Sabine},
-  year = {2013},
-  month = jan,
-  pages = {168--179},
-  publisher = {{IEEE}},
-  issn = {21583978},
-  doi = {10.1109/WACV.2013.6475015},
-  abstract = {Camera spectral sensitivity functions relate scene radiance with captured RGB triplets. They are important for many computer vision tasks that use color information, such as multispectral imaging, color rendering, and color constancy. In this paper, we aim to explore the space of spectral sensitivity functions for digital color cameras. After collecting a database of 28 cameras covering a variety of types, we find this space convex and two-dimensional. Based on this statistical model, we propose two methods to recover camera spectral sensitivities using regular reflective color targets (e.g., color checker) from a single image with and without knowing the illumination. We show the proposed model is more accurate and robust for estimating camera spectral sensitivities than other basis functions. We also show two applications for the recovery of camera spectral sensitivities - simulation of color rendering for cameras and computational color constancy.},
-  isbn = {978-1-4673-5054-9},
-  file = {/Users/kelsolaar/Zotero/storage/C5AX2F8S/css_code.zip;/Users/kelsolaar/Zotero/storage/PW3KVAWY/Jiang et al. - 2013 - What is the space of spectral sensitivity functions for digital color cameras.pdf}
+  title        = {What Is the Space of Spectral Sensitivity Functions
+    for Digital Color Cameras?},
+  booktitle    = {2013 {{IEEE Workshop}} on {{Applications}} of
+    {{Computer Vision}} ({{WACV}})},
+  author       = {Jiang, Jun and Liu, Dengyu and Gu, Jinwei and
+    Susstrunk, Sabine},
+  year         = 2013,
+  month        = jan,
+  pages        = {168--179},
+  publisher    = {{IEEE}},
+  issn         = 21583978,
+  doi          = {10.1109/WACV.2013.6475015},
+  abstract     = {Camera spectral sensitivity functions relate scene
+    radiance with captured RGB triplets. They are important for many
+    computer vision tasks that use color information, such as
+    multispectral imaging, color rendering, and color constancy. In
+    this paper, we aim to explore the space of spectral sensitivity
+    functions for digital color cameras. After collecting a database
+    of 28 cameras covering a variety of types, we find this space
+    convex and two-dimensional. Based on this statistical model, we
+    propose two methods to recover camera spectral sensitivities using
+    regular reflective color targets (e.g., color checker) from a
+    single image with and without knowing the illumination. We show
+    the proposed model is more accurate and robust for estimating
+    camera spectral sensitivities than other basis functions. We also
+    show two applications for the recovery of camera spectral
+    sensitivities - simulation of color rendering for cameras and
+    computational color constancy.},
+  isbn         = {978-1-4673-5054-9},
 }
-
 @article{Kang2002a,
-  title = {Design of Advanced Color: {{Temperature}} Control System for {{HDTV}} Applications},
-  author = {Kang, Bongsoon and Moon, Ohak and Hong, Changhee and Lee, Honam and Cho, Bonghwan and Kim, Youngsun},
-  year = {2002},
-  journal = {Journal of the Korean Physical Society},
-  volume = {41},
-  number = {6},
-  pages = {865--871},
-  keywords = {chromaticity,cie-xyz,color temperature,hdtv},
-  file = {/Users/kelsolaar/Zotero/storage/2FHQYEP3/Kang et al. - 2002 - Design of advanced color Temperature control system for HDTV applications.pdf}
+  title        = {Design of Advanced Color: {{Temperature}} Control
+    System for {{HDTV}} Applications},
+  author       = {Kang, Bongsoon and Moon, Ohak and Hong, Changhee and
+    Lee, Honam and Cho, Bonghwan and Kim, Youngsun},
+  year         = 2002,
+  journal      = {Journal of the Korean Physical Society},
+  volume       = 41,
+  number       = 6,
+  pages        = {865--871},
+  keywords     = {chromaticity,cie-xyz,color temperature,hdtv},
 }
-
 @misc{Kienzle2011a,
-  title = {Refl1d.Numpyerrors - {{Refl1D}} v0.6.19 Documentation},
-  author = {Kienzle, Paul and Patel, Nikunj and Krycka, James},
-  year = {2011},
-  howpublished = {http://www.reflectometry.org/danse/docs/refl1d/\_modules/refl1d/numpyerrors.html}
+  title        = {Refl1d.Numpyerrors - {{Refl1D}} v0.6.19
+    Documentation},
+  author       = {Kienzle, Paul and Patel, Nikunj and Krycka, James},
+  year         = 2011,
+  howpublished = {http://www.reflectometry.org/danse/docs/refl1d/\_modules/refl1d/numpyerrors.html},
 }
-
 @article{Kim2009,
-  title = {Modeling {{Human Color Perception}} under {{Extended Luminance Levels}}},
-  author = {Kim, Mh and Weyrich, T and Kautz, J},
-  year = {2009},
-  journal = {ACM Transactions on Graphics},
-  volume = {28},
-  number = {3},
-  pages = {27:1--27:9},
-  issn = {07300301},
-  doi = {10.1145/1531326.1531333},
-  abstract = {Display technology is advancing quickly with peak luminance increasing significantly, enabling high-dynamic-range displays. However, perceptual color appearance under extended luminance levels has not been studied, mainly due to the unavailability of psychophysical data. Therefore, we conduct a psychophysical study in order to acquire appearance data for many different luminance levels (up to 16,860 cd/m(2)) covering most of the dynamic range of the human visual system. These experimental data allow us to quantify human color perception under extended luminance levels, yielding a generalized color appearance model. Our proposed appearance model is efficient, accurate and invertible. It can be used to adapt the tone and color of images to different dynamic ranges for cross-media reproduction while maintaining appearance that is close to human perception.},
-  isbn = {978-1-60558-726-4},
-  keywords = {color appearance,color reproduction,psychophysics},
-  file = {/Users/kelsolaar/Zotero/storage/455PTBES/Kim, Weyrich, Kautz - 2009 - Modeling Human Color Perception under Extended Luminance Levels.pdf}
+  title        = {Modeling {{Human Color Perception}} under {{Extended
+    Luminance Levels}}},
+  author       = {Kim, Mh and Weyrich, T and Kautz, J},
+  year         = 2009,
+  journal      = {ACM Transactions on Graphics},
+  volume       = 28,
+  number       = 3,
+  pages        = {27:1--27:9},
+  issn         = 07300301,
+  doi          = {10.1145/1531326.1531333},
+  abstract     = {Display technology is advancing quickly with peak
+    luminance increasing significantly, enabling high-dynamic-range
+    displays. However, perceptual color appearance under extended
+    luminance levels has not been studied, mainly due to the
+    unavailability of psychophysical data. Therefore, we conduct a
+    psychophysical study in order to acquire appearance data for many
+    different luminance levels (up to 16,860 cd/m(2)) covering most of
+    the dynamic range of the human visual system. These experimental
+    data allow us to quantify human color perception under extended
+    luminance levels, yielding a generalized color appearance model.
+    Our proposed appearance model is efficient, accurate and
+    invertible. It can be used to adapt the tone and color of images
+    to different dynamic ranges for cross-media reproduction while
+    maintaining appearance that is close to human perception.},
+  isbn         = {978-1-60558-726-4},
+  keywords     = {color appearance,color reproduction,psychophysics},
 }
-
 @misc{Kirk2006,
-  title = {Truelight {{Software Library}} 2.0},
-  author = {Kirk, Richard},
-  year = {2006},
-  file = {/Users/kelsolaar/Zotero/storage/RAPRQZ32/Kirk - 2006 - Truelight Software Library 2.0.pdf}
+  title        = {Truelight {{Software Library}} 2.0},
+  author       = {Kirk, Richard},
+  year         = 2006,
 }
-
 @article{Konovalenko2021,
-  title = {{{ProLab}}: Perceptually Uniform Projective Colour Coordinate System},
-  shorttitle = {{{ProLab}}},
-  author = {Konovalenko, Ivan A. and Smagina, Anna A. and Nikolaev, Dmitry P. and Nikolaev, Petr P.},
-  year = {2021},
-  month = jan,
-  journal = {arXiv:2012.07653 [cs]},
-  eprint = {2012.07653},
-  eprinttype = {arxiv},
+  title        = {{{ProLab}}: Perceptually Uniform Projective Colour
+    Coordinate System},
+  shorttitle   = {{{ProLab}}},
+  author       = {Konovalenko, Ivan A. and Smagina, Anna A. and
+    Nikolaev, Dmitry P. and Nikolaev, Petr P.},
+  year         = 2021,
+  month        = jan,
+  journal      = {arXiv:2012.07653 [cs]},
+  eprint       = {2012.07653},
+  eprinttype   = {arxiv},
   primaryclass = {cs},
-  abstract = {In this work, we propose proLab: a new colour coordinate system derived as a 3D projective transformation of CIE XYZ. We show that proLab is far ahead of the widely used CIELAB coordinate system (though inferior to the modern CAM16-UCS) according to perceptual uniformity evaluated by the STRESS metric in reference to the CIEDE2000 colour difference formula. At the same time, angular errors of chromaticity estimation that are standard for linear colour spaces can also be used in proLab since projective transformations preserve the linearity of manifolds. Unlike in linear spaces, angular errors for different hues are normalized according to human colour discrimination thresholds within proLab. We also demonstrate that shot noise in proLab is more homoscedastic than in CAM16-UCS or other standard colour spaces. This makes proLab a convenient coordinate system in which to perform linear colour analysis.},
+  abstract     = {In this work, we propose proLab: a new colour
+    coordinate system derived as a 3D projective transformation of CIE
+    XYZ. We show that proLab is far ahead of the widely used CIELAB
+    coordinate system (though inferior to the modern CAM16-UCS)
+    according to perceptual uniformity evaluated by the STRESS metric
+    in reference to the CIEDE2000 colour difference formula. At the
+    same time, angular errors of chromaticity estimation that are
+    standard for linear colour spaces can also be used in proLab since
+    projective transformations preserve the linearity of manifolds.
+    Unlike in linear spaces, angular errors for different hues are
+    normalized according to human colour discrimination thresholds
+    within proLab. We also demonstrate that shot noise in proLab is
+    more homoscedastic than in CAM16-UCS or other standard colour
+    spaces. This makes proLab a convenient coordinate system in which
+    to perform linear colour analysis.},
   archiveprefix = {arXiv},
-  langid = {english},
-  keywords = {⛔ No DOI found,Computer Science - Computer Vision and Pattern Recognition},
-  file = {/Users/kelsolaar/Zotero/storage/8SSWGENA/Konovalenko et al. - 2021 - ProLab perceptually uniform projective colour coo.pdf}
+  langid       = {english},
+  keywords     = {⛔ No DOI found,Computer Science - Computer Vision
+    and Pattern Recognition},
 }
-
 @misc{Konovalenko2021a,
-  title = {{{proLab}}\_param.m},
-  author = {Konovalenko, Ivan A.},
-  year = {2021}
+  title        = {{{proLab}}\_param.m},
+  author       = {Konovalenko, Ivan A.},
+  year         = 2021,
 }
-
 @article{Krystek1985b,
-  title = {An Algorithm to Calculate Correlated Colour Temperature},
-  author = {Krystek, M},
-  year = {1985},
-  journal = {Color Research \& Application},
-  volume = {10},
-  number = {1},
-  pages = {38--40},
-  publisher = {{Wiley Subscription Services, Inc., A Wiley Company}},
-  issn = {03612317},
-  doi = {10.1002/col.5080100109},
-  file = {/Users/kelsolaar/Zotero/storage/9B8G9ZP2/Krystek - 1985 - An algorithm to calculate correlated colour temperature.pdf}
+  title        = {An Algorithm to Calculate Correlated Colour
+    Temperature},
+  author       = {Krystek, M},
+  year         = 1985,
+  journal      = {Color Research \& Application},
+  volume       = 10,
+  number       = 1,
+  pages        = {38--40},
+  publisher    = {{Wiley Subscription Services, Inc., A Wiley Company}},
+  issn         = 03612317,
+  doi          = {10.1002/col.5080100109},
 }
-
 @misc{Laurent2012a,
-  title = {Reproducibility of Python Pseudo-Random Numbers across Systems and Versions?},
-  author = {{Laurent}},
-  year = {2012},
-  howpublished = {http://stackoverflow.com/questions/8786084/reproducibility-of-python-pseudo-random-numbers-across-systems-and-versions}
+  title        = {Reproducibility of Python Pseudo-Random Numbers
+    across Systems and Versions?},
+  author       = {{Laurent}},
+  year         = 2012,
+  howpublished = {http://stackoverflow.com/questions/8786084/reproducibility-of-python-pseudo-random-numbers-across-systems-and-versions},
 }
-
 @misc{LeicaCameraAG2022,
-  title = {Leica {{L-Log Reference Manual}}},
-  author = {{Leica Camera AG}},
-  year = {2022},
-  file = {/Users/kelsolaar/Zotero/storage/G44PWG9J/Leica L-Log Reference Manual.pdf}
+  title        = {Leica {{L-Log Reference Manual}}},
+  author       = {{Leica Camera AG}},
+  year         = 2022,
 }
-
 @article{Li2002a,
-  title = {{{CMC}} 2000 Chromatic Adaptation Transform: {{CMCCAT2000}}},
-  author = {Li, Changjun and Luo, Ming Ronnier and Rigg, Bryan and Hunt, Robert W. G.},
-  year = {2002},
-  month = feb,
-  journal = {Color Research \& Application},
-  volume = {27},
-  number = {1},
-  pages = {49--58},
-  issn = {0361-2317},
-  doi = {10.1002/col.10005},
-  abstract = {CMCCAT97 is a chromatic adaptation transform included in CIECAM97s, the CIE 1997 colour appearance model, for describing colour appearance under different viewing conditions and is recommended by, the Colour Measurement Committee of the Society, of Dyers and Colourists for predicting the degree of colour inconstancy, of surface colours. Among the many, transforms tested, this transform gave the most accurate predictions to a number of experimental data sets. However, the structure of CMCCAT97 is considered complicated and causes problems when applications require the use of its reverse mode. This article describes a simplified version of CMCCAT97-CMCCAT2000-which not only, is significantly, simpler and eliminates the problems of reversibility, but also gives a more accurate prediction to almost all experimental data sets than does the original transform. (C) 2002 John Wiley \& Sons, Inc.},
-  keywords = {Chromatic adaptation,Color appearance},
-  file = {/Users/kelsolaar/Zotero/storage/YEWEZRH4/Li et al. - 2002 - CMC 2000 chromatic adaptation transform CMCCAT2000.pdf}
+  title        = {{{CMC}} 2000 Chromatic Adaptation Transform:
+    {{CMCCAT2000}}},
+  author       = {Li, Changjun and Luo, Ming Ronnier and Rigg, Bryan
+    and Hunt, Robert W. G.},
+  year         = 2002,
+  month        = feb,
+  journal      = {Color Research \& Application},
+  volume       = 27,
+  number       = 1,
+  pages        = {49--58},
+  issn         = {0361-2317},
+  doi          = {10.1002/col.10005},
+  abstract     = {CMCCAT97 is a chromatic adaptation transform
+    included in CIECAM97s, the CIE 1997 colour appearance model, for
+    describing colour appearance under different viewing conditions
+    and is recommended by, the Colour Measurement Committee of the
+    Society, of Dyers and Colourists for predicting the degree of
+    colour inconstancy, of surface colours. Among the many, transforms
+    tested, this transform gave the most accurate predictions to a
+    number of experimental data sets. However, the structure of
+    CMCCAT97 is considered complicated and causes problems when
+    applications require the use of its reverse mode. This article
+    describes a simplified version of CMCCAT97-CMCCAT2000-which not
+    only, is significantly, simpler and eliminates the problems of
+    reversibility, but also gives a more accurate prediction to almost
+    all experimental data sets than does the original transform. (C)
+    2002 John Wiley \& Sons, Inc.},
+  keywords     = {Chromatic adaptation,Color appearance},
 }
-
 @misc{Li2007e,
-  title = {The {{Problem}} with {{CAT02}} and {{Its Correction}}},
-  author = {Li, Changjun and Perales, Esther and Luo, Ming Ronnier and {Martinez-verdu}, Francisco},
-  year = {2007},
-  file = {/Users/kelsolaar/Zotero/storage/AW3KVZ5D/Li et al. - 2007 - The Problem with CAT02 and Its Correction.pdf}
+  title        = {The {{Problem}} with {{CAT02}} and {{Its
+    Correction}}},
+  author       = {Li, Changjun and Perales, Esther and Luo, Ming
+    Ronnier and {Martinez-verdu}, Francisco},
+  year         = 2007,
 }
-
 @article{Li2017,
-  title = {Comprehensive Color Solutions: {{CAM16}}, {{CAT16}}, and {{CAM16-UCS}}},
-  author = {Li, Changjun and Li, Zhiqiang and Wang, Zhifeng and Xu, Yang and Luo, Ming Ronnier and Cui, Guihua and Melgosa, Manuel and Brill, Michael H and Pointer, Michael},
-  year = {2017},
-  month = dec,
-  journal = {Color Research \& Application},
-  volume = {42},
-  number = {6},
-  pages = {703--718},
-  issn = {03612317},
-  doi = {10.1002/col.22131},
-  keywords = {CAM02-UCS,CAT02,chromatic adaptation,color-appearance models,color-difference evaluation CIECAM02,corresponding color datasets,LUTCHI color-appearance datasets},
-  file = {/Users/kelsolaar/Zotero/storage/I59PN938/Li et al. - 2017 - Comprehensive color solutions CAM16, CAT16, and CAM16-UCS.pdf}
+  title        = {Comprehensive Color Solutions: {{CAM16}}, {{CAT16}},
+    and {{CAM16-UCS}}},
+  author       = {Li, Changjun and Li, Zhiqiang and Wang, Zhifeng and
+    Xu, Yang and Luo, Ming Ronnier and Cui, Guihua and Melgosa, Manuel
+    and Brill, Michael H and Pointer, Michael},
+  year         = 2017,
+  month        = dec,
+  journal      = {Color Research \& Application},
+  volume       = 42,
+  number       = 6,
+  pages        = {703--718},
+  issn         = 03612317,
+  doi          = {10.1002/col.22131},
+  keywords     = {CAM02-UCS,CAT02,chromatic
+    adaptation,color-appearance models,color-difference evaluation
+    CIECAM02,corresponding color datasets,LUTCHI color-appearance
+    datasets},
 }
-
 @misc{Lindbloom2003c,
-  title = {Delta {{E}} ({{CIE}} 1976)},
-  author = {Lindbloom, Bruce},
-  year = {2003},
-  howpublished = {http://brucelindbloom.com/Eqn\_DeltaE\_CIE76.html}
+  title        = {Delta {{E}} ({{CIE}} 1976)},
+  author       = {Lindbloom, Bruce},
+  year         = 2003,
+  howpublished = {http://brucelindbloom.com/Eqn\_DeltaE\_CIE76.html},
 }
-
 @misc{Lindbloom2003e,
-  title = {{{XYZ}} to {{xyY}}},
-  author = {Lindbloom, Bruce},
-  year = {2003},
-  howpublished = {http://www.brucelindbloom.com/Eqn\_XYZ\_to\_xyY.html}
+  title        = {{{XYZ}} to {{xyY}}},
+  author       = {Lindbloom, Bruce},
+  year         = 2003,
+  howpublished = {http://www.brucelindbloom.com/Eqn\_XYZ\_to\_xyY.html},
 }
-
 @misc{Lindbloom2007a,
-  title = {Spectral {{Power Distribution}} of a {{CIE D-Illuminant}}},
-  author = {Lindbloom, Bruce},
-  year = {2007},
-  howpublished = {http://www.brucelindbloom.com/Eqn\_DIlluminant.html}
+  title        = {Spectral {{Power Distribution}} of a {{CIE
+    D-Illuminant}}},
+  author       = {Lindbloom, Bruce},
+  year         = 2007,
+  howpublished = {http://www.brucelindbloom.com/Eqn\_DIlluminant.html},
 }
-
 @misc{Lindbloom2009d,
-  title = {{{xyY}} to {{XYZ}}},
-  author = {Lindbloom, Bruce},
-  year = {2009},
-  howpublished = {http://www.brucelindbloom.com/Eqn\_xyY\_to\_XYZ.html}
+  title        = {{{xyY}} to {{XYZ}}},
+  author       = {Lindbloom, Bruce},
+  year         = 2009,
+  howpublished = {http://www.brucelindbloom.com/Eqn\_xyY\_to\_XYZ.html},
 }
-
 @misc{Lindbloom2009e,
-  title = {Delta {{E}} ({{CIE}} 2000)},
-  author = {Lindbloom, Bruce},
-  year = {2009},
-  howpublished = {http://brucelindbloom.com/Eqn\_DeltaE\_CIE2000.html}
+  title        = {Delta {{E}} ({{CIE}} 2000)},
+  author       = {Lindbloom, Bruce},
+  year         = 2009,
+  howpublished = {http://brucelindbloom.com/Eqn\_DeltaE\_CIE2000.html},
 }
-
 @misc{Lindbloom2009f,
-  title = {Delta {{E}} ({{CMC}})},
-  author = {Lindbloom, Bruce},
-  year = {2009},
-  howpublished = {http://brucelindbloom.com/Eqn\_DeltaE\_CMC.html}
+  title        = {Delta {{E}} ({{CMC}})},
+  author       = {Lindbloom, Bruce},
+  year         = 2009,
+  howpublished = {http://brucelindbloom.com/Eqn\_DeltaE\_CMC.html},
 }
-
 @misc{Lindbloom2009g,
-  title = {Chromatic {{Adaptation}}},
-  author = {Lindbloom, Bruce},
-  year = {2009},
-  howpublished = {http://brucelindbloom.com/Eqn\_ChromAdapt.html}
+  title        = {Chromatic {{Adaptation}}},
+  author       = {Lindbloom, Bruce},
+  year         = 2009,
+  howpublished = {http://brucelindbloom.com/Eqn\_ChromAdapt.html},
 }
-
 @misc{Lindbloom2011a,
-  title = {Delta {{E}} ({{CIE}} 1994)},
-  author = {Lindbloom, Bruce},
-  year = {2011},
-  howpublished = {http://brucelindbloom.com/Eqn\_DeltaE\_CIE94.html}
+  title        = {Delta {{E}} ({{CIE}} 1994)},
+  author       = {Lindbloom, Bruce},
+  year         = 2011,
+  howpublished = {http://brucelindbloom.com/Eqn\_DeltaE\_CIE94.html},
 }
-
 @misc{Lindbloom2014a,
-  title = {{{RGB Working Space Information}}},
-  author = {Lindbloom, Bruce},
-  year = {2014},
-  howpublished = {http://www.brucelindbloom.com/WorkingSpaceInfo.html}
+  title        = {{{RGB Working Space Information}}},
+  author       = {Lindbloom, Bruce},
+  year         = 2014,
+  howpublished = {http://www.brucelindbloom.com/WorkingSpaceInfo.html},
 }
-
 @misc{Lindbloom2015,
-  title = {About the {{Lab Gamut}}},
-  author = {Lindbloom, Bruce},
-  year = {2015},
-  howpublished = {http://www.brucelindbloom.com/LabGamutDisplayHelp.html}
+  title        = {About the {{Lab Gamut}}},
+  author       = {Lindbloom, Bruce},
+  year         = 2015,
+  howpublished = {http://www.brucelindbloom.com/LabGamutDisplayHelp.html},
 }
-
 @article{Lu2016c,
-  title = {{{ITP Colour Space}} and {{Its Compression Performance}} for {{High Dynamic Range}} and {{Wide Colour Gamut Video Distribution}}},
-  author = {Lu, Taoran and Pu, Fangjun and Yin, Peng and Chen, Tao and Husak, Walt and Pytlarz, Jaclyn and Atkins, Robin and Froehlich, Jan and Su, Guan-Ming},
-  year = {2016},
-  journal = {ZTE Communications},
-  volume = {14},
-  number = {1},
-  pages = {32--38},
-  abstract = {High Dynamic Range (HDR) and Wider Colour Gamut (WCG) content represents a greater range of luminance levels and a more complete reproduction of colours found in real{$\hyphenbullet$}world scenes. The current video distribution environments deliver Standard Dynamic Range (SDR) signal Y{${'}$}CbCr. For HDR and WCG content, it is desirable to examine if such signal format still works well for compression, and to know if the overall system performance can be further improved by exploring different signal formats. In this paper, ITP (ICTCP) colour space is presented. The paper concentrates on examining the two aspects of ITP colour space: 1) ITP characteristics in terms of signal quantization at a given bit depth; 2) ITP compression performance. The analysis and simulation results show that ITP 10 bit has better properties than Y{${'}$}CbCr{$\hyphenbullet$}PQ 10bit in colour quantization, constant luminance, hue property and chroma subsampling, and it also has good compression efficiency. Therefore it is desirable to adopt ITP colour space as a new signal format for HDR/WCG video compression.},
-  keywords = {HDR,ICT CP,ITP,WCG,Y′CbCr},
-  file = {/Users/kelsolaar/Zotero/storage/M4WKAIWF/Lu et al. - 2016 - ITP Colour Space and Its Compression Performance for High Dynamic Range and Wide Colour Gamut Video Distribution.pdf}
+  title        = {{{ITP Colour Space}} and {{Its Compression
+    Performance}} for {{High Dynamic Range}} and {{Wide Colour Gamut
+    Video Distribution}}},
+  author       = {Lu, Taoran and Pu, Fangjun and Yin, Peng and Chen,
+    Tao and Husak, Walt and Pytlarz, Jaclyn and Atkins, Robin and
+    Froehlich, Jan and Su, Guan-Ming},
+  year         = 2016,
+  journal      = {ZTE Communications},
+  volume       = 14,
+  number       = 1,
+  pages        = {32--38},
+  abstract     = {High Dynamic Range (HDR) and Wider Colour Gamut
+    (WCG) content represents a greater range of luminance levels and a
+    more complete reproduction of colours found in
+    real{$\hyphenbullet$}world scenes. The current video distribution
+    environments deliver Standard Dynamic Range (SDR) signal
+    Y{${'}$}CbCr. For HDR and WCG content, it is desirable to examine
+    if such signal format still works well for compression, and to
+    know if the overall system performance can be further improved by
+    exploring different signal formats. In this paper, ITP (ICTCP)
+    colour space is presented. The paper concentrates on examining the
+    two aspects of ITP colour space: 1) ITP characteristics in terms
+    of signal quantization at a given bit depth; 2) ITP compression
+    performance. The analysis and simulation results show that ITP 10
+    bit has better properties than Y{${'}$}CbCr{$\hyphenbullet$}PQ
+    10bit in colour quantization, constant luminance, hue property and
+    chroma subsampling, and it also has good compression efficiency.
+    Therefore it is desirable to adopt ITP colour space as a new
+    signal format for HDR/WCG video compression.},
+  keywords     = {HDR,ICT CP,ITP,WCG,Y′CbCr},
 }
-
 @article{Luo1996b,
-  title = {The {{LLAB}} (l:C) Colour Model},
-  author = {Luo, Ming Ronnier and Lo, Mei-Chun and Kuo, Wen-Guey},
-  year = {1996},
-  month = dec,
-  journal = {Color Research \& Application},
-  volume = {21},
-  number = {6},
-  pages = {412--429},
-  publisher = {{Wiley Subscription Services, Inc., A Wiley Company}},
-  issn = {0361-2317},
-  doi = {10.1002/(SICI)1520-6378(199612)21:6<412::AID-COL4>3.0.CO;2-Z},
-  abstract = {A new colour model, named LLAB(l:c) is derived. It includes two parts: the BFD chromatic adaptation transform derived by Lam and Rigg, and a modified CIELAB uniform colour space. The model's performance was compared with the other spaces and models using the LUTCHI Colour Appearance Data Set. The results show that LLAB(l:c) model is capable of precisely quantifying the change of colour appearance under a wide range of viewing parameters such as light sources, surrounds/media, achromatic backgrounds, sizes of stimuli, and luminance levels. It had a similar performance as that of the Hunt colour appearance model. The LLAB(l:c) model was also tested using various colour difference datasets. The model gave a similar performance as the state-of-the-art colour difference formulae such as CMC, CIE94, and BFD. This performance is considered to be very satisfactory, and the model, therefore, should be considered for field trials in applications such as colour specification, colour difference evaluation, cross-image reproduction, gamut mapping, prediction of metamerism and colour constancy, and quantification of colour-rendering properties. The model does not give predictions for chroma (as distinct from colourfulness), or for brightness, and it does not include any rod response. \textcopyright{} 1996 John Wiley \& Sons, Inc.},
-  keywords = {chromatic adaptation transform,colour appearance,colour appearance model,colour difference,colour difference formula,corresponding colours,uniform colour space}
+  title        = {The {{LLAB}} (l:C) Colour Model},
+  author       = {Luo, Ming Ronnier and Lo, Mei-Chun and Kuo, Wen-Guey},
+  year         = 1996,
+  month        = dec,
+  journal      = {Color Research \& Application},
+  volume       = 21,
+  number       = 6,
+  pages        = {412--429},
+  publisher    = {{Wiley Subscription Services, Inc., A Wiley Company}},
+  issn         = {0361-2317},
+  doi          = {10.1002/(SICI)1520-6378(199612)21:6<412::AID-COL4>3.0.CO;2-Z},
+  abstract     = {A new colour model, named LLAB(l:c) is derived. It
+    includes two parts: the BFD chromatic adaptation transform derived
+    by Lam and Rigg, and a modified CIELAB uniform colour space. The
+    model's performance was compared with the other spaces and models
+    using the LUTCHI Colour Appearance Data Set. The results show that
+    LLAB(l:c) model is capable of precisely quantifying the change of
+    colour appearance under a wide range of viewing parameters such as
+    light sources, surrounds/media, achromatic backgrounds, sizes of
+    stimuli, and luminance levels. It had a similar performance as
+    that of the Hunt colour appearance model. The LLAB(l:c) model was
+    also tested using various colour difference datasets. The model
+    gave a similar performance as the state-of-the-art colour
+    difference formulae such as CMC, CIE94, and BFD. This performance
+    is considered to be very satisfactory, and the model, therefore,
+    should be considered for field trials in applications such as
+    colour specification, colour difference evaluation, cross-image
+    reproduction, gamut mapping, prediction of metamerism and colour
+    constancy, and quantification of colour-rendering properties. The
+    model does not give predictions for chroma (as distinct from
+    colourfulness), or for brightness, and it does not include any rod
+    response. \textcopyright{} 1996 John Wiley \& Sons, Inc.},
+  keywords     = {chromatic adaptation transform,colour
+    appearance,colour appearance model,colour difference,colour
+    difference formula,corresponding colours,uniform colour space},
 }
-
 @inproceedings{Luo1996c,
-  title = {Two {{Unsolved Issues}} in {{Colour Management}} - {{Colour Appearance}} and {{Gamut Mapping}}},
-  booktitle = {Conference: 5th {{International Conference}} on {{High Technology}}: {{Imaging Science}} and {{Technology}} \textendash{} {{Evolution}} \& {{Promise}}},
-  author = {Luo, Ming Ronnier and Morovic, J{\'a}n},
-  year = {1996},
-  pages = {136--147}
+  title        = {Two {{Unsolved Issues}} in {{Colour Management}} -
+    {{Colour Appearance}} and {{Gamut Mapping}}},
+  booktitle    = {Conference: 5th {{International Conference}} on
+    {{High Technology}}: {{Imaging Science}} and {{Technology}}
+    \textendash{} {{Evolution}} \& {{Promise}}},
+  author       = {Luo, Ming Ronnier and Morovic, J{\'a}n},
+  year         = 1996,
+  pages        = {136--147},
 }
-
 @article{Luo1999,
-  title = {Corresponding-Colour Datasets},
-  author = {Luo, M. Ronnier and Rhodes, Peter A.},
-  year = {1999},
-  month = aug,
-  journal = {Color Research \& Application},
-  volume = {24},
-  number = {4},
-  pages = {295--296},
-  issn = {0361-2317},
-  doi = {10.1002/(SICI)1520-6378(199908)24:4<295::AID-COL10>3.0.CO;2-K},
-  abstract = {Predicting the binding mode of flexible polypeptides to proteins is an important task that falls outside the domain of applicability of most small molecule and protein-protein docking tools. Here, we test the small molecule flexible ligand docking program Glide on a set of 19 non-{$\alpha$}-helical peptides and systematically improve pose prediction accuracy by enhancing Glide sampling for flexible polypeptides. In addition, scoring of the poses was improved by post-processing with physics-based implicit solvent MM- GBSA calculations. Using the best RMSD among the top 10 scoring poses as a metric, the success rate (RMSD {$\leq$} 2.0 \AA{} for the interface backbone atoms) increased from 21\% with default Glide SP settings to 58\% with the enhanced peptide sampling and scoring protocol in the case of redocking to the native protein structure. This approaches the accuracy of the recently developed Rosetta FlexPepDock method (63\% success for these 19 peptides) while being over 100 times faster. Cross-docking was performed for a subset of cases where an unbound receptor structure was available, and in that case, 40\% of peptides were docked successfully. We analyze the results and find that the optimized polypeptide protocol is most accurate for extended peptides of limited size and number of formal charges, defining a domain of applicability for this approach.},
-  file = {/Users/kelsolaar/Zotero/storage/EWXV8F23/Luo, Rhodes - 1999 - Corresponding-colour datasets.pdf}
+  title        = {Corresponding-Colour Datasets},
+  author       = {Luo, M. Ronnier and Rhodes, Peter A.},
+  year         = 1999,
+  month        = aug,
+  journal      = {Color Research \& Application},
+  volume       = 24,
+  number       = 4,
+  pages        = {295--296},
+  issn         = {0361-2317},
+  doi          = {10.1002/(SICI)1520-6378(199908)24:4<295::AID-COL10>3.0.CO;2-K},
+  abstract     = {Predicting the binding mode of flexible polypeptides
+    to proteins is an important task that falls outside the domain of
+    applicability of most small molecule and protein-protein docking
+    tools. Here, we test the small molecule flexible ligand docking
+    program Glide on a set of 19 non-{$\alpha$}-helical peptides and
+    systematically improve pose prediction accuracy by enhancing Glide
+    sampling for flexible polypeptides. In addition, scoring of the
+    poses was improved by post-processing with physics-based implicit
+    solvent MM- GBSA calculations. Using the best RMSD among the top
+    10 scoring poses as a metric, the success rate (RMSD {$\leq$} 2.0
+    \AA{} for the interface backbone atoms) increased from 21\% with
+    default Glide SP settings to 58\% with the enhanced peptide
+    sampling and scoring protocol in the case of redocking to the
+    native protein structure. This approaches the accuracy of the
+    recently developed Rosetta FlexPepDock method (63\% success for
+    these 19 peptides) while being over 100 times faster.
+    Cross-docking was performed for a subset of cases where an unbound
+    receptor structure was available, and in that case, 40\% of
+    peptides were docked successfully. We analyze the results and find
+    that the optimized polypeptide protocol is most accurate for
+    extended peptides of limited size and number of formal charges,
+    defining a domain of applicability for this approach.},
 }
-
 @article{Luo2006b,
-  title = {Uniform Colour Spaces Based on {{CIECAM02}} Colour Appearance Model},
-  author = {Luo, M. Ronnier and Cui, Guihua and Li, Changjun},
-  year = {2006},
-  month = aug,
-  journal = {Color Research \& Application},
-  volume = {31},
-  number = {4},
-  pages = {320--330},
-  issn = {0361-2317},
-  doi = {10.1002/col.20227},
-  abstract = {Can a single colour model be used for all colorimetric applications? This article intends to answer that question. Colour appearance models have been developed to predict colour appearance under different viewing conditions. They are also capable of evaluating colour differences because of their embedded uniform colour spaces. This article first tests the performance of the CIE 2002 colour appearance model, CIECAM02, in predicting three types of colour discrimination data sets: large- and small-magnitude colour differences under daylight illuminants and small-magnitude colour differences under illuminant A. The results showed that CIECAM02 gave reasonable performance compared with the best available formulae and uniform colour spaces. It was further extended to give accurate predictions to all types of colour discrimination data. The results were very encouraging in that the CIECAM02 extensions performed second best among all the colour models tested and only slightly poorer than the models that were developed to fit a particular data set. One extension derived to fit all types of data can predict well for colour differences having a large range of difference magnitudes. 2006 Wiley Periodicals, Inc. Col Res Appl, 31, 320-330, 2006; Published online in Wiley InterScience DOI 10.1002/col.20227},
-  isbn = {0361-2317},
-  keywords = {Colour appearance data,Colour appearance model,Colour difference data,Colour difference formula,Uniform colour space},
-  file = {/Users/kelsolaar/Zotero/storage/QZ9277YZ/Luo, Cui, Li - 2006 - Uniform colour spaces based on CIECAM02 colour appearance model.pdf}
+  title        = {Uniform Colour Spaces Based on {{CIECAM02}} Colour
+    Appearance Model},
+  author       = {Luo, M. Ronnier and Cui, Guihua and Li, Changjun},
+  year         = 2006,
+  month        = aug,
+  journal      = {Color Research \& Application},
+  volume       = 31,
+  number       = 4,
+  pages        = {320--330},
+  issn         = {0361-2317},
+  doi          = {10.1002/col.20227},
+  abstract     = {Can a single colour model be used for all
+    colorimetric applications? This article intends to answer that
+    question. Colour appearance models have been developed to predict
+    colour appearance under different viewing conditions. They are
+    also capable of evaluating colour differences because of their
+    embedded uniform colour spaces. This article first tests the
+    performance of the CIE 2002 colour appearance model, CIECAM02, in
+    predicting three types of colour discrimination data sets: large-
+    and small-magnitude colour differences under daylight illuminants
+    and small-magnitude colour differences under illuminant A. The
+    results showed that CIECAM02 gave reasonable performance compared
+    with the best available formulae and uniform colour spaces. It was
+    further extended to give accurate predictions to all types of
+    colour discrimination data. The results were very encouraging in
+    that the CIECAM02 extensions performed second best among all the
+    colour models tested and only slightly poorer than the models that
+    were developed to fit a particular data set. One extension derived
+    to fit all types of data can predict well for colour differences
+    having a large range of difference magnitudes. 2006 Wiley
+    Periodicals, Inc. Col Res Appl, 31, 320-330, 2006; Published
+    online in Wiley InterScience DOI 10.1002/col.20227},
+  isbn         = {0361-2317},
+  keywords     = {Colour appearance data,Colour appearance
+    model,Colour difference data,Colour difference formula,Uniform
+    colour space},
 }
-
 @incollection{Luo2013,
-  title = {{{CIECAM02}} and {{Its Recent Developments}}},
-  booktitle = {Advanced {{Color Image Processing}} and {{Analysis}}},
-  author = {Luo, Ming Ronnier and Li, Changjun},
-  editor = {{Fernandez-Maloigne}, Christine},
-  year = {2013},
-  pages = {19--58},
-  publisher = {{Springer New York}},
-  address = {{New York, NY}},
-  doi = {10.1007/978-1-4419-6190-7},
-  isbn = {978-1-4419-6189-1},
-  keywords = {cam,cat,chromatic adap-,ciecam02,color appearance model,colour appearance attributes,tation transforms,uniform colour spaces,visual phenomena},
-  file = {/Users/kelsolaar/Zotero/storage/IUV33VDG/Luo, Li - 2013 - CIECAM02 and Its Recent Developments.pdf}
+  title        = {{{CIECAM02}} and {{Its Recent Developments}}},
+  booktitle    = {Advanced {{Color Image Processing}} and {{Analysis}}},
+  author       = {Luo, Ming Ronnier and Li, Changjun},
+  editor       = {{Fernandez-Maloigne}, Christine},
+  year         = 2013,
+  pages        = {19--58},
+  publisher    = {{Springer New York}},
+  address      = {{New York, NY}},
+  doi          = {10.1007/978-1-4419-6190-7},
+  isbn         = {978-1-4419-6189-1},
+  keywords     = {cam,cat,chromatic adap-,ciecam02,color appearance
+    model,colour appearance attributes,tation transforms,uniform
+    colour spaces,visual phenomena},
 }
-
 @article{MacAdam1935a,
-  title = {Maximum {{Visual Efficiency}} of {{Colored Materials}}},
-  author = {MacAdam, David L.},
-  year = {1935},
-  month = nov,
-  journal = {Journal of the Optical Society of America},
-  volume = {25},
-  number = {11},
-  pages = {361--367},
-  publisher = {{OSA}},
-  doi = {10.1364/JOSA.25.000361},
-  abstract = {Tristimulus values have been computed for hypothetical spectrophotometric curves of the type found to give the maximum visual reflectance factor (or transmission factor) for specified chromaticities. These computations have been based on the I.C.I. 1931 data for the normal observer for colorimetry, and on the I.C.I. Illuminants ``A'' and ``C.'' By plotting the results on the I.C.I. color mixture diagram, the loci of points characterized by equal maximum efficiencies have been established. Tables have been prepared showing the maximum visual efficiency as a function of excitation purity for twenty-four dominant wave-lengths.},
-  file = {/Users/kelsolaar/Zotero/storage/VLH43XR2/MacAdam - 1935 - Maximum Visual Efficiency of Colored Materials.pdf}
+  title        = {Maximum {{Visual Efficiency}} of {{Colored
+    Materials}}},
+  author       = {MacAdam, David L.},
+  year         = 1935,
+  month        = nov,
+  journal      = {Journal of the Optical Society of America},
+  volume       = 25,
+  number       = 11,
+  pages        = {361--367},
+  publisher    = {{OSA}},
+  doi          = {10.1364/JOSA.25.000361},
+  abstract     = {Tristimulus values have been computed for
+    hypothetical spectrophotometric curves of the type found to give
+    the maximum visual reflectance factor (or transmission factor) for
+    specified chromaticities. These computations have been based on
+    the I.C.I. 1931 data for the normal observer for colorimetry, and
+    on the I.C.I. Illuminants ``A'' and ``C.'' By plotting the results
+    on the I.C.I. color mixture diagram, the loci of points
+    characterized by equal maximum efficiencies have been established.
+    Tables have been prepared showing the maximum visual efficiency as
+    a function of excitation purity for twenty-four dominant
+    wave-lengths.},
 }
-
 @article{Macadam1942,
-  title = {Visual {{Sensitivities}} to {{Color Differences}} in {{Daylight}}},
-  author = {Macadam, David L.},
-  year = {1942},
-  journal = {Journal of the Optical Society of America},
-  volume = {32},
-  number = {5},
-  pages = {28},
-  issn = {0030-3941},
-  doi = {10.1364/JOSA.32.000247},
-  abstract = {An apparatus is described which facilitates the presentation of pairs of variable colors without variation of luminance. With this instrument, various criteria of visual sensitivity to color difference have been investigated. The standard deviation of color matching was finally adopted as the most reproducible criterion. The test field was two degrees in diameter, divided by a vertical biprism edge, and was viewed centrally with a surrounding field of fortytwo degrees diameter uniformly illuminated so as to have a chromaticity similar to that of the I.C.I. Standard Illuminant C (average daylight). The luminance of the test field was maintained constant at 15 millilamberts, and the surrounding field was 7.5 millilamberts. These fields were viewed monocularly through an artificial pupil, 2.6 mm in diameter. Over twenty-five thousand trials at color matching have been recorded for a single observer, and the readings are analyzed in detail and compared with previously available data. The standard deviations of the trials are represented in terms of distance in the standard 1931 I.C.I. chromaticity diagram. These increments of distance are represented as functions of position along straight lines in the chromaticity diagram, and also as functions of direction of departure from points representing certain standard chromaticities. Such representations are simpler than the traditional representations of wavelength thresholds and purity thresholds as functions of wave-length, and the accuracy of the representations is improved by this simplicity. Chromaticity discrimination for non-spectral colors is represented simultaneously and on the same basis as for spectral colors. Small, equally noticeable chromaticity differences are represented for all chromaticities and for all kinds of variations by the lengths of the radii of a family of ellipses drawn on the standard chromaticity diagram. These ellipses cannot be transformed into equal-sized circles by any projective transformation of the standard chromaticity diagram. The consistency of these data with the results of other investigators is exhibited in terms of the noticeabilities of wave-length differences in the spectrum and of the noticeabilities of purity differences from a neutral stimulus, as functions of dominant wave-length.},
-  isbn = {0030-3941},
-  file = {/Users/kelsolaar/Zotero/storage/L8UUNKEM/Macadam - 1942 - Visual Sensitivities to Color Differences in Daylight.pdf}
+  title        = {Visual {{Sensitivities}} to {{Color Differences}} in
+    {{Daylight}}},
+  author       = {Macadam, David L.},
+  year         = 1942,
+  journal      = {Journal of the Optical Society of America},
+  volume       = 32,
+  number       = 5,
+  pages        = 28,
+  issn         = {0030-3941},
+  doi          = {10.1364/JOSA.32.000247},
+  abstract     = {An apparatus is described which facilitates the
+    presentation of pairs of variable colors without variation of
+    luminance. With this instrument, various criteria of visual
+    sensitivity to color difference have been investigated. The
+    standard deviation of color matching was finally adopted as the
+    most reproducible criterion. The test field was two degrees in
+    diameter, divided by a vertical biprism edge, and was viewed
+    centrally with a surrounding field of fortytwo degrees diameter
+    uniformly illuminated so as to have a chromaticity similar to that
+    of the I.C.I. Standard Illuminant C (average daylight). The
+    luminance of the test field was maintained constant at 15
+    millilamberts, and the surrounding field was 7.5 millilamberts.
+    These fields were viewed monocularly through an artificial pupil,
+    2.6 mm in diameter. Over twenty-five thousand trials at color
+    matching have been recorded for a single observer, and the
+    readings are analyzed in detail and compared with previously
+    available data. The standard deviations of the trials are
+    represented in terms of distance in the standard 1931 I.C.I.
+    chromaticity diagram. These increments of distance are represented
+    as functions of position along straight lines in the chromaticity
+    diagram, and also as functions of direction of departure from
+    points representing certain standard chromaticities. Such
+    representations are simpler than the traditional representations
+    of wavelength thresholds and purity thresholds as functions of
+    wave-length, and the accuracy of the representations is improved
+    by this simplicity. Chromaticity discrimination for non-spectral
+    colors is represented simultaneously and on the same basis as for
+    spectral colors. Small, equally noticeable chromaticity
+    differences are represented for all chromaticities and for all
+    kinds of variations by the lengths of the radii of a family of
+    ellipses drawn on the standard chromaticity diagram. These
+    ellipses cannot be transformed into equal-sized circles by any
+    projective transformation of the standard chromaticity diagram.
+    The consistency of these data with the results of other
+    investigators is exhibited in terms of the noticeabilities of
+    wave-length differences in the spectrum and of the noticeabilities
+    of purity differences from a neutral stimulus, as functions of
+    dominant wave-length.},
+  isbn         = {0030-3941},
 }
-
 @article{Machado2009,
-  title = {A {{Physiologically-based Model}} for {{Simulation}} of {{Color Vision Deficiency}}},
-  author = {Machado, G.M. and Oliveira, M.M. and Fernandes, L.},
-  year = {2009},
-  month = nov,
-  journal = {IEEE Transactions on Visualization and Computer Graphics},
-  volume = {15},
-  number = {6},
-  pages = {1291--1298},
-  issn = {1077-2626},
-  doi = {10.1109/TVCG.2009.113},
-  abstract = {Color vision deficiency (CVD) affects approximately 200 million people worldwide, compromising the ability of these individuals to effectively perform color and visualization-related tasks. This has a significant impact on their private and professional lives. We present a physiologically-based model for simulating color vision. Our model is based on the stage theory of human color vision and is derived from data reported in electrophysiological studies. It is the first model to consistently handle normal color vision, anomalous trichromacy, and dichromacy in a unified way. We have validated the proposed model through an experimental evaluation involving groups of color vision deficient individuals and normal color vision ones. Our model can provide insights and feedback on how to improve visualization experiences for individuals with CVD. It also provides a framework for testing hypotheses about some aspects of the retinal photoreceptors in color vision deficient individuals.},
-  pmid = {19834201},
-  keywords = {Anomalous Trichromacy,Color Perception,Dichromacy,Models of Color Vision,Simulation of Color Vision Deficiency},
-  file = {/Users/kelsolaar/Zotero/storage/323M7A9C/Machado, Oliveira, Fernandes - 2009 - A Physiologically-based Model for Simulation of Color Vision Deficiency.pdf}
+  title        = {A {{Physiologically-based Model}} for {{Simulation}}
+    of {{Color Vision Deficiency}}},
+  author       = {Machado, G.M. and Oliveira, M.M. and Fernandes, L.},
+  year         = 2009,
+  month        = nov,
+  journal      = {IEEE Transactions on Visualization and Computer
+    Graphics},
+  volume       = 15,
+  number       = 6,
+  pages        = {1291--1298},
+  issn         = {1077-2626},
+  doi          = {10.1109/TVCG.2009.113},
+  abstract     = {Color vision deficiency (CVD) affects approximately
+    200 million people worldwide, compromising the ability of these
+    individuals to effectively perform color and visualization-related
+    tasks. This has a significant impact on their private and
+    professional lives. We present a physiologically-based model for
+    simulating color vision. Our model is based on the stage theory of
+    human color vision and is derived from data reported in
+    electrophysiological studies. It is the first model to
+    consistently handle normal color vision, anomalous trichromacy,
+    and dichromacy in a unified way. We have validated the proposed
+    model through an experimental evaluation involving groups of color
+    vision deficient individuals and normal color vision ones. Our
+    model can provide insights and feedback on how to improve
+    visualization experiences for individuals with CVD. It also
+    provides a framework for testing hypotheses about some aspects of
+    the retinal photoreceptors in color vision deficient individuals.},
+  pmid         = 19834201,
+  keywords     = {Anomalous Trichromacy,Color
+    Perception,Dichromacy,Models of Color Vision,Simulation of Color
+    Vision Deficiency},
 }
-
 @misc{Machado2010a,
-  title = {A Model for Simulation of Color Vision Deficiency and a Color Contrast Enhancement Technique for Dichromats.},
-  author = {Machado, Gustavo Mello},
-  year = {2010},
-  pages = {1--94},
-  keywords = {Anomalous Trichromacy,Color Perception,Color Vision Deficiency,Color-Contrast Enhancement,Dichromacy,Models of Color Vision,Recoloring Algorithm,Simulation of Color Vision Deficiency},
-  file = {/Users/kelsolaar/Zotero/storage/FH4PP3LV/Machado - 2010 - A model for simulation of color vision deficiency and a color contrast enhancement technique for dichromats.pdf}
+  title        = {A Model for Simulation of Color Vision Deficiency
+    and a Color Contrast Enhancement Technique for Dichromats.},
+  author       = {Machado, Gustavo Mello},
+  year         = 2010,
+  pages        = {1--94},
+  keywords     = {Anomalous Trichromacy,Color Perception,Color Vision
+    Deficiency,Color-Contrast Enhancement,Dichromacy,Models of Color
+    Vision,Recoloring Algorithm,Simulation of Color Vision Deficiency},
 }
-
 @article{Mallett2019,
-  title = {Spectral {{Primary Decomposition}} for {{Rendering}} with {{sRGB Reflectance}}},
-  author = {Mallett, Ian and Yuksel, Cem},
-  year = {2019},
-  journal = {Eurographics Symposium on Rendering - DL-only and Industry Track},
-  pages = {7 pages},
-  publisher = {{The Eurographics Association}},
-  issn = {1727-3463},
-  doi = {10.2312/SR.20191216},
-  abstract = {Spectral renderers, as-compared to RGB renderers, are able to simulate light transport that is closer to reality, capturing light behavior that is impossible to simulate with any three-primary decomposition. However, spectral rendering requires spectral scene data (e.g. textures and material properties), which is not widely available, severely limiting the practicality of spectral rendering. Unfortunately, producing a physically valid reflectance spectrum from a given sRGB triple has been a challenging problem, and indeed until very recently constructing a spectrum without colorimetric round-trip error was thought to be impossible. In this paper, we introduce a new procedure for efficiently generating a reflectance spectrum from any given sRGB input data. We show for the first time that it is possible to create any sRGB reflectance spectrum as a linear combination of three separate spectra, each directly corresponding to one of the BT.709 primaries. Our approach produces consistent results, such that the input sRGB value is perfectly reproduced by the corresponding reflectance spectrum under D65 illumination, bounded only by Monte Carlo and numerical error. We provide a complete implementation, including a precomputed spectral basis, and discuss important optimizations and generalization to other RGB spaces.},
-  isbn = {9783038680956},
-  keywords = {Computing methodologies,Reflectance modeling},
-  file = {/Users/kelsolaar/Zotero/storage/8Z8H5WBD/Mallett and Yuksel - 2019 - Spectral Primary Decomposition for Rendering with .pdf;/Users/kelsolaar/Zotero/storage/YIIB4GJC/Mallett and Yuksel - 2019 - Spectral Primary Decomposition for Rendering with .pdf}
+  title        = {Spectral {{Primary Decomposition}} for {{Rendering}}
+    with {{sRGB Reflectance}}},
+  author       = {Mallett, Ian and Yuksel, Cem},
+  year         = 2019,
+  journal      = {Eurographics Symposium on Rendering - DL-only and
+    Industry Track},
+  pages        = {7 pages},
+  publisher    = {{The Eurographics Association}},
+  issn         = {1727-3463},
+  doi          = {10.2312/SR.20191216},
+  abstract     = {Spectral renderers, as-compared to RGB renderers,
+    are able to simulate light transport that is closer to reality,
+    capturing light behavior that is impossible to simulate with any
+    three-primary decomposition. However, spectral rendering requires
+    spectral scene data (e.g. textures and material properties), which
+    is not widely available, severely limiting the practicality of
+    spectral rendering. Unfortunately, producing a physically valid
+    reflectance spectrum from a given sRGB triple has been a
+    challenging problem, and indeed until very recently constructing a
+    spectrum without colorimetric round-trip error was thought to be
+    impossible. In this paper, we introduce a new procedure for
+    efficiently generating a reflectance spectrum from any given sRGB
+    input data. We show for the first time that it is possible to
+    create any sRGB reflectance spectrum as a linear combination of
+    three separate spectra, each directly corresponding to one of the
+    BT.709 primaries. Our approach produces consistent results, such
+    that the input sRGB value is perfectly reproduced by the
+    corresponding reflectance spectrum under D65 illumination, bounded
+    only by Monte Carlo and numerical error. We provide a complete
+    implementation, including a precomputed spectral basis, and
+    discuss important optimizations and generalization to other RGB
+    spaces.},
+  isbn         = 9783038680956,
+  keywords     = {Computing methodologies,Reflectance modeling},
 }
-
 @misc{Malvar2003,
-  title = {{{YCoCg-R}}: {{A Color Space}} with {{RGB Reversibility}} and {{Low Dynamic Range}}},
-  author = {Malvar, Henrique and Sullivan, Gary},
-  year = {2003},
-  file = {/Users/kelsolaar/Zotero/storage/3ZQJ76UA/Malvar, Sullivan - 2003 - YCoCg-R A Color Space with RGB Reversibility and Low Dynamic Range.pdf}
+  title        = {{{YCoCg-R}}: {{A Color Space}} with {{RGB
+    Reversibility}} and {{Low Dynamic Range}}},
+  author       = {Malvar, Henrique and Sullivan, Gary},
+  year         = 2003,
 }
-
 @misc{Mansencal2015d,
-  title = {{{RED Colourspaces Derivation}}},
-  author = {Mansencal, Thomas},
-  year = {2015},
-  howpublished = {https://www.colour-science.org/posts/red-colourspaces-derivation}
+  title        = {{{RED Colourspaces Derivation}}},
+  author       = {Mansencal, Thomas},
+  year         = 2015,
+  howpublished = {https://www.colour-science.org/posts/red-colourspaces-derivation},
 }
-
 @misc{Mansencal2018,
-  title = {How Is the Visible Gamut Bounded?},
-  author = {Mansencal, Thomas},
-  year = {2018},
-  howpublished = {https://stackoverflow.com/a/48396021/931625}
+  title        = {How Is the Visible Gamut Bounded?},
+  author       = {Mansencal, Thomas},
+  year         = 2018,
+  howpublished = {https://stackoverflow.com/a/48396021/931625},
 }
-
 @misc{Mansencal2019,
-  title = {Colour - {{Datasets}}},
-  author = {Mansencal, Thomas},
-  year = {2019},
-  doi = {10.5281/zenodo.3362520}
+  title        = {Colour - {{Datasets}}},
+  author       = {Mansencal, Thomas},
+  year         = 2019,
+  doi          = {10.5281/zenodo.3362520},
 }
-
 @misc{Mansencalc,
-  title = {Lookup},
-  author = {Mansencal, Thomas}
+  title        = {Lookup},
+  author       = {Mansencal, Thomas},
 }
-
 @misc{Mansencald,
-  title = {Structure},
-  author = {Mansencal, Thomas}
+  title        = {Structure},
+  author       = {Mansencal, Thomas},
 }
-
 @article{Martinez-Verdu2007,
-  title = {Computation and Visualization of the {{MacAdam}} Limits for Any Lightness, Hue Angle, and Light Source},
-  author = {{Mart{\'i}nez-Verd{\'u}}, Francisco and Perales, Esther and Chorro, Elisabet and {de Fez}, Dolores and Viqueira, Valent{\'i}n and Gilabert, Eduardo},
-  year = {2007},
-  month = jun,
-  journal = {Journal of the Optical Society of America A},
-  volume = {24},
-  number = {6},
-  pages = {1501},
-  issn = {1084-7529, 1520-8532},
-  doi = {10.1364/JOSAA.24.001501},
-  langid = {english},
-  file = {/Users/kelsolaar/Zotero/storage/6SLGV92H/16355068.pdf;/Users/kelsolaar/Zotero/storage/JDD38TZG/Martínez-Verdú et al. - 2007 - Computation and visualization of the MacAdam limit.pdf}
+  title        = {Computation and Visualization of the {{MacAdam}}
+    Limits for Any Lightness, Hue Angle, and Light Source},
+  author       = {{Mart{\'i}nez-Verd{\'u}}, Francisco and Perales,
+    Esther and Chorro, Elisabet and {de Fez}, Dolores and Viqueira,
+    Valent{\'i}n and Gilabert, Eduardo},
+  year         = 2007,
+  month        = jun,
+  journal      = {Journal of the Optical Society of America A},
+  volume       = 24,
+  number       = 6,
+  pages        = 1501,
+  issn         = {1084-7529, 1520-8532},
+  doi          = {10.1364/JOSAA.24.001501},
+  langid       = {english},
 }
-
 @misc{Melgosa2013b,
-  title = {{{CIE}} / {{ISO}} New Standard: {{CIEDE2000}}},
-  author = {Melgosa, Manuel},
-  year = {2013},
-  file = {/Users/kelsolaar/Zotero/storage/GMJRKCQV/Melgosa - 2013 - CIE ISO new standard CIEDE2000.pdf}
+  title        = {{{CIE}} / {{ISO}} New Standard: {{CIEDE2000}}},
+  author       = {Melgosa, Manuel},
+  year         = 2013,
 }
-
 @article{Meng2015c,
-  title = {Physically {{Meaningful Rendering}} Using {{Tristimulus Colours}}},
-  author = {Meng, Johannes and Simon, Florian and Hanika, Johannes and Dachsbacher, Carsten},
-  year = {2015},
-  month = jul,
-  journal = {Computer Graphics Forum},
-  volume = {34},
-  number = {4},
-  pages = {31--40},
-  issn = {01677055},
-  doi = {10.1111/cgf.12676},
-  file = {/Users/kelsolaar/Zotero/storage/LU9L6CQP/Meng et al. - 2015 - Physically Meaningful Rendering using Tristimulus Colours.pdf}
+  title        = {Physically {{Meaningful Rendering}} Using
+    {{Tristimulus Colours}}},
+  author       = {Meng, Johannes and Simon, Florian and Hanika,
+    Johannes and Dachsbacher, Carsten},
+  year         = 2015,
+  month        = jul,
+  journal      = {Computer Graphics Forum},
+  volume       = 34,
+  number       = 4,
+  pages        = {31--40},
+  issn         = 01677055,
+  doi          = {10.1111/cgf.12676},
 }
-
 @misc{Miller2014a,
-  title = {A {{Perceptual EOTF}} for {{Extended Dynamic Range Imagery}}},
-  author = {Miller, Scott},
-  year = {2014},
-  pages = {1--17},
-  file = {/Users/kelsolaar/Zotero/storage/E3D2ZNEY/Miller - 2014 - A Perceptual EOTF for Extended Dynamic Range Imagery.pdf}
+  title        = {A {{Perceptual EOTF}} for {{Extended Dynamic Range
+    Imagery}}},
+  author       = {Miller, Scott},
+  year         = 2014,
+  pages        = {1--17},
 }
-
 @article{Mokrzycki2011,
-  title = {Color Difference {{Delta E}} - {{A}} Survey},
-  author = {Mokrzycki, Wojciech and Tatol, Maciej},
-  year = {2011},
-  month = apr,
-  journal = {Machine Graphics and Vision},
-  volume = {20},
-  pages = {383--411},
-  abstract = {Color perception is crucial for human existence. For this purpose, color spaces have been developed to describe mathematically the color that a person can feel with unaided eye. There was a new need to distinguish colors, define them as similar, identical or completely different. However colormatching technique requires a color palette with perceptually linear characteristics. In this article, will be presented to the most popular colors spaces, as both linear and nonlinear due to perceptual abilities, and are briefly discussed and compared to the sample values.},
-  keywords = {⛔ No DOI found},
-  file = {/Users/kelsolaar/Zotero/storage/W937M5MV/Mokrzycki, Tatol - 2011 - Color difference Delta E - A survey.pdf}
+  title        = {Color Difference {{Delta E}} - {{A}} Survey},
+  author       = {Mokrzycki, Wojciech and Tatol, Maciej},
+  year         = 2011,
+  month        = apr,
+  journal      = {Machine Graphics and Vision},
+  volume       = 20,
+  pages        = {383--411},
+  abstract     = {Color perception is crucial for human existence. For
+    this purpose, color spaces have been developed to describe
+    mathematically the color that a person can feel with unaided eye.
+    There was a new need to distinguish colors, define them as
+    similar, identical or completely different. However colormatching
+    technique requires a color palette with perceptually linear
+    characteristics. In this article, will be presented to the most
+    popular colors spaces, as both linear and nonlinear due to
+    perceptual abilities, and are briefly discussed and compared to
+    the sample values.},
+  keywords     = {⛔ No DOI found},
 }
-
 @article{Moroney2003,
-  title = {A {{Radial Sampling}} of the {{OSA Uniform Color Scales}}},
-  author = {Moroney, Nathan},
-  year = {2003},
-  journal = {Color and Imaging Conference},
-  volume = {2003},
-  number = {1},
-  pages = {175--180},
-  issn = {2166-9635},
-  abstract = {The OSA Uniform Color Scales were derived using a unique geometry for the physical samples. Regular rhombohedral packing allows each sample to be compared to twelve other equally distant samples. While this sampling scheme provides an efficient geometry for sample comparison and allows multiple cleavage planes, it obscures the underlying perceptual attributes. However, it is relatively straightforward to compute a radial sampling of data points in OSA. This radial sampling results in a distance from the achromatic axis and an angular quantity and can be used to compare other color spaces. This paper presents a method and considerations for computing the radial sampling. The utility of this data is demonstrated by comparing the perceptual uniformity of five different color spaces.},
-  eissn = {2169-2629},
-  itemtype = {ARTICLE},
+  title        = {A {{Radial Sampling}} of the {{OSA Uniform Color
+    Scales}}},
+  author       = {Moroney, Nathan},
+  year         = 2003,
+  journal      = {Color and Imaging Conference},
+  volume       = 2003,
+  number       = 1,
+  pages        = {175--180},
+  issn         = {2166-9635},
+  abstract     = {The OSA Uniform Color Scales were derived using a
+    unique geometry for the physical samples. Regular rhombohedral
+    packing allows each sample to be compared to twelve other equally
+    distant samples. While this sampling scheme provides an efficient
+    geometry for sample comparison and allows multiple cleavage
+    planes, it obscures the underlying perceptual attributes. However,
+    it is relatively straightforward to compute a radial sampling of
+    data points in OSA. This radial sampling results in a distance
+    from the achromatic axis and an angular quantity and can be used
+    to compare other color spaces. This paper presents a method and
+    considerations for computing the radial sampling. The utility of
+    this data is demonstrated by comparing the perceptual uniformity
+    of five different color spaces.},
+  eissn        = {2169-2629},
+  itemtype     = {ARTICLE},
   parent_itemid = {infobike://ist/cic},
   publication_date = {2003-01-01T00:00:00},
   publishercode = {ist},
-  keywords = {⛔ No DOI found},
-  file = {/Users/kelsolaar/Zotero/storage/HZFF8LSC/Moroney - 2003 - A radial sampling of the OSA uniform color scales.pdf}
+  keywords     = {⛔ No DOI found},
 }
-
 @article{Moroneya,
-  title = {The {{CIECAM02}} Color Appearance Model},
-  author = {Moroney, Nathan and Fairchild, Mark D. and Hunt, Robert W. G. and Li, Changjun and Luo, Ming Ronnier and Newman, Todd},
-  year = {2002},
-  journal = {Color and Imaging Conference},
-  number = {1},
-  pages = {23--27},
-  abstract = {The CIE Technical Committee 8-01, color appearance models for color management applications, has recently proposed a single set of revisions to the CIECAM97s color appearance model. This new model, called CIECAM02, is based on CIECAM97s but includes many revisions and some simplifications. A partial list of revisions includes a linear chromatic adaptation transform, a new non-linear response compression function and modifications to the calculations for the perceptual attribute correlates. The format of this paper is an annotated description of the forward equations for the model.},
-  file = {/Users/kelsolaar/Zotero/storage/LJ3HN5QK/Moroney et al. - 2002 - The CIECAM02 color appearance model.pdf}
+  title        = {The {{CIECAM02}} Color Appearance Model},
+  author       = {Moroney, Nathan and Fairchild, Mark D. and Hunt,
+    Robert W. G. and Li, Changjun and Luo, Ming Ronnier and Newman,
+    Todd},
+  year         = 2002,
+  journal      = {Color and Imaging Conference},
+  number       = 1,
+  pages        = {23--27},
+  abstract     = {The CIE Technical Committee 8-01, color appearance
+    models for color management applications, has recently proposed a
+    single set of revisions to the CIECAM97s color appearance model.
+    This new model, called CIECAM02, is based on CIECAM97s but
+    includes many revisions and some simplifications. A partial list
+    of revisions includes a linear chromatic adaptation transform, a
+    new non-linear response compression function and modifications to
+    the calculations for the perceptual attribute correlates. The
+    format of this paper is an annotated description of the forward
+    equations for the model.},
 }
-
 @article{Morovic2000,
-  title = {Calculating Medium and Image Gamut Boundaries for Gamut Mapping},
-  author = {Morovi{\v c}, J{\'a}n and Luo, M. Ronnier},
-  year = {2000},
-  journal = {Color Research and Application},
-  volume = {25},
-  number = {6},
-  pages = {394--401},
-  issn = {03612317},
-  doi = {10.1002/1520-6378(200012)25:63.0.CO;2-Y},
-  abstract = {The Segment Maxima Method for calculating gamut boundary descriptors of both colour reproduction media and colour images is introduced. Methods for determining the gamut boundary along a given line of mapping used by gamut mapping algorithms are then described, whereby these methods use the Gamut Boundary Descriptor obtained using the Segment Maxima Method. Throughout the article, the focus is both on colour reproduction media and colour images as well as on the suitability of the methods for use in gamut mapping. \textcopyright{} 2000 John Wiley \& Sons. Inc.},
-  keywords = {Cross-media reproduction,Gamut boundary calculation,Gamut mapping},
-  file = {/Users/kelsolaar/Zotero/storage/VD5SFTFE/Morovič, Luo - 2000 - Calculating medium and image gamut boundaries for gamut mapping.pdf}
+  title        = {Calculating Medium and Image Gamut Boundaries for
+    Gamut Mapping},
+  author       = {Morovi{\v c}, J{\'a}n and Luo, M. Ronnier},
+  year         = 2000,
+  journal      = {Color Research and Application},
+  volume       = 25,
+  number       = 6,
+  pages        = {394--401},
+  issn         = 03612317,
+  doi          = {10.1002/1520-6378(200012)25:63.0.CO;2-Y},
+  abstract     = {The Segment Maxima Method for calculating gamut
+    boundary descriptors of both colour reproduction media and colour
+    images is introduced. Methods for determining the gamut boundary
+    along a given line of mapping used by gamut mapping algorithms are
+    then described, whereby these methods use the Gamut Boundary
+    Descriptor obtained using the Segment Maxima Method. Throughout
+    the article, the focus is both on colour reproduction media and
+    colour images as well as on the suitability of the methods for use
+    in gamut mapping. \textcopyright{} 2000 John Wiley \& Sons. Inc.},
+  keywords     = {Cross-media reproduction,Gamut boundary
+    calculation,Gamut mapping},
 }
-
 @article{MunishRagoo2021,
-  title = {Optimising a {{Euclidean Colour Space Transform}} for {{Colour Order}} and {{Perceptual Uniformity}}},
-  author = {Munish Ragoo, Luvin and Farup, Ivar},
-  year = {2021},
-  month = nov,
-  journal = {Color and Imaging Conference},
-  volume = {29},
-  number = {1},
-  pages = {282--287},
-  issn = {2166-9635},
-  doi = {10.2352/issn.2169-2629.2021.29.282},
-  file = {/Users/kelsolaar/Zotero/storage/5AR4C5XH/Munish Ragoo and Farup - 2021 - Optimising a Euclidean Colour Space Transform for .pdf}
+  title        = {Optimising a {{Euclidean Colour Space Transform}}
+    for {{Colour Order}} and {{Perceptual Uniformity}}},
+  author       = {Munish Ragoo, Luvin and Farup, Ivar},
+  year         = 2021,
+  month        = nov,
+  journal      = {Color and Imaging Conference},
+  volume       = 29,
+  number       = 1,
+  pages        = {282--287},
+  issn         = {2166-9635},
+  doi          = {10.2352/issn.2169-2629.2021.29.282},
 }
-
 @misc{MunsellColorScienceb,
-  title = {Macbeth {{Colorchecker}}},
-  author = {{Munsell Color Science}}
+  title        = {Macbeth {{Colorchecker}}},
+  author       = {{Munsell Color Science}},
 }
-
 @misc{MunsellColorSciencec,
-  title = {Munsell {{Colours Data}}},
-  author = {{Munsell Color Science}},
-  howpublished = {http://www.cis.rit.edu/research/mcsl2/online/munsell.php}
+  title        = {Munsell {{Colours Data}}},
+  author       = {{Munsell Color Science}},
+  howpublished = {http://www.cis.rit.edu/research/mcsl2/online/munsell.php},
 }
-
 @misc{NationalElectricalManufacturersAssociation2004b,
-  title = {Digital {{Imaging}} and {{Communications}} in {{Medicine}} ({{DICOM}}) {{Part}} 14: {{Grayscale Standard Display Function}}},
-  author = {{National Electrical Manufacturers Association}},
-  year = {2004},
-  file = {/Users/kelsolaar/Zotero/storage/RNJQ44Y2/National Electrical Manufacturers Association - 2004 - Digital Imaging and Communications in Medicine (DICOM) Part 14 Grayscale Standard.pdf}
+  title        = {Digital {{Imaging}} and {{Communications}} in
+    {{Medicine}} ({{DICOM}}) {{Part}} 14: {{Grayscale Standard Display
+    Function}}},
+  author       = {{National Electrical Manufacturers Association}},
+  year         = 2004,
 }
-
 @misc{Nattress2016a,
-  title = {Private {{Discussion}} with {{Shaw}}, {{N}}.},
-  author = {Nattress, Graeme},
-  year = {2016}
+  title        = {Private {{Discussion}} with {{Shaw}}, {{N}}.},
+  author       = {Nattress, Graeme},
+  year         = 2016,
 }
-
 @article{Nayatani1995a,
-  title = {Lightness Dependency of Chroma Scales of a Nonlinear Color-Appearance Model and Its Latest Formulation},
-  author = {Nayatani, Yoshinobu and Sobagaki, Hiroaki and Yano, Kenjiro Hashimoto Tadashi},
-  year = {1995},
-  month = jun,
-  journal = {Color Research \& Application},
-  volume = {20},
-  number = {3},
-  pages = {156--167},
-  publisher = {{Wiley Subscription Services, Inc., A Wiley Company}},
-  issn = {03612317},
-  doi = {10.1002/col.5080200305},
-  keywords = {color-vision model,lightness dependency of chroma,nonlinear color-appearance model},
-  file = {/Users/kelsolaar/Zotero/storage/J5IY5UKH/Nayatani, Sobagaki, Yano - 1995 - Lightness dependency of chroma scales of a nonlinear color-appearance model and its latest formulation.pdf}
+  title        = {Lightness Dependency of Chroma Scales of a Nonlinear
+    Color-Appearance Model and Its Latest Formulation},
+  author       = {Nayatani, Yoshinobu and Sobagaki, Hiroaki and Yano,
+    Kenjiro Hashimoto Tadashi},
+  year         = 1995,
+  month        = jun,
+  journal      = {Color Research \& Application},
+  volume       = 20,
+  number       = 3,
+  pages        = {156--167},
+  publisher    = {{Wiley Subscription Services, Inc., A Wiley Company}},
+  issn         = 03612317,
+  doi          = {10.1002/col.5080200305},
+  keywords     = {color-vision model,lightness dependency of
+    chroma,nonlinear color-appearance model},
 }
-
 @article{Nayatani1997,
-  title = {Simple Estimation Methods for the {{Helmholtz}}\textemdash{{Kohlrausch}} Effect},
-  author = {Nayatani, Yoshinobu},
-  year = {1997},
-  journal = {Color Research \& Application},
-  volume = {22},
-  number = {6},
-  pages = {385--401},
-  issn = {1520-6378},
-  doi = {10.1002/(SICI)1520-6378(199712)22:6<385::AID-COL6>3.0.CO;2-R},
-  abstract = {Four kinds of simple estimation equations are proposed for the Helmholtz\textemdash Kohlrausch effect. Two of them can be used for luminous colors, and the other two for object colors. In each of luminous and object colors, the two estimation equations are given to each of the Variable-Achromatic-Color (VAC) and the Variable-Chromatic-Color (VCC) methods. All the equations are similar in type to the Ware\textemdash Cowan equation. They give the ratio between luminance (or metric lightness) of test color stimulus and its equivalent luminance (or equivalent lightness) directly. Though their computations are simple, they can apply to various H\textemdash K effects including their adapting luminance dependency. The applicable fields of the proposed equations are wider than those of the Ware\textemdash Cowan equation. The proposed equations can be applied to predict the H\textemdash K effect within the whole chromaticity gamut including spectral colors, spectral luminosity functions based on direct color matching from 0.01 Td to 100 000 Td using the photopic and the scotopic spectral luminosity functions specified by CIE, equivalent lightness values of NCS colors, and others. \textcopyright{} 1997 John Wiley \& Sons, Inc. Col Res Appl. 22, 385\textendash 401, 1997},
-  copyright = {Copyright \textcopyright{} 1997 John Wiley \& Sons, Inc.},
-  langid = {english},
-  keywords = {CIELUV formula,color appearance,equivalent lightness,equivalent luminance,Helmholtz—Kohlrausch effect},
-  annotation = {\_eprint: https://onlinelibrary.wiley.com/doi/pdf/10.1002/\%28SICI\%291520-6378\%28199712\%2922\%3A6\%3C385\%3A\%3AAID-COL6\%3E3.0.CO\%3B2-R},
-  file = {/Users/kelsolaar/Zotero/storage/HR4D25I9/Nayatani - 1997 - Simple estimation methods for the Helmholtz—Kohlra.pdf;/Users/kelsolaar/Zotero/storage/8Q2NHT7G/(SICI)1520-6378(199712)226385AID-COL63.0.html}
+  title        = {Simple Estimation Methods for the
+    {{Helmholtz}}\textemdash{{Kohlrausch}} Effect},
+  author       = {Nayatani, Yoshinobu},
+  year         = 1997,
+  journal      = {Color Research \& Application},
+  volume       = 22,
+  number       = 6,
+  pages        = {385--401},
+  issn         = {1520-6378},
+  doi          = {10.1002/(SICI)1520-6378(199712)22:6<385::AID-COL6>3.0.CO;2-R},
+  abstract     = {Four kinds of simple estimation equations are
+    proposed for the Helmholtz\textemdash Kohlrausch effect. Two of
+    them can be used for luminous colors, and the other two for object
+    colors. In each of luminous and object colors, the two estimation
+    equations are given to each of the Variable-Achromatic-Color (VAC)
+    and the Variable-Chromatic-Color (VCC) methods. All the equations
+    are similar in type to the Ware\textemdash Cowan equation. They
+    give the ratio between luminance (or metric lightness) of test
+    color stimulus and its equivalent luminance (or equivalent
+    lightness) directly. Though their computations are simple, they
+    can apply to various H\textemdash K effects including their
+    adapting luminance dependency. The applicable fields of the
+    proposed equations are wider than those of the Ware\textemdash
+    Cowan equation. The proposed equations can be applied to predict
+    the H\textemdash K effect within the whole chromaticity gamut
+    including spectral colors, spectral luminosity functions based on
+    direct color matching from 0.01 Td to 100 000 Td using the
+    photopic and the scotopic spectral luminosity functions specified
+    by CIE, equivalent lightness values of NCS colors, and others.
+    \textcopyright{} 1997 John Wiley \& Sons, Inc. Col Res Appl. 22,
+    385\textendash 401, 1997},
+  copyright    = {Copyright \textcopyright{} 1997 John Wiley \& Sons,
+    Inc.},
+  langid       = {english},
+  keywords     = {CIELUV formula,color appearance,equivalent
+    lightness,equivalent luminance,Helmholtz—Kohlrausch effect},
+  annotation   = {\_eprint:
+    https://onlinelibrary.wiley.com/doi/pdf/10.1002/\%28SICI\%291520-6378\%28199712\%2922\%3A6\%3C385\%3A\%3AAID-COL6\%3E3.0.CO\%3B2-R},
 }
-
 @article{Newhall1943a,
-  title = {Final {{Report}} of the {{OSA Subcommittee}} on the {{Spacing}} of the {{Munsell Colors}}},
-  author = {Newhall, Sidney M. and Nickerson, Dorothy and Judd, Deane B.},
-  year = {1943},
-  month = jul,
-  journal = {Journal of the Optical Society of America},
-  volume = {33},
-  number = {7},
-  pages = {385},
-  issn = {0030-3941},
-  doi = {10.1364/JOSA.33.000385},
-  abstract = {This report presents the characteristics of a modified and enlarged Munsell solid which has been evolved from the 1940 visual estimates of the Munsell Book of Color samples. All three dimensions have been carefully reviewed and extensively revised. The newly defined loci of constant hue have been extended closer to the extremes of value while the loci of constant chroma have been extrapolated to the pigment maximum. The dimension of value has been redefined without substantial departure from the Munsell-Sloan-Godlove scale. By the above changes a solid is achieved which approaches more closely to A. H. Munsell's dual ideal of psychological equispacing and precise applicability. The new solid is defined in terms of the I.C.I. standard coordinate system and Illuminant C.},
-  file = {/Users/kelsolaar/Zotero/storage/7X756UGG/Newhall, Nickerson, Judd - 1943 - Final Report of the OSA Subcommittee on the Spacing of the Munsell Colors.pdf}
+  title        = {Final {{Report}} of the {{OSA Subcommittee}} on the
+    {{Spacing}} of the {{Munsell Colors}}},
+  author       = {Newhall, Sidney M. and Nickerson, Dorothy and Judd,
+    Deane B.},
+  year         = 1943,
+  month        = jul,
+  journal      = {Journal of the Optical Society of America},
+  volume       = 33,
+  number       = 7,
+  pages        = 385,
+  issn         = {0030-3941},
+  doi          = {10.1364/JOSA.33.000385},
+  abstract     = {This report presents the characteristics of a
+    modified and enlarged Munsell solid which has been evolved from
+    the 1940 visual estimates of the Munsell Book of Color samples.
+    All three dimensions have been carefully reviewed and extensively
+    revised. The newly defined loci of constant hue have been extended
+    closer to the extremes of value while the loci of constant chroma
+    have been extrapolated to the pigment maximum. The dimension of
+    value has been redefined without substantial departure from the
+    Munsell-Sloan-Godlove scale. By the above changes a solid is
+    achieved which approaches more closely to A. H. Munsell's dual
+    ideal of psychological equispacing and precise applicability. The
+    new solid is defined in terms of the I.C.I. standard coordinate
+    system and Illuminant C.},
 }
-
 @misc{Nikon2018,
-  title = {N-{{Log Specification Document}} - {{Version}} 1.0.0},
-  author = {{Nikon}},
-  year = {2018},
-  pages = {1--5},
-  file = {/Users/kelsolaar/Zotero/storage/B9YHNF6B/Nikon - 2018 - N-Log Specification Document - Version 1.0.0.pdf}
+  title        = {N-{{Log Specification Document}} - {{Version}} 1.0.0},
+  author       = {{Nikon}},
+  year         = 2018,
+  pages        = {1--5},
 }
-
 @article{Ohno2005,
-  title = {Spectral Design Considerations for White {{LED}} Color Rendering},
-  author = {Ohno, Yoshi},
-  year = {2005},
-  journal = {Optical Engineering},
-  volume = {44},
-  number = {11},
-  pages = {111302},
-  issn = {0091-3286},
-  doi = {10.1117/1.2130694},
-  abstract = {White LED spectra for general lighting should be designed for high luminous efficacy as well as good color rendering. Multichip and phosphor-type white LED models were analyzed by simulation of their color characteristics and luminous efficacy of radiation, compared with those of conventional light sources for general lighting. Color rendering characteristics were evaluated based on the CIE Color Rendering Index (CRI), examining not only Ra but also the special color rendering indices Ri, as well as on the CIELAB color difference {$\Delta$}Eab* for the 14 color samples defined in CIE 13.3. Several models of three-chip and four-chip white LEDs as well as phosphor-type LEDs are optimized for various parameters, and some guidance is given for designing these white LEDs. The simulation analysis also demonstrated several problems with the current CRI, and the need for improvements is discussed.},
-  isbn = {3018408551},
-  file = {/Users/kelsolaar/Zotero/storage/WTUC2EBX/Ohno - 2005 - Spectral design considerations for white LED color rendering.pdf}
+  title        = {Spectral Design Considerations for White {{LED}}
+    Color Rendering},
+  author       = {Ohno, Yoshi},
+  year         = 2005,
+  journal      = {Optical Engineering},
+  volume       = 44,
+  number       = 11,
+  pages        = 111302,
+  issn         = {0091-3286},
+  doi          = {10.1117/1.2130694},
+  abstract     = {White LED spectra for general lighting should be
+    designed for high luminous efficacy as well as good color
+    rendering. Multichip and phosphor-type white LED models were
+    analyzed by simulation of their color characteristics and luminous
+    efficacy of radiation, compared with those of conventional light
+    sources for general lighting. Color rendering characteristics were
+    evaluated based on the CIE Color Rendering Index (CRI), examining
+    not only Ra but also the special color rendering indices Ri, as
+    well as on the CIELAB color difference {$\Delta$}Eab* for the 14
+    color samples defined in CIE 13.3. Several models of three-chip
+    and four-chip white LEDs as well as phosphor-type LEDs are
+    optimized for various parameters, and some guidance is given for
+    designing these white LEDs. The simulation analysis also
+    demonstrated several problems with the current CRI, and the need
+    for improvements is discussed.},
+  isbn         = 3018408551,
 }
-
 @misc{Ohno2008a,
-  title = {{{NIST CQS}} Simulation},
-  author = {Ohno, Yoshiro and Davis, Wendy},
-  year = {2008},
-  file = {/Users/kelsolaar/Zotero/storage/C99BIK93/Ohno, Davis - 2008 - NIST CQS simulation 7.4.xls}
+  title        = {{{NIST CQS}} Simulation},
+  author       = {Ohno, Yoshiro and Davis, Wendy},
+  year         = 2008,
 }
-
 @misc{Ohno2013,
-  title = {{{NIST CQS}} Simulation},
-  author = {Ohno, Yoshiro and Davis, Wendy},
-  year = {2013}
+  title        = {{{NIST CQS}} Simulation},
+  author       = {Ohno, Yoshiro and Davis, Wendy},
+  year         = 2013,
 }
-
 @article{Ohno2014a,
-  title = {Practical {{Use}} and {{Calculation}} of {{CCT}} and {{Duv}}},
-  author = {Ohno, Yoshiro},
-  year = {2014},
-  month = jan,
-  journal = {LEUKOS},
-  volume = {10},
-  number = {1},
-  pages = {47--55},
-  issn = {1550-2724},
-  doi = {10.1080/15502724.2014.839020},
-  keywords = {chromaticity,correlated color temperature,duv,Duv,light source,planckian locus,Planckian locus},
-  file = {/Users/kelsolaar/Zotero/storage/WJRYC8KZ/Ohno - 2014 - Practical Use and Calculation of CCT and Duv.pdf}
+  title        = {Practical {{Use}} and {{Calculation}} of {{CCT}} and
+    {{Duv}}},
+  author       = {Ohno, Yoshiro},
+  year         = 2014,
+  month        = jan,
+  journal      = {LEUKOS},
+  volume       = 10,
+  number       = 1,
+  pages        = {47--55},
+  issn         = {1550-2724},
+  doi          = {10.1080/15502724.2014.839020},
+  keywords     = {chromaticity,correlated color
+    temperature,duv,Duv,light source,planckian locus,Planckian locus},
 }
-
 @misc{Ohta1997a,
-  title = {The Basis of Color Reproduction Engineering},
-  author = {Ohta, N.},
-  year = {1997}
+  title        = {The Basis of Color Reproduction Engineering},
+  author       = {Ohta, N.},
+  year         = 1997,
 }
-
 @article{Otsu2018,
-  title = {Reproducing {{Spectral Reflectances From Tristimulus Colours}}},
-  shorttitle = {Reproducing {{Spectral Reflectances From Tristimulus Colours}}},
-  author = {Otsu, H. and Yamamoto, M. and Hachisuka, T.},
-  year = {2018},
-  month = sep,
-  journal = {Computer Graphics Forum},
-  volume = {37},
-  number = {6},
-  pages = {370--381},
-  issn = {01677055},
-  doi = {10.1111/cgf.13332},
-  langid = {english},
-  keywords = {3,7,according to acm ccs,and texture,categories and subject descriptors,color,computer graphics,i,realism,shading,shadowing,spectral reflectance reconstruction,spectral rendering,three-dimensional graphics and},
-  file = {/Users/kelsolaar/Zotero/storage/HC7MJ5LW/Otsu, Yamamoto, Hachisuka - Unknown - Reproducing Spectral Reflectances from Tristimulus Colors.pdf;/Users/kelsolaar/Zotero/storage/R7SYAXJ3/rgb2spec.zip}
+  title        = {Reproducing {{Spectral Reflectances From Tristimulus
+    Colours}}},
+  shorttitle   = {Reproducing {{Spectral Reflectances From Tristimulus
+    Colours}}},
+  author       = {Otsu, H. and Yamamoto, M. and Hachisuka, T.},
+  year         = 2018,
+  month        = sep,
+  journal      = {Computer Graphics Forum},
+  volume       = 37,
+  number       = 6,
+  pages        = {370--381},
+  issn         = 01677055,
+  doi          = {10.1111/cgf.13332},
+  langid       = {english},
+  keywords     = {3,7,according to acm ccs,and texture,categories and
+    subject descriptors,color,computer
+    graphics,i,realism,shading,shadowing,spectral reflectance
+    reconstruction,spectral rendering,three-dimensional graphics and},
 }
-
 @misc{Ottosson2020,
-  title = {A Perceptual Color Space for Image Processing},
-  author = {Ottosson, Bj{\"o}rn},
-  year = {2020},
-  howpublished = {https://bottosson.github.io/posts/oklab/}
+  title        = {A Perceptual Color Space for Image Processing},
+  author       = {Ottosson, Bj{\"o}rn},
+  year         = 2020,
+  howpublished = {https://bottosson.github.io/posts/oklab/},
 }
-
 @misc{Panasonic2014a,
-  title = {{{VARICAM V-Log}}/{{V-Gamut}}},
-  author = {{Panasonic}},
-  year = {2014},
-  pages = {1--7},
-  file = {/Users/kelsolaar/Zotero/storage/V3PP87S3/Panasonic - 2014 - VARICAM V-LogV-Gamut.pdf}
+  title        = {{{VARICAM V-Log}}/{{V-Gamut}}},
+  author       = {{Panasonic}},
+  year         = 2014,
+  pages        = {1--7},
 }
-
 @misc{Pointer1980a,
-  title = {Pointer's {{Gamut Data}}},
-  author = {Pointer, Michael R.},
-  year = {1980},
-  file = {/Users/kelsolaar/Zotero/storage/ZW4DDJU4/Pointer - 1980 - Pointer's Gamut Data.xls}
+  title        = {Pointer's {{Gamut Data}}},
+  author       = {Pointer, Michael R.},
+  year         = 1980,
 }
-
 @misc{REDDigitalCinema2017,
-  title = {White {{Paper}} on {{REDWideGamutRGB}} and {{Log3G10}}},
-  author = {{RED Digital Cinema}},
-  year = {2017},
-  file = {/Users/kelsolaar/Zotero/storage/AZSRMF37/RED Digital Cinema - 2017 - White Paper on REDWideGamutRGB and Log3G10.pdf}
+  title        = {White {{Paper}} on {{REDWideGamutRGB}} and
+    {{Log3G10}}},
+  author       = {{RED Digital Cinema}},
+  year         = 2017,
 }
-
 @misc{RenewableResourceDataCenter2003a,
-  title = {Reference {{Solar Spectral Irradiance}}: {{ASTM G-173}}},
-  author = {{Renewable Resource Data Center}},
-  year = {2003},
-  howpublished = {http://rredc.nrel.gov/solar/spectra/am1.5/ASTMG173/ASTMG173.html}
+  title        = {Reference {{Solar Spectral Irradiance}}: {{ASTM
+    G-173}}},
+  author       = {{Renewable Resource Data Center}},
+  year         = 2003,
+  howpublished = {http://rredc.nrel.gov/solar/spectra/am1.5/ASTMG173/ASTMG173.html},
 }
-
 @misc{RisingSunResearch,
-  title = {{{cineSpace LUT Library}}},
-  author = {{Rising Sun Research}},
-  howpublished = {https://sourceforge.net/projects/cinespacelutlib/}
+  title        = {{{cineSpace LUT Library}}},
+  author       = {{Rising Sun Research}},
+  howpublished = {https://sourceforge.net/projects/cinespacelutlib/},
 }
-
 @misc{Saeedna,
-  title = {Extend a Line Segment a Specific Distance},
-  author = {{Saeedn}},
-  howpublished = {http://stackoverflow.com/questions/7740507/extend-a-line-segment-a-specific-distance}
+  title        = {Extend a Line Segment a Specific Distance},
+  author       = {{Saeedn}},
+  howpublished = {http://stackoverflow.com/questions/7740507/extend-a-line-segment-a-specific-distance},
 }
-
 @article{Safdar2017,
-  title = {Perceptually Uniform Color Space for Image Signals Including High Dynamic Range and Wide Gamut},
-  author = {Safdar, Muhammad and Cui, Guihua and Kim, Youn Jin and Luo, Ming Ronnier},
-  year = {2017},
-  month = jun,
-  journal = {Optics Express},
-  volume = {25},
-  number = {13},
-  pages = {15131},
-  issn = {1094-4087},
-  doi = {10.1364/OE.25.015131},
-  abstract = {A perceptually uniform color space has been long desired for a wide range of imaging applications. Such a color space should be able to represent a color pixel in three unique and independent attributes (lightness, chroma, and hue). Such a space would be perceptually uniform over a wide gamut, linear in iso-hue directions, and can predict both small and large color differences as well as lightness in high dynamic range environments. It would also have minimum computational cost for real time or quasi-real time processing. Presently available color spaces are not able to achieve these goals satisfactorily and comprehensively. In this study, a uniform color space is proposed and its performance in predicting a wide range of experimental data is presented in comparison with the other state of the art color spaces.},
-  keywords = {and visual optics,color,Color,Color vision,Colorimetry,Vision},
-  file = {/Users/kelsolaar/Zotero/storage/54BGXKPS/Safdar et al. - 2017 - Perceptually uniform color space for image signals including high dynamic range and wide gamut.pdf}
+  title        = {Perceptually Uniform Color Space for Image Signals
+    Including High Dynamic Range and Wide Gamut},
+  author       = {Safdar, Muhammad and Cui, Guihua and Kim, Youn Jin
+    and Luo, Ming Ronnier},
+  year         = 2017,
+  month        = jun,
+  journal      = {Optics Express},
+  volume       = 25,
+  number       = 13,
+  pages        = 15131,
+  issn         = {1094-4087},
+  doi          = {10.1364/OE.25.015131},
+  abstract     = {A perceptually uniform color space has been long
+    desired for a wide range of imaging applications. Such a color
+    space should be able to represent a color pixel in three unique
+    and independent attributes (lightness, chroma, and hue). Such a
+    space would be perceptually uniform over a wide gamut, linear in
+    iso-hue directions, and can predict both small and large color
+    differences as well as lightness in high dynamic range
+    environments. It would also have minimum computational cost for
+    real time or quasi-real time processing. Presently available color
+    spaces are not able to achieve these goals satisfactorily and
+    comprehensively. In this study, a uniform color space is proposed
+    and its performance in predicting a wide range of experimental
+    data is presented in comparison with the other state of the art
+    color spaces.},
+  keywords     = {and visual optics,color,Color,Color
+    vision,Colorimetry,Vision},
 }
-
 @article{Safdar2018,
-  ids = {Safdar2019},
-  title = {A {{Colour Appearance Model}} Based on {{J}} z a z b z {{Colour Space}}},
-  author = {Safdar, Muhammad and Hardeberg, Jon Y. and Kim, Youn Jin and Luo, Ming Ronnier},
-  year = {2018},
-  month = nov,
-  journal = {Color and Imaging Conference},
-  volume = {2018},
-  number = {1},
-  pages = {96--101},
-  issn = {2166-9635},
-  doi = {10.2352/ISSN.2169-2629.2018.26.96},
-  abstract = {The current CIE colour appearance model CIECAM02 and its variant named CAM16 can well predict common colour appearance attributes including lightness, brightness, chroma, colourfulness, saturation, hue angle, and hue composition. These models are complicated as well as have mathematical problems. The current study aimed a new colour appearance model based on Jzazbz color space to obtain either better or similar performance compared with CAM16 but the new model should be computationally simple and robust. Such a model will particularly be suitable for color management in high dynamic range and wide color gamut applications. A range of experimental data were collected and a set of equations was derived. Some initial test results are presented in this paper.},
-  isbn = {9780892083374},
-  file = {/Users/kelsolaar/Zotero/storage/5KKXQBU2/Safdar et al. - 2019 - A Colour Appearance Model based on J z a z b z Colour Space.pdf}
+  ids          = {Safdar2019},
+  title        = {A {{Colour Appearance Model}} Based on {{J}} z a z b
+    z {{Colour Space}}},
+  author       = {Safdar, Muhammad and Hardeberg, Jon Y. and Kim, Youn
+    Jin and Luo, Ming Ronnier},
+  year         = 2018,
+  month        = nov,
+  journal      = {Color and Imaging Conference},
+  volume       = 2018,
+  number       = 1,
+  pages        = {96--101},
+  issn         = {2166-9635},
+  doi          = {10.2352/ISSN.2169-2629.2018.26.96},
+  abstract     = {The current CIE colour appearance model CIECAM02 and
+    its variant named CAM16 can well predict common colour appearance
+    attributes including lightness, brightness, chroma, colourfulness,
+    saturation, hue angle, and hue composition. These models are
+    complicated as well as have mathematical problems. The current
+    study aimed a new colour appearance model based on Jzazbz color
+    space to obtain either better or similar performance compared with
+    CAM16 but the new model should be computationally simple and
+    robust. Such a model will particularly be suitable for color
+    management in high dynamic range and wide color gamut
+    applications. A range of experimental data were collected and a
+    set of equations was derived. Some initial test results are
+    presented in this paper.},
+  isbn         = 9780892083374,
 }
-
 @article{Safdar2021,
-  title = {{{ZCAM}}, a Colour Appearance Model Based on a High Dynamic Range Uniform Colour Space},
-  author = {Safdar, Muhammad and Hardeberg, Jon Yngve and Ronnier Luo, Ming},
-  year = {2021},
-  month = feb,
-  journal = {Optics Express},
-  volume = {29},
-  number = {4},
-  pages = {6036},
-  issn = {1094-4087},
-  doi = {10.1364/OE.413659},
-  abstract = {A colour appearance model based on a uniform colour space is proposed. The proposed colour appearance model, ZCAM, comprises of comparatively simple mathematical equations, and plausibly agrees with the psychophysical phenomenon of colour appearance perception. ZCAM consists of ten colour appearance attributes including brightness, lightness, colourfulness, chroma, hue angle, hue composition, saturation, vividness, blackness, and whiteness. Despite its relatively simpler mathematical structure, ZCAM performed at least similar to the CIE standard colour appearance model CIECAM02 and its revision, CAM16, in predicting a range of reliable experimental data.},
-  langid = {english},
-  file = {/Users/kelsolaar/Zotero/storage/3P2S3WX3/5022171.pdf;/Users/kelsolaar/Zotero/storage/GKHAC8VL/Safdar et al. - 2021 - ZCAM, a colour appearance model based on a high dy.pdf}
+  title        = {{{ZCAM}}, a Colour Appearance Model Based on a High
+    Dynamic Range Uniform Colour Space},
+  author       = {Safdar, Muhammad and Hardeberg, Jon Yngve and
+    Ronnier Luo, Ming},
+  year         = 2021,
+  month        = feb,
+  journal      = {Optics Express},
+  volume       = 29,
+  number       = 4,
+  pages        = 6036,
+  issn         = {1094-4087},
+  doi          = {10.1364/OE.413659},
+  abstract     = {A colour appearance model based on a uniform colour
+    space is proposed. The proposed colour appearance model, ZCAM,
+    comprises of comparatively simple mathematical equations, and
+    plausibly agrees with the psychophysical phenomenon of colour
+    appearance perception. ZCAM consists of ten colour appearance
+    attributes including brightness, lightness, colourfulness, chroma,
+    hue angle, hue composition, saturation, vividness, blackness, and
+    whiteness. Despite its relatively simpler mathematical structure,
+    ZCAM performed at least similar to the CIE standard colour
+    appearance model CIECAM02 and its revision, CAM16, in predicting a
+    range of reliable experimental data.},
+  langid       = {english},
 }
-
 @misc{Sarifuddin2005,
-  title = {A {{New Perceptually Uniform Color Space}} with {{Associated Color Similarity Measure}} for {{ContentBased Image}} and {{Video Retrieval}}},
-  author = {Sarifuddin, Madenda and Missaoui, Rokia},
-  year = {2005},
-  file = {/Users/kelsolaar/Zotero/storage/Y8VCE33M/Sarifuddin and Missaoui - 2005 - A New Perceptually Uniform Color Space with Associ.pdf}
+  title        = {A {{New Perceptually Uniform Color Space}} with
+    {{Associated Color Similarity Measure}} for {{ContentBased Image}}
+    and {{Video Retrieval}}},
+  author       = {Sarifuddin, Madenda and Missaoui, Rokia},
+  year         = 2005,
 }
-
 @misc{Sastanina,
-  title = {How to Make Scipy.Interpolate Give an Extrapolated Result beyond the Input Range?},
-  author = {{sastanin}},
-  howpublished = {http://stackoverflow.com/a/2745496/931625}
+  title        = {How to Make Scipy.Interpolate Give an Extrapolated
+    Result beyond the Input Range?},
+  author       = {{sastanin}},
+  howpublished = {http://stackoverflow.com/a/2745496/931625},
 }
-
 @article{Sharma2005b,
-  title = {The {{CIEDE2000}} Color-Difference Formula: {{Implementation}} Notes, Supplementary Test Data, and Mathematical Observations},
-  author = {Sharma, Gaurav and Wu, Wencheng and Dalal, Edul N.},
-  year = {2005},
-  month = feb,
-  journal = {Color Research \& Application},
-  volume = {30},
-  number = {1},
-  pages = {21--30},
-  issn = {0361-2317},
-  doi = {10.1002/col.20070},
-  abstract = {This article and the associated data and programs\textbackslash nprovided with it are intended to assist color engineers and\textbackslash nscientists in correctly implementing the recently developed\textbackslash nCIEDE2000 color-difference formula. We indicate several\textbackslash npotential implementation errors that are not uncovered in\textbackslash ntests performed using the original sample data published\textbackslash nwith the standard. A supplemental set of data is provided for\textbackslash ncomprehensive testing of implementations. The test data,\textbackslash nMicrosoft Excel spreadsheets, and MATLAB scripts for\textbackslash nevaluating the CIEDE2000 color difference are made avail-\textbackslash nable at the first author's website. Finally, we also point out\textbackslash nsmall mathematical discontinuities in the formula.},
-  keywords = {CIE,CIE94,CIEDE2000,CIELAB,CMC,Color-difference metrics},
-  file = {/Users/kelsolaar/Zotero/storage/JN5I56SG/Sharma, Wu, Dalal - 2005 - The CIEDE2000 color-difference formula Implementation notes, supplementary test data, and mathematical observ.pdf}
+  title        = {The {{CIEDE2000}} Color-Difference Formula:
+    {{Implementation}} Notes, Supplementary Test Data, and
+    Mathematical Observations},
+  author       = {Sharma, Gaurav and Wu, Wencheng and Dalal, Edul N.},
+  year         = 2005,
+  month        = feb,
+  journal      = {Color Research \& Application},
+  volume       = 30,
+  number       = 1,
+  pages        = {21--30},
+  issn         = {0361-2317},
+  doi          = {10.1002/col.20070},
+  abstract     = {This article and the associated data and
+    programs\textbackslash nprovided with it are intended to assist
+    color engineers and\textbackslash nscientists in correctly
+    implementing the recently developed\textbackslash nCIEDE2000
+    color-difference formula. We indicate several\textbackslash
+    npotential implementation errors that are not uncovered
+    in\textbackslash ntests performed using the original sample data
+    published\textbackslash nwith the standard. A supplemental set of
+    data is provided for\textbackslash ncomprehensive testing of
+    implementations. The test data,\textbackslash nMicrosoft Excel
+    spreadsheets, and MATLAB scripts for\textbackslash nevaluating the
+    CIEDE2000 color difference are made avail-\textbackslash nable at
+    the first author's website. Finally, we also point
+    out\textbackslash nsmall mathematical discontinuities in the
+    formula.},
+  keywords     = {CIE,CIE94,CIEDE2000,CIELAB,CMC,Color-difference
+    metrics},
 }
-
 @misc{Shirley2015a,
-  title = {The Prismatic Color Space for Rgb Computations},
-  author = {Shirley, Peter and Hart, David},
-  year = {2015},
-  pages = {2--7},
-  abstract = {In the spirit of the HSV color space, we introduce a simple transform of the RGB color cube into a light/dark dimension and a 2D hue. The hue is a normalized (barycentric) triangle with pure red, green, and blue at the vertices, often called the Maxwell Color Tri- angle. Each cross section of the space is the same barycentric triangle, and the light/dark dimension runs zero to one for each hue so the whole color volume takes the form of a prism. This prismatic space has advantages computationally and intuitively for some common color operations used in computer graphics and image processing.},
-  file = {/Users/kelsolaar/Zotero/storage/8C7YKTL6/Shirley, Hart - 2015 - The prismatic color space for rgb computations.pdf}
+  title        = {The Prismatic Color Space for Rgb Computations},
+  author       = {Shirley, Peter and Hart, David},
+  year         = 2015,
+  pages        = {2--7},
+  abstract     = {In the spirit of the HSV color space, we introduce a
+    simple transform of the RGB color cube into a light/dark dimension
+    and a 2D hue. The hue is a normalized (barycentric) triangle with
+    pure red, green, and blue at the vertices, often called the
+    Maxwell Color Tri- angle. Each cross section of the space is the
+    same barycentric triangle, and the light/dark dimension runs zero
+    to one for each hue so the whole color volume takes the form of a
+    prism. This prismatic space has advantages computationally and
+    intuitively for some common color operations used in computer
+    graphics and image processing.},
 }
-
 @misc{Siragusano2018a,
-  title = {Private {{Discussion}} with {{Shaw}}, {{Nick}}.},
-  author = {Siragusano, Daniele},
-  year = {2018}
+  title        = {Private {{Discussion}} with {{Shaw}}, {{Nick}}.},
+  author       = {Siragusano, Daniele},
+  year         = 2018,
 }
-
 @inproceedings{Smith1978b,
-  title = {Color Gamut Transform Pairs},
-  booktitle = {Proceedings of the 5th Annual Conference on {{Computer}} Graphics and Interactive Techniques - {{SIGGRAPH}} '78},
-  author = {Smith, Alvy Ray},
-  year = {1978},
-  pages = {12--19},
-  publisher = {{ACM Press}},
-  address = {{New York, New York, USA}},
-  doi = {10.1145/800248.807361},
-  keywords = {Brightness,Color,Color transform,color transforms,Gamut,HSL,HSV,Hue,Luminance,NTSC,RGB,Saturation,Value},
-  file = {/Users/kelsolaar/Zotero/storage/YKE7U9QG/Smith - 1978 - Color gamut transform pairs.pdf}
+  title        = {Color Gamut Transform Pairs},
+  booktitle    = {Proceedings of the 5th Annual Conference on
+    {{Computer}} Graphics and Interactive Techniques - {{SIGGRAPH}}
+    '78},
+  author       = {Smith, Alvy Ray},
+  year         = 1978,
+  pages        = {12--19},
+  publisher    = {{ACM Press}},
+  address      = {{New York, New York, USA}},
+  doi          = {10.1145/800248.807361},
+  keywords     = {Brightness,Color,Color transform,color
+    transforms,Gamut,HSL,HSV,Hue,Luminance,NTSC,RGB,Saturation,Value},
 }
-
 @article{Smits1999a,
-  title = {An {{RGB-to-Spectrum Conversion}} for {{Reflectances}}},
-  author = {Smits, Brian},
-  year = {1999},
-  month = jan,
-  journal = {Journal of Graphics Tools},
-  volume = {4},
-  number = {4},
-  pages = {11--22},
-  publisher = {{AK Peters, Ltd.}},
-  issn = {1086-7651},
-  doi = {10.1080/10867651.1999.10487511},
-  abstract = {The desire for accuracy and realism in images requires a physically-based rendering system. Often this can mean using a full spectral representation, as RGB represen- tations have limitations in some situations4. The spectral representation does come at some cost, not ...},
-  file = {/Users/kelsolaar/Zotero/storage/Y2GXKCH3/Smits - 1999 - An RGB-to-Spectrum Conversion for Reflectances.pdf}
+  title        = {An {{RGB-to-Spectrum Conversion}} for
+    {{Reflectances}}},
+  author       = {Smits, Brian},
+  year         = 1999,
+  month        = jan,
+  journal      = {Journal of Graphics Tools},
+  volume       = 4,
+  number       = 4,
+  pages        = {11--22},
+  publisher    = {{AK Peters, Ltd.}},
+  issn         = {1086-7651},
+  doi          = {10.1080/10867651.1999.10487511},
+  abstract     = {The desire for accuracy and realism in images
+    requires a physically-based rendering system. Often this can mean
+    using a full spectral representation, as RGB represen- tations
+    have limitations in some situations4. The spectral representation
+    does come at some cost, not ...},
 }
-
 @book{SocietyofMotionPictureandTelevisionEngineers1993a,
-  title = {{{RP}} 177:1993 - {{Derivation}} of {{Basic Television Color Equations}}},
-  author = {{Society of Motion Picture and Television Engineers}},
-  year = {1993},
-  month = jan,
-  journal = {RP 177:1993},
-  volume = {RP 177:199},
-  publisher = {{The Society of Motion Picture and Television Engineers}},
-  doi = {10.5594/S9781614821915},
-  abstract = {color white whitepoint matrix Scope This practice is intended to define the numerical procedures for deriving basic color equations for color television and other systems using additive display devices. These equations are first, the normalized reference primary matrix which defines the relationship between RGB signals and CIE tristimulus values XYZ; then, the system luminance equation; and finally, the color primary transformation matrix for transforming signals from one set of reference primaries to another set of reference primaries or to a set of display primaries.},
-  isbn = {978-1-61482-191-5},
-  file = {/Users/kelsolaar/Zotero/storage/4MU8972R/SMPTE - 1993 - RP 177-1993 Derivation of Basic Television Color Equations.pdf}
+  title        = {{{RP}} 177:1993 - {{Derivation}} of {{Basic
+    Television Color Equations}}},
+  author       = {{Society of Motion Picture and Television Engineers}},
+  year         = 1993,
+  month        = jan,
+  journal      = {RP 177:1993},
+  volume       = {RP 177:199},
+  publisher    = {{The Society of Motion Picture and Television
+    Engineers}},
+  doi          = {10.5594/S9781614821915},
+  abstract     = {color white whitepoint matrix Scope This practice is
+    intended to define the numerical procedures for deriving basic
+    color equations for color television and other systems using
+    additive display devices. These equations are first, the
+    normalized reference primary matrix which defines the relationship
+    between RGB signals and CIE tristimulus values XYZ; then, the
+    system luminance equation; and finally, the color primary
+    transformation matrix for transforming signals from one set of
+    reference primaries to another set of reference primaries or to a
+    set of display primaries.},
+  isbn         = {978-1-61482-191-5},
 }
-
 @misc{SocietyofMotionPictureandTelevisionEngineers1999b,
-  title = {{{ANSI}}/{{SMPTE 240M-1995}} - {{Signal Parameters}} - 1125-{{Line High-Definition Production Systems}}},
-  author = {{Society of Motion Picture and Television Engineers}},
-  year = {1999},
-  pages = {1--7},
-  file = {/Users/kelsolaar/Zotero/storage/TZBEIHWT/Society of Motion Picture and Television Engineers - 1999 - ANSISMPTE 240M-1995 - Signal Parameters - 1125-Line High-Definition Producti.pdf}
+  title        = {{{ANSI}}/{{SMPTE 240M-1995}} - {{Signal Parameters}}
+    - 1125-{{Line High-Definition Production Systems}}},
+  author       = {{Society of Motion Picture and Television Engineers}},
+  year         = 1999,
+  pages        = {1--7},
 }
-
 @book{SocietyofMotionPictureandTelevisionEngineers2004a,
-  title = {{{RP}} 145:2004: {{SMPTE C Color Monitor Colorimetry}}},
-  author = {{Society of Motion Picture and Television Engineers}},
-  year = {2004},
-  month = jan,
-  journal = {RP 145:2004},
-  volume = {RP 145:200},
-  publisher = {{The Society of Motion Picture and Television Engineers}},
-  doi = {10.5594/S9781614821649},
-  abstract = {cie Scope This practice specifies the chromaticity values of the red, green, and blue visible radiation emitted by the primaries and the chromaticity of the white point for professional monitors used in systems based on SMPTE C colorimetry.},
-  isbn = {978-1-61482-164-9},
-  file = {/Users/kelsolaar/Zotero/storage/7H8RLDDE/Society of Motion Picture and Television Engineers - 2004 - RP 1452004 SMPTE C Color Monitor Colorimetry.pdf}
+  title        = {{{RP}} 145:2004: {{SMPTE C Color Monitor
+    Colorimetry}}},
+  author       = {{Society of Motion Picture and Television Engineers}},
+  year         = 2004,
+  month        = jan,
+  journal      = {RP 145:2004},
+  volume       = {RP 145:200},
+  publisher    = {{The Society of Motion Picture and Television
+    Engineers}},
+  doi          = {10.5594/S9781614821649},
+  abstract     = {cie Scope This practice specifies the chromaticity
+    values of the red, green, and blue visible radiation emitted by
+    the primaries and the chromaticity of the white point for
+    professional monitors used in systems based on SMPTE C
+    colorimetry.},
+  isbn         = {978-1-61482-164-9},
 }
-
 @misc{SocietyofMotionPictureandTelevisionEngineers2014a,
-  title = {{{SMPTE ST}} 2084:2014 - {{Dynamic Range Electro-Optical Transfer Function}} of {{Mastering Reference Displays}}},
-  author = {{Society of Motion Picture and Television Engineers}},
-  year = {2014},
-  pages = {1--14},
-  doi = {10.5594/SMPTE.ST2084.2014},
-  abstract = {This standard specifies an EOTF characterizing high-dynamic-range reference displays used primarily for mastering non-broadcast content. This standard also specifies an Inverse-EOTF derived from the EOTF.},
-  file = {/Users/kelsolaar/Zotero/storage/URPC65KE/Society of Motion Picture and Television Engineers - 2014 - SMPTE ST 20842014 - Dynamic Range Electro-Optical Transfer Function of Maste.pdf}
+  title        = {{{SMPTE ST}} 2084:2014 - {{Dynamic Range
+    Electro-Optical Transfer Function}} of {{Mastering Reference
+    Displays}}},
+  author       = {{Society of Motion Picture and Television Engineers}},
+  year         = 2014,
+  pages        = {1--14},
+  doi          = {10.5594/SMPTE.ST2084.2014},
+  abstract     = {This standard specifies an EOTF characterizing
+    high-dynamic-range reference displays used primarily for mastering
+    non-broadcast content. This standard also specifies an
+    Inverse-EOTF derived from the EOTF.},
 }
-
 @misc{SocietyofMotionPictureandTelevisionEngineers2019,
-  title = {{{ST}} 428-1:2019 - {{D-Cinema Distribution Master}} \textemdash{} {{Image Characteristic}}},
-  author = {{Society of Motion Picture and Television Engineers}},
-  year = {2019},
-  doi = {10.5594/SMPTE.ST428-1.2019},
-  file = {/Users/kelsolaar/Zotero/storage/P4KVRVHW/Society of Motion Picture and Television Engineers - 2019 - ST 428-12019 - D-Cinema Distribution Master — Ima.pdf}
+  title        = {{{ST}} 428-1:2019 - {{D-Cinema Distribution Master}}
+    \textemdash{} {{Image Characteristic}}},
+  author       = {{Society of Motion Picture and Television Engineers}},
+  year         = 2019,
+  doi          = {10.5594/SMPTE.ST428-1.2019},
 }
-
 @misc{SonyCorporation,
-  title = {S-{{Log Whitepaper}}},
-  author = {{Sony Corporation}},
-  pages = {1--17},
-  file = {/Users/kelsolaar/Zotero/storage/RY8LB8EP/Sony Corporation - Unknown - S-Log Whitepaper.pdf}
+  title        = {S-{{Log Whitepaper}}},
+  author       = {{Sony Corporation}},
+  pages        = {1--17},
 }
-
 @misc{SonyCorporation2012a,
-  title = {S-{{Log2 Technical Paper}}},
-  author = {{Sony Corporation}},
-  year = {2012},
-  pages = {1--9},
-  file = {/Users/kelsolaar/Zotero/storage/A3MRGAEZ/Sony Corporation - 2012 - S-Log2 Technical Paper.pdf}
+  title        = {S-{{Log2 Technical Paper}}},
+  author       = {{Sony Corporation}},
+  year         = 2012,
+  pages        = {1--9},
 }
-
 @misc{SonyCorporationd,
-  title = {Technical {{Summary}} for {{S-Gamut3}}.{{Cine}}/{{S-Log3}} and {{S-Gamut3}}/{{S-Log3}}},
-  author = {{Sony Corporation}},
-  pages = {1--7},
-  file = {/Users/kelsolaar/Zotero/storage/X6Y94MBS/Sony Corporation - Unknown - Technical Summary for S-Gamut3.CineS-Log3 and S-Gamut3S-Log3.pdf}
+  title        = {Technical {{Summary}} for
+    {{S-Gamut3}}.{{Cine}}/{{S-Log3}} and {{S-Gamut3}}/{{S-Log3}}},
+  author       = {{Sony Corporation}},
+  pages        = {1--7},
 }
-
 @misc{SonyCorporatione,
-  title = {S-{{Gamut3}}\_{{S-Gamut3Cine}}\_{{Matrix}}.Xlsx},
-  author = {{Sony Corporation}}
+  title        = {S-{{Gamut3}}\_{{S-Gamut3Cine}}\_{{Matrix}}.Xlsx},
+  author       = {{Sony Corporation}},
 }
-
 @misc{SonyElectronicsCorporation2020,
-  title = {{{IDT}}.{{Sony}}.{{Venice}}\_{{SLog3}}\_{{SGamut3}}.Ctl},
-  author = {{Sony Electronics Corporation}},
-  year = {2020}
+  title        = {{{IDT}}.{{Sony}}.{{Venice}}\_{{SLog3}}\_{{SGamut3}}.Ctl},
+  author       = {{Sony Electronics Corporation}},
+  year         = 2020,
 }
-
 @misc{SonyElectronicsCorporation2020a,
-  title = {{{IDT}}.{{Sony}}.{{Venice}}\_{{SLog3}}\_{{SGamut3Cine}}.Ctl},
-  author = {{Sony Electronics Corporation}},
-  year = {2020}
+  title        = {{{IDT}}.{{Sony}}.{{Venice}}\_{{SLog3}}\_{{SGamut3Cine}}.Ctl},
+  author       = {{Sony Electronics Corporation}},
+  year         = 2020,
 }
-
 @misc{SonyImageworks2012a,
-  title = {Make.Py},
-  author = {{Sony Imageworks}},
-  year = {2012},
-  pages = {1},
-  howpublished = {https://github.com/imageworks/OpenColorIO-Configs/blob/master/nuke-default/make.py}
+  title        = {Make.Py},
+  author       = {{Sony Imageworks}},
+  year         = 2012,
+  pages        = 1,
+  howpublished = {https://github.com/imageworks/OpenColorIO-Configs/blob/master/nuke-default/make.py},
 }
-
 @misc{Spaulding2000b,
-  title = {Reference {{Input}}/{{Output Medium Metric RGB Color Encodings}} ({{RIMM}}/{{ROMM RGB}})},
-  author = {Spaulding, K E and Woolfe, G J and Giorgianni, E J},
-  year = {2000},
-  pages = {1--8},
-  abstract = {A new color encoding specification known as Reference Output Medium Metric RGB (ROMM RGB) is defined. This color encoding is intended to be used for storing, interchanging and manipulating images that exist in a rendered image state without imposing the gamut limitations normally associated with device-specific color spaces. ROMM RGB was designed to provide a large enough color gamut to encompass most common output devices, while simultaneously satisfying a number of other important criteria. It is defined in a way that is tightly linked to the ICC profile connection space (PCS) and is suitable for use as an Adobe PhotoshopTM working color space. A companion color encoding specification, known as Reference Input Medium Metric RGB (RIMM RGB), is also defined. This encoding can be used to represent images in an unrendered scene image state.},
-  file = {/Users/kelsolaar/Zotero/storage/HCY4FKUP/Spaulding, Woolfe, Giorgianni - 2000 - Reference InputOutput Medium Metric RGB Color Encodings (RIMMROMM RGB).pdf}
+  title        = {Reference {{Input}}/{{Output Medium Metric RGB Color
+    Encodings}} ({{RIMM}}/{{ROMM RGB}})},
+  author       = {Spaulding, K E and Woolfe, G J and Giorgianni, E J},
+  year         = 2000,
+  pages        = {1--8},
+  abstract     = {A new color encoding specification known as
+    Reference Output Medium Metric RGB (ROMM RGB) is defined. This
+    color encoding is intended to be used for storing, interchanging
+    and manipulating images that exist in a rendered image state
+    without imposing the gamut limitations normally associated with
+    device-specific color spaces. ROMM RGB was designed to provide a
+    large enough color gamut to encompass most common output devices,
+    while simultaneously satisfying a number of other important
+    criteria. It is defined in a way that is tightly linked to the ICC
+    profile connection space (PCS) and is suitable for use as an Adobe
+    PhotoshopTM working color space. A companion color encoding
+    specification, known as Reference Input Medium Metric RGB (RIMM
+    RGB), is also defined. This encoding can be used to represent
+    images in an unrendered scene image state.},
 }
-
 @misc{Spiker2015a,
-  title = {Private {{Discussion}} with {{Mansencal}}, {{T}}.},
-  author = {Spiker, Nick},
-  year = {2015}
+  title        = {Private {{Discussion}} with {{Mansencal}}, {{T}}.},
+  author       = {Spiker, Nick},
+  year         = 2015,
 }
-
 @article{Stearns1988a,
-  title = {An Example of a Method for Correcting Radiance Data for {{Bandpass}} Error},
-  author = {Stearns, E. I. and Stearns, R. E.},
-  year = {1988},
-  month = aug,
-  journal = {Color Research \& Application},
-  volume = {13},
-  number = {4},
-  pages = {257--259},
-  publisher = {{Wiley Subscription Services, Inc., A Wiley Company}},
-  issn = {03612317},
-  doi = {10.1002/col.5080130410}
+  title        = {An Example of a Method for Correcting Radiance Data
+    for {{Bandpass}} Error},
+  author       = {Stearns, E. I. and Stearns, R. E.},
+  year         = 1988,
+  month        = aug,
+  journal      = {Color Research \& Application},
+  volume       = 13,
+  number       = 4,
+  pages        = {257--259},
+  publisher    = {{Wiley Subscription Services, Inc., A Wiley Company}},
+  issn         = 03612317,
+  doi          = {10.1002/col.5080130410},
 }
-
 @misc{Susstrunk1999a,
-  title = {Standard {{RGB Color Spaces}}},
-  author = {Susstrunk, Sabine and Buckley, Robert and Swen, Steve},
-  year = {1999},
-  abstract = {This paper describes the specifications and usage of standard RGB color spaces promoted today by standard bodies and/or the imaging industry. As in the past, most of the new standard RGB color spaces were developed for specific imaging workflow and applications. They are used as interchange spaces to communicate color and/or as working spaces in imaging applications. Standard color spaces can facilitate color communication: if an image is in `knownRGB,' the user, application, and/or device can unambiguously understand the color of the image, and further color manage from there if necessary. When applied correctly, a standard RGB space can minimize color space conversions in an imaging workflow, improve image reproducibility, and facilitate accountability.\textbackslash nThe digital image color workflow is examined with emphasis on when an RGB color space is appropriate, and when to apply color management by profile. An RGB space is ``standard'' because either it is defined in an official standards document (a de jure standard) or it is supported by commonly used tools (a de facto standard). Examples of standard RGB color spaces are ISO RGB, sRGB, ROMM RGB, Adobe RGB 98, Apple RGB, and video RGB spaces (NTSC, EBU, ITU-R BT.709). As there is no one RGB color space that is suitable for all imaging needs, factors to consider when choosing an RGB color space are discussed.},
-  keywords = {are becoming a thing,color communication,color image workflow,color management,color spaces,color standards,it is quite common,of the,past,skilled operators manage color,to be scanned by,today for an image},
-  file = {/Users/kelsolaar/Zotero/storage/52Y2H29A/Susstrunk, Buckley, Swen - 1999 - Standard RGB Color Spaces.pdf}
+  title        = {Standard {{RGB Color Spaces}}},
+  author       = {Susstrunk, Sabine and Buckley, Robert and Swen,
+    Steve},
+  year         = 1999,
+  abstract     = {This paper describes the specifications and usage of
+    standard RGB color spaces promoted today by standard bodies and/or
+    the imaging industry. As in the past, most of the new standard RGB
+    color spaces were developed for specific imaging workflow and
+    applications. They are used as interchange spaces to communicate
+    color and/or as working spaces in imaging applications. Standard
+    color spaces can facilitate color communication: if an image is in
+    `knownRGB,' the user, application, and/or device can unambiguously
+    understand the color of the image, and further color manage from
+    there if necessary. When applied correctly, a standard RGB space
+    can minimize color space conversions in an imaging workflow,
+    improve image reproducibility, and facilitate
+    accountability.\textbackslash nThe digital image color workflow is
+    examined with emphasis on when an RGB color space is appropriate,
+    and when to apply color management by profile. An RGB space is
+    ``standard'' because either it is defined in an official standards
+    document (a de jure standard) or it is supported by commonly used
+    tools (a de facto standard). Examples of standard RGB color spaces
+    are ISO RGB, sRGB, ROMM RGB, Adobe RGB 98, Apple RGB, and video
+    RGB spaces (NTSC, EBU, ITU-R BT.709). As there is no one RGB color
+    space that is suitable for all imaging needs, factors to consider
+    when choosing an RGB color space are discussed.},
+  keywords     = {are becoming a thing,color communication,color image
+    workflow,color management,color spaces,color standards,it is quite
+    common,of the,past,skilled operators manage color,to be scanned
+    by,today for an image},
 }
-
 @inproceedings{Susstrunk2000,
-  title = {Chromatic Adaptation Performance of Different {{RGB}} Sensors},
-  booktitle = {Photonics {{West}} 2001 - {{Electronic Imaging}}},
-  author = {Susstrunk, Sabine E. and Holm, Jack M. and Finlayson, Graham D.},
-  editor = {Eschbach, Reiner and Marcu, Gabriel G.},
-  year = {2000},
-  month = dec,
-  volume = {4300},
-  pages = {172--183},
-  doi = {10.1117/12.410788},
-  abstract = {Chromatic adaptation transforms are used in imaging system to map image appearance to colorimetry under different illumination sources. In this paper, the performance of different chromatic adaptation transforms (CAT) is compared with the performance of transforms based on RGB primaries that have been investigated in relation to standard color spaces for digital still camera characterization and image interchange. The chromatic adaptation transforms studied are von Kries, Bradford, Sharp, and CMCCAT2000. The RGB primaries investigated are ROMM, ITU-R BT.709, and 'prime wavelength' RGB. The chromatic adaptation model used is a von Kries model that linearly scales post-adaptation cone response with illuminant dependent coefficients. The transforms were evaluated using 16 sets of corresponding color dat. The actual and predicted tristimulus values were converted to CIELAB, and three different error prediction metrics, (Delta) ELab, (Delta) ECIE94, and (Delta) ECMC(1:1) were applied to the results. One-tail Student-t tests for matched pairs were calculated to compare if the variations in errors are statistically significant. For the given corresponding color data sets, the traditional chromatic adaptation transforms, Sharp CAT and CMCCAT2000, performed best. However, some transforms based on RGB primaries also exhibit good chromatic adaptation behavior, leading to the conclusion that white-point independent RGB spaces for image encoding can be defined. This conclusion holds only if the linear von Kries model is considered adequate to predict chromatic adaptation behavior.},
-  keywords = {1,709,adaptation can be considered,as a dynamic mechanism,bradford transform,cat,chromatic adaptation,chromatic adaptation transform,cmccat2000,corresponding color data,equi-energy rgb,itu-r bt,of the human visual,prime wavelength rgb,rgb,romm,sharp transform,system to optimize the,visual response to a,von kries},
-  file = {/Users/kelsolaar/Zotero/storage/T65EJXTR/Susstrunk, Holm, Finlayson - 2000 - Chromatic adaptation performance of different RGB sensors.pdf}
+  title        = {Chromatic Adaptation Performance of Different
+    {{RGB}} Sensors},
+  booktitle    = {Photonics {{West}} 2001 - {{Electronic Imaging}}},
+  author       = {Susstrunk, Sabine E. and Holm, Jack M. and
+    Finlayson, Graham D.},
+  editor       = {Eschbach, Reiner and Marcu, Gabriel G.},
+  year         = 2000,
+  month        = dec,
+  volume       = 4300,
+  pages        = {172--183},
+  doi          = {10.1117/12.410788},
+  abstract     = {Chromatic adaptation transforms are used in imaging
+    system to map image appearance to colorimetry under different
+    illumination sources. In this paper, the performance of different
+    chromatic adaptation transforms (CAT) is compared with the
+    performance of transforms based on RGB primaries that have been
+    investigated in relation to standard color spaces for digital
+    still camera characterization and image interchange. The chromatic
+    adaptation transforms studied are von Kries, Bradford, Sharp, and
+    CMCCAT2000. The RGB primaries investigated are ROMM, ITU-R BT.709,
+    and 'prime wavelength' RGB. The chromatic adaptation model used is
+    a von Kries model that linearly scales post-adaptation cone
+    response with illuminant dependent coefficients. The transforms
+    were evaluated using 16 sets of corresponding color dat. The
+    actual and predicted tristimulus values were converted to CIELAB,
+    and three different error prediction metrics, (Delta) ELab,
+    (Delta) ECIE94, and (Delta) ECMC(1:1) were applied to the results.
+    One-tail Student-t tests for matched pairs were calculated to
+    compare if the variations in errors are statistically significant.
+    For the given corresponding color data sets, the traditional
+    chromatic adaptation transforms, Sharp CAT and CMCCAT2000,
+    performed best. However, some transforms based on RGB primaries
+    also exhibit good chromatic adaptation behavior, leading to the
+    conclusion that white-point independent RGB spaces for image
+    encoding can be defined. This conclusion holds only if the linear
+    von Kries model is considered adequate to predict chromatic
+    adaptation behavior.},
+  keywords     = {1,709,adaptation can be considered,as a dynamic
+    mechanism,bradford transform,cat,chromatic adaptation,chromatic
+    adaptation transform,cmccat2000,corresponding color
+    data,equi-energy rgb,itu-r bt,of the human visual,prime wavelength
+    rgb,rgb,romm,sharp transform,system to optimize the,visual
+    response to a,von kries},
 }
-
 @misc{TheAcademyofMotionPictureArtsandSciences2014q,
-  title = {Technical {{Bulletin TB-2014-004}} - {{Informative Notes}} on {{SMPTE ST}} 2065-1 - {{Academy Color Encoding Specification}} ({{ACES}})},
-  author = {{The Academy of Motion Picture Arts and Sciences} and {Science and Technology Council} and {Academy Color Encoding System (ACES) Project Subcommittee}},
-  year = {2014},
-  pages = {1--40},
-  file = {/Users/kelsolaar/Zotero/storage/YYCGCTW4/The Academy of Motion Picture Arts and Sciences, Science and Technology Council, Academy Color Encoding System (ACES) Project Subcommi.pdf}
+  title        = {Technical {{Bulletin TB-2014-004}} - {{Informative
+    Notes}} on {{SMPTE ST}} 2065-1 - {{Academy Color Encoding
+    Specification}} ({{ACES}})},
+  author       = {{The Academy of Motion Picture Arts and Sciences}
+    and {Science and Technology Council} and {Academy Color Encoding
+    System (ACES) Project Subcommittee}},
+  year         = 2014,
+  pages        = {1--40},
 }
-
 @misc{TheAcademyofMotionPictureArtsandSciences2014r,
-  title = {Technical {{Bulletin TB-2014-012}} - {{Academy Color Encoding System Version}} 1.0 {{Component Names}}},
-  author = {{The Academy of Motion Picture Arts and Sciences} and {Science and Technology Council} and {Academy Color Encoding System (ACES) Project Subcommittee}},
-  year = {2014},
-  pages = {1--8},
-  file = {/Users/kelsolaar/Zotero/storage/M5RLPB8S/The Academy of Motion Picture Arts and Sciences, Science and Technology Council, Academy Color Encoding System (ACES) Project Subcom(12).pdf}
+  title        = {Technical {{Bulletin TB-2014-012}} - {{Academy Color
+    Encoding System Version}} 1.0 {{Component Names}}},
+  author       = {{The Academy of Motion Picture Arts and Sciences}
+    and {Science and Technology Council} and {Academy Color Encoding
+    System (ACES) Project Subcommittee}},
+  year         = 2014,
+  pages        = {1--8},
 }
-
 @misc{TheAcademyofMotionPictureArtsandSciences2014s,
-  ids = {TheAcademyofMotionPictureArtsandSciences2013b},
-  title = {Specification {{S-2013-001}} - {{ACESproxy}}, an {{Integer Log Encoding}} of {{ACES Image Data}}},
-  author = {{The Academy of Motion Picture Arts and Sciences} and {Science and Technology Council} and {Academy Color Encoding System (ACES) Project Subcommittee}},
-  year = {2013},
-  pages = {1--13},
-  file = {/Users/kelsolaar/Zotero/storage/ND8LP4GZ/The Academy of Motion Picture Arts and Sciences, Science and Technology Council, Academy Color Encoding System (ACES) Project Subcomm(2).pdf;/Users/kelsolaar/Zotero/storage/R4XCBCWV/The Academy of Motion Picture Arts and Sciences, Science and Technology Council, Academy Color Encoding System (ACES) Project Subcomm(5).pdf}
+  ids          = {TheAcademyofMotionPictureArtsandSciences2013b},
+  title        = {Specification {{S-2013-001}} - {{ACESproxy}}, an
+    {{Integer Log Encoding}} of {{ACES Image Data}}},
+  author       = {{The Academy of Motion Picture Arts and Sciences}
+    and {Science and Technology Council} and {Academy Color Encoding
+    System (ACES) Project Subcommittee}},
+  year         = 2013,
+  pages        = {1--13},
 }
-
 @misc{TheAcademyofMotionPictureArtsandSciences2014t,
-  title = {Specification {{S-2014-003}} - {{ACEScc}}, {{A Logarithmic Encoding}} of {{ACES Data}} for Use within {{Color Grading Systems}}},
-  author = {{The Academy of Motion Picture Arts and Sciences} and {Science and Technology Council} and {Academy Color Encoding System (ACES) Project Subcommittee}},
-  year = {2014},
-  pages = {1--12},
-  file = {/Users/kelsolaar/Zotero/storage/TX3MTN9S/The Academy of Motion Picture Arts and Sciences, Science and Technology Council, Academy Color Encoding System (ACES) Project Subcomm(6).pdf}
+  title        = {Specification {{S-2014-003}} - {{ACEScc}}, {{A
+    Logarithmic Encoding}} of {{ACES Data}} for Use within {{Color
+    Grading Systems}}},
+  author       = {{The Academy of Motion Picture Arts and Sciences}
+    and {Science and Technology Council} and {Academy Color Encoding
+    System (ACES) Project Subcommittee}},
+  year         = 2014,
+  pages        = {1--12},
 }
-
 @misc{TheAcademyofMotionPictureArtsandSciences2015b,
-  title = {Specification {{S-2014-004}} - {{ACEScg}} - {{A Working Space}} for {{CGI Render}} and {{Compositing}}},
-  author = {{The Academy of Motion Picture Arts and Sciences} and {Science {and} Technology Council} and {Academy Color Encoding System (ACES) Project Subcommittee}},
-  year = {2015},
-  pages = {1--9},
-  file = {/Users/kelsolaar/Zotero/storage/LPMBZDM3/The Academy of Motion Picture Arts and Sciences, Science and Technology Council, Academy Color Encoding System (ACES) Project Subcom(13).pdf}
+  title        = {Specification {{S-2014-004}} - {{ACEScg}} - {{A
+    Working Space}} for {{CGI Render}} and {{Compositing}}},
+  author       = {{The Academy of Motion Picture Arts and Sciences}
+    and {Science {and} Technology Council} and {Academy Color Encoding
+    System (ACES) Project Subcommittee}},
+  year         = 2015,
+  pages        = {1--9},
 }
-
 @misc{TheAcademyofMotionPictureArtsandSciences2015c,
-  title = {Procedure {{P-2013-001}} - {{Recommended Procedures}} for the {{Creation}} and {{Use}} of {{Digital Camera System Input Device Transforms}} ({{IDTs}})},
-  author = {{The Academy of Motion Picture Arts and Sciences} and {Science and Technology Council} and {Academy Color Encoding System (ACES) Project Subcommittee}},
-  year = {2015},
-  pages = {1--29},
-  file = {/Users/kelsolaar/Zotero/storage/GL22IAAL/The Academy of Motion Picture Arts and Sciences, Science and Technology Council, Academy Color Encoding System (ACES) Project Subcom(17).pdf}
+  title        = {Procedure {{P-2013-001}} - {{Recommended
+    Procedures}} for the {{Creation}} and {{Use}} of {{Digital Camera
+    System Input Device Transforms}} ({{IDTs}})},
+  author       = {{The Academy of Motion Picture Arts and Sciences}
+    and {Science and Technology Council} and {Academy Color Encoding
+    System (ACES) Project Subcommittee}},
+  year         = 2015,
+  pages        = {1--29},
 }
-
 @misc{TheAcademyofMotionPictureArtsandSciences2016c,
-  title = {Specification {{S-2016-001}} - {{ACEScct}}, {{A Quasi-Logarithmic Encoding}} of {{ACES Data}} for Use within {{Color Grading Systems}}},
-  author = {{The Academy of Motion Picture Arts and Sciences} and {Science and Technology Council} and {Academy Color Encoding System (ACES) Project}},
-  year = {2016},
-  howpublished = {http://j.mp/S-2016-001}
+  title        = {Specification {{S-2016-001}} - {{ACEScct}}, {{A
+    Quasi-Logarithmic Encoding}} of {{ACES Data}} for Use within
+    {{Color Grading Systems}}},
+  author       = {{The Academy of Motion Picture Arts and Sciences}
+    and {Science and Technology Council} and {Academy Color Encoding
+    System (ACES) Project}},
+  year         = 2016,
+  howpublished = {http://j.mp/S-2016-001},
 }
-
 @misc{TheAcademyofMotionPictureArtsandSciences2019,
-  title = {Academy {{Spectral Similarity Index}} ({{SSI}}): {{Overview}}},
-  author = {{The Academy of Motion Picture Arts and Sciences}},
-  year = {2019},
-  pages = {1--7},
-  file = {/Users/kelsolaar/Zotero/storage/HNYR6UY6/The Academy of Motion Picture Arts and Sciences - 2019 - Academy Spectral Similarity Index (SSI) Overview.pdf}
+  title        = {Academy {{Spectral Similarity Index}} ({{SSI}}):
+    {{Overview}}},
+  author       = {{The Academy of Motion Picture Arts and Sciences}},
+  year         = 2019,
+  pages        = {1--7},
 }
-
 @misc{TheAcademyofMotionPictureArtsandSciences2020,
-  title = {Specification {{S-2014-006}} - {{Common LUT Format}} ({{CLF}}) - {{A Common File Format}} for {{Look-Up Tables}}},
-  author = {{The Academy of Motion Picture Arts and Sciences} and {Science and Technology Council} and {Academy Color Encoding System (ACES) Project Subcommittee}},
-  year = {2020},
-  file = {/Users/kelsolaar/Zotero/storage/S4BZYY4H/The Academy of Motion Picture Arts and Sciences et al. - 2020 - Specification S-2014-006 - Common LUT Format (CLF).pdf}
+  title        = {Specification {{S-2014-006}} - {{Common LUT Format}}
+    ({{CLF}}) - {{A Common File Format}} for {{Look-Up Tables}}},
+  author       = {{The Academy of Motion Picture Arts and Sciences}
+    and {Science and Technology Council} and {Academy Color Encoding
+    System (ACES) Project Subcommittee}},
+  year         = 2020,
 }
-
 @misc{TheAcademyofMotionPictureArtsandSciencesa,
-  title = {{{ACESutil}}.{{Lin}}\_to\_{{Log2}}\_param.Ctl},
-  author = {{The Academy of Motion Picture Arts and Sciences} and {Science and Technology Council} and {Academy Color Encoding System (ACES) Project Subcommittee}},
-  howpublished = {https://github.com/ampas/aces-dev/blob/518c27f577e99cdecfddf2ebcfaa53444b1f9343/transforms/ctl/utilities/ACESutil.Lin\_to\_Log2\_param.ctl}
+  title        = {{{ACESutil}}.{{Lin}}\_to\_{{Log2}}\_param.Ctl},
+  author       = {{The Academy of Motion Picture Arts and Sciences}
+    and {Science and Technology Council} and {Academy Color Encoding
+    System (ACES) Project Subcommittee}},
+  howpublished = {https://github.com/ampas/aces-dev/blob/518c27f577e99cdecfddf2ebcfaa53444b1f9343/transforms/ctl/utilities/ACESutil.Lin\_to\_Log2\_param.ctl},
 }
-
 @misc{TheAcademyofMotionPictureArtsandSciencesb,
-  title = {{{ACESutil}}.{{Log2}}\_to\_{{Lin}}\_param.Ctl},
-  author = {{The Academy of Motion Picture Arts and Sciences} and {Science and Technology Council} and {Academy Color Encoding System (ACES) Project Subcommittee}},
-  howpublished = {https://github.com/ampas/aces-dev/blob/518c27f577e99cdecfddf2ebcfaa53444b1f9343/transforms/ctl/utilities/ACESutil.Log2\_to\_Lin\_param.ctl}
+  title        = {{{ACESutil}}.{{Log2}}\_to\_{{Lin}}\_param.Ctl},
+  author       = {{The Academy of Motion Picture Arts and Sciences}
+    and {Science and Technology Council} and {Academy Color Encoding
+    System (ACES) Project Subcommittee}},
+  howpublished = {https://github.com/ampas/aces-dev/blob/518c27f577e99cdecfddf2ebcfaa53444b1f9343/transforms/ctl/utilities/ACESutil.Log2\_to\_Lin\_param.ctl},
 }
-
 @misc{TheAcademyofMotionPictureArtsandSciencese,
-  title = {Academy {{Color Encoding System}}},
-  author = {{The Academy of Motion Picture Arts and Sciences} and {Science and Technology Council} and {Academy Color Encoding System (ACES) Project Subcommittee}},
-  howpublished = {http://www.oscars.org/science-technology/council/projects/aces.html}
+  title        = {Academy {{Color Encoding System}}},
+  author       = {{The Academy of Motion Picture Arts and Sciences}
+    and {Science and Technology Council} and {Academy Color Encoding
+    System (ACES) Project Subcommittee}},
+  howpublished = {http://www.oscars.org/science-technology/council/projects/aces.html},
 }
-
 @misc{Thorpe2012a,
-  title = {{{CANON-LOG TRANSFER CHARACTERISTIC}}},
-  author = {Thorpe, Larry},
-  year = {2012},
-  file = {/Users/kelsolaar/Zotero/storage/SN7V3V4I/Thorpe - 2012 - CANON-LOG TRANSFER CHARACTERISTIC.pdf}
+  title        = {{{CANON-LOG TRANSFER CHARACTERISTIC}}},
+  author       = {Thorpe, Larry},
+  year         = 2012,
 }
-
 @misc{Trieu2015a,
-  title = {Private {{Discussion}} with {{Mansencal}}, {{T}}.},
-  author = {Trieu, Tashi},
-  year = {2015}
+  title        = {Private {{Discussion}} with {{Mansencal}}, {{T}}.},
+  author       = {Trieu, Tashi},
+  year         = 2015,
 }
-
 @article{Ward2002,
-  title = {Picture {{Perfect RGB Rendering Using Spectral Prefiltering}} and {{Sharp Color Primaries}}},
-  author = {Ward, Greg and {Eydelberg-Vileshin}, Elena},
-  year = {2002},
-  journal = {Eurographics workshop on Rendering},
-  pages = {117--124},
-  publisher = {{Eurographics Association}},
-  doi = {10.2312/EGWR/EGWR02/117-124},
-  abstract = {Abstract Accurate color requires the consideration of many samples over the visible , and advanced tools developed by the research community offer multispectral sampling towards this goal. However, for practical reasons including efficiency, white},
-  file = {/Users/kelsolaar/Zotero/storage/3IY6NHKV/Ward, Eydelberg-Vileshin - 2002 - Picture Perfect RGB Rendering Using Spectral Prefiltering and Sharp Color Primaries.pdf}
+  title        = {Picture {{Perfect RGB Rendering Using Spectral
+    Prefiltering}} and {{Sharp Color Primaries}}},
+  author       = {Ward, Greg and {Eydelberg-Vileshin}, Elena},
+  year         = 2002,
+  journal      = {Eurographics workshop on Rendering},
+  pages        = {117--124},
+  publisher    = {{Eurographics Association}},
+  doi          = {10.2312/EGWR/EGWR02/117-124},
+  abstract     = {Abstract Accurate color requires the consideration
+    of many samples over the visible , and advanced tools developed by
+    the research community offer multispectral sampling towards this
+    goal. However, for practical reasons including efficiency, white},
 }
-
 @misc{Ward2016,
-  title = {Private {{Discussion}} with {{Mansencal}}, {{T}}.},
-  author = {Ward, Greg},
-  year = {2016}
+  title        = {Private {{Discussion}} with {{Mansencal}}, {{T}}.},
+  author       = {Ward, Greg},
+  year         = 2016,
 }
-
 @article{Watson2012,
-  title = {A Unified Formula for Light-Adapted Pupil Size},
-  author = {Watson, Andrew B. and Yellott, John I.},
-  year = {2012},
-  month = sep,
-  journal = {Journal of Vision},
-  volume = {12},
-  number = {10},
-  pages = {12},
-  issn = {1534-7362},
-  doi = {10.1167/12.10.12},
-  langid = {english},
-  file = {/Users/kelsolaar/Zotero/storage/URQJ6VQY/Watson and Yellott - 2012 - A unified formula for light-adapted pupil size.pdf}
+  title        = {A Unified Formula for Light-Adapted Pupil Size},
+  author       = {Watson, Andrew B. and Yellott, John I.},
+  year         = 2012,
+  month        = sep,
+  journal      = {Journal of Vision},
+  volume       = 12,
+  number       = 10,
+  pages        = 12,
+  issn         = {1534-7362},
+  doi          = {10.1167/12.10.12},
+  langid       = {english},
 }
-
 @incollection{Westland2004,
-  title = {Table 8.2},
-  booktitle = {Computational {{Colour Science Using MATLAB}}},
-  author = {Westland, Stephen and Ripamonti, Caterina},
-  year = {2004},
-  month = mar,
-  edition = {First},
-  pages = {137},
-  publisher = {{John Wiley \& Sons, Ltd}},
-  address = {{Chichester, UK}},
-  doi = {10.1002/0470020326},
-  isbn = {978-0-470-84562-2},
-  file = {/Users/kelsolaar/Zotero/storage/DLFJRX5W/Westland, Ripamonti - 2004 - Table 8.2.pdf}
+  title        = {Table 8.2},
+  booktitle    = {Computational {{Colour Science Using MATLAB}}},
+  author       = {Westland, Stephen and Ripamonti, Caterina},
+  year         = 2004,
+  month        = mar,
+  edition      = {First},
+  pages        = 137,
+  publisher    = {{John Wiley \& Sons, Ltd}},
+  address      = {{Chichester, UK}},
+  doi          = {10.1002/0470020326},
+  isbn         = {978-0-470-84562-2},
 }
-
 @incollection{Westland2012f,
-  title = {Correction for {{Spectral Bandpass}}},
-  booktitle = {Computational {{Colour Science Using MATLAB}}},
-  author = {Westland, Stephen and Ripamonti, Caterina and Cheung, Vien},
-  year = {2012},
-  edition = {Second},
-  pages = {38},
-  isbn = {978-0-470-66569-5}
+  title        = {Correction for {{Spectral Bandpass}}},
+  booktitle    = {Computational {{Colour Science Using MATLAB}}},
+  author       = {Westland, Stephen and Ripamonti, Caterina and
+    Cheung, Vien},
+  year         = 2012,
+  edition      = {Second},
+  pages        = 38,
+  isbn         = {978-0-470-66569-5},
 }
-
 @incollection{Westland2012g,
-  title = {{{CMCCAT97}}},
-  booktitle = {Computational {{Colour Science Using MATLAB}}},
-  author = {Westland, Stephen and Ripamonti, Caterina and Cheung, Vien},
-  year = {2012},
-  edition = {Second},
-  pages = {80},
-  isbn = {978-0-470-66569-5}
+  title        = {{{CMCCAT97}}},
+  booktitle    = {Computational {{Colour Science Using MATLAB}}},
+  author       = {Westland, Stephen and Ripamonti, Caterina and
+    Cheung, Vien},
+  year         = 2012,
+  edition      = {Second},
+  pages        = 80,
+  isbn         = {978-0-470-66569-5},
 }
-
 @incollection{Westland2012h,
-  title = {Interpolation {{Methods}}},
-  booktitle = {Computational {{Colour Science Using MATLAB}}},
-  author = {Westland, Stephen and Ripamonti, Caterina and Cheung, Vien},
-  year = {2012},
-  edition = {Second},
-  pages = {29--37},
-  isbn = {978-0-470-66569-5}
+  title        = {Interpolation {{Methods}}},
+  booktitle    = {Computational {{Colour Science Using MATLAB}}},
+  author       = {Westland, Stephen and Ripamonti, Caterina and
+    Cheung, Vien},
+  year         = 2012,
+  edition      = {Second},
+  pages        = {29--37},
+  isbn         = {978-0-470-66569-5},
 }
-
 @incollection{Westland2012i,
-  title = {Extrapolation {{Methods}}},
-  booktitle = {Computational {{Colour Science Using MATLAB}}},
-  author = {Westland, Stephen and Ripamonti, Caterina and Cheung, Vien},
-  year = {2012},
-  edition = {Second},
-  pages = {38},
-  isbn = {978-0-470-66569-5}
+  title        = {Extrapolation {{Methods}}},
+  booktitle    = {Computational {{Colour Science Using MATLAB}}},
+  author       = {Westland, Stephen and Ripamonti, Caterina and
+    Cheung, Vien},
+  year         = 2012,
+  edition      = {Second},
+  pages        = 38,
+  isbn         = {978-0-470-66569-5},
 }
-
 @incollection{Westland2012k,
-  title = {{{CMCCAT2000}}},
-  booktitle = {Computational {{Colour Science Using MATLAB}}},
-  author = {Westland, Stephen and Ripamonti, Caterina and Cheung, Vien},
-  year = {2012},
-  edition = {Second},
-  pages = {83--86},
-  isbn = {978-0-470-66569-5}
+  title        = {{{CMCCAT2000}}},
+  booktitle    = {Computational {{Colour Science Using MATLAB}}},
+  author       = {Westland, Stephen and Ripamonti, Caterina and
+    Cheung, Vien},
+  year         = 2012,
+  edition      = {Second},
+  pages        = {83--86},
+  isbn         = {978-0-470-66569-5},
 }
-
 @misc{Wikipedia,
-  title = {Ellipse},
-  author = {{Wikipedia}},
-  howpublished = {https://en.wikipedia.org/wiki/Ellipse}
+  title        = {Ellipse},
+  author       = {{Wikipedia}},
+  howpublished = {https://en.wikipedia.org/wiki/Ellipse},
 }
-
 @misc{Wikipedia2001,
-  title = {Approximation},
-  author = {{Wikipedia}},
-  year = {2001},
-  howpublished = {http://en.wikipedia.org/wiki/Color\_temperature\#Approximation}
+  title        = {Approximation},
+  author       = {{Wikipedia}},
+  year         = 2001,
+  howpublished = {http://en.wikipedia.org/wiki/Color\_temperature\#Approximation},
 }
-
 @misc{Wikipedia2001a,
-  title = {Color Temperature},
-  author = {{Wikipedia}},
-  year = {2001},
-  howpublished = {http://en.wikipedia.org/wiki/Color\_temperature}
+  title        = {Color Temperature},
+  author       = {{Wikipedia}},
+  year         = 2001,
+  howpublished = {http://en.wikipedia.org/wiki/Color\_temperature},
 }
-
 @misc{Wikipedia2001b,
-  title = {Luminance},
-  author = {{Wikipedia}},
-  year = {2001},
-  howpublished = {https://en.wikipedia.org/wiki/Luminance}
+  title        = {Luminance},
+  author       = {{Wikipedia}},
+  year         = 2001,
+  howpublished = {https://en.wikipedia.org/wiki/Luminance},
 }
-
 @misc{Wikipedia2001c,
-  title = {Rayleigh Scattering},
-  author = {{Wikipedia}},
-  year = {2001},
-  howpublished = {http://en.wikipedia.org/wiki/Rayleigh\_scattering}
+  title        = {Rayleigh Scattering},
+  author       = {{Wikipedia}},
+  year         = 2001,
+  howpublished = {http://en.wikipedia.org/wiki/Rayleigh\_scattering},
 }
-
 @misc{Wikipedia2003,
-  title = {{{HSL}} and {{HSV}}},
-  author = {{Wikipedia}},
-  year = {2003},
-  howpublished = {http://en.wikipedia.org/wiki/HSL\_and\_HSV}
+  title        = {{{HSL}} and {{HSV}}},
+  author       = {{Wikipedia}},
+  year         = 2003,
+  howpublished = {http://en.wikipedia.org/wiki/HSL\_and\_HSV},
 }
-
 @misc{Wikipedia2003a,
-  title = {Lagrange Polynomial - {{Definition}}},
-  author = {{Wikipedia}},
-  year = {2003},
-  howpublished = {https://en.wikipedia.org/wiki/Lagrange\_polynomial\#Definition}
+  title        = {Lagrange Polynomial - {{Definition}}},
+  author       = {{Wikipedia}},
+  year         = 2003,
+  howpublished = {https://en.wikipedia.org/wiki/Lagrange\_polynomial\#Definition},
 }
-
 @misc{Wikipedia2003b,
-  title = {Luminosity Function},
-  author = {{Wikipedia}},
-  year = {2003},
-  howpublished = {https://en.wikipedia.org/wiki/Luminosity\_function\#Details}
+  title        = {Luminosity Function},
+  author       = {{Wikipedia}},
+  year         = 2003,
+  howpublished = {https://en.wikipedia.org/wiki/Luminosity\_function\#Details},
 }
-
 @misc{Wikipedia2003c,
-  title = {Mean Squared Error},
-  author = {{Wikipedia}},
-  year = {2003},
-  howpublished = {https://en.wikipedia.org/wiki/Mean\_squared\_error}
+  title        = {Mean Squared Error},
+  author       = {{Wikipedia}},
+  year         = 2003,
+  howpublished = {https://en.wikipedia.org/wiki/Mean\_squared\_error},
 }
-
 @misc{Wikipedia2003d,
-  title = {Michaelis-{{Menten}} Kinetics},
-  author = {{Wikipedia}},
-  year = {2003},
-  howpublished = {https://en.wikipedia.org/wiki/Michaelis\%E2\%80\%93Menten\_kinetics}
+  title        = {Michaelis-{{Menten}} Kinetics},
+  author       = {{Wikipedia}},
+  year         = 2003,
+  howpublished = {https://en.wikipedia.org/wiki/Michaelis\%E2\%80\%93Menten\_kinetics},
 }
-
 @misc{Wikipedia2003e,
-  title = {Vandermonde Matrix},
-  author = {{Wikipedia}},
-  year = {2003},
-  howpublished = {https://en.wikipedia.org/wiki/Vandermonde\_matrix}
+  title        = {Vandermonde Matrix},
+  author       = {{Wikipedia}},
+  year         = 2003,
+  howpublished = {https://en.wikipedia.org/wiki/Vandermonde\_matrix},
 }
-
 @misc{Wikipedia2003f,
-  title = {Rayleigh\textendash{{Jeans}} Law},
-  author = {{Wikipedia}},
-  year = {2003},
-  howpublished = {https://en.wikipedia.org/wiki/Rayleigh\textendash Jeans\_law}
+  title        = {Rayleigh\textendash{{Jeans}} Law},
+  author       = {{Wikipedia}},
+  year         = 2003,
+  howpublished = {https://en.wikipedia.org/wiki/Rayleigh\textendash
+    Jeans\_law},
 }
-
 @misc{Wikipedia2004,
-  title = {Peak Signal-to-Noise Ratio},
-  author = {{Wikipedia}},
-  year = {2004},
-  howpublished = {https://en.wikipedia.org/wiki/Peak\_signal-to-noise\_ratio}
+  title        = {Peak Signal-to-Noise Ratio},
+  author       = {{Wikipedia}},
+  year         = 2004,
+  howpublished = {https://en.wikipedia.org/wiki/Peak\_signal-to-noise\_ratio},
 }
-
 @misc{Wikipedia2004a,
-  title = {Surfaces},
-  author = {{Wikipedia}},
-  year = {2004},
-  howpublished = {http://en.wikipedia.org/wiki/Gamut\#Surfaces}
+  title        = {Surfaces},
+  author       = {{Wikipedia}},
+  year         = 2004,
+  howpublished = {http://en.wikipedia.org/wiki/Gamut\#Surfaces},
 }
-
 @misc{Wikipedia2004b,
-  title = {Whiteness},
-  author = {{Wikipedia}},
-  year = {2004},
-  howpublished = {http://en.wikipedia.org/wiki/Whiteness}
+  title        = {Whiteness},
+  author       = {{Wikipedia}},
+  year         = 2004,
+  howpublished = {http://en.wikipedia.org/wiki/Whiteness},
 }
-
 @misc{Wikipedia2004c,
-  title = {Wide-Gamut {{RGB}} Color Space},
-  author = {{Wikipedia}},
-  year = {2004},
-  howpublished = {http://en.wikipedia.org/wiki/Wide-gamut\_RGB\_color\_space}
+  title        = {Wide-Gamut {{RGB}} Color Space},
+  author       = {{Wikipedia}},
+  year         = 2004,
+  howpublished = {http://en.wikipedia.org/wiki/Wide-gamut\_RGB\_color\_space},
 }
-
 @misc{Wikipedia2004d,
-  title = {{{YCbCr}}},
-  author = {{Wikipedia}},
-  year = {2004},
-  howpublished = {https://en.wikipedia.org/wiki/YCbCr}
+  title        = {{{YCbCr}}},
+  author       = {{Wikipedia}},
+  year         = 2004,
+  howpublished = {https://en.wikipedia.org/wiki/YCbCr},
 }
-
 @misc{Wikipedia2005,
-  title = {{{CIE}} 1931 Color Space},
-  author = {{Wikipedia}},
-  year = {2005},
-  howpublished = {http://en.wikipedia.org/wiki/CIE\_1931\_color\_space}
+  title        = {{{CIE}} 1931 Color Space},
+  author       = {{Wikipedia}},
+  year         = 2005,
+  howpublished = {http://en.wikipedia.org/wiki/CIE\_1931\_color\_space},
 }
-
 @misc{Wikipedia2005a,
-  title = {{{ISO}} 31-11},
-  author = {{Wikipedia}},
-  year = {2005},
-  howpublished = {https://en.wikipedia.org/wiki/ISO\_31-11}
+  title        = {{{ISO}} 31-11},
+  author       = {{Wikipedia}},
+  year         = 2005,
+  howpublished = {https://en.wikipedia.org/wiki/ISO\_31-11},
 }
-
 @misc{Wikipedia2005b,
-  title = {Lanczos Resampling},
-  author = {{Wikipedia}},
-  year = {2005},
-  howpublished = {https://en.wikipedia.org/wiki/Lanczos\_resampling}
+  title        = {Lanczos Resampling},
+  author       = {{Wikipedia}},
+  year         = 2005,
+  howpublished = {https://en.wikipedia.org/wiki/Lanczos\_resampling},
 }
-
 @misc{Wikipedia2005c,
-  title = {Luminous {{Efficacy}}},
-  author = {{Wikipedia}},
-  year = {2005},
-  howpublished = {https://en.wikipedia.org/wiki/Luminous\_efficacy}
+  title        = {Luminous {{Efficacy}}},
+  author       = {{Wikipedia}},
+  year         = 2005,
+  howpublished = {https://en.wikipedia.org/wiki/Luminous\_efficacy},
 }
-
 @misc{Wikipedia2005d,
-  title = {Mesopic Weighting Function},
-  author = {{Wikipedia}},
-  year = {2005},
-  howpublished = {http://en.wikipedia.org/wiki/Mesopic\_vision\#Mesopic\_weighting\_function}
+  title        = {Mesopic Weighting Function},
+  author       = {{Wikipedia}},
+  year         = 2005,
+  howpublished = {http://en.wikipedia.org/wiki/Mesopic\_vision\#Mesopic\_weighting\_function},
 }
-
 @misc{Wikipedia2006,
-  title = {List of Common Coordinate Transformations},
-  author = {{Wikipedia}},
-  year = {2006},
-  howpublished = {http://en.wikipedia.org/wiki/List\_of\_common\_coordinate\_transformations}
+  title        = {List of Common Coordinate Transformations},
+  author       = {{Wikipedia}},
+  year         = 2006,
+  howpublished = {http://en.wikipedia.org/wiki/List\_of\_common\_coordinate\_transformations},
 }
-
 @misc{Wikipedia2006a,
-  title = {White Points of Standard Illuminants},
-  author = {{Wikipedia}},
-  year = {2006},
-  howpublished = {http://en.wikipedia.org/wiki/Standard\_illuminant\#White\_points\_of\_standard\_illuminants}
+  title        = {White Points of Standard Illuminants},
+  author       = {{Wikipedia}},
+  year         = 2006,
+  howpublished = {http://en.wikipedia.org/wiki/Standard\_illuminant\#White\_points\_of\_standard\_illuminants},
 }
-
 @misc{Wikipedia2007,
-  title = {{{CAT02}}},
-  author = {{Wikipedia}},
-  year = {2007},
-  howpublished = {http://en.wikipedia.org/wiki/CIECAM02\#CAT02}
+  title        = {{{CAT02}}},
+  author       = {{Wikipedia}},
+  year         = 2007,
+  howpublished = {http://en.wikipedia.org/wiki/CIECAM02\#CAT02},
 }
-
 @misc{Wikipedia2007a,
-  title = {{{CIECAM02}}},
-  author = {{Wikipedia}},
-  year = {2007},
-  howpublished = {http://en.wikipedia.org/wiki/CIECAM02}
+  title        = {{{CIECAM02}}},
+  author       = {{Wikipedia}},
+  year         = 2007,
+  howpublished = {http://en.wikipedia.org/wiki/CIECAM02},
 }
-
 @misc{Wikipedia2007b,
-  title = {{{CIELUV}}},
-  author = {{Wikipedia}},
-  year = {2007},
-  howpublished = {http://en.wikipedia.org/wiki/CIELUV}
+  title        = {{{CIELUV}}},
+  author       = {{Wikipedia}},
+  year         = 2007,
+  howpublished = {http://en.wikipedia.org/wiki/CIELUV},
 }
-
 @misc{Wikipedia2007c,
-  title = {Lightness},
-  author = {{Wikipedia}},
-  year = {2007},
-  howpublished = {http://en.wikipedia.org/wiki/Lightness}
+  title        = {Lightness},
+  author       = {{Wikipedia}},
+  year         = 2007,
+  howpublished = {http://en.wikipedia.org/wiki/Lightness},
 }
-
 @misc{Wikipedia2007d,
-  title = {The Reverse Transformation},
-  author = {{Wikipedia}},
-  year = {2007},
-  howpublished = {http://en.wikipedia.org/wiki/CIELUV\#The\_reverse\_transformation}
+  title        = {The Reverse Transformation},
+  author       = {{Wikipedia}},
+  year         = 2007,
+  howpublished = {http://en.wikipedia.org/wiki/CIELUV\#The\_reverse\_transformation},
 }
-
 @misc{Wikipedia2008,
-  title = {{{CIE}} 1960 Color Space},
-  author = {{Wikipedia}},
-  year = {2008},
-  howpublished = {http://en.wikipedia.org/wiki/CIE\_1960\_color\_space}
+  title        = {{{CIE}} 1960 Color Space},
+  author       = {{Wikipedia}},
+  year         = 2008,
+  howpublished = {http://en.wikipedia.org/wiki/CIE\_1960\_color\_space},
 }
-
 @misc{Wikipedia2008a,
-  title = {{{CIE}} 1964 Color Space},
-  author = {{Wikipedia}},
-  year = {2008},
-  howpublished = {http://en.wikipedia.org/wiki/CIE\_1964\_color\_space}
+  title        = {{{CIE}} 1964 Color Space},
+  author       = {{Wikipedia}},
+  year         = 2008,
+  howpublished = {http://en.wikipedia.org/wiki/CIE\_1964\_color\_space},
 }
-
 @misc{Wikipedia2008b,
-  title = {Color Difference},
-  author = {{Wikipedia}},
-  year = {2008},
-  howpublished = {http://en.wikipedia.org/wiki/Color\_difference}
+  title        = {Color Difference},
+  author       = {{Wikipedia}},
+  year         = 2008,
+  howpublished = {http://en.wikipedia.org/wiki/Color\_difference},
 }
-
 @misc{Wikipedia2008c,
-  title = {Relation to {{CIE XYZ}}},
-  author = {{Wikipedia}},
-  year = {2008},
-  howpublished = {http://en.wikipedia.org/wiki/CIE\_1960\_color\_space\#Relation\_to\_CIE\_XYZ}
+  title        = {Relation to {{CIE XYZ}}},
+  author       = {{Wikipedia}},
+  year         = 2008,
+  howpublished = {http://en.wikipedia.org/wiki/CIE\_1960\_color\_space\#Relation\_to\_CIE\_XYZ},
 }
-
 @misc{Wikipedia2015,
-  title = {{{HCL}} Color Space},
-  author = {{Wikipedia}},
-  year = {2015},
-  howpublished = {https://en.wikipedia.org/wiki/HCL\_color\_space}
+  title        = {{{HCL}} Color Space},
+  author       = {{Wikipedia}},
+  year         = 2015,
+  howpublished = {https://en.wikipedia.org/wiki/HCL\_color\_space},
 }
-
 @article{Wyszecki1963b,
-  title = {Proposal for a {{New Color-Difference Formula}}},
-  author = {Wyszecki, G{\"u}nter},
-  year = {1963},
-  month = nov,
-  journal = {Journal of the Optical Society of America},
-  volume = {53},
-  number = {11},
-  pages = {1318},
-  publisher = {{OSA}},
-  issn = {0030-3941},
-  doi = {10.1364/JOSA.53.001318},
-  file = {/Users/kelsolaar/Zotero/storage/KVA7WU28/Wyszecki - 1963 - Proposal for a New Color-Difference Formula.pdf}
+  title        = {Proposal for a {{New Color-Difference Formula}}},
+  author       = {Wyszecki, G{\"u}nter},
+  year         = 1963,
+  month        = nov,
+  journal      = {Journal of the Optical Society of America},
+  volume       = 53,
+  number       = 11,
+  pages        = 1318,
+  publisher    = {{OSA}},
+  issn         = {0030-3941},
+  doi          = {10.1364/JOSA.53.001318},
 }
-
 @incollection{Wyszecki2000,
-  title = {Table 2(5.4.1) {{MacAdam Ellipses}} ({{Observer PGN}}) {{Observed}} and {{Calculated}} on the {{Basis}} of a {{Normal Distribution}} of {{Color Matches}} about a {{Color Center}} ({{Silberstein}} and {{MacAdam}}, 1945)},
-  booktitle = {Color {{Science}}: {{Concepts}} and {{Methods}}, {{Quantitative Data}} and {{Formulae}}},
-  author = {Wyszecki, G{\"u}nther and Stiles, W S},
-  year = {2000},
-  pages = {309},
-  publisher = {{Wiley}},
-  isbn = {978-0-471-39918-6}
+  title        = {Table 2(5.4.1) {{MacAdam Ellipses}} ({{Observer
+    PGN}}) {{Observed}} and {{Calculated}} on the {{Basis}} of a
+    {{Normal Distribution}} of {{Color Matches}} about a {{Color
+    Center}} ({{Silberstein}} and {{MacAdam}}, 1945)},
+  booktitle    = {Color {{Science}}: {{Concepts}} and {{Methods}},
+    {{Quantitative Data}} and {{Formulae}}},
+  author       = {Wyszecki, G{\"u}nther and Stiles, W S},
+  year         = 2000,
+  pages        = 309,
+  publisher    = {{Wiley}},
+  isbn         = {978-0-471-39918-6},
 }
-
 @incollection{Wyszecki2000a,
-  title = {Equation {{I}}(1.2.1)},
-  booktitle = {Color {{Science}}: {{Concepts}} and {{Methods}}, {{Quantitative Data}} and {{Formulae}}},
-  author = {Wyszecki, G{\"u}nther and Stiles, W S},
-  year = {2000},
-  pages = {8},
-  publisher = {{Wiley}},
-  isbn = {978-0-471-39918-6}
+  title        = {Equation {{I}}(1.2.1)},
+  booktitle    = {Color {{Science}}: {{Concepts}} and {{Methods}},
+    {{Quantitative Data}} and {{Formulae}}},
+  author       = {Wyszecki, G{\"u}nther and Stiles, W S},
+  year         = 2000,
+  pages        = 8,
+  publisher    = {{Wiley}},
+  isbn         = {978-0-471-39918-6},
 }
-
 @incollection{Wyszecki2000ba,
-  title = {Table {{I}}(6.5.3) {{Whiteness Formulae}} ({{Whiteness Measure Denoted}} by {{W}})},
-  booktitle = {Color {{Science}}: {{Concepts}} and {{Methods}}, {{Quantitative Data}} and {{Formulae}}},
-  author = {Wyszecki, G{\"u}nther and Stiles, W. S.},
-  year = {2000},
-  pages = {837--839},
-  publisher = {{Wiley}},
-  isbn = {978-0-471-39918-6}
+  title        = {Table {{I}}(6.5.3) {{Whiteness Formulae}}
+    ({{Whiteness Measure Denoted}} by {{W}})},
+  booktitle    = {Color {{Science}}: {{Concepts}} and {{Methods}},
+    {{Quantitative Data}} and {{Formulae}}},
+  author       = {Wyszecki, G{\"u}nther and Stiles, W. S.},
+  year         = 2000,
+  pages        = {837--839},
+  publisher    = {{Wiley}},
+  isbn         = {978-0-471-39918-6},
 }
-
 @incollection{Wyszecki2000bb,
-  title = {Table {{I}}(3.7)},
-  booktitle = {Color {{Science}}: {{Concepts}} and {{Methods}}, {{Quantitative Data}} and {{Formulae}}},
-  author = {Wyszecki, G{\"u}nther and Stiles, W. S.},
-  year = {2000},
-  pages = {776--777},
-  publisher = {{Wiley}},
-  isbn = {978-0-471-39918-6}
+  title        = {Table {{I}}(3.7)},
+  booktitle    = {Color {{Science}}: {{Concepts}} and {{Methods}},
+    {{Quantitative Data}} and {{Formulae}}},
+  author       = {Wyszecki, G{\"u}nther and Stiles, W. S.},
+  year         = 2000,
+  pages        = {776--777},
+  publisher    = {{Wiley}},
+  isbn         = {978-0-471-39918-6},
 }
-
 @incollection{Wyszecki2000bd,
-  title = {{{CIE}} 1976 ({{L}}*u*v*)-{{Space}} and {{Color-Difference Formula}}},
-  booktitle = {Color {{Science}}: {{Concepts}} and {{Methods}}, {{Quantitative Data}} and {{Formulae}}},
-  author = {Wyszecki, G{\"u}nther and Stiles, W. S.},
-  year = {2000},
-  pages = {167},
-  publisher = {{Wiley}},
-  isbn = {978-0-471-39918-6}
+  title        = {{{CIE}} 1976 ({{L}}*u*v*)-{{Space}} and
+    {{Color-Difference Formula}}},
+  booktitle    = {Color {{Science}}: {{Concepts}} and {{Methods}},
+    {{Quantitative Data}} and {{Formulae}}},
+  author       = {Wyszecki, G{\"u}nther and Stiles, W. S.},
+  year         = 2000,
+  pages        = 167,
+  publisher    = {{Wiley}},
+  isbn         = {978-0-471-39918-6},
 }
-
 @incollection{Wyszecki2000be,
-  title = {The {{CIE}} 1964 {{Standard Observer}}},
-  booktitle = {Color {{Science}}: {{Concepts}} and {{Methods}}, {{Quantitative Data}} and {{Formulae}}},
-  author = {Wyszecki, G{\"u}nther and Stiles, W. S.},
-  year = {2000},
-  pages = {141},
-  publisher = {{Wiley}},
-  isbn = {978-0-471-39918-6}
+  title        = {The {{CIE}} 1964 {{Standard Observer}}},
+  booktitle    = {Color {{Science}}: {{Concepts}} and {{Methods}},
+    {{Quantitative Data}} and {{Formulae}}},
+  author       = {Wyszecki, G{\"u}nther and Stiles, W. S.},
+  year         = 2000,
+  pages        = 141,
+  publisher    = {{Wiley}},
+  isbn         = {978-0-471-39918-6},
 }
-
 @incollection{Wyszecki2000bf,
-  title = {Integration {{Replaced}} by {{Summation}}},
-  booktitle = {Color {{Science}}: {{Concepts}} and {{Methods}}, {{Quantitative Data}} and {{Formulae}}},
-  author = {Wyszecki, G{\"u}nther and Stiles, W. S.},
-  year = {2000},
-  pages = {158--163},
-  publisher = {{Wiley}},
-  isbn = {978-0-471-39918-6}
+  title        = {Integration {{Replaced}} by {{Summation}}},
+  booktitle    = {Color {{Science}}: {{Concepts}} and {{Methods}},
+    {{Quantitative Data}} and {{Formulae}}},
+  author       = {Wyszecki, G{\"u}nther and Stiles, W. S.},
+  year         = 2000,
+  pages        = {158--163},
+  publisher    = {{Wiley}},
+  isbn         = {978-0-471-39918-6},
 }
-
 @incollection{Wyszecki2000bg,
-  title = {Table 1(3.3.3)},
-  booktitle = {Color {{Science}}: {{Concepts}} and {{Methods}}, {{Quantitative Data}} and {{Formulae}}},
-  author = {Wyszecki, G{\"u}nther and Stiles, W. S.},
-  year = {2000},
-  pages = {138--139},
-  publisher = {{Wiley}},
-  isbn = {978-0-471-39918-6}
+  title        = {Table 1(3.3.3)},
+  booktitle    = {Color {{Science}}: {{Concepts}} and {{Methods}},
+    {{Quantitative Data}} and {{Formulae}}},
+  author       = {Wyszecki, G{\"u}nther and Stiles, W. S.},
+  year         = 2000,
+  pages        = {138--139},
+  publisher    = {{Wiley}},
+  isbn         = {978-0-471-39918-6},
 }
-
 @incollection{Wyszecki2000bh,
-  title = {Table {{II}}(3.7)},
-  booktitle = {Color {{Science}}: {{Concepts}} and {{Methods}}, {{Quantitative Data}} and {{Formulae}}},
-  author = {Wyszecki, G{\"u}nther and Stiles, W. S.},
-  year = {2000},
-  pages = {778--779},
-  publisher = {{Wiley}},
-  isbn = {978-0-471-39918-6}
+  title        = {Table {{II}}(3.7)},
+  booktitle    = {Color {{Science}}: {{Concepts}} and {{Methods}},
+    {{Quantitative Data}} and {{Formulae}}},
+  author       = {Wyszecki, G{\"u}nther and Stiles, W. S.},
+  year         = 2000,
+  pages        = {778--779},
+  publisher    = {{Wiley}},
+  isbn         = {978-0-471-39918-6},
 }
-
 @incollection{Wyszecki2000s,
-  title = {Standard {{Photometric Observers}}},
-  booktitle = {Color {{Science}}: {{Concepts}} and {{Methods}}, {{Quantitative Data}} and {{Formulae}}},
-  author = {Wyszecki, G{\"u}nther and Stiles, W. S.},
-  year = {2000},
-  pages = {256--259,395},
-  publisher = {{Wiley}},
-  isbn = {978-0-471-39918-6}
+  title        = {Standard {{Photometric Observers}}},
+  booktitle    = {Color {{Science}}: {{Concepts}} and {{Methods}},
+    {{Quantitative Data}} and {{Formulae}}},
+  author       = {Wyszecki, G{\"u}nther and Stiles, W. S.},
+  year         = 2000,
+  pages        = {256--259,395},
+  publisher    = {{Wiley}},
+  isbn         = {978-0-471-39918-6},
 }
-
 @incollection{Wyszecki2000x,
-  title = {Table 1(3.11) {{Isotemperature Lines}}},
-  booktitle = {Color {{Science}}: {{Concepts}} and {{Methods}}, {{Quantitative Data}} and {{Formulae}}},
-  author = {Wyszecki, G{\"u}nther and Stiles, W. S.},
-  year = {2000},
-  pages = {228},
-  publisher = {{Wiley}},
-  isbn = {978-0-471-39918-6}
+  title        = {Table 1(3.11) {{Isotemperature Lines}}},
+  booktitle    = {Color {{Science}}: {{Concepts}} and {{Methods}},
+    {{Quantitative Data}} and {{Formulae}}},
+  author       = {Wyszecki, G{\"u}nther and Stiles, W. S.},
+  year         = 2000,
+  pages        = 228,
+  publisher    = {{Wiley}},
+  isbn         = {978-0-471-39918-6},
 }
-
 @incollection{Wyszecki2000y,
-  title = {{{DISTRIBUTION TEMPERATURE}}, {{COLOR TEMPERATURE}}, {{AND CORRELATED COLOR TEMPERATURE}}},
-  booktitle = {Color {{Science}}: {{Concepts}} and {{Methods}}, {{Quantitative Data}} and {{Formulae}}},
-  author = {Wyszecki, G{\"u}nther and Stiles, W. S.},
-  year = {2000},
-  pages = {224--229},
-  publisher = {{Wiley}},
-  isbn = {978-0-471-39918-6}
+  title        = {{{DISTRIBUTION TEMPERATURE}}, {{COLOR TEMPERATURE}},
+    {{AND CORRELATED COLOR TEMPERATURE}}},
+  booktitle    = {Color {{Science}}: {{Concepts}} and {{Methods}},
+    {{Quantitative Data}} and {{Formulae}}},
+  author       = {Wyszecki, G{\"u}nther and Stiles, W. S.},
+  year         = 2000,
+  pages        = {224--229},
+  publisher    = {{Wiley}},
+  isbn         = {978-0-471-39918-6},
 }
-
 @incollection{Wyszecki2000z,
-  title = {{{CIE Method}} of {{Calculating D-Illuminants}}},
-  booktitle = {Color {{Science}}: {{Concepts}} and {{Methods}}, {{Quantitative Data}} and {{Formulae}}},
-  author = {Wyszecki, G{\"u}nther and Stiles, W. S.},
-  year = {2000},
-  pages = {145--146},
-  publisher = {{Wiley}},
-  isbn = {978-0-471-39918-6}
+  title        = {{{CIE Method}} of {{Calculating D-Illuminants}}},
+  booktitle    = {Color {{Science}}: {{Concepts}} and {{Methods}},
+    {{Quantitative Data}} and {{Formulae}}},
+  author       = {Wyszecki, G{\"u}nther and Stiles, W. S.},
+  year         = 2000,
+  pages        = {145--146},
+  publisher    = {{Wiley}},
+  isbn         = {978-0-471-39918-6},
 }
-
 @misc{X-Rite2012a,
-  title = {Color {{iQC}} and {{Color iMatch Color Calculations Guide}}},
-  author = {{X-Rite} and {Pantone}},
-  year = {2012},
-  file = {/Users/kelsolaar/Zotero/storage/2F3A6AZ3/X-Rite, Pantone - 2012 - Color iQC and Color iMatch Color Calculations Guide.pdf}
+  title        = {Color {{iQC}} and {{Color iMatch Color Calculations
+    Guide}}},
+  author       = {{X-Rite} and {Pantone}},
+  year         = 2012,
 }
-
 @misc{X-Rite2016,
-  title = {New Color Specifications for {{ColorChecker SG}} and {{Classic Charts}}},
-  author = {{X-Rite}},
-  year = {2016},
-  howpublished = {http://xritephoto.com/ph\_product\_overview.aspx?ID=938\&Action=Support\&SupportID=5884\#}
+  title        = {New Color Specifications for {{ColorChecker SG}} and
+    {{Classic Charts}}},
+  author       = {{X-Rite}},
+  year         = 2016,
+  howpublished = {http://xritephoto.com/ph\_product\_overview.aspx?ID=938\&Action=Support\&SupportID=5884\#},
 }
-
 @misc{Yorke2014a,
-  title = {Python: {{Change}} Format of Np.Array or Allow Tolerance in In1d Function},
-  author = {Yorke, Rory},
-  year = {2014},
-  howpublished = {http://stackoverflow.com/a/23521245/931625}
+  title        = {Python: {{Change}} Format of Np.Array or Allow
+    Tolerance in In1d Function},
+  author       = {Yorke, Rory},
+  year         = 2014,
+  howpublished = {http://stackoverflow.com/a/23521245/931625},
 }
-
 @article{Zhai2018,
-  title = {Study of Chromatic Adaptation via Neutral White Matches on Different Viewing Media},
-  author = {Zhai, Qiyan and Luo, Ming R.},
-  year = {2018},
-  month = mar,
-  journal = {Optics Express},
-  volume = {26},
-  number = {6},
-  pages = {7724},
-  issn = {1094-4087},
-  doi = {10.1364/OE.26.007724},
-  langid = {english},
-  file = {/Users/kelsolaar/Zotero/storage/BQKEE7MK/Zhai and Luo - 2018 - Study of chromatic adaptation via neutral white ma.pdf}
+  title        = {Study of Chromatic Adaptation via Neutral White
+    Matches on Different Viewing Media},
+  author       = {Zhai, Qiyan and Luo, Ming R.},
+  year         = 2018,
+  month        = mar,
+  journal      = {Optics Express},
+  volume       = 26,
+  number       = 6,
+  pages        = 7724,
+  issn         = {1094-4087},
+  doi          = {10.1364/OE.26.007724},
+  langid       = {english},
 }
-
-

--- a/colour/__init__.py
+++ b/colour/__init__.py
@@ -144,12 +144,10 @@ from .blindness import (
     msds_cmfs_anomalous_trichromacy_Machado2009,
 )
 from .appearance import (
-    CAM16_METHODS,
     CAM_Specification_ATD95,
     CAM_Specification_CAM16,
     CAM_Specification_CIECAM02,
     CAM_Specification_CIECAM16,
-    CAM_Specification_CAM16_Hellwig2022,
     CAM_Specification_Hellwig2022,
     CAM_Specification_Hunt,
     CAM_Specification_Kim2009,
@@ -568,12 +566,9 @@ __all__ += [
     "msds_cmfs_anomalous_trichromacy_Machado2009",
 ]
 __all__ += [
-    "CAM16_METHODS",
     "CAM_Specification_ATD95",
     "CAM_Specification_CAM16",
-    "CAM_Specification_CAM16_Hellwig2022",
     "CAM_Specification_CIECAM02",
-    "CAM_Specification_CIECAM02_Hellwig2022",
     "CAM_Specification_CIECAM16",
     "CAM_Specification_Hellwig2022",
     "CAM_Specification_Hunt",
@@ -583,7 +578,6 @@ __all__ += [
     "CAM_Specification_RLAB",
     "CAM_Specification_ZCAM",
     "CAM16_to_XYZ",
-    "CIECAM02_METHODS",
     "CIECAM02_to_XYZ",
     "CIECAM16_to_XYZ",
     "HKE_NAYATANI1997_METHODS",

--- a/colour/appearance/__init__.py
+++ b/colour/appearance/__init__.py
@@ -10,8 +10,6 @@ from .ciecam02 import (
     VIEWING_CONDITIONS_CIECAM02,
     CAM_KWARGS_CIECAM02_sRGB,
     CAM_Specification_CIECAM02,
-    CAM_Specification_CIECAM02_Hellwig2022,
-    CIECAM02_METHODS,
     XYZ_to_CIECAM02,
     CIECAM02_to_XYZ,
 )
@@ -19,8 +17,6 @@ from .cam16 import (
     InductionFactors_CAM16,
     VIEWING_CONDITIONS_CAM16,
     CAM_Specification_CAM16,
-    CAM_Specification_CAM16_Hellwig2022,
-    CAM16_METHODS,
     XYZ_to_CAM16,
     CAM16_to_XYZ,
 )
@@ -89,8 +85,6 @@ __all__ += [
     "VIEWING_CONDITIONS_CIECAM02",
     "CAM_KWARGS_CIECAM02_sRGB",
     "CAM_Specification_CIECAM02",
-    "CAM_Specification_CIECAM02_Hellwig2022",
-    "CIECAM02_METHODS",
     "XYZ_to_CIECAM02",
     "CIECAM02_to_XYZ",
 ]
@@ -98,8 +92,6 @@ __all__ += [
     "InductionFactors_CAM16",
     "VIEWING_CONDITIONS_CAM16",
     "CAM_Specification_CAM16",
-    "CAM_Specification_CAM16_Hellwig2022",
-    "CAM16_METHODS",
     "XYZ_to_CAM16",
     "CAM16_to_XYZ",
 ]

--- a/colour/appearance/cam16.py
+++ b/colour/appearance/cam16.py
@@ -7,8 +7,6 @@ Defines the *CAM16* colour appearance model objects:
 -   :class:`colour.appearance.InductionFactors_CAM16`
 -   :attr:`colour.VIEWING_CONDITIONS_CAM16`
 -   :class:`colour.CAM_Specification_CAM16`
--   :class:`colour.CAM_Specification_CAM16_Hellwig2022`
--   :func:`colour.CAM16_METHODS`
 -   :func:`colour.XYZ_to_CAM16`
 -   :func:`colour.CAM16_to_XYZ`
 
@@ -18,9 +16,6 @@ References
     Melgosa, M., Brill, M. H., & Pointer, M. (2017). Comprehensive color
     solutions: CAM16, CAT16, and CAM16-UCS. Color Research & Application,
     42(6), 703-718. doi:10.1002/col.22131
--   :cite:`Hellwig2022a` : Hellwig, L., Stolitzka, D., & Fairchild, M. D.
-    (2022). Extending CIECAM02 and CAM16 for the Helmholtz–Kohlrausch effect.
-    Color Research & Application, col.22793. doi:10.1002/col.22793
 """
 
 from __future__ import annotations
@@ -59,10 +54,8 @@ from colour.hints import (
     Boolean,
     FloatingOrArrayLike,
     FloatingOrNDArray,
-    Literal,
     NDArray,
     Optional,
-    Tuple,
     Union,
 )
 from colour.utilities import (
@@ -77,11 +70,6 @@ from colour.utilities import (
     to_domain_100,
     to_domain_degrees,
     tsplit,
-    validate_method,
-)
-from colour.utilities.documentation import (
-    DocstringTuple,
-    is_documentation_building,
 )
 
 __author__ = "Colour Developers"
@@ -97,11 +85,8 @@ __all__ = [
     "InductionFactors_CAM16",
     "VIEWING_CONDITIONS_CAM16",
     "CAM_Specification_CAM16",
-    "CAM_Specification_CAM16_Hellwig2022",
-    "CAM16_METHODS",
     "XYZ_to_CAM16",
     "CAM16_to_XYZ",
-    "hue_angle_dependency_Hellwig2022",
 ]
 
 MATRIX_16: NDArray = CAT_CAT16
@@ -188,66 +173,6 @@ class CAM_Specification_CAM16(MixinDataclassArithmetic):
     HC: Optional[FloatingOrNDArray] = field(default_factory=lambda: None)
 
 
-@dataclass
-class CAM_Specification_CAM16_Hellwig2022(MixinDataclassArithmetic):
-    """
-    Define the *CAM16* colour appearance model specification with the
-    *Helmholtz–Kohlrausch* effect extension from :cite:`Hellwig2022a`.
-
-    Parameters
-    ----------
-    J
-        Correlate of *Lightness* :math:`J`.
-    C
-        Correlate of *chroma* :math:`C`.
-    h
-        *Hue* angle :math:`h` in degrees.
-    s
-        Correlate of *saturation* :math:`s`.
-    Q
-        Correlate of *brightness* :math:`Q`.
-    M
-        Correlate of *colourfulness* :math:`M`.
-    H
-        *Hue* :math:`h` quadrature :math:`H`.
-    HC
-        *Hue* :math:`h` composition :math:`H^C`.
-    J_HK
-        Correlate of *Lightness* :math:`J_{HK}` accounting for
-        *Helmholtz–Kohlrausch* effect.
-    Q_HK
-        Correlate of *brightness* :math:`Q_{HK}` accounting for
-        *Helmholtz–Kohlrausch* effect.
-
-    References
-    ----------
-    :cite:`Hellwig2022a`
-    """
-
-    J: Optional[FloatingOrNDArray] = field(default_factory=lambda: None)
-    C: Optional[FloatingOrNDArray] = field(default_factory=lambda: None)
-    h: Optional[FloatingOrNDArray] = field(default_factory=lambda: None)
-    s: Optional[FloatingOrNDArray] = field(default_factory=lambda: None)
-    Q: Optional[FloatingOrNDArray] = field(default_factory=lambda: None)
-    M: Optional[FloatingOrNDArray] = field(default_factory=lambda: None)
-    H: Optional[FloatingOrNDArray] = field(default_factory=lambda: None)
-    HC: Optional[FloatingOrNDArray] = field(default_factory=lambda: None)
-    J_HK: Optional[FloatingOrNDArray] = field(default_factory=lambda: None)
-    Q_HK: Optional[FloatingOrNDArray] = field(default_factory=lambda: None)
-
-
-CAM16_METHODS: Tuple = ("Li 2017", "Hellwig 2022")
-if is_documentation_building():  # pragma: no cover
-    CAM16_METHODS = DocstringTuple(CAM16_METHODS)
-    CAM16_METHODS.__doc__ = """
-Supported *CAM16* colour appearance model computation methods.
-
-References
-----------
-:cite:`Li2017`, :cite:`Hellwig2022a`
-"""
-
-
 def XYZ_to_CAM16(
     XYZ: ArrayLike,
     XYZ_w: ArrayLike,
@@ -257,14 +182,10 @@ def XYZ_to_CAM16(
         InductionFactors_CIECAM02, InductionFactors_CAM16
     ] = VIEWING_CONDITIONS_CAM16["Average"],
     discount_illuminant: Boolean = False,
-    method: Union[Literal["Li 2017", "Hellwig 2022"], str] = "Li 2017",
-) -> Union[CAM_Specification_CAM16, CAM_Specification_CAM16_Hellwig2022]:
+) -> CAM_Specification_CAM16:
     """
     Compute the *CAM16* colour appearance model correlates from given
     *CIE XYZ* tristimulus values.
-
-    This implementation supports the *Helmholtz–Kohlrausch* effect extension
-    from :cite:`Hellwig2022a`.
 
     Parameters
     ----------
@@ -286,13 +207,10 @@ def XYZ_to_CAM16(
         Surround viewing conditions induction factors.
     discount_illuminant
         Truth value indicating if the illuminant should be discounted.
-    method
-        Computation method.
 
     Returns
     -------
-    :class:`colour.CAM_Specification_CAM16` or \
-:class:`colour.CAM_Specification_CAM16_Hellwig2022`
+    :class:`colour.CAM_Specification_CAM16`
         *CAM16* colour appearance model specification.
 
     Notes
@@ -305,31 +223,27 @@ def XYZ_to_CAM16(
     | ``XYZ_w``  | [0, 100]              | [0, 1]        |
     +------------+-----------------------+---------------+
 
-    +----------------------------------+-----------------------+---------------+
-    | **Range**                        | **Scale - Reference** | **Scale - 1** |
-    +==================================+=======================+===============+
-    | ``CAM_Specification_CAM16.J``    | [0, 100]              | [0, 1]        |
-    +----------------------------------+-----------------------+---------------+
-    | ``CAM_Specification_CAM16.C``    | [0, 100]              | [0, 1]        |
-    +----------------------------------+-----------------------+---------------+
-    | ``CAM_Specification_CAM16.h``    | [0, 360]              | [0, 1]        |
-    +----------------------------------+-----------------------+---------------+
-    | ``CAM_Specification_CAM16.s``    | [0, 100]              | [0, 1]        |
-    +----------------------------------+-----------------------+---------------+
-    | ``CAM_Specification_CAM16.Q``    | [0, 100]              | [0, 1]        |
-    +----------------------------------+-----------------------+---------------+
-    | ``CAM_Specification_CAM16.M``    | [0, 100]              | [0, 1]        |
-    +----------------------------------+-----------------------+---------------+
-    | ``CAM_Specification_CAM16.H``    | [0, 400]              | [0, 1]        |
-    +----------------------------------+-----------------------+---------------+
-    | ``CAM_Specification_CAM16.J_HK`` | [0, 100]              | [0, 1]        |
-    +----------------------------------+-----------------------+---------------+
-    | ``CAM_Specification_CAM16.Q_HK`` | [0, 100]              | [0, 1]        |
-    +----------------------------------+-----------------------+---------------+
+    +-------------------------------+-----------------------+---------------+
+    | **Range**                     | **Scale - Reference** | **Scale - 1** |
+    +===============================+=======================+===============+
+    | ``CAM_Specification_CAM16.J`` | [0, 100]              | [0, 1]        |
+    +-------------------------------+-----------------------+---------------+
+    | ``CAM_Specification_CAM16.C`` | [0, 100]              | [0, 1]        |
+    +-------------------------------+-----------------------+---------------+
+    | ``CAM_Specification_CAM16.h`` | [0, 360]              | [0, 1]        |
+    +-------------------------------+-----------------------+---------------+
+    | ``CAM_Specification_CAM16.s`` | [0, 100]              | [0, 1]        |
+    +-------------------------------+-----------------------+---------------+
+    | ``CAM_Specification_CAM16.Q`` | [0, 100]              | [0, 1]        |
+    +-------------------------------+-----------------------+---------------+
+    | ``CAM_Specification_CAM16.M`` | [0, 100]              | [0, 1]        |
+    +-------------------------------+-----------------------+---------------+
+    | ``CAM_Specification_CAM16.H`` | [0, 400]              | [0, 1]        |
+    +-------------------------------+-----------------------+---------------+
 
     References
     ----------
-    :cite:`Li2017`, :cite:`Hellwig2022a`
+    :cite:`Li2017`
 
     Examples
     --------
@@ -342,14 +256,7 @@ def XYZ_to_CAM16(
     CAM_Specification_CAM16(J=41.7312079..., C=0.1033557..., \
 h=217.0679597..., s=2.3450150..., Q=195.3717089..., M=0.1074367..., \
 H=275.5949861..., HC=None)
-    >>> XYZ_to_CAM16(XYZ, XYZ_w, L_A, Y_b, surround, method="Hellwig 2022")
-    ... # doctest: +ELLIPSIS
-    CAM_Specification_CAM16_Hellwig2022(J=41.7312079..., C=0.1033557..., \
-h=217.0679597..., s=2.3450150..., Q=195.3717089..., M=0.1074367..., \
-H=275.5949861..., HC=None, J_HK=42.0681418..., Q_HK=56.3203856...)
     """
-
-    method = validate_method(method, CAM16_METHODS)
 
     XYZ = to_domain_100(XYZ)
     XYZ_w = to_domain_100(XYZ_w)
@@ -431,39 +338,20 @@ H=275.5949861..., HC=None, J_HK=42.0681418..., Q_HK=56.3203856...)
     # Computing the correlate of *saturation* :math:`s`.
     s = saturation_correlate(M, Q)
 
-    if method == "li 2017":
-        return CAM_Specification_CAM16(
-            as_float(from_range_100(J)),
-            as_float(from_range_100(C)),
-            as_float(from_range_degrees(h)),
-            as_float(from_range_100(s)),
-            as_float(from_range_100(Q)),
-            as_float(from_range_100(M)),
-            as_float(from_range_degrees(H, 400)),
-            None,
-        )
-    else:  # method == "hellwig 2022"
-        J_HK = J + hue_angle_dependency_Hellwig2022(h) * spow(C, 0.587)
-        Q_HK = (2 / surround.c) * (J_HK / 100) * A_w
-
-        return CAM_Specification_CAM16_Hellwig2022(
-            as_float(from_range_100(J)),
-            as_float(from_range_100(C)),
-            as_float(from_range_degrees(h)),
-            as_float(from_range_100(s)),
-            as_float(from_range_100(Q)),
-            as_float(from_range_100(M)),
-            as_float(from_range_degrees(H, 400)),
-            None,
-            as_float(from_range_100(J_HK)),
-            as_float(from_range_100(Q_HK)),
-        )
+    return CAM_Specification_CAM16(
+        as_float(from_range_100(J)),
+        as_float(from_range_100(C)),
+        as_float(from_range_degrees(h)),
+        as_float(from_range_100(s)),
+        as_float(from_range_100(Q)),
+        as_float(from_range_100(M)),
+        as_float(from_range_degrees(H, 400)),
+        None,
+    )
 
 
 def CAM16_to_XYZ(
-    specification: Union[
-        CAM_Specification_CAM16, CAM_Specification_CAM16_Hellwig2022
-    ],
+    specification: CAM_Specification_CAM16,
     XYZ_w: ArrayLike,
     L_A: FloatingOrArrayLike,
     Y_b: FloatingOrArrayLike,
@@ -471,13 +359,9 @@ def CAM16_to_XYZ(
         InductionFactors_CIECAM02, InductionFactors_CAM16
     ] = VIEWING_CONDITIONS_CAM16["Average"],
     discount_illuminant: Boolean = False,
-    method: Union[Literal["Li 2017", "Hellwig 2022"], str] = "Li 2017",
 ) -> NDArray:
     """
     Convert from *CAM16* specification to *CIE XYZ* tristimulus values.
-
-    This implementation supports the *Helmholtz–Kohlrausch* effect extension
-    from :cite:`Hellwig2022a`.
 
     Parameters
     ----------
@@ -502,8 +386,6 @@ def CAM16_to_XYZ(
         Surround viewing conditions.
     discount_illuminant
         Discount the illuminant.
-    method
-        Computation method.
 
     Returns
     -------
@@ -518,29 +400,25 @@ def CAM16_to_XYZ(
 
     Notes
     -----
-    +----------------------------------+-----------------------+---------------+
-    | **Domain**                       | **Scale - Reference** | **Scale - 1** |
-    +==================================+=======================+===============+
-    | ``CAM_Specification_CAM16.J``    | [0, 100]              | [0, 1]        |
-    +----------------------------------+-----------------------+---------------+
-    | ``CAM_Specification_CAM16.C``    | [0, 100]              | [0, 1]        |
-    +----------------------------------+-----------------------+---------------+
-    | ``CAM_Specification_CAM16.h``    | [0, 360]              | [0, 1]        |
-    +----------------------------------+-----------------------+---------------+
-    | ``CAM_Specification_CAM16.s``    | [0, 100]              | [0, 1]        |
-    +----------------------------------+-----------------------+---------------+
-    | ``CAM_Specification_CAM16.Q``    | [0, 100]              | [0, 1]        |
-    +----------------------------------+-----------------------+---------------+
-    | ``CAM_Specification_CAM16.M``    | [0, 100]              | [0, 1]        |
-    +----------------------------------+-----------------------+---------------+
-    | ``CAM_Specification_CAM16.H``    | [0, 400]              | [0, 1]        |
-    +----------------------------------+-----------------------+---------------+
-    | ``CAM_Specification_CAM16.J_HK`` | [0, 100]              | [0, 1]        |
-    +----------------------------------+-----------------------+---------------+
-    | ``CAM_Specification_CAM16.Q_HK`` | [0, 100]              | [0, 1]        |
-    +----------------------------------+-----------------------+---------------+
-    | ``XYZ_w``                        | [0, 100]              | [0, 1]        |
-    +----------------------------------+-----------------------+---------------+
+    +-------------------------------+-----------------------+---------------+
+    | **Domain**                    | **Scale - Reference** | **Scale - 1** |
+    +===============================+=======================+===============+
+    | ``CAM_Specification_CAM16.J`` | [0, 100]              | [0, 1]        |
+    +-------------------------------+-----------------------+---------------+
+    | ``CAM_Specification_CAM16.C`` | [0, 100]              | [0, 1]        |
+    +-------------------------------+-----------------------+---------------+
+    | ``CAM_Specification_CAM16.h`` | [0, 360]              | [0, 1]        |
+    +-------------------------------+-----------------------+---------------+
+    | ``CAM_Specification_CAM16.s`` | [0, 100]              | [0, 1]        |
+    +-------------------------------+-----------------------+---------------+
+    | ``CAM_Specification_CAM16.Q`` | [0, 100]              | [0, 1]        |
+    +-------------------------------+-----------------------+---------------+
+    | ``CAM_Specification_CAM16.M`` | [0, 100]              | [0, 1]        |
+    +-------------------------------+-----------------------+---------------+
+    | ``CAM_Specification_CAM16.H`` | [0, 360]              | [0, 1]        |
+    +-------------------------------+-----------------------+---------------+
+    | ``XYZ_w``                     | [0, 100]              | [0, 1]        |
+    +-------------------------------+-----------------------+---------------+
 
     +-----------+-----------------------+---------------+
     | **Range** | **Scale - Reference** | **Scale - 1** |
@@ -550,7 +428,7 @@ def CAM16_to_XYZ(
 
     References
     ----------
-    :cite:`Li2017`, :cite:`Hellwig2022a`
+    :cite:`Li2017`
 
     Examples
     --------
@@ -563,42 +441,14 @@ def CAM16_to_XYZ(
     >>> Y_b = 20.0
     >>> CAM16_to_XYZ(specification, XYZ_w, L_A, Y_b)  # doctest: +ELLIPSIS
     array([ 19.01...,  20...  ,  21.78...])
-    >>> specification = CAM_Specification_CAM16_Hellwig2022(
-    ...     J_HK=42.068141846439374,
-    ...     C=0.103355738709070,
-    ...     h=217.067959767393010)
-    >>> CAM16_to_XYZ(specification, XYZ_w, L_A, Y_b, method="Hellwig 2022")
-    ... # doctest: +ELLIPSIS
-    array([ 19.01...,  20...  ,  21.78...])
     """
 
-    method = validate_method(method, CAM16_METHODS)
+    J, C, h, _s, _Q, M, _H, _HC = astuple(specification)
 
-    if method == "li 2017" and isinstance(
-        specification, CAM_Specification_CAM16
-    ):
-        J, C, h, _s, _Q, M, _H, _HC = astuple(specification)
-
-        J = to_domain_100(J)
-        C = to_domain_100(C)
-        h = to_domain_degrees(h)
-        M = to_domain_100(M)
-    else:  # method == "hellwig 2022"
-        _J, C, h, _s, _Q, M, _H, _HC, J_HK, _Q_HK = astuple(specification)
-
-        if has_only_nan(J_HK):
-            raise ValueError(
-                '"J_HK" correlate must be defined in the '
-                '"CAM_Specification_CAM16_Hellwig2022" argument!'
-            )
-
-        C = to_domain_100(C)
-        h = to_domain_degrees(h)
-        M = to_domain_100(M)
-        J_HK = to_domain_100(J_HK)
-
-        J = J_HK - hue_angle_dependency_Hellwig2022(h) * spow(C, 0.587)
-
+    J = to_domain_100(J)
+    C = to_domain_100(C)
+    h = to_domain_degrees(h)
+    M = to_domain_100(M)
     L_A = as_float_array(L_A)
     XYZ_w = to_domain_100(XYZ_w)
     _X_w, Y_w, _Z_w = tsplit(XYZ_w)
@@ -635,8 +485,7 @@ def CAM16_to_XYZ(
     elif has_only_nan(C):
         raise ValueError(
             'Either "C" or "M" correlate must be defined in '
-            'the "CAM_Specification_CAM16" or '
-            '"CAM_Specification_CAM16_Hellwig2022" argument!'
+            'the "CAM_Specification_CAM16" argument!'
         )
 
     # Step 2
@@ -673,43 +522,3 @@ def CAM16_to_XYZ(
     XYZ = vector_dot(MATRIX_INVERSE_16, RGB)
 
     return from_range_100(XYZ)
-
-
-def hue_angle_dependency_Hellwig2022(
-    h: FloatingOrArrayLike,
-) -> FloatingOrNDArray:
-    """
-    Compute the hue angle dependency of the *Helmholtz–Kohlrausch* effect.
-
-    Parameters
-    ----------
-    h
-        Hue :math:`h` angle in degrees.
-
-    Returns
-    -------
-    :class:`numpy.floating` or :class:`numpy.ndarray`
-        Hue angle dependency.
-
-    References
-    ----------
-    :cite:`Hellwig2022a`
-
-    Examples
-    --------
-    >>> hue_angle_dependency_Hellwig2022(217.06795976739301)
-    ... # doctest: +ELLIPSIS
-    1.2768219...
-    """
-
-    h = as_float_array(h)
-
-    h_r = np.radians(h)
-
-    return as_float(
-        -0.160 * np.cos(h_r)
-        + 0.132 * np.cos(2 * h_r)
-        - 0.405 * np.sin(h_r)
-        + 0.080 * np.sin(2 * h_r)
-        + 0.792
-    )

--- a/colour/appearance/ciecam02.py
+++ b/colour/appearance/ciecam02.py
@@ -7,8 +7,6 @@ Defines the *CIECAM02* colour appearance model objects:
 -   :class:`colour.appearance.InductionFactors_CIECAM02`
 -   :attr:`colour.VIEWING_CONDITIONS_CIECAM02`
 -   :class:`colour.CAM_Specification_CIECAM02`
--   :class:`colour.CAM_Specification_CIECAM02_Hellwig2022`
--   :func:`colour.CIECAM02_METHODS`
 -   :func:`colour.XYZ_to_CIECAM02`
 -   :func:`colour.CIECAM02_to_XYZ`
 
@@ -16,9 +14,6 @@ References
 ----------
 -   :cite:`Fairchild2004c` : Fairchild, M. D. (2004). CIECAM02. In Color
     Appearance Models (2nd ed., pp. 289-301). Wiley. ISBN:978-0-470-01216-1
--   :cite:`Hellwig2022a` : Hellwig, L., Stolitzka, D., & Fairchild, M. D.
-    (2022). Extending CIECAM02 and CAM16 for the Helmholtz–Kohlrausch effect.
-    Color Research & Application, col.22793. doi:10.1002/col.22793
 -   :cite:`InternationalElectrotechnicalCommission1999a` : International
     Electrotechnical Commission. (1999). IEC 61966-2-1:1999 - Multimedia
     systems and equipment - Colour measurement and management - Part 2-1:
@@ -56,11 +51,9 @@ from colour.hints import (
     Dict,
     FloatingOrArrayLike,
     FloatingOrNDArray,
-    Literal,
     NDArray,
     Optional,
     Tuple,
-    Union,
     cast,
 )
 from colour.models import xy_to_XYZ
@@ -78,12 +71,10 @@ from colour.utilities import (
     to_domain_degrees,
     tsplit,
     tstack,
-    validate_method,
     zeros,
 )
 from colour.utilities.documentation import (
     DocstringDict,
-    DocstringTuple,
     is_documentation_building,
 )
 
@@ -101,8 +92,6 @@ __all__ = [
     "HUE_DATA_FOR_HUE_QUADRATURE",
     "CAM_KWARGS_CIECAM02_sRGB",
     "CAM_Specification_CIECAM02",
-    "CAM_Specification_CIECAM02_Hellwig2022",
-    "CIECAM02_METHODS",
     "XYZ_to_CIECAM02",
     "CIECAM02_to_XYZ",
     "chromatic_induction_factors",
@@ -131,7 +120,6 @@ __all__ = [
     "saturation_correlate",
     "P",
     "matrix_post_adaptation_non_linear_response_compression",
-    "hue_angle_dependency_Hellwig2022",
 ]
 
 CAT_INVERSE_CAT02: NDArray = np.linalg.inv(CAT_CAT02)
@@ -244,67 +232,6 @@ class CAM_Specification_CIECAM02(MixinDataclassArithmetic):
     HC: Optional[FloatingOrNDArray] = field(default_factory=lambda: None)
 
 
-@dataclass
-class CAM_Specification_CIECAM02_Hellwig2022(MixinDataclassArithmetic):
-    """
-    Define the *CIECAM02* colour appearance model specification with the
-    *Helmholtz–Kohlrausch* effect extension from :cite:`Hellwig2022a`.
-
-    Parameters
-    ----------
-    J
-        Correlate of *Lightness* :math:`J`.
-    C
-        Correlate of *chroma* :math:`C`.
-    h
-        *Hue* angle :math:`h` in degrees.
-    s
-        Correlate of *saturation* :math:`s`.
-    Q
-        Correlate of *brightness* :math:`Q`.
-    M
-        Correlate of *colourfulness* :math:`M`.
-    H
-        *Hue* :math:`h` quadrature :math:`H`.
-    HC
-        *Hue* :math:`h` composition :math:`H^C`.
-    J_HK
-        Correlate of *Lightness* :math:`J_{HK}` accounting for
-        *Helmholtz–Kohlrausch* effect.
-    Q_HK
-        Correlate of *brightness* :math:`Q_{HK}` accounting for
-        *Helmholtz–Kohlrausch* effect.
-
-    References
-    ----------
-    :cite:`Hellwig2022a`
-    """
-
-    J: Optional[FloatingOrNDArray] = field(default_factory=lambda: None)
-    C: Optional[FloatingOrNDArray] = field(default_factory=lambda: None)
-    h: Optional[FloatingOrNDArray] = field(default_factory=lambda: None)
-    s: Optional[FloatingOrNDArray] = field(default_factory=lambda: None)
-    Q: Optional[FloatingOrNDArray] = field(default_factory=lambda: None)
-    M: Optional[FloatingOrNDArray] = field(default_factory=lambda: None)
-    H: Optional[FloatingOrNDArray] = field(default_factory=lambda: None)
-    HC: Optional[FloatingOrNDArray] = field(default_factory=lambda: None)
-    J_HK: Optional[FloatingOrNDArray] = field(default_factory=lambda: None)
-    Q_HK: Optional[FloatingOrNDArray] = field(default_factory=lambda: None)
-
-
-CIECAM02_METHODS: Tuple = ("CIE", "Hellwig 2022")
-if is_documentation_building():  # pragma: no cover
-    CIECAM02_METHODS = DocstringTuple(CIECAM02_METHODS)
-    CIECAM02_METHODS.__doc__ = """
-Supported *CIECAM02* colour appearance model computation methods.
-
-References
-----------
-:cite:`Fairchild2004c`, :cite:`Luo2013`, :cite:`Moroneya`,
-:cite:`Wikipedia2007a`, :cite:`Hellwig2022a`
-"""
-
-
 def XYZ_to_CIECAM02(
     XYZ: ArrayLike,
     XYZ_w: ArrayLike,
@@ -314,14 +241,10 @@ def XYZ_to_CIECAM02(
         "Average"
     ],
     discount_illuminant: Boolean = False,
-    method: Union[Literal["CIE", "Hellwig 2022"], str] = "CIE",
-) -> Union[CAM_Specification_CIECAM02, CAM_Specification_CIECAM02_Hellwig2022]:
+) -> CAM_Specification_CIECAM02:
     """
     Compute the *CIECAM02* colour appearance model correlates from given
     *CIE XYZ* tristimulus values.
-
-    This implementation supports the *Helmholtz–Kohlrausch* effect extension
-    from :cite:`Hellwig2022a`.
 
     Parameters
     ----------
@@ -343,13 +266,10 @@ def XYZ_to_CIECAM02(
         Surround viewing conditions induction factors.
     discount_illuminant
         Truth value indicating if the illuminant should be discounted.
-    method
-        Computation method.
 
     Returns
     -------
-    :class:`colour.CAM_Specification_CIECAM02` or \
-:class:`colour.CAM_Specification_CIECAM02_Hellwig2022`
+    :class:`colour.CAM_Specification_CIECAM02`
         *CIECAM02* colour appearance model specification.
 
     Notes
@@ -362,53 +282,45 @@ def XYZ_to_CIECAM02(
     | ``XYZ_w``  | [0, 100]              | [0, 1]        |
     +------------+-----------------------+---------------+
 
-    +-------------------------------------+-----------------------\
+    +----------------------------------+-----------------------\
 +---------------+
-    | **Range**                           | **Scale - Reference** \
+    | **Range**                        | **Scale - Reference** \
 | **Scale - 1** |
-    +=====================================+=======================\
+    +==================================+=======================\
 +===============+
-    | ``CAM_Specification_CIECAM02.J``    | [0, 100]              \
+    | ``CAM_Specification_CIECAM02.J`` | [0, 100]              \
 | [0, 1]        |
-    +-------------------------------------+-----------------------\
+    +----------------------------------+-----------------------\
 +---------------+
-    | ``CAM_Specification_CIECAM02.C``    | [0, 100]              \
+    | ``CAM_Specification_CIECAM02.C`` | [0, 100]              \
 | [0, 1]        |
-    +-------------------------------------+-----------------------\
+    +----------------------------------+-----------------------\
 +---------------+
-    | ``CAM_Specification_CIECAM02.h``    | [0, 360]              \
+    | ``CAM_Specification_CIECAM02.h`` | [0, 360]              \
 | [0, 1]        |
-    +-------------------------------------+-----------------------\
+    +----------------------------------+-----------------------\
 +---------------+
-    | ``CAM_Specification_CIECAM02.s``    | [0, 100]              \
+    | ``CAM_Specification_CIECAM02.s`` | [0, 100]              \
 | [0, 1]        |
-    +-------------------------------------+-----------------------\
+    +----------------------------------+-----------------------\
 +---------------+
-    | ``CAM_Specification_CIECAM02.Q``    | [0, 100]              \
+    | ``CAM_Specification_CIECAM02.Q`` | [0, 100]              \
 | [0, 1]        |
-    +-------------------------------------+-----------------------\
+    +----------------------------------+-----------------------\
 +---------------+
-    | ``CAM_Specification_CIECAM02.M``    | [0, 100]              \
+    | ``CAM_Specification_CIECAM02.M`` | [0, 100]              \
 | [0, 1]        |
-    +-------------------------------------+-----------------------\
+    +----------------------------------+-----------------------\
 +---------------+
-    | ``CAM_Specification_CIECAM02.H``    | [0, 400]              \
+    | ``CAM_Specification_CIECAM02.H`` | [0, 400]              \
 | [0, 1]        |
-    +-------------------------------------+-----------------------\
-+---------------+
-    | ``CAM_Specification_CIECAM02.J_HK`` | [0, 100]              \
-| [0, 1]        |
-    +-------------------------------------+-----------------------\
-+---------------+
-    | ``CAM_Specification_CIECAM02.Q_HK`` | [0, 100]              \
-| [0, 1]        |
-    +-------------------------------------+-----------------------\
+    +----------------------------------+-----------------------\
 +---------------+
 
     References
     ----------
     :cite:`Fairchild2004c`, :cite:`Luo2013`, :cite:`Moroneya`,
-    :cite:`Wikipedia2007a`, :cite:`Hellwig2022a`
+    :cite:`Wikipedia2007a`
 
     Examples
     --------
@@ -421,14 +333,7 @@ def XYZ_to_CIECAM02(
     CAM_Specification_CIECAM02(J=41.7310911..., C=0.1047077..., \
 h=219.0484326..., s=2.3603053..., Q=195.3713259..., M=0.1088421..., \
 H=278.0607358..., HC=None)
-    >>> XYZ_to_CIECAM02(XYZ, XYZ_w, L_A, Y_b, surround, method="Hellwig 2022")
-    ... # doctest: +ELLIPSIS
-    CAM_Specification_CIECAM02_Hellwig2022(J=41.7310911..., C=0.1047077..., \
-h=219.0484326..., s=2.3603053..., Q=195.3713259..., M=0.1088421..., \
-H=278.0607358..., HC=None, J_HK=42.1326591..., Q_HK=56.4067263...)
     """
-
-    method = validate_method(method, CIECAM02_METHODS)
 
     XYZ = to_domain_100(XYZ)
     XYZ_w = to_domain_100(XYZ_w)
@@ -498,39 +403,20 @@ H=278.0607358..., HC=None, J_HK=42.1326591..., Q_HK=56.4067263...)
     # Computing the correlate of *saturation* :math:`s`.
     s = saturation_correlate(M, Q)
 
-    if method == "cie":
-        return CAM_Specification_CIECAM02(
-            as_float(from_range_100(J)),
-            as_float(from_range_100(C)),
-            as_float(from_range_degrees(h)),
-            as_float(from_range_100(s)),
-            as_float(from_range_100(Q)),
-            as_float(from_range_100(M)),
-            as_float(from_range_degrees(H, 400)),
-            None,
-        )
-    else:  # method == "hellwig 2022"
-        J_HK = J + hue_angle_dependency_Hellwig2022(h) * spow(C, 0.565)
-        Q_HK = (2 / surround.c) * (J_HK / 100) * A_w
-
-        return CAM_Specification_CIECAM02_Hellwig2022(
-            as_float(from_range_100(J)),
-            as_float(from_range_100(C)),
-            as_float(from_range_degrees(h)),
-            as_float(from_range_100(s)),
-            as_float(from_range_100(Q)),
-            as_float(from_range_100(M)),
-            as_float(from_range_degrees(H, 400)),
-            None,
-            as_float(from_range_100(J_HK)),
-            as_float(from_range_100(Q_HK)),
-        )
+    return CAM_Specification_CIECAM02(
+        as_float(from_range_100(J)),
+        as_float(from_range_100(C)),
+        as_float(from_range_degrees(h)),
+        as_float(from_range_100(s)),
+        as_float(from_range_100(Q)),
+        as_float(from_range_100(M)),
+        as_float(from_range_degrees(H, 400)),
+        None,
+    )
 
 
 def CIECAM02_to_XYZ(
-    specification: Union[
-        CAM_Specification_CIECAM02, CAM_Specification_CIECAM02_Hellwig2022
-    ],
+    specification: CAM_Specification_CIECAM02,
     XYZ_w: ArrayLike,
     L_A: FloatingOrArrayLike,
     Y_b: FloatingOrArrayLike,
@@ -538,13 +424,9 @@ def CIECAM02_to_XYZ(
         "Average"
     ],
     discount_illuminant: Boolean = False,
-    method: Union[Literal["CIE", "Hellwig 2022"], str] = "CIE",
 ) -> NDArray:
     """
     Convert from *CIECAM02* specification to *CIE XYZ* tristimulus values.
-
-    This implementation supports the *Helmholtz–Kohlrausch* effect extension
-    from :cite:`Hellwig2022a`.
 
     Parameters
     ----------
@@ -569,8 +451,6 @@ def CIECAM02_to_XYZ(
         Surround viewing conditions.
     discount_illuminant
         Discount the illuminant.
-    method
-        Computation method.
 
     Returns
     -------
@@ -585,51 +465,43 @@ def CIECAM02_to_XYZ(
 
     Notes
     -----
-    +-------------------------------------+-----------------------\
+    +----------------------------------+-----------------------\
 +---------------+
-    | **Domain**                          | **Scale - Reference** \
+    | **Domain**                       | **Scale - Reference** \
 | **Scale - 1** |
-    +=====================================+=======================\
+    +==================================+=======================\
 +===============+
-    | ``CAM_Specification_CIECAM02.J``    | [0, 100]              \
+    | ``CAM_Specification_CIECAM02.J`` | [0, 100]              \
 | [0, 1]        |
-    +-------------------------------------+-----------------------\
+    +----------------------------------+-----------------------\
 +---------------+
-    | ``CAM_Specification_CIECAM02.C``    | [0, 100]              \
+    | ``CAM_Specification_CIECAM02.C`` | [0, 100]              \
 | [0, 1]        |
-    +-------------------------------------+-----------------------\
+    +----------------------------------+-----------------------\
 +---------------+
-    | ``CAM_Specification_CIECAM02.h``    | [0, 360]              \
+    | ``CAM_Specification_CIECAM02.h`` | [0, 360]              \
 | [0, 1]        |
-    +-------------------------------------+-----------------------\
+    +----------------------------------+-----------------------\
 +---------------+
-    | ``CAM_Specification_CIECAM02.s``    | [0, 100]              \
+    | ``CAM_Specification_CIECAM02.s`` | [0, 100]              \
 | [0, 1]        |
-    +-------------------------------------+-----------------------\
+    +----------------------------------+-----------------------\
 +---------------+
-    | ``CAM_Specification_CIECAM02.Q``    | [0, 100]              \
+    | ``CAM_Specification_CIECAM02.Q`` | [0, 100]              \
 | [0, 1]        |
-    +-------------------------------------+-----------------------\
+    +----------------------------------+-----------------------\
 +---------------+
-    | ``CAM_Specification_CIECAM02.M``    | [0, 100]              \
+    | ``CAM_Specification_CIECAM02.M`` | [0, 100]              \
 | [0, 1]        |
-    +-------------------------------------+-----------------------\
+    +----------------------------------+-----------------------\
 +---------------+
-    | ``CAM_Specification_CIECAM02.H``    | [0, 400]              \
+    | ``CAM_Specification_CIECAM02.H`` | [0, 360]              \
 | [0, 1]        |
-    +-------------------------------------+-----------------------\
+    +----------------------------------+-----------------------\
 +---------------+
-    | ``CAM_Specification_CIECAM02.J_HK`` | [0, 100]              \
+    | ``XYZ_w``                        | [0, 100]              \
 | [0, 1]        |
-    +-------------------------------------+-----------------------\
-+---------------+
-    | ``CAM_Specification_CIECAM02.Q_HK`` | [0, 100]              \
-| [0, 1]        |
-    +-------------------------------------+-----------------------\
-+---------------+
-    | ``XYZ_w``                           | [0, 100]              \
-| [0, 1]        |
-    +-------------------------------------+-----------------------\
+    +----------------------------------+-----------------------\
 +---------------+
 
     +-----------+-----------------------+---------------+
@@ -641,7 +513,7 @@ def CIECAM02_to_XYZ(
     References
     ----------
     :cite:`Fairchild2004c`, :cite:`Luo2013`, :cite:`Moroneya`,
-    :cite:`Wikipedia2007a`,  :cite:`Hellwig2022a`
+    :cite:`Wikipedia2007a`
 
     Examples
     --------
@@ -654,42 +526,14 @@ def CIECAM02_to_XYZ(
     >>> Y_b = 20.0
     >>> CIECAM02_to_XYZ(specification, XYZ_w, L_A, Y_b)  # doctest: +ELLIPSIS
     array([ 19.01...,  20...  ,  21.78...])
-    >>> specification = CAM_Specification_CIECAM02_Hellwig2022(
-    ...     J_HK=42.132659151487516,
-    ...     C=0.104707757171031,
-    ...     h=219.048432658311780)
-    >>> CIECAM02_to_XYZ(specification, XYZ_w, L_A, Y_b, method="Hellwig 2022")
-    ... # doctest: +ELLIPSIS
-    array([ 19.01...,  20...  ,  21.78...])
     """
 
-    method = validate_method(method, CIECAM02_METHODS)
+    J, C, h, _s, _Q, M, _H, _HC = astuple(specification)
 
-    if method == "cie" and isinstance(
-        specification, CAM_Specification_CIECAM02
-    ):
-        J, C, h, _s, _Q, M, _H, _HC = astuple(specification)
-
-        J = to_domain_100(J)
-        C = to_domain_100(C)
-        h = to_domain_degrees(h)
-        M = to_domain_100(M)
-    else:  # method == "hellwig 2022"
-        _J, C, h, _s, _Q, M, _H, _HC, J_HK, _Q_HK = astuple(specification)
-
-        if has_only_nan(J_HK):
-            raise ValueError(
-                '"J_HK" correlate must be defined in the '
-                '"CAM_Specification_CIECAM02_Hellwig2022" argument!'
-            )
-
-        C = to_domain_100(C)
-        h = to_domain_degrees(h)
-        M = to_domain_100(M)
-        J_HK = to_domain_100(J_HK)
-
-        J = J_HK - hue_angle_dependency_Hellwig2022(h) * spow(C, 0.565)
-
+    J = to_domain_100(J)
+    C = to_domain_100(C)
+    h = to_domain_degrees(h)
+    M = to_domain_100(M)
     L_A = as_float_array(L_A)
     XYZ_w = to_domain_100(XYZ_w)
     _X_w, Y_w, _Z_w = tsplit(XYZ_w)
@@ -703,8 +547,7 @@ def CIECAM02_to_XYZ(
     elif has_only_nan(C):
         raise ValueError(
             'Either "C" or "M" correlate must be defined in '
-            'the "CAM_Specification_CIECAM02" or '
-            '"CAM_Specification_CIECAM02_Hellwig2022" argument!'
+            'the "CAM_Specification_CIECAM02" argument!'
         )
 
     # Converting *CIE XYZ* tristimulus values to *CMCCAT2000* transform
@@ -1900,43 +1743,3 @@ def matrix_post_adaptation_non_linear_response_compression(
     )
 
     return RGB_a
-
-
-def hue_angle_dependency_Hellwig2022(
-    h: FloatingOrArrayLike,
-) -> FloatingOrNDArray:
-    """
-    Compute the hue angle dependency of the *Helmholtz–Kohlrausch* effect.
-
-    Parameters
-    ----------
-    h
-        Hue :math:`h` angle in degrees.
-
-    Returns
-    -------
-    :class:`numpy.floating` or :class:`numpy.ndarray`
-        Hue angle dependency.
-
-    References
-    ----------
-    :cite:`Hellwig2022a`
-
-    Examples
-    --------
-    >>> hue_angle_dependency_Hellwig2022(219.0484326582719)
-    ... # doctest: +ELLIPSIS
-    1.4370473...
-    """
-
-    h = as_float_array(h)
-
-    h_r = np.radians(h)
-
-    return as_float(
-        -0.218 * np.cos(h_r)
-        + 0.167 * np.cos(2 * h_r)
-        - 0.500 * np.sin(h_r)
-        + 0.032 * np.sin(2 * h_r)
-        + 0.887
-    )

--- a/colour/appearance/hellwig2022.py
+++ b/colour/appearance/hellwig2022.py
@@ -32,7 +32,6 @@ from colour.algebra import sdiv, sdiv_mode, spow, vector_dot
 from colour.appearance.cam16 import (
     MATRIX_16,
     MATRIX_INVERSE_16,
-    hue_angle_dependency_Hellwig2022,
 )
 from colour.appearance.ciecam02 import (
     InductionFactors_CIECAM02,
@@ -87,6 +86,16 @@ __all__ = [
     "CAM_Specification_Hellwig2022",
     "XYZ_to_Hellwig2022",
     "Hellwig2022_to_XYZ",
+    "viewing_conditions_dependent_parameters",
+    "achromatic_response_forward",
+    "opponent_colour_dimensions_inverse",
+    "eccentricity_factor",
+    "brightness_correlate",
+    "colourfulness_correlate",
+    "chroma_correlate",
+    "saturation_correlate",
+    "P_p",
+    "hue_angle_dependency_Hellwig2022",
 ]
 
 
@@ -973,3 +982,43 @@ def P_p(
     P_p_n = tstack([P_p_1, P_p_2])
 
     return P_p_n
+
+
+def hue_angle_dependency_Hellwig2022(
+    h: FloatingOrArrayLike,
+) -> FloatingOrNDArray:
+    """
+    Compute the hue angle dependency of the *Helmholtz–Kohlrausch* effect.
+
+    Parameters
+    ----------
+    h
+        Hue :math:`h` angle in degrees.
+
+    Returns
+    -------
+    :class:`numpy.floating` or :class:`numpy.ndarray`
+        Hue angle dependency.
+
+    References
+    ----------
+    :cite:`Hellwig2022a`
+
+    Examples
+    --------
+    >>> hue_angle_dependency_Hellwig2022(217.06795976739301)
+    ... # doctest: +ELLIPSIS
+    1.2768219...
+    """
+
+    h = as_float_array(h)
+
+    h_r = np.radians(h)
+
+    return as_float(
+        -0.160 * np.cos(h_r)
+        + 0.132 * np.cos(2 * h_r)
+        - 0.405 * np.sin(h_r)
+        + 0.080 * np.sin(2 * h_r)
+        + 0.792
+    )

--- a/colour/appearance/tests/test_cam16.py
+++ b/colour/appearance/tests/test_cam16.py
@@ -9,7 +9,6 @@ from colour.appearance import (
     VIEWING_CONDITIONS_CAM16,
     InductionFactors_CAM16,
     CAM_Specification_CAM16,
-    CAM_Specification_CAM16_Hellwig2022,
     XYZ_to_CAM16,
     CAM16_to_XYZ,
 )
@@ -142,32 +141,6 @@ class TestXYZ_to_CAM16(unittest.TestCase):
             decimal=7,
         )
 
-        XYZ = np.array([19.01, 20.00, 21.78])
-        XYZ_w = np.array([95.05, 100.00, 108.88])
-        L_A = 318.31
-        Y_b = 20
-        surround = VIEWING_CONDITIONS_CAM16["Average"]
-        np.testing.assert_array_almost_equal(
-            XYZ_to_CAM16(
-                XYZ, XYZ_w, L_A, Y_b, surround, method="Hellwig 2022"
-            ),
-            np.array(
-                [
-                    41.73120791,
-                    0.10335574,
-                    217.06795977,
-                    2.34501507,
-                    195.37170899,
-                    0.10743677,
-                    275.59498615,
-                    np.nan,
-                    42.0681418,
-                    56.3203856,
-                ]
-            ),
-            decimal=7,
-        )
-
     def test_n_dimensional_XYZ_to_CAM16(self):
         """
         Test :func:`colour.appearance.cam16.XYZ_to_CAM16` definition
@@ -253,51 +226,6 @@ class TestXYZ_to_CAM16(unittest.TestCase):
                     decimal=7,
                 )
 
-        specification = XYZ_to_CAM16(
-            XYZ, XYZ_w, L_A, Y_b, surround, method="Hellwig 2022"
-        )
-
-        d_r = (
-            ("reference", 1, 1),
-            (
-                "1",
-                0.01,
-                np.array(
-                    [
-                        1 / 100,
-                        1 / 100,
-                        1 / 360,
-                        1 / 100,
-                        1 / 100,
-                        1 / 100,
-                        1 / 400,
-                        np.nan,
-                        1 / 100,
-                        1 / 100,
-                    ]
-                ),
-            ),
-            (
-                "100",
-                1,
-                np.array([1, 1, 100 / 360, 1, 1, 1, 100 / 400, np.nan, 1, 1]),
-            ),
-        )
-        for scale, factor_a, factor_b in d_r:
-            with domain_range_scale(scale):
-                np.testing.assert_array_almost_equal(
-                    XYZ_to_CAM16(
-                        XYZ * factor_a,
-                        XYZ_w * factor_a,
-                        L_A,
-                        Y_b,
-                        surround,
-                        method="Hellwig 2022",
-                    ),
-                    as_float_array(specification) * factor_b,
-                    decimal=7,
-                )
-
     @ignore_numpy_errors
     def test_nan_XYZ_to_CAM16(self):
         """
@@ -374,21 +302,6 @@ class TestCAM16_to_XYZ(unittest.TestCase):
         np.testing.assert_array_almost_equal(
             CAM16_to_XYZ(specification, XYZ_w, L_A, Y_b, surround),
             np.array([61.45276998, 7.00421901, 82.2406738]),
-            decimal=7,
-        )
-
-        specification = CAM_Specification_CAM16_Hellwig2022(
-            J_HK=42.0681418, C=0.10335574, h=217.06795977
-        )
-        XYZ_w = np.array([95.05, 100.00, 108.88])
-        L_A = 318.31
-        Y_b = 20
-        surround = VIEWING_CONDITIONS_CAM16["Average"]
-        np.testing.assert_array_almost_equal(
-            CAM16_to_XYZ(
-                specification, XYZ_w, L_A, Y_b, surround, method="Hellwig 2022"
-            ),
-            np.array([19.01, 20.00, 21.78]),
             decimal=7,
         )
 
@@ -487,73 +400,12 @@ class TestCAM16_to_XYZ(unittest.TestCase):
                     decimal=7,
                 )
 
-        specification = XYZ_to_CAM16(
-            XYZ, XYZ_w, L_A, Y_b, surround, method="Hellwig 2022"
-        )
-        XYZ = CAM16_to_XYZ(
-            specification, XYZ_w, L_A, Y_b, surround, method="Hellwig 2022"
-        )
-
-        d_r = (
-            ("reference", 1, 1),
-            (
-                "1",
-                np.array(
-                    [
-                        1 / 100,
-                        1 / 100,
-                        1 / 360,
-                        1 / 100,
-                        1 / 100,
-                        1 / 100,
-                        1 / 400,
-                        np.nan,
-                        1 / 100,
-                        1 / 100,
-                    ]
-                ),
-                0.01,
-            ),
-            (
-                "100",
-                np.array([1, 1, 100 / 360, 1, 1, 1, 100 / 400, np.nan, 1, 1]),
-                1,
-            ),
-        )
-        for scale, factor_a, factor_b in d_r:
-            with domain_range_scale(scale):
-                np.testing.assert_array_almost_equal(
-                    CAM16_to_XYZ(
-                        specification * factor_a,
-                        XYZ_w * factor_b,
-                        L_A,
-                        Y_b,
-                        surround,
-                        method="Hellwig 2022",
-                    ),
-                    XYZ * factor_b,
-                    decimal=7,
-                )
-
     @ignore_numpy_errors
     def test_raise_exception_CAM16_to_XYZ(self):
         """
         Test :func:`colour.appearance.cam16.CAM16_to_XYZ` definition raised
         exception.
         """
-
-        self.assertRaises(
-            ValueError,
-            CAM16_to_XYZ,
-            CAM_Specification_CAM16_Hellwig2022(
-                J_HK=None, C=0.103355738709070, h=217.06795976739301
-            ),
-            np.array([95.05, 100.00, 108.88]),
-            318.31,
-            20.0,
-            VIEWING_CONDITIONS_CAM16["Average"],
-            method="Hellwig 2022",
-        )
 
         self.assertRaises(
             ValueError,

--- a/colour/appearance/tests/test_ciecam02.py
+++ b/colour/appearance/tests/test_ciecam02.py
@@ -9,7 +9,6 @@ from colour.appearance import (
     VIEWING_CONDITIONS_CIECAM02,
     InductionFactors_CIECAM02,
     CAM_Specification_CIECAM02,
-    CAM_Specification_CIECAM02_Hellwig2022,
     XYZ_to_CIECAM02,
     CIECAM02_to_XYZ,
 )
@@ -117,32 +116,6 @@ class TestXYZ_to_CIECAM02(unittest.TestCase):
             atol=0.01,
         )
 
-        XYZ = np.array([19.01, 20.00, 21.78])
-        XYZ_w = np.array([95.05, 100.00, 108.88])
-        L_A = 318.31
-        Y_b = 20
-        surround = InductionFactors_CIECAM02(1, 0.69, 1)
-        np.testing.assert_array_almost_equal(
-            XYZ_to_CIECAM02(
-                XYZ, XYZ_w, L_A, Y_b, surround, method="Hellwig 2022"
-            ),
-            np.array(
-                [
-                    41.73109113,
-                    0.10470776,
-                    219.04843266,
-                    2.36030537,
-                    195.37132597,
-                    0.10884218,
-                    278.06073586,
-                    np.nan,
-                    42.13265915,
-                    56.40672631,
-                ]
-            ),
-            decimal=7,
-        )
-
     def test_n_dimensional_XYZ_to_CIECAM02(self):
         """
         Test :func:`colour.appearance.ciecam02.XYZ_to_CIECAM02` definition
@@ -228,51 +201,6 @@ class TestXYZ_to_CIECAM02(unittest.TestCase):
                     decimal=7,
                 )
 
-        specification = XYZ_to_CIECAM02(
-            XYZ, XYZ_w, L_A, Y_b, surround, method="Hellwig 2022"
-        )
-
-        d_r = (
-            ("reference", 1, 1),
-            (
-                "1",
-                0.01,
-                np.array(
-                    [
-                        1 / 100,
-                        1 / 100,
-                        1 / 360,
-                        1 / 100,
-                        1 / 100,
-                        1 / 100,
-                        1 / 400,
-                        np.nan,
-                        1 / 100,
-                        1 / 100,
-                    ]
-                ),
-            ),
-            (
-                "100",
-                1,
-                np.array([1, 1, 100 / 360, 1, 1, 1, 100 / 400, np.nan, 1, 1]),
-            ),
-        )
-        for scale, factor_a, factor_b in d_r:
-            with domain_range_scale(scale):
-                np.testing.assert_array_almost_equal(
-                    XYZ_to_CIECAM02(
-                        XYZ * factor_a,
-                        XYZ_w * factor_a,
-                        L_A,
-                        Y_b,
-                        surround,
-                        method="Hellwig 2022",
-                    ),
-                    as_float_array(specification) * factor_b,
-                    decimal=7,
-                )
-
     @ignore_numpy_errors
     def test_nan_XYZ_to_CIECAM02(self):
         """
@@ -295,9 +223,7 @@ class TestCIECAM02_to_XYZ(unittest.TestCase):
     """
 
     def test_CIECAM02_to_XYZ(self):
-        """
-        Test :func:`colour.appearance.ciecam02.CIECAM02_to_XYZ` definition.
-        """
+        """Test :func:`colour.appearance.ciecam02.CIECAM02_to_XYZ` definition."""
 
         specification = CAM_Specification_CIECAM02(
             41.73, 0.1, 219, 2.36, 195.37, 0.11, 278.1
@@ -364,30 +290,6 @@ class TestCIECAM02_to_XYZ(unittest.TestCase):
             np.array([61.45276998, 7.00421901, 82.24067384]),
             rtol=0.01,
             atol=0.01,
-        )
-
-        specification = CAM_Specification_CIECAM02_Hellwig2022(
-            41.73109113,
-            0.10470776,
-            219.04843266,
-            2.36030537,
-            195.37132597,
-            0.10884218,
-            278.06073586,
-            np.nan,
-            42.13265915,
-            56.40672631,
-        )
-        XYZ_w = np.array([95.05, 100.00, 108.88])
-        L_A = 318.31
-        Y_b = 20
-        surround = InductionFactors_CIECAM02(1, 0.69, 1)
-        np.testing.assert_array_almost_equal(
-            CIECAM02_to_XYZ(
-                specification, XYZ_w, L_A, Y_b, surround, method="Hellwig 2022"
-            ),
-            np.array([19.01, 20.00, 21.78]),
-            decimal=7,
         )
 
     def test_n_dimensional_CIECAM02_to_XYZ(self):
@@ -485,73 +387,12 @@ class TestCIECAM02_to_XYZ(unittest.TestCase):
                     decimal=7,
                 )
 
-        specification = XYZ_to_CIECAM02(
-            XYZ_i, XYZ_w, L_A, Y_b, surround, method="Hellwig 2022"
-        )
-        XYZ = CIECAM02_to_XYZ(
-            specification, XYZ_w, L_A, Y_b, surround, method="Hellwig 2022"
-        )
-
-        d_r = (
-            ("reference", 1, 1),
-            (
-                "1",
-                np.array(
-                    [
-                        1 / 100,
-                        1 / 100,
-                        1 / 360,
-                        1 / 100,
-                        1 / 100,
-                        1 / 100,
-                        1 / 400,
-                        np.nan,
-                        1 / 100,
-                        1 / 100,
-                    ]
-                ),
-                0.01,
-            ),
-            (
-                "100",
-                np.array([1, 1, 100 / 360, 1, 1, 1, 100 / 400, np.nan, 1, 1]),
-                1,
-            ),
-        )
-        for scale, factor_a, factor_b in d_r:
-            with domain_range_scale(scale):
-                np.testing.assert_array_almost_equal(
-                    CIECAM02_to_XYZ(
-                        specification * factor_a,
-                        XYZ_w * factor_b,
-                        L_A,
-                        Y_b,
-                        surround,
-                        method="Hellwig 2022",
-                    ),
-                    XYZ * factor_b,
-                    decimal=7,
-                )
-
     @ignore_numpy_errors
     def test_raise_exception_CIECAM02_to_XYZ(self):
         """
         Test :func:`colour.appearance.ciecam02.CIECAM02_to_XYZ` definition
         raised exception.
         """
-
-        self.assertRaises(
-            ValueError,
-            CIECAM02_to_XYZ,
-            CAM_Specification_CIECAM02_Hellwig2022(
-                J_HK=None, C=0.1047077571711053, h=219.04843265831178
-            ),
-            np.array([95.05, 100.00, 108.88]),
-            318.31,
-            20.0,
-            VIEWING_CONDITIONS_CIECAM02["Average"],
-            method="Hellwig 2022",
-        )
 
         self.assertRaises(
             ValueError,

--- a/colour/quality/cfi2017.py
+++ b/colour/quality/cfi2017.py
@@ -456,10 +456,7 @@ def tcs_colorimetry_data(
     tcs_data = []
     for sd_tcs in sds_tcs.to_sds():
         XYZ = sd_to_XYZ(sd_tcs, cmfs, sd_irradiance)
-        specification = cast(
-            CAM_Specification_CIECAM02,
-            XYZ_to_CIECAM02(XYZ, XYZ_w, L_A, Y_b, surround, True),
-        )
+        specification = XYZ_to_CIECAM02(XYZ, XYZ_w, L_A, Y_b, surround, True)
         JMh = tstack(
             [
                 cast(FloatingOrNDArray, specification.J),

--- a/docs/colour.appearance.rst
+++ b/docs/colour.appearance.rst
@@ -26,9 +26,7 @@ CIECAM02
 
     XYZ_to_CIECAM02
     CIECAM02_to_XYZ
-    CIECAM02_METHODS
     CAM_Specification_CIECAM02
-    CAM_Specification_CIECAM02_Hellwig2022
     VIEWING_CONDITIONS_CIECAM02
 
 **Ancillary Objects**
@@ -81,9 +79,7 @@ CAM16
 
     XYZ_to_CAM16
     CAM16_to_XYZ
-    CAM16_METHODS
     CAM_Specification_CAM16
-    CAM_Specification_CAM16_Hellwig2022
     VIEWING_CONDITIONS_CAM16
 
 **Ancillary Objects**


### PR DESCRIPTION
<!--
Thank you for taking the time to create this pull request. If it is the first
time you are contributing to a colour-science repository, a contributing guide
is available to guide the process: https://www.colour-science.org/contributing/.
-->

# Summary

<!-- Please write a summary describing the changes that this PR implements. -->

The current implementation for *CIECAM02* and *CAM16* is incorrect as it needs to use the modified chroma correlate which turns out the be the new Hellwig 2022 CAM. See #1047 for more details.

# Preflight

<!-- Please mark any checkboxes that do not apply to this pull request as [N/A]. -->

**Code Style and Quality**

- [x] Unit tests have been implemented and passed.
- [x] Mypy static checking has been run and passed.
- [x] Pre-commit hooks have been run and passed.
- [N/A] New transformations have been added to the *Automatic Colour Conversion Graph*.
- [N/A] New transformations have been exported to the relevant namespaces, e.g. `colour`, `colour.models`.

<!-- The unit tests can be invoked with `poetry run invoke tests` -->
<!-- Mypy can be started with `dmypy run -- --show-error-codes --warn-unused-ignores --warn-redundant-casts --install-types --non-interactive -p colour` -->

**Documentation**

- [N/A] New features are documented along with examples if relevant.
- [N/A] The documentation is [Sphinx](https://www.sphinx-doc.org/en/master/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant.

<!--
Thank you again!
-->
