### PR TITLE
PR: Implement support for continuous function iteration.

### DIFF
--- a/colour/continuous/abstract.py
+++ b/colour/continuous/abstract.py
@@ -19,6 +19,7 @@ from colour.hints import (
     ArrayLike,
     Callable,
     DTypeFloat,
+    Generator,
     Literal,
     NDArrayFloat,
     Optional,
@@ -96,6 +97,7 @@ AbstractContinuousFunction.extrapolator_kwargs`
     -   :meth:`~colour.continuous.AbstractContinuousFunction.__getitem__`
     -   :meth:`~colour.continuous.AbstractContinuousFunction.__setitem__`
     -   :meth:`~colour.continuous.AbstractContinuousFunction.__contains__`
+    -   :meth:`~colour.continuous.AbstractContinuousFunction.__iter__`
     -   :meth:`~colour.continuous.AbstractContinuousFunction.__len__`
     -   :meth:`~colour.continuous.AbstractContinuousFunction.__eq__`
     -   :meth:`~colour.continuous.AbstractContinuousFunction.__ne__`
@@ -483,6 +485,18 @@ arithmetical_operation`
         """
 
         ...  # pragma: no cover
+
+    def __iter__(self) -> Generator:
+        """
+        Return a generator for the abstract continuous function.
+
+        Yields
+        ------
+        Generator
+           Abstract continuous function generator.
+        """
+
+        yield from np.column_stack([self.domain, self.range])
 
     def __len__(self) -> int:
         """

--- a/colour/continuous/tests/test_abstract.py
+++ b/colour/continuous/tests/test_abstract.py
@@ -51,6 +51,7 @@ class TestAbstractContinuousFunction(unittest.TestCase):
             "__getitem__",
             "__setitem__",
             "__contains__",
+            "__iter__",
             "__len__",
             "__eq__",
             "__ne__",

--- a/colour/continuous/tests/test_multi_signal.py
+++ b/colour/continuous/tests/test_multi_signal.py
@@ -79,6 +79,7 @@ class TestMultiSignals(unittest.TestCase):
             "__getitem__",
             "__setitem__",
             "__contains__",
+            "__iter__",
             "__eq__",
             "__ne__",
             "arithmetical_operation",
@@ -744,6 +745,16 @@ function` property raised exception.
         self.assertIn(0, self._multi_signals)
         self.assertIn(0.5, self._multi_signals)
         self.assertNotIn(1000, self._multi_signals)
+
+    def test__iter__(self):
+        """Test :func:`colour.continuous.signal.Signal.__iter__` method."""
+
+        domain = np.arange(0, 10)
+        for i, domain_range_value in enumerate(self._multi_signals):
+            np.testing.assert_array_equal(domain_range_value[0], domain[i])
+            np.testing.assert_array_equal(
+                domain_range_value[1:], self._range_2[i]
+            )
 
     def test__len__(self):
         """

--- a/colour/continuous/tests/test_signal.py
+++ b/colour/continuous/tests/test_signal.py
@@ -65,6 +65,7 @@ class TestSignal(unittest.TestCase):
             "__getitem__",
             "__setitem__",
             "__contains__",
+            "__iter__",
             "__eq__",
             "__ne__",
             "arithmetical_operation",
@@ -476,6 +477,14 @@ class TestSignal(unittest.TestCase):
         self.assertIn(0, self._signal)
         self.assertIn(0.5, self._signal)
         self.assertNotIn(1000, self._signal)
+
+    def test__iter__(self):
+        """Test :func:`colour.continuous.signal.Signal.__iter__` method."""
+
+        domain = np.arange(0, 10)
+        for i, (domain_value, range_value) in enumerate(self._signal):
+            np.testing.assert_array_equal(domain_value, domain[i])
+            np.testing.assert_array_equal(range_value, self._range[i])
 
     def test__len__(self):
         """Test :func:`colour.continuous.signal.Signal.__len__` method."""


### PR DESCRIPTION
<!--
Thank you for taking the time to create this pull request. If it is the first
time you are contributing to a colour-science repository, a contributing guide
is available to guide the process: https://www.colour-science.org/contributing/.
-->

# Summary

<!-- Please write a summary describing the changes that this PR implements. -->

This PR implements support for continuous signal iteration while preventing code hanging while iterating by error on a `colour.SpectralDistribution` or `colour.MultiSpectralDistributions` class instances.


```python
import colour

sd = colour.SDS_ILLUMINANTS["A"]
for i in sd:
    print(i)
```

```
[ 300.          0.930483]
[ 305.         1.12821]
[ 310.         1.35769]
[ 315.         1.62219]
[ 320.         1.92508]
[ 325.        2.2698]
[ 330.         2.65981]
[ 335.         3.09861]
[ 340.         3.58968]
[ 345.         4.13648]
[ 350.         4.74238]
[ 355.        5.4107]
[ 360.         6.14462]
[ 365.        6.9472]
[ 370.         7.82135]
[ 375.        8.7698]
[ 380.        9.7951]
[ 385.       10.8996]
[ 390.       12.0853]
[ 395.       13.3543]
[ 400.      14.708]
[ 405.      16.148]
[ 410.       17.6753]
[ 415.       19.2907]
[ 420.      20.995]
[ 425.       22.7883]
[ 430.       24.6709]
[ 435.       26.6425]
[ 440.       28.7027]
[ 445.       30.8508]
[ 450.       33.0859]
[ 455.       35.4068]
[ 460.       37.8121]
[ 465.       40.3002]
[ 470.       42.8693]
[ 475.       45.5174]
[ 480.       48.2423]
[ 485.       51.0418]
[ 490.       53.9132]
[ 495.       56.8539]
[ 500.       59.8611]
[ 505.      62.932]
[ 510.       66.0635]
[ 515.       69.2525]
[ 520.       72.4959]
[ 525.       75.7903]
[ 530.       79.1326]
[ 535.       82.5193]
[ 540.      85.947]
[ 545.       89.4124]
[ 550.      92.912]
[ 555.       96.4423]
[ 560.  100.]
[ 565.     103.582]
[ 570.     107.184]
[ 575.     110.803]
[ 580.     114.436]
[ 585.    118.08]
[ 590.     121.731]
[ 595.     125.386]
[ 600.     129.043]
[ 605.     132.697]
[ 610.     136.346]
[ 615.     139.988]
[ 620.     143.618]
[ 625.     147.235]
[ 630.     150.836]
[ 635.     154.418]
[ 640.     157.979]
[ 645.     161.516]
[ 650.     165.028]
[ 655.    168.51]
[ 660.     171.963]
[ 665.     175.383]
[ 670.     178.769]
[ 675.     182.118]
[ 680.     185.429]
[ 685.     188.701]
[ 690.     191.931]
[ 695.     195.118]
[ 700.     198.261]
[ 705.     201.359]
[ 710.     204.409]
[ 715.     207.411]
[ 720.     210.365]
[ 725.     213.268]
[ 730.    216.12]
[ 735.    218.92]
[ 740.     221.667]
[ 745.     224.361]
[ 750.  227.]
[ 755.     229.585]
[ 760.     232.115]
[ 765.     234.589]
[ 770.     237.008]
[ 775.    239.37]
[ 780.     241.675]
```

```python
import colour

sd = colour.MSDS_CMFS["CIE 2012 2 Degree Standard Observer"]
for i in sd:
    print(i)
```

```
[  3.90000000e+02   3.76964700e-03   4.14616100e-04   1.84726000e-02]
[  3.91000000e+02   4.53241600e-03   5.02833300e-04   2.22110100e-02]
[  3.92000000e+02   5.44655300e-03   6.08499100e-04   2.66981900e-02]
[  3.93000000e+02   6.53886800e-03   7.34443600e-04   3.20693700e-02]
[  3.94000000e+02   7.83969900e-03   8.83738900e-04   3.84783200e-02]
[  3.95000000e+02   9.38296700e-03   1.05964600e-03   4.60978400e-02]
[  3.96000000e+02   1.12060800e-02   1.26553200e-03   5.51195300e-02]
[  3.97000000e+02   1.33496500e-02   1.50475300e-03   6.57525700e-02]
[  3.98000000e+02   1.58569000e-02   1.78049300e-03   7.82211300e-02]
[  3.99000000e+02   1.87728600e-02   2.09557200e-03   9.27601300e-02]
[  4.00000000e+02   2.21430200e-02   2.45219400e-03   1.09609000e-01]
[  4.01000000e+02   2.60128500e-02   2.85221600e-03   1.29007700e-01]
[  4.02000000e+02   3.04303600e-02   3.29911500e-03   1.51204700e-01]
[  4.03000000e+02   3.54432500e-02   3.79746600e-03   1.76444100e-01]
[  4.04000000e+02   4.10964000e-02   4.35276800e-03   2.04951700e-01]
[  4.05000000e+02   4.74298600e-02   4.97171700e-03   2.36924600e-01]
[  4.06000000e+02   5.44739400e-02   5.66101400e-03   2.72512300e-01]
[  4.07000000e+02   6.22361200e-02   6.42161500e-03   3.11782000e-01]
[  4.08000000e+02   7.07004800e-02   7.25031200e-03   3.54706400e-01]
[  4.09000000e+02   7.98251300e-02   8.14017300e-03   4.01147300e-01]
[  4.10000000e+02   8.95380300e-02   9.07986000e-03   4.50836900e-01]
[  4.11000000e+02   9.97484800e-02   1.00560800e-02   5.03416400e-01]
[  4.12000000e+02   1.10401900e-01   1.10645600e-02   5.58636100e-01]
[  4.13000000e+02   1.21456600e-01   1.21052200e-02   6.16273400e-01]
[  4.14000000e+02   1.32874100e-01   1.31801400e-02   6.76098200e-01]
[  4.15000000e+02   1.44621400e-01   1.42937700e-02   7.37882200e-01]
[  4.16000000e+02   1.56646800e-01   1.54500400e-02   8.01301900e-01]
[  4.17000000e+02   1.68790100e-01   1.66409300e-02   8.65557300e-01]
[  4.18000000e+02   1.80832800e-01   1.78530200e-02   9.29579100e-01]
[  4.19000000e+02   1.92521600e-01   1.90701800e-02   9.92129300e-01]
[  4.20000000e+02   2.03572900e-01   2.02736900e-02   1.05182100e+00]
[  4.21000000e+02   2.13753100e-01   2.14480500e-02   1.10750900e+00]
[  4.22000000e+02   2.23134800e-01   2.26004100e-02   1.15952700e+00]
[  4.23000000e+02   2.31924500e-01   2.37478900e-02   1.20886900e+00]
[  4.24000000e+02   2.40389200e-01   2.49124700e-02   1.25683400e+00]
[  4.25000000e+02   2.48852300e-01   2.61210600e-02   1.30500800e+00]
[  4.26000000e+02   2.57589600e-01   2.73992300e-02   1.35475800e+00]
[  4.27000000e+02   2.66499100e-01   2.87499300e-02   1.40559400e+00]
[  4.28000000e+02   2.75353200e-01   3.01690900e-02   1.45641400e+00]
[  4.29000000e+02   2.83892100e-01   3.16514500e-02   1.50596000e+00]
[  4.30000000e+02   2.91824600e-01   3.31903800e-02   1.55282600e+00]
[  4.31000000e+02   2.98920000e-01   3.47791200e-02   1.59590200e+00]
[  4.32000000e+02   3.05299300e-01   3.64149500e-02   1.63576800e+00]
[  4.33000000e+02   3.11203100e-01   3.80956900e-02   1.67357300e+00]
[  4.34000000e+02   3.16904700e-01   3.98184300e-02   1.71060400e+00]
[  4.35000000e+02   3.22708700e-01   4.15794000e-02   1.74828000e+00]
[  4.36000000e+02   3.28819400e-01   4.33709800e-02   1.78750400e+00]
[  4.37000000e+02   3.34924200e-01   4.51718000e-02   1.82660900e+00]
[  4.38000000e+02   3.40545200e-01   4.69542000e-02   1.86310800e+00]
[  4.39000000e+02   3.45168800e-01   4.86871800e-02   1.89433200e+00]
[  4.40000000e+02   3.48255400e-01   5.03365700e-02   1.91747900e+00]
[  4.41000000e+02   3.49415300e-01   5.18761100e-02   1.93052900e+00]
[  4.42000000e+02   3.48907500e-01   5.33221800e-02   1.93481900e+00]
[  4.43000000e+02   3.47174600e-01   5.47060300e-02   1.93265000e+00]
[  4.44000000e+02   3.44670500e-01   5.60633500e-02   1.92639500e+00]
[  4.45000000e+02   3.41848300e-01   5.74339300e-02   1.91843700e+00]
[  4.46000000e+02   3.39024000e-01   5.88510700e-02   1.91043000e+00]
[  4.47000000e+02   3.35992600e-01   6.03080900e-02   1.90122400e+00]
[  4.48000000e+02   3.32427600e-01   6.17864400e-02   1.88900000e+00]
[  4.49000000e+02   3.28015700e-01   6.32657000e-02   1.87199600e+00]
[  4.50000000e+02   3.22463700e-01   6.47235200e-02   1.84854500e+00]
[  4.51000000e+02   3.15622500e-01   6.61474900e-02   1.81779200e+00]
[  4.52000000e+02   3.07820100e-01   6.75725600e-02   1.78162700e+00]
[  4.53000000e+02   2.99477100e-01   6.90492800e-02   1.74251400e+00]
[  4.54000000e+02   2.90977600e-01   7.06328000e-02   1.70274900e+00]
[  4.55000000e+02   2.82664600e-01   7.23833900e-02   1.66443900e+00]
[  4.56000000e+02   2.74796200e-01   7.43596000e-02   1.62920700e+00]
[  4.57000000e+02   2.67431200e-01   7.65938300e-02   1.59736000e+00]
[  4.58000000e+02   2.60584700e-01   7.91143600e-02   1.56889600e+00]
[  4.59000000e+02   2.54274900e-01   8.19534500e-02   1.54382300e+00]
[  4.60000000e+02   2.48525400e-01   8.51481600e-02   1.52215700e+00]
[  4.61000000e+02   2.43303900e-01   8.87265700e-02   1.50361100e+00]
[  4.62000000e+02   2.38341400e-01   9.26600800e-02   1.48667300e+00]
[  4.63000000e+02   2.33325300e-01   9.68972300e-02   1.46959500e+00]
[  4.64000000e+02   2.27961900e-01   1.01374600e-01   1.45070900e+00]
[  4.65000000e+02   2.21978100e-01   1.06014500e-01   1.42844000e+00]
[  4.66000000e+02   2.15173500e-01   1.10737700e-01   1.40158700e+00]
[  4.67000000e+02   2.07561900e-01   1.15511100e-01   1.37009400e+00]
[  4.68000000e+02   1.99218300e-01   1.20312200e-01   1.33422000e+00]
[  4.69000000e+02   1.90229000e-01   1.25116100e-01   1.29427500e+00]
[  4.70000000e+02   1.80690500e-01   1.29895700e-01   1.25061000e+00]
[  4.71000000e+02   1.70715400e-01   1.34629900e-01   1.20369600e+00]
[  4.72000000e+02   1.60447100e-01   1.39330900e-01   1.15431600e+00]
[  4.73000000e+02   1.50024400e-01   1.44023500e-01   1.10328400e+00]
[  4.74000000e+02   1.39570500e-01   1.48737200e-01   1.05134700e+00]
[  4.75000000e+02   1.29192000e-01   1.53506600e-01   9.99178900e-01]
[  4.76000000e+02   1.18985900e-01   1.58364400e-01   9.47395800e-01]
[  4.77000000e+02   1.09061500e-01   1.63319900e-01   8.96622200e-01]
[  4.78000000e+02   9.95142400e-02   1.68376100e-01   8.47398100e-01]
[  4.79000000e+02   9.04185000e-02   1.73536500e-01   8.00157600e-01]
[  4.80000000e+02   8.18289500e-02   1.78804800e-01   7.55237900e-01]
[  4.81000000e+02   7.37681700e-02   1.84181900e-01   7.12787900e-01]
[  4.82000000e+02   6.61947700e-02   1.89655900e-01   6.72519800e-01]
[  4.83000000e+02   5.90638000e-02   1.95210100e-01   6.34097600e-01]
[  4.84000000e+02   5.23424200e-02   2.00825900e-01   5.97243300e-01]
[  4.85000000e+02   4.60086500e-02   2.06482800e-01   5.61731300e-01]
[  4.86000000e+02   4.00615400e-02   2.12182600e-01   5.27492100e-01]
[  4.87000000e+02   3.45437300e-02   2.18027900e-01   4.94880900e-01]
[  4.88000000e+02   2.94909100e-02   2.24158600e-01   4.64258600e-01]
[  4.89000000e+02   2.49214000e-02   2.30730200e-01   4.35884100e-01]
[  4.90000000e+02   2.08398100e-02   2.37916000e-01   4.09931300e-01]
[  4.91000000e+02   1.72359100e-02   2.45870600e-01   3.86426100e-01]
[  4.92000000e+02   1.40792400e-02   2.54602300e-01   3.65056600e-01]
[  4.93000000e+02   1.13451600e-02   2.64076000e-01   3.45481200e-01]
[  4.94000000e+02   9.01965800e-03   2.74249000e-01   3.27409500e-01]
[  4.95000000e+02   7.09773100e-03   2.85068000e-01   3.10593900e-01]
[  4.96000000e+02   5.57114500e-03   2.96483700e-01   2.94810200e-01]
[  4.97000000e+02   4.39456600e-03   3.08501000e-01   2.79819400e-01]
[  4.98000000e+02   3.51630300e-03   3.21139300e-01   2.65410000e-01]
[  4.99000000e+02   2.88763800e-03   3.34417500e-01   2.51408400e-01]
[  5.00000000e+02   2.46158800e-03   3.48353600e-01   2.37675300e-01]
[  5.01000000e+02   2.20634800e-03   3.62960100e-01   2.24121100e-01]
[  5.02000000e+02   2.14955900e-03   3.78227500e-01   2.10748400e-01]
[  5.03000000e+02   2.33709100e-03   3.94135900e-01   1.97583900e-01]
[  5.04000000e+02   2.81893100e-03   4.10658200e-01   1.84657400e-01]
[  5.05000000e+02   3.64917800e-03   4.27759500e-01   1.72001800e-01]
[  5.06000000e+02   4.89135900e-03   4.45399300e-01   1.59691800e-01]
[  5.07000000e+02   6.62936400e-03   4.63539600e-01   1.47941500e-01]
[  5.08000000e+02   8.94290200e-03   4.82137600e-01   1.36942800e-01]
[  5.09000000e+02   1.19022400e-02   5.01143000e-01   1.26827900e-01]
[  5.10000000e+02   1.55698900e-02   5.20497200e-01   1.17679600e-01]
[  5.11000000e+02   1.99766800e-02   5.40138700e-01   1.09497000e-01]
[  5.12000000e+02   2.50469800e-02   5.60020800e-01   1.02094300e-01]
[  5.13000000e+02   3.06753000e-02   5.80097200e-01   9.52799300e-02]
[  5.14000000e+02   3.67499900e-02   6.00317200e-01   8.89007500e-02]
[  5.15000000e+02   4.31517100e-02   6.20625600e-01   8.28354800e-02]
[  5.16000000e+02   4.97858400e-02   6.40939800e-01   7.70098200e-02]
[  5.17000000e+02   5.66855400e-02   6.61077200e-01   7.14400100e-02]
[  5.18000000e+02   6.39165100e-02   6.80813400e-01   6.61543600e-02]
[  5.19000000e+02   7.15435200e-02   6.99904400e-01   6.11719900e-02]
[  5.20000000e+02   7.96291700e-02   7.18089000e-01   5.65040700e-02]
[  5.21000000e+02   8.82147300e-02   7.35159300e-01   5.21512100e-02]
[  5.22000000e+02   9.72697800e-02   7.51182100e-01   4.80956600e-02]
[  5.23000000e+02   1.06750400e-01   7.66314300e-01   4.43172000e-02]
[  5.24000000e+02   1.16619200e-01   7.80735200e-01   4.07973400e-02]
[  5.25000000e+02   1.26846800e-01   7.94644800e-01   3.75191200e-02]
[  5.26000000e+02   1.37406000e-01   8.08207400e-01   3.44684600e-02]
[  5.27000000e+02   1.48247100e-01   8.21381700e-01   3.16376400e-02]
[  5.28000000e+02   1.59307600e-01   8.34070100e-01   2.90190100e-02]
[  5.29000000e+02   1.70518100e-01   8.46171100e-01   2.66036400e-02]
[  5.30000000e+02   1.81802600e-01   8.57579900e-01   2.43816400e-02]
[  5.31000000e+02   1.93109000e-01   8.68240800e-01   2.23409700e-02]
[  5.32000000e+02   2.04508500e-01   8.78306100e-01   2.04641500e-02]
[  5.33000000e+02   2.16116600e-01   8.87990700e-01   1.87345600e-02]
[  5.34000000e+02   2.28065000e-01   8.97521100e-01   1.71378800e-02]
[  5.35000000e+02   2.40501500e-01   9.07134700e-01   1.56617400e-02]
[  5.36000000e+02   2.53544100e-01   9.16994700e-01   1.42964400e-02]
[  5.37000000e+02   2.67130000e-01   9.26929500e-01   1.30370200e-02]
[  5.38000000e+02   2.81135100e-01   9.36673100e-01   1.18789700e-02]
[  5.39000000e+02   2.95416400e-01   9.45948200e-01   1.08172500e-02]
[  5.40000000e+02   3.09811700e-01   9.54467500e-01   9.84647000e-03]
[  5.41000000e+02   3.24167800e-01   9.61983400e-01   8.96068700e-03]
[  5.42000000e+02   3.38431900e-01   9.68439000e-01   8.15281100e-03]
[  5.43000000e+02   3.52578600e-01   9.73828900e-01   7.41602500e-03]
[  5.44000000e+02   3.66583900e-01   9.78151900e-01   6.74411500e-03]
[  5.45000000e+02   3.80424400e-01   9.81410600e-01   6.13142100e-03]
[  5.46000000e+02   3.94098800e-01   9.83666900e-01   5.57277800e-03]
[  5.47000000e+02   4.07697200e-01   9.85208100e-01   5.06346300e-03]
[  5.48000000e+02   4.21348400e-01   9.86381300e-01   4.59916900e-03]
[  5.49000000e+02   4.35200300e-01   9.87535700e-01   4.17597100e-03]
[  5.50000000e+02   4.49420600e-01   9.89022800e-01   3.79029100e-03]
[  5.51000000e+02   4.64161600e-01   9.91081100e-01   3.43895200e-03]
[  5.52000000e+02   4.79439500e-01   9.93491300e-01   3.11934100e-03]
[  5.53000000e+02   4.95218000e-01   9.95917200e-01   2.82903800e-03]
[  5.54000000e+02   5.11439500e-01   9.98020500e-01   2.56572200e-03]
[  5.55000000e+02   5.28023300e-01   9.99460800e-01   2.32718600e-03]
[  5.56000000e+02   5.44869600e-01   9.99993000e-01   2.11128000e-03]
[  5.57000000e+02   5.61889800e-01   9.99755700e-01   1.91576600e-03]
[  5.58000000e+02   5.79013700e-01   9.98983900e-01   1.73858900e-03]
[  5.59000000e+02   5.96188200e-01   9.97912300e-01   1.57792000e-03]
[  5.60000000e+02   6.13378400e-01   9.96773700e-01   1.43212800e-03]
[  5.61000000e+02   6.30589700e-01   9.95735600e-01   1.29978100e-03]
[  5.62000000e+02   6.47922300e-01   9.94711500e-01   1.17966700e-03]
[  5.63000000e+02   6.65486600e-01   9.93553400e-01   1.07069400e-03]
[  5.64000000e+02   6.83378200e-01   9.92115600e-01   9.71862300e-04]
[  5.65000000e+02   7.01677400e-01   9.90254900e-01   8.82253100e-04]
[  5.66000000e+02   7.20411000e-01   9.87859600e-01   8.01023100e-04]
[  5.67000000e+02   7.39449500e-01   9.84932400e-01   7.27388400e-04]
[  5.68000000e+02   7.58628500e-01   9.81503600e-01   6.60634700e-04]
[  5.69000000e+02   7.77788500e-01   9.77603500e-01   6.00114600e-04]
[  5.70000000e+02   7.96775000e-01   9.73261100e-01   5.45241600e-04]
[  5.71000000e+02   8.15453000e-01   9.68476400e-01   4.95484700e-04]
[  5.72000000e+02   8.33738900e-01   9.63136900e-01   4.50364200e-04]
[  5.73000000e+02   8.51549300e-01   9.57106200e-01   4.09445500e-04]
[  5.74000000e+02   8.68786200e-01   9.50254000e-01   3.72334500e-04]
[  5.75000000e+02   8.85337600e-01   9.42456900e-01   3.38673900e-04]
[  5.76000000e+02   9.01158800e-01   9.33689700e-01   3.08139600e-04]
[  5.77000000e+02   9.16527800e-01   9.24289300e-01   2.80437000e-04]
[  5.78000000e+02   9.31824500e-01   9.14670700e-01   2.55299600e-04]
[  5.79000000e+02   9.47452400e-01   9.05233300e-01   2.32485900e-04]
[  5.80000000e+02   9.63838800e-01   8.96361300e-01   2.11777200e-04]
[  5.81000000e+02   9.81259600e-01   8.88306900e-01   1.92975800e-04]
[  5.82000000e+02   9.99295300e-01   8.80846200e-01   1.75902400e-04]
[  5.83000000e+02   1.01734300e+00   8.73644500e-01   1.60394700e-04]
[  5.84000000e+02   1.03479000e+00   8.66375500e-01   1.46305900e-04]
[  5.85000000e+02   1.05101100e+00   8.58720300e-01   1.33503100e-04]
[  5.86000000e+02   1.06552200e+00   8.50429500e-01   1.21866000e-04]
[  5.87000000e+02   1.07842100e+00   8.41504700e-01   1.11285700e-04]
[  5.88000000e+02   1.08994400e+00   8.32010900e-01   1.01663400e-04]
[  5.89000000e+02   1.10032000e+00   8.22015400e-01   9.29100300e-05]
[  5.90000000e+02   1.10976700e+00   8.11586800e-01   8.49446800e-05]
[  5.91000000e+02   1.11843800e+00   8.00787400e-01   7.76942500e-05]
[  5.92000000e+02   1.12626600e+00   7.89651500e-01   7.10924700e-05]
[  5.93000000e+02   1.13313800e+00   7.78205300e-01   6.50793600e-05]
[  5.94000000e+02   1.13895200e+00   7.66473300e-01   5.96006100e-05]
[  5.95000000e+02   1.14362000e+00   7.54478500e-01   5.46070600e-05]
[  5.96000000e+02   1.14709500e+00   7.42247300e-01   5.00541700e-05]
[  5.97000000e+02   1.14946400e+00   7.29822900e-01   4.59015700e-05]
[  5.98000000e+02   1.15083800e+00   7.17252500e-01   4.21126800e-05]
[  5.99000000e+02   1.15132600e+00   7.04581800e-01   3.86543700e-05]
[  6.00000000e+02   1.15103300e+00   6.91855300e-01   3.54966100e-05]
[  6.01000000e+02   1.15000200e+00   6.79100900e-01   3.26122000e-05]
[  6.02000000e+02   1.14806100e+00   6.66284600e-01   2.99764300e-05]
[  6.03000000e+02   1.14499800e+00   6.53359500e-01   2.75669300e-05]
[  6.04000000e+02   1.14062200e+00   6.40280700e-01   2.53633900e-05]
[  6.05000000e+02   1.13475700e+00   6.27006600e-01   2.33473800e-05]
[  6.06000000e+02   1.12729800e+00   6.13514800e-01   2.15022100e-05]
[  6.07000000e+02   1.11834200e+00   5.99849400e-01   1.98126800e-05]
[  6.08000000e+02   1.10803300e+00   5.86068200e-01   1.82650000e-05]
[  6.09000000e+02   1.09651500e+00   5.72226100e-01   1.68466700e-05]
[  6.10000000e+02   1.08392800e+00   5.58374600e-01   1.55463100e-05]
[  6.11000000e+02   1.07038700e+00   5.44553500e-01   1.43536000e-05]
[  6.12000000e+02   1.05593400e+00   5.30767300e-01   1.32591500e-05]
[  6.13000000e+02   1.04059200e+00   5.17013000e-01   1.22544300e-05]
[  6.14000000e+02   1.02438500e+00   5.03288900e-01   1.13316900e-05]
[  6.15000000e+02   1.00734400e+00   4.89595000e-01   1.04838700e-05]
[  6.16000000e+02   9.89526800e-01   4.75944200e-01   0.00000000e+00]
[  6.17000000e+02   9.71121300e-01   4.62395800e-01   0.00000000e+00]
[  6.18000000e+02   9.52325700e-01   4.49015400e-01   0.00000000e+00]
[  6.19000000e+02   9.33324800e-01   4.35862200e-01   0.00000000e+00]
[  6.20000000e+02   9.14287700e-01   4.22989700e-01   0.00000000e+00]
[  6.21000000e+02   8.95279800e-01   4.10415200e-01   0.00000000e+00]
[  6.22000000e+02   8.76015700e-01   3.98035600e-01   0.00000000e+00]
[  6.23000000e+02   8.56160700e-01   3.85730000e-01   0.00000000e+00]
[  6.24000000e+02   8.35423500e-01   3.73390700e-01   0.00000000e+00]
[  6.25000000e+02   8.13556500e-01   3.60924500e-01   0.00000000e+00]
[  6.26000000e+02   7.90456500e-01   3.48286000e-01   0.00000000e+00]
[  6.27000000e+02   7.66436400e-01   3.35570200e-01   0.00000000e+00]
[  6.28000000e+02   7.41877700e-01   3.22896300e-01   0.00000000e+00]
[  6.29000000e+02   7.17121900e-01   3.10370400e-01   0.00000000e+00]
[  6.30000000e+02   6.92471700e-01   2.98086500e-01   0.00000000e+00]
[  6.31000000e+02   6.68160000e-01   2.86116000e-01   0.00000000e+00]
[  6.32000000e+02   6.44269700e-01   2.74482200e-01   0.00000000e+00]
[  6.33000000e+02   6.20845000e-01   2.63195300e-01   0.00000000e+00]
[  6.34000000e+02   5.97924300e-01   2.52262800e-01   0.00000000e+00]
[  6.35000000e+02   5.75541000e-01   2.41690200e-01   0.00000000e+00]
[  6.36000000e+02   5.53729600e-01   2.31480900e-01   0.00000000e+00]
[  6.37000000e+02   5.32541200e-01   2.21637800e-01   0.00000000e+00]
[  6.38000000e+02   5.12021800e-01   2.12162200e-01   0.00000000e+00]
[  6.39000000e+02   4.92207000e-01   2.03054200e-01   0.00000000e+00]
[  6.40000000e+02   4.73122400e-01   1.94312400e-01   0.00000000e+00]
[  6.41000000e+02   4.54741700e-01   1.85922700e-01   0.00000000e+00]
[  6.42000000e+02   4.36871900e-01   1.77827400e-01   0.00000000e+00]
[  6.43000000e+02   4.19312100e-01   1.69965400e-01   0.00000000e+00]
[  6.44000000e+02   4.01898000e-01   1.62284100e-01   0.00000000e+00]
[  6.45000000e+02   3.84498600e-01   1.54739700e-01   0.00000000e+00]
[  6.46000000e+02   3.67059200e-01   1.47308100e-01   0.00000000e+00]
[  6.47000000e+02   3.49716700e-01   1.40016900e-01   0.00000000e+00]
[  6.48000000e+02   3.32630500e-01   1.32901300e-01   0.00000000e+00]
[  6.49000000e+02   3.15934100e-01   1.25991300e-01   0.00000000e+00]
[  6.50000000e+02   2.99737400e-01   1.19312000e-01   0.00000000e+00]
[  6.51000000e+02   2.84118900e-01   1.12882000e-01   0.00000000e+00]
[  6.52000000e+02   2.69105300e-01   1.06711300e-01   0.00000000e+00]
[  6.53000000e+02   2.54707700e-01   1.00805200e-01   0.00000000e+00]
[  6.54000000e+02   2.40931900e-01   9.51665300e-02   0.00000000e+00]
[  6.55000000e+02   2.27779200e-01   8.97959400e-02   0.00000000e+00]
[  6.56000000e+02   2.15243100e-01   8.46904400e-02   0.00000000e+00]
[  6.57000000e+02   2.03301000e-01   7.98400900e-02   0.00000000e+00]
[  6.58000000e+02   1.91927600e-01   7.52337200e-02   0.00000000e+00]
[  6.59000000e+02   1.81098700e-01   7.08606100e-02   0.00000000e+00]
[  6.60000000e+02   1.70791400e-01   6.67104500e-02   0.00000000e+00]
[  6.61000000e+02   1.60984200e-01   6.27736000e-02   0.00000000e+00]
[  6.62000000e+02   1.51657700e-01   5.90417900e-02   0.00000000e+00]
[  6.63000000e+02   1.42793600e-01   5.55070300e-02   0.00000000e+00]
[  6.64000000e+02   1.34373700e-01   5.21613900e-02   0.00000000e+00]
[  6.65000000e+02   1.26380800e-01   4.89969900e-02   0.00000000e+00]
[  6.66000000e+02   1.18797900e-01   4.60057800e-02   0.00000000e+00]
[  6.67000000e+02   1.11608800e-01   4.31788500e-02   0.00000000e+00]
[  6.68000000e+02   1.04797500e-01   4.05075500e-02   0.00000000e+00]
[  6.69000000e+02   9.83483500e-02   3.79837600e-02   0.00000000e+00]
[  6.70000000e+02   9.22459700e-02   3.55998200e-02   0.00000000e+00]
[  6.71000000e+02   8.64750600e-02   3.33485600e-02   0.00000000e+00]
[  6.72000000e+02   8.10198600e-02   3.12233200e-02   0.00000000e+00]
[  6.73000000e+02   7.58651400e-02   2.92178000e-02   0.00000000e+00]
[  6.74000000e+02   7.09963300e-02   2.73260100e-02   0.00000000e+00]
[  6.75000000e+02   6.63996000e-02   2.55422300e-02   0.00000000e+00]
[  6.76000000e+02   6.20622500e-02   2.38612100e-02   0.00000000e+00]
[  6.77000000e+02   5.79740900e-02   2.22785900e-02   0.00000000e+00]
[  6.78000000e+02   5.41253300e-02   2.07902000e-02   0.00000000e+00]
[  6.79000000e+02   5.05060000e-02   1.93918500e-02   0.00000000e+00]
[  6.80000000e+02   4.71060600e-02   1.80793900e-02   0.00000000e+00]
[  6.81000000e+02   4.39141100e-02   1.68481700e-02   0.00000000e+00]
[  6.82000000e+02   4.09141100e-02   1.56918800e-02   0.00000000e+00]
[  6.83000000e+02   3.80906700e-02   1.46044600e-02   0.00000000e+00]
[  6.84000000e+02   3.54303400e-02   1.35806200e-02   0.00000000e+00]
[  6.85000000e+02   3.29213800e-02   1.26157300e-02   0.00000000e+00]
[  6.86000000e+02   3.05567200e-02   1.17069600e-02   0.00000000e+00]
[  6.87000000e+02   2.83414600e-02   1.08560800e-02   0.00000000e+00]
[  6.88000000e+02   2.62803300e-02   1.00647600e-02   0.00000000e+00]
[  6.89000000e+02   2.43746500e-02   9.33337600e-03   0.00000000e+00]
[  6.90000000e+02   2.26230600e-02   8.66128400e-03   0.00000000e+00]
[  6.91000000e+02   2.10193500e-02   8.04604800e-03   0.00000000e+00]
[  6.92000000e+02   1.95464700e-02   7.48113000e-03   0.00000000e+00]
[  6.93000000e+02   1.81872700e-02   6.95998700e-03   0.00000000e+00]
[  6.94000000e+02   1.69272700e-02   6.47707000e-03   0.00000000e+00]
[  6.95000000e+02   1.57541700e-02   6.02767700e-03   0.00000000e+00]
[  6.96000000e+02   1.46585400e-02   5.60816900e-03   0.00000000e+00]
[  6.97000000e+02   1.36357100e-02   5.21669100e-03   0.00000000e+00]
[  6.98000000e+02   1.26820500e-02   4.85178500e-03   0.00000000e+00]
[  6.99000000e+02   1.17939400e-02   4.51200800e-03   0.00000000e+00]
[  7.00000000e+02   1.09677800e-02   4.19594100e-03   0.00000000e+00]
[  7.01000000e+02   1.01996400e-02   3.90205700e-03   0.00000000e+00]
[  7.02000000e+02   9.48431700e-03   3.62837100e-03   0.00000000e+00]
[  7.03000000e+02   8.81685100e-03   3.37300500e-03   0.00000000e+00]
[  7.04000000e+02   8.19292100e-03   3.13431500e-03   0.00000000e+00]
[  7.05000000e+02   7.60875000e-03   2.91086400e-03   0.00000000e+00]
[  7.06000000e+02   7.06139100e-03   2.70152800e-03   0.00000000e+00]
[  7.07000000e+02   6.54950900e-03   2.50579600e-03   0.00000000e+00]
[  7.08000000e+02   6.07197000e-03   2.32323100e-03   0.00000000e+00]
[  7.09000000e+02   5.62747600e-03   2.15333300e-03   0.00000000e+00]
[  7.10000000e+02   5.21460800e-03   1.99555700e-03   0.00000000e+00]
[  7.11000000e+02   4.83184800e-03   1.84931600e-03   0.00000000e+00]
[  7.12000000e+02   4.47757900e-03   1.71397600e-03   0.00000000e+00]
[  7.13000000e+02   4.15016600e-03   1.58889900e-03   0.00000000e+00]
[  7.14000000e+02   3.84798800e-03   1.47345300e-03   0.00000000e+00]
[  7.15000000e+02   3.56945200e-03   1.36702200e-03   0.00000000e+00]
[  7.16000000e+02   3.31285700e-03   1.26895400e-03   0.00000000e+00]
[  7.17000000e+02   3.07602200e-03   1.17842100e-03   0.00000000e+00]
[  7.18000000e+02   2.85689400e-03   1.09464400e-03   0.00000000e+00]
[  7.19000000e+02   2.65368100e-03   1.01694300e-03   0.00000000e+00]
[  7.20000000e+02   2.46482100e-03   9.44726900e-04   0.00000000e+00]
[  7.21000000e+02   2.28906000e-03   8.77517100e-04   0.00000000e+00]
[  7.22000000e+02   2.12569400e-03   8.15043800e-04   0.00000000e+00]
[  7.23000000e+02   1.97412100e-03   7.57075500e-04   0.00000000e+00]
[  7.24000000e+02   1.83372300e-03   7.03375500e-04   0.00000000e+00]
[  7.25000000e+02   1.70387600e-03   6.53705000e-04   0.00000000e+00]
[  7.26000000e+02   1.58390400e-03   6.07804800e-04   0.00000000e+00]
[  7.27000000e+02   1.47293900e-03   5.65343500e-04   0.00000000e+00]
[  7.28000000e+02   1.37015100e-03   5.26004600e-04   0.00000000e+00]
[  7.29000000e+02   1.27480300e-03   4.89506100e-04   0.00000000e+00]
[  7.30000000e+02   1.18623800e-03   4.55597000e-04   0.00000000e+00]
[  7.31000000e+02   1.10387100e-03   4.24054800e-04   0.00000000e+00]
[  7.32000000e+02   1.02719400e-03   3.94686000e-04   0.00000000e+00]
[  7.33000000e+02   9.55749300e-04   3.67317800e-04   0.00000000e+00]
[  7.34000000e+02   8.89126200e-04   3.41794100e-04   0.00000000e+00]
[  7.35000000e+02   8.26953500e-04   3.17973800e-04   0.00000000e+00]
[  7.36000000e+02   7.68935100e-04   2.95744100e-04   0.00000000e+00]
[  7.37000000e+02   7.14942500e-04   2.75055800e-04   0.00000000e+00]
[  7.38000000e+02   6.64859000e-04   2.55864000e-04   0.00000000e+00]
[  7.39000000e+02   6.18542100e-04   2.38114200e-04   0.00000000e+00]
[  7.40000000e+02   5.75830300e-04   2.21744500e-04   0.00000000e+00]
[  7.41000000e+02   5.36504600e-04   2.06671100e-04   0.00000000e+00]
[  7.42000000e+02   5.00184200e-04   1.92747400e-04   0.00000000e+00]
[  7.43000000e+02   4.66500500e-04   1.79831500e-04   0.00000000e+00]
[  7.44000000e+02   4.35138600e-04   1.67802300e-04   0.00000000e+00]
[  7.45000000e+02   4.05830300e-04   1.56556600e-04   0.00000000e+00]
[  7.46000000e+02   3.78373300e-04   1.46016800e-04   0.00000000e+00]
[  7.47000000e+02   3.52689200e-04   1.36153500e-04   0.00000000e+00]
[  7.48000000e+02   3.28719900e-04   1.26945100e-04   0.00000000e+00]
[  7.49000000e+02   3.06399800e-04   1.18367100e-04   0.00000000e+00]
[  7.50000000e+02   2.85657700e-04   1.10392800e-04   0.00000000e+00]
[  7.51000000e+02   2.66410800e-04   1.02990800e-04   0.00000000e+00]
[  7.52000000e+02   2.48546200e-04   9.61183600e-05   0.00000000e+00]
[  7.53000000e+02   2.31952900e-04   8.97332300e-05   0.00000000e+00]
[  7.54000000e+02   2.16530000e-04   8.37969400e-05   0.00000000e+00]
[  7.55000000e+02   2.02185300e-04   7.82744200e-05   0.00000000e+00]
[  7.56000000e+02   1.88833800e-04   7.31331200e-05   0.00000000e+00]
[  7.57000000e+02   1.76393500e-04   6.83414200e-05   0.00000000e+00]
[  7.58000000e+02   1.64789500e-04   6.38703500e-05   0.00000000e+00]
[  7.59000000e+02   1.53954200e-04   5.96938900e-05   0.00000000e+00]
[  7.60000000e+02   1.43827000e-04   5.57886200e-05   0.00000000e+00]
[  7.61000000e+02   1.34357200e-04   5.21350900e-05   0.00000000e+00]
[  7.62000000e+02   1.25514100e-04   4.87217900e-05   0.00000000e+00]
[  7.63000000e+02   1.17270600e-04   4.55384500e-05   0.00000000e+00]
[  7.64000000e+02   1.09598300e-04   4.25744300e-05   0.00000000e+00]
[  7.65000000e+02   1.02468500e-04   3.98188400e-05   0.00000000e+00]
[  7.66000000e+02   9.58471500e-05   3.72587700e-05   0.00000000e+00]
[  7.67000000e+02   8.96831600e-05   3.48746700e-05   0.00000000e+00]
[  7.68000000e+02   8.39273400e-05   3.26476500e-05   0.00000000e+00]
[  7.69000000e+02   7.85370800e-05   3.05614000e-05   0.00000000e+00]
[  7.70000000e+02   7.34755100e-05   2.86017500e-05   0.00000000e+00]
[  7.71000000e+02   6.87157600e-05   2.67584100e-05   0.00000000e+00]
[  7.72000000e+02   6.42525700e-05   2.50294300e-05   0.00000000e+00]
[  7.73000000e+02   6.00829200e-05   2.34137300e-05   0.00000000e+00]
[  7.74000000e+02   5.62009800e-05   2.19091400e-05   0.00000000e+00]
[  7.75000000e+02   5.25987000e-05   2.05125900e-05   0.00000000e+00]
[  7.76000000e+02   4.92627900e-05   1.92190200e-05   0.00000000e+00]
[  7.77000000e+02   4.61662300e-05   1.80179600e-05   0.00000000e+00]
[  7.78000000e+02   4.32821200e-05   1.68989900e-05   0.00000000e+00]
[  7.79000000e+02   4.05871500e-05   1.58530900e-05   0.00000000e+00]
[  7.80000000e+02   3.80611400e-05   1.48724300e-05   0.00000000e+00]
[  7.81000000e+02   3.56881800e-05   1.39508500e-05   0.00000000e+00]
[  7.82000000e+02   3.34602300e-05   1.30852800e-05   0.00000000e+00]
[  7.83000000e+02   3.13709000e-05   1.22732700e-05   0.00000000e+00]
[  7.84000000e+02   2.94137100e-05   1.15123300e-05   0.00000000e+00]
[  7.85000000e+02   2.75822200e-05   1.08000100e-05   0.00000000e+00]
[  7.86000000e+02   2.58695100e-05   1.01336400e-05   0.00000000e+00]
[  7.87000000e+02   2.42670100e-05   9.50991900e-06   0.00000000e+00]
[  7.88000000e+02   2.27663900e-05   8.92563000e-06   0.00000000e+00]
[  7.89000000e+02   2.13600900e-05   8.37785200e-06   0.00000000e+00]
[  7.90000000e+02   2.00412200e-05   7.86392000e-06   0.00000000e+00]
[  7.91000000e+02   1.88038000e-05   7.38153900e-06   0.00000000e+00]
[  7.92000000e+02   1.76435800e-05   6.92909600e-06   0.00000000e+00]
[  7.93000000e+02   1.65567100e-05   6.50513600e-06   0.00000000e+00]
[  7.94000000e+02   1.55393900e-05   6.10822100e-06   0.00000000e+00]
[  7.95000000e+02   1.45879200e-05   5.73693500e-06   0.00000000e+00]
[  7.96000000e+02   1.36985300e-05   5.38983100e-06   0.00000000e+00]
[  7.97000000e+02   1.28670500e-05   5.06526900e-06   0.00000000e+00]
[  7.98000000e+02   1.20894700e-05   4.76166700e-06   0.00000000e+00]
[  7.99000000e+02   1.13620700e-05   4.47756100e-06   0.00000000e+00]
[  8.00000000e+02   1.06814100e-05   4.21159700e-06   0.00000000e+00]
[  8.01000000e+02   1.00441100e-05   3.96245700e-06   0.00000000e+00]
[  8.02000000e+02   9.44639900e-06   3.72867400e-06   0.00000000e+00]
[  8.03000000e+02   8.88475400e-06   3.50888100e-06   0.00000000e+00]
[  8.04000000e+02   8.35605000e-06   3.30186800e-06   0.00000000e+00]
[  8.05000000e+02   7.85752100e-06   3.10656100e-06   0.00000000e+00]
[  8.06000000e+02   7.38699600e-06   2.92211900e-06   0.00000000e+00]
[  8.07000000e+02   6.94357600e-06   2.74820800e-06   0.00000000e+00]
[  8.08000000e+02   6.52654800e-06   2.58456000e-06   0.00000000e+00]
[  8.09000000e+02   6.13508700e-06   2.43086700e-06   0.00000000e+00]
[  8.10000000e+02   5.76828400e-06   2.28678600e-06   0.00000000e+00]
[  8.11000000e+02   5.42506900e-06   2.15190500e-06   0.00000000e+00]
[  8.12000000e+02   5.10397400e-06   2.02565600e-06   0.00000000e+00]
[  8.13000000e+02   4.80352500e-06   1.90746400e-06   0.00000000e+00]
[  8.14000000e+02   4.52235000e-06   1.79679400e-06   0.00000000e+00]
[  8.15000000e+02   4.25916600e-06   1.69314700e-06   0.00000000e+00]
[  8.16000000e+02   4.01271500e-06   1.59603200e-06   0.00000000e+00]
[  8.17000000e+02   3.78159700e-06   1.50490300e-06   0.00000000e+00]
[  8.18000000e+02   3.56449600e-06   1.41924500e-06   0.00000000e+00]
[  8.19000000e+02   3.36023600e-06   1.33860000e-06   0.00000000e+00]
[  8.20000000e+02   3.16776500e-06   1.26255600e-06   0.00000000e+00]
[  8.21000000e+02   2.98620600e-06   1.19077100e-06   0.00000000e+00]
[  8.22000000e+02   2.81499900e-06   1.12303100e-06   0.00000000e+00]
[  8.23000000e+02   2.65366300e-06   1.05915100e-06   0.00000000e+00]
[  8.24000000e+02   2.50172500e-06   9.98950700e-07   0.00000000e+00]
[  8.25000000e+02   2.35872300e-06   9.42251400e-07   0.00000000e+00]
[  8.26000000e+02   2.22420600e-06   8.88880400e-07   0.00000000e+00]
[  8.27000000e+02   2.09773700e-06   8.38669000e-07   0.00000000e+00]
[  8.28000000e+02   1.97889400e-06   7.91453900e-07   0.00000000e+00]
[  8.29000000e+02   1.86726800e-06   7.47077000e-07   0.00000000e+00]
[  8.30000000e+02   1.76246500e-06   7.05386000e-07   0.00000000e+00]
```

# Preflight

<!-- Please mark any checkboxes that do not apply to this pull request as [N/A]. -->

**Code Style and Quality**

- [x] Unit tests have been implemented and passed.
- [x] Pyright static checking has been run and passed.
- [x] Pre-commit hooks have been run and passed.
- [N/A] New transformations have been added to the *Automatic Colour Conversion Graph*.
- [N/A] New transformations have been exported to the relevant namespaces, e.g. `colour`, `colour.models`.

<!-- The unit tests can be invoked with `poetry run invoke tests` -->
<!-- Pyright can be started with `pyright --skipunannotated` -->

**Documentation**

- [x] New features are documented along with examples if relevant.
- [x] The documentation is [Sphinx](https://www.sphinx-doc.org/en/master/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant.

<!--
Thank you again!
-->
