### PR TITLE
performance improvements for Signal

### DIFF
--- a/colour/continuous/signal.py
+++ b/colour/continuous/signal.py
@@ -301,7 +301,8 @@ class Signal(AbstractContinuousFunction):
 
         attest(
             value in np.sctypes["float"],
-            f'"dtype" must be one of the following types: ' f"{np.sctypes['float']}",
+            f'"dtype" must be one of the following types: '
+            f"{np.sctypes['float']}",
         )
 
         self._dtype = value
@@ -447,6 +448,7 @@ class Signal(AbstractContinuousFunction):
         )
 
         self._interpolator_kwargs = value
+        self._function = None
 
     @property
     def extrapolator(self) -> Type[TypeExtrapolator]:
@@ -588,7 +590,9 @@ class Signal(AbstractContinuousFunction):
 
         try:
             representation = repr(tstack([self.domain, self.range]))
-            representation = representation.replace("array", self.__class__.__name__)
+            representation = representation.replace(
+                "array", self.__class__.__name__
+            )
             representation = representation.replace(
                 "       [",
                 f"{' ' * (len(self.__class__.__name__) + 2)}[",
@@ -629,7 +633,9 @@ class Signal(AbstractContinuousFunction):
             )
         )
 
-    def __getitem__(self, x: Union[FloatingOrArrayLike, slice]) -> FloatingOrNDArray:
+    def __getitem__(
+        self, x: Union[FloatingOrArrayLike, slice]
+    ) -> FloatingOrNDArray:
         """
         Return the corresponding range variable :math:`y` for independent
         domain variable :math:`x`.
@@ -675,7 +681,9 @@ class Signal(AbstractContinuousFunction):
         else:
             return self.function(x)
 
-    def __setitem__(self, x: Union[FloatingOrArrayLike, slice], y: FloatingOrArrayLike):
+    def __setitem__(
+        self, x: Union[FloatingOrArrayLike, slice], y: FloatingOrArrayLike
+    ):
         """
         Set the corresponding range variable :math:`y` for independent domain
         variable :math:`x`.
@@ -925,7 +933,9 @@ class Signal(AbstractContinuousFunction):
 
     def _fill_domain_nan(
         self,
-        method: Union[Literal["Constant", "Interpolation"], str] = "Interpolation",
+        method: Union[
+            Literal["Constant", "Interpolation"], str
+        ] = "Interpolation",
         default: Number = 0,
     ):
         """
@@ -951,7 +961,9 @@ class Signal(AbstractContinuousFunction):
 
     def _fill_range_nan(
         self,
-        method: Union[Literal["Constant", "Interpolation"], str] = "Interpolation",
+        method: Union[
+            Literal["Constant", "Interpolation"], str
+        ] = "Interpolation",
         default: Number = 0,
     ):
         """
@@ -1202,7 +1214,9 @@ class Signal(AbstractContinuousFunction):
 
     def fill_nan(
         self,
-        method: Union[Literal["Constant", "Interpolation"], str] = "Interpolation",
+        method: Union[
+            Literal["Constant", "Interpolation"], str
+        ] = "Interpolation",
         default: Number = 0,
     ) -> AbstractContinuousFunction:
         """

--- a/colour/continuous/tests/test_signal.py
+++ b/colour/continuous/tests/test_signal.py
@@ -311,10 +311,10 @@ class TestSignal(unittest.TestCase):
                         [   7.,   80.],
                         [   8.,   90.],
                         [   9.,  100.]],
-                       KernelInterpolator,
-                       {},
-                       Extrapolator,
-                       {'method': 'Constant', 'left': nan, 'right': nan})
+                       interpolator=KernelInterpolator,
+                       interpolator_kwargs={},
+                       extrapolator=Extrapolator,
+                       extrapolator_kwargs={'method': 'Constant', 'left': nan, 'right': nan})
                 """
             ).strip(),
         )

--- a/colour/continuous/tests/test_signal.py
+++ b/colour/continuous/tests/test_signal.py
@@ -297,10 +297,12 @@ class TestSignal(unittest.TestCase):
     def test__repr__(self):
         """Test :func:`colour.continuous.signal.Signal.__repr__` method."""
 
+        # Workaround for flake8 line length
+        s = "extrapolator_kwargs={'method': 'Constant', 'left': nan, 'right': nan})"
         self.assertEqual(
             repr(self._signal),
             textwrap.dedent(
-                """
+                f"""
                 Signal([[   0.,   10.],
                         [   1.,   20.],
                         [   2.,   30.],
@@ -312,9 +314,9 @@ class TestSignal(unittest.TestCase):
                         [   8.,   90.],
                         [   9.,  100.]],
                        interpolator=KernelInterpolator,
-                       interpolator_kwargs={},
+                       interpolator_kwargs={{}},
                        extrapolator=Extrapolator,
-                       extrapolator_kwargs={'method': 'Constant', 'left': nan, 'right': nan})
+                       {s}
                 """
             ).strip(),
         )


### PR DESCRIPTION
<!--
Thank you for taking the time to create this pull request. If it is the first
time you are contributing to a colour-science repository, a contributing guide
is available to guide the process: https://www.colour-science.org/contributing/.
-->

# Summary

This PR implements a performance improvement for `Signal` in `signal.py`. 

The initialization of _function, the private backing attribute for the `function` property, is relatively expensive. This performance issue was discovered when creating an MSDS object from a long list of SpectralDistributions or large ndarrays. The _create_function is invoked frequently when not needed. This PR updates relavent code to always use the function property. the function property has been changed to only invoke _create_function if the _function property has been invalidated (by setting it equal to None). If the function property is never accessed, then the relevant initialization does not take place (lazy initialization)

# Preflight

<!-- Please mark any checkboxes that do not apply to this pull request as [N/A]. -->

**Code Style and Quality**

- [x] Unit tests have been implemented and passed.
- [x] Mypy static checking has been run and passed.
- [x] Pre-commit hooks have been run and passed.
- [N/A] New transformations have been added to the *Automatic Colour Conversion Graph*.
- [N/A] New transformations have been exported to the relevant namespaces, e.g. `colour`, `colour.models`.

<!-- The unit tests can be invoked with `poetry run invoke tests` -->
<!-- Mypy can be started with `dmypy run -- --show-error-codes --warn-unused-ignores --warn-redundant-casts --install-types --non-interactive -p colour` -->

**Documentation**

- [N/A] New features are documented along with examples if relevant.
- [N/A] The documentation is [Sphinx](https://www.sphinx-doc.org/en/master/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant.

No public API changes.

<!--
Thank you again!
-->
