### PR TITLE
PR: Improve initialization time of "Signal", a core component of "Colour".

### DIFF
--- a/colour/continuous/signal.py
+++ b/colour/continuous/signal.py
@@ -276,7 +276,7 @@ class Signal(AbstractContinuousFunction):
             "extrapolator_kwargs", self._extrapolator_kwargs
         )
 
-        self._create_function()
+        self._function = None
 
     @property
     def dtype(self) -> Type[DTypeFloating]:
@@ -349,7 +349,7 @@ class Signal(AbstractContinuousFunction):
             self._range = np.resize(self._range, value.shape)
 
         self._domain = value
-        self._create_function()
+        self._function = None  # Invalidate internal _function
 
     @property
     def range(self) -> NDArray:
@@ -389,7 +389,7 @@ class Signal(AbstractContinuousFunction):
         )
 
         self._range = value
-        self._create_function()
+        self._function = None  # Invalidate internal _function
 
     @property
     def interpolator(self) -> Type[TypeInterpolator]:
@@ -416,7 +416,7 @@ class Signal(AbstractContinuousFunction):
 
         # TODO: Check for interpolator compatibility.
         self._interpolator = value
-        self._create_function()
+        self._function = None  # Invalidate internal _function
 
     @property
     def interpolator_kwargs(self) -> Dict:
@@ -449,7 +449,7 @@ class Signal(AbstractContinuousFunction):
         )
 
         self._interpolator_kwargs = value
-        self._create_function()
+        self._function = None  # Invalidate internal _function
 
     @property
     def extrapolator(self) -> Type[TypeExtrapolator]:
@@ -476,7 +476,7 @@ class Signal(AbstractContinuousFunction):
 
         # TODO: Check for extrapolator compatibility.
         self._extrapolator = value
-        self._create_function()
+        self._function = None  # Invalidate internal _function
 
     @property
     def extrapolator_kwargs(self) -> Dict:
@@ -509,7 +509,7 @@ class Signal(AbstractContinuousFunction):
         )
 
         self._extrapolator_kwargs = value
-        self._create_function()
+        self._function = None  # Invalidate internal _function
 
     @property
     def function(self) -> Callable:
@@ -522,6 +522,8 @@ class Signal(AbstractContinuousFunction):
             Continuous signal callable.
         """
 
+        if self._function is None:
+            self._create_function()
         return self._function
 
     def __str__(self) -> str:
@@ -677,7 +679,7 @@ class Signal(AbstractContinuousFunction):
         if isinstance(x, slice):
             return self._range[x]
         else:
-            return self._function(x)
+            return self.function(x)
 
     def __setitem__(
         self, x: Union[FloatingOrArrayLike, slice], y: FloatingOrArrayLike
@@ -769,7 +771,7 @@ class Signal(AbstractContinuousFunction):
                 self._domain = np.insert(self._domain, indexes, x_nm)
                 self._range = np.insert(self._range, indexes, y[~mask])
 
-        self._create_function()
+        self._function = None  # Invalidate internal _function
 
     def __contains__(self, x: Union[FloatingOrArrayLike, slice]) -> bool:
         """
@@ -955,7 +957,7 @@ class Signal(AbstractContinuousFunction):
         """
 
         self._domain = fill_nan(self._domain, method, default)
-        self._create_function()
+        self._function = None  # Invalidate internal _function
 
     def _fill_range_nan(
         self,
@@ -983,7 +985,7 @@ class Signal(AbstractContinuousFunction):
         """
 
         self._range = fill_nan(self._range, method, default)
-        self._create_function()
+        self._function = None  # Invalidate internal _function
 
     def arithmetical_operation(
         self,

--- a/colour/continuous/signal.py
+++ b/colour/continuous/signal.py
@@ -523,7 +523,7 @@ class Signal(AbstractContinuousFunction):
         """
 
         if self._function is None:
-            ## Create the underlying continuous function
+            # Create the underlying continuous function
 
             if self._domain.size != 0 and self._range.size != 0:
                 self._function = self._extrapolator(

--- a/colour/continuous/signal.py
+++ b/colour/continuous/signal.py
@@ -523,8 +523,42 @@ class Signal(AbstractContinuousFunction):
         """
 
         if self._function is None:
-            self._create_function()
-        return self._function
+            ## Create the underlying continuous function
+
+            if self._domain.size != 0 and self._range.size != 0:
+                self._function = self._extrapolator(
+                    self._interpolator(
+                        self.domain, self.range, **self._interpolator_kwargs
+                    ),
+                    **self._extrapolator_kwargs,
+                )
+            else:
+
+                def _undefined_function(*args: Any, **kwargs: Any):
+                    """
+                    Raise a :class:`ValueError` exception.
+
+                    Other Parameters
+                    ----------------
+                    args
+                        Arguments.
+                    kwargs
+                        Keywords arguments.
+
+                    Raises
+                    ------
+                    ValueError
+                    """
+
+                    raise ValueError(
+                        "Underlying signal interpolator function does not exists, "
+                        "please ensure you defined both "
+                        '"domain" and "range" variables!'
+                    )
+
+                self._function = _undefined_function
+
+        return cast(Callable, self._function)
 
     def __str__(self) -> str:
         """
@@ -894,42 +928,6 @@ class Signal(AbstractContinuousFunction):
         """
 
         return not (self == other)
-
-    def _create_function(self):
-        """Create the continuous signal underlying function."""
-
-        if self._domain.size != 0 and self._range.size != 0:
-            self._function = self._extrapolator(
-                self._interpolator(
-                    self.domain, self.range, **self._interpolator_kwargs
-                ),
-                **self._extrapolator_kwargs,
-            )
-        else:
-
-            def _undefined_function(*args: Any, **kwargs: Any):
-                """
-                Raise a :class:`ValueError` exception.
-
-                Other Parameters
-                ----------------
-                args
-                    Arguments.
-                kwargs
-                    Keywords arguments.
-
-                Raises
-                ------
-                ValueError
-                """
-
-                raise ValueError(
-                    "Underlying signal interpolator function does not exists, "
-                    "please ensure you defined both "
-                    '"domain" and "range" variables!'
-                )
-
-            self._function = _undefined_function
 
     def _fill_domain_nan(
         self,

--- a/colour/continuous/signal.py
+++ b/colour/continuous/signal.py
@@ -276,7 +276,7 @@ class Signal(AbstractContinuousFunction):
             "extrapolator_kwargs", self._extrapolator_kwargs
         )
 
-        self._function = None
+        self._function: Callable | None = None
 
     @property
     def dtype(self) -> Type[DTypeFloating]:
@@ -556,7 +556,7 @@ class Signal(AbstractContinuousFunction):
                         '"domain" and "range" variables!'
                     )
 
-                self._function = _undefined_function
+                self._function = cast(Callable, _undefined_function)
 
         return cast(Callable, self._function)
 


### PR DESCRIPTION
<!--
Thank you for taking the time to create this pull request. If it is the first
time you are contributing to a colour-science repository, a contributing guide
is available to guide the process: https://www.colour-science.org/contributing/.
-->

# Summary

<!-- Please write a summary describing the changes that this PR implements. -->

This PR implements a performance improvement for `Signal` in `signal.py`. 

The initialization of _function, the private backing attribute for the `function` property, is relatively expensive. This performance issue was discovered when creating an MSDS object from a long list of SpectralDistributions or large ndarrays. The _create_function is invoked frequently when not needed. This PR updates relavent code to always use the function property. the function property has been changed to only invoke _create_function if the _function property has been invalidated (by setting it equal to None). If the function property is never accessed, then the relevant initialization does not take place (lazy initialization)

Under some conditions, this change results in a 90% reduction in Signal initialization run time

# Preflight

<!-- Please mark any checkboxes that do not apply to this pull request as [N/A]. -->

**Code Style and Quality**

- [x] Unit tests have been implemented and passed.
- [x] Mypy static checking has been run and passed.
- [x] Pre-commit hooks have been run and passed.
- [N/A] New transformations have been added to the *Automatic Colour Conversion Graph*.
- [N/A] New transformations have been exported to the relevant namespaces, e.g. `colour`, `colour.models`.

<!-- The unit tests can be invoked with `poetry run invoke tests` -->
<!-- Mypy can be started with `dmypy run -- --show-error-codes --warn-unused-ignores --warn-redundant-casts --install-types --non-interactive -p colour` -->

**Documentation**

- [N/A] New features are documented along with examples if relevant.
- [N/A] The documentation is [Sphinx](https://www.sphinx-doc.org/en/master/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant.

<!--
Thank you again!
-->
