### PR TITLE
PR: Performance improvements to `colour.SpectralDistribution.wavelengths` property and various definitions in `colour.utilities.array` module.

### DIFF
--- a/colour/colorimetry/spectrum.py
+++ b/colour/colorimetry/spectrum.py
@@ -843,11 +843,19 @@ class SpectralDistribution(Signal):
                 f"minimum interval!"
             )
 
-        return SpectralShape(
-            min(self.wavelengths),
-            max(self.wavelengths),
-            min(wavelengths_interval),
-        )
+        # If wavelegths is sorted, then go fast. Otherwise compute the shape.
+        if np.all(self.wavelengths[:-1] <= self.wavelengths[1:]):
+            return SpectralShape(
+                self.wavelengths[0],
+                self.wavelengths[-1],
+                min(wavelengths_interval),
+            )
+        else:
+            return SpectralShape(
+                min(self.wavelengths),
+                max(self.wavelengths),
+                min(wavelengths_interval),
+            )
 
     def interpolate(
         self,

--- a/colour/colorimetry/spectrum.py
+++ b/colour/colorimetry/spectrum.py
@@ -843,17 +843,17 @@ class SpectralDistribution(Signal):
                 f"minimum interval!"
             )
 
-        # If wavelegths is sorted, then go fast. Otherwise compute the shape.
-        if np.all(self.wavelengths[:-1] <= self.wavelengths[1:]):
+        # If wavelengths is sorted, then go fast. Otherwise compute the shape.
+        if np.all(self.domain[:-1] <= self.domain[1:]):
             return SpectralShape(
-                self.wavelengths[0],
-                self.wavelengths[-1],
+                self.domain[0],
+                self.domain[-1],
                 min(wavelengths_interval),
             )
         else:
             return SpectralShape(
-                min(self.wavelengths),
-                max(self.wavelengths),
+                min(self.domain),
+                max(self.domain),
                 min(wavelengths_interval),
             )
 

--- a/colour/utilities/array.py
+++ b/colour/utilities/array.py
@@ -928,7 +928,7 @@ def get_domain_range_scale() -> Union[
 
 def set_domain_range_scale(
     scale: Union[
-        Literal["ignore", "reference" "Ignore", "Reference", "1", "100"], str
+        Literal["ignore", "reference", "Ignore", "Reference", "1", "100"], str
     ] = "reference"
 ):
     """
@@ -1027,7 +1027,7 @@ class domain_range_scale:
     def __init__(
         self,
         scale: Union[
-            Literal["ignore", "reference" "Ignore", "Reference", "1", "100"],
+            Literal["ignore", "reference", "Ignore", "Reference", "1", "100"],
             str,
         ],
     ) -> None:
@@ -2096,7 +2096,13 @@ def tsplit(
 
     a = as_array(a, dtype)
 
-    return np.array([a[..., x] for x in range(a.shape[-1])])
+    if a.ndim <= 2:
+        return a.T
+
+    return np.transpose(
+        a,
+        np.concatenate((np.array([a.ndim - 1]), np.arange(0, a.ndim - 1))),
+    )
 
 
 def row_as_diagonal(a: ArrayLike) -> NDArray:

--- a/colour/utilities/array.py
+++ b/colour/utilities/array.py
@@ -1885,9 +1885,9 @@ def interval(distribution: ArrayLike, unique: Boolean = True) -> NDArray:
     """
 
     distribution = as_float_array(distribution)
-    i = np.arange(distribution.size - 1)
 
     differences = np.abs(distribution[1:] - distribution[:-1])
+
     if unique:
         return np.unique(differences)
     else:
@@ -2031,6 +2031,8 @@ def tstack(
     dtype = cast(Type[DTypeFloating], optional(dtype, DEFAULT_FLOAT_DTYPE))
 
     a = as_array(a, dtype)
+    if a.ndim <= 2:
+        return a.T
 
     return np.concatenate([x[..., None] for x in a], axis=-1)
 
@@ -2101,7 +2103,7 @@ def tsplit(
 
     return np.transpose(
         a,
-        np.concatenate((np.array([a.ndim - 1]), np.arange(0, a.ndim - 1))),
+        np.concatenate(([a.ndim - 1], np.arange(0, a.ndim - 1))),
     )
 
 

--- a/colour/utilities/array.py
+++ b/colour/utilities/array.py
@@ -1887,7 +1887,7 @@ def interval(distribution: ArrayLike, unique: Boolean = True) -> NDArray:
     distribution = as_float_array(distribution)
     i = np.arange(distribution.size - 1)
 
-    differences = np.abs(distribution[i + 1] - distribution[i])
+    differences = np.abs(distribution[1:] - distribution[:-1])
     if unique:
         return np.unique(differences)
     else:

--- a/colour/utilities/array.py
+++ b/colour/utilities/array.py
@@ -2103,7 +2103,7 @@ def tsplit(
 
     return np.transpose(
         a,
-        np.concatenate(([a.ndim - 1], np.arange(0, a.ndim - 1))),
+        np.concatenate([[a.ndim - 1], np.arange(0, a.ndim - 1)]),
     )
 
 


### PR DESCRIPTION
<!--
Thank you for taking the time to create this pull request. If it is the first
time you are contributing to a colour-science repository, a contributing guide
is available to guide the process: https://www.colour-science.org/contributing/.
-->

# Summary

This PR makes small changes to improve the performance of several critical paths that are found throughout the code base. For example, tsplit and tstack are called very often. Additionally, the `shape` getter of `SpectralDistribution` is called very often in code that is manipulating spectral data. In one example calculating color rendering simulations, calling the .shape getter was responsible for around 10% of total execution time, but is now responsible for less than 0.1% 

The particular examples that found these critical paths are not expected to be representative of all performance cases, none the less nearly all applications of colour-science should see some benefit. 

<!-- Please write a summary describing the changes that this PR implements. -->

# Preflight

<!-- Please mark any checkboxes that do not apply to this pull request as [N/A]. -->

**Code Style and Quality**

- [x] Unit tests have been implemented and passed.
- [x] Mypy static checking has been run and passed.
- [x] Pre-commit hooks have been run and passed.
- [N/A] New transformations have been added to the *Automatic Colour Conversion Graph*.
- [N/A] New transformations have been exported to the relevant namespaces, e.g. `colour`, `colour.models`.

<!-- The unit tests can be invoked with `poetry run invoke tests` -->
<!-- Mypy can be started with `dmypy run -- --show-error-codes --warn-unused-ignores --warn-redundant-casts --install-types --non-interactive -p colour` -->

**Documentation**

- [N/A] New features are documented along with examples if relevant.
- [N/A] The documentation is [Sphinx](https://www.sphinx-doc.org/en/master/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant.

<!--
Thank you again!
-->
