### PR TITLE
PR: Implement support for "CCT" to "mired" conversion.

### DIFF
--- a/colour/plotting/temperature.py
+++ b/colour/plotting/temperature.py
@@ -83,6 +83,7 @@ def plot_planckian_locus(
     planckian_locus_opacity: float = 1,
     planckian_locus_labels: Sequence | None = None,
     planckian_locus_use_mireds: bool = False,
+    planckian_locus_iso_temperature_lines_D_uv: float = 0.05,
     method: Literal["CIE 1931", "CIE 1960 UCS", "CIE 1976 UCS"]
     | str = "CIE 1931",
     **kwargs: Any,
@@ -104,6 +105,10 @@ def plot_planckian_locus(
         in no iso-temperature lines being drawn.
     planckian_locus_use_mireds
         Whether to use micro reciprocal degrees for the iso-temperature lines.
+    planckian_locus_iso_temperature_lines_D_uv
+        Iso-temperature lines :math:`\\Delta_{uv}` length on each side of the
+        *Planckian Locus*.
+
     method
         *Chromaticity Diagram* method.
 
@@ -150,7 +155,7 @@ def plot_planckian_locus(
             else (1e6 / 600, 2000, 2500, 3000, 4000, 6000, 1e6 / 100),
         ),
     )
-    D_uv = 0.05
+    D_uv = planckian_locus_iso_temperature_lines_D_uv
 
     settings: Dict[str, Any] = {"uniform": True}
     settings.update(kwargs)

--- a/colour/temperature/__init__.py
+++ b/colour/temperature/__init__.py
@@ -55,7 +55,12 @@ from .krystek1985 import uv_to_CCT_Krystek1985, CCT_to_uv_Krystek1985
 from .mccamy1992 import xy_to_CCT_McCamy1992, CCT_to_xy_McCamy1992
 from .planck1900 import uv_to_CCT_Planck1900, CCT_to_uv_Planck1900
 from .ohno2013 import uv_to_CCT_Ohno2013, CCT_to_uv_Ohno2013
-from .robertson1968 import uv_to_CCT_Robertson1968, CCT_to_uv_Robertson1968
+from .robertson1968 import (
+    CCT_to_mired,
+    mired_to_CCT,
+    uv_to_CCT_Robertson1968,
+    CCT_to_uv_Robertson1968,
+)
 
 __all__ = [
     "xy_to_CCT_CIE_D",
@@ -86,6 +91,8 @@ __all__ += [
     "CCT_to_uv_Ohno2013",
 ]
 __all__ += [
+    "CCT_to_mired",
+    "mired_to_CCT",
     "uv_to_CCT_Robertson1968",
     "CCT_to_uv_Robertson1968",
 ]

--- a/colour/temperature/robertson1968.py
+++ b/colour/temperature/robertson1968.py
@@ -5,6 +5,10 @@ Robertson (1968) Correlated Colour Temperature
 Defines the *Robertson (1968)* correlated colour temperature :math:`T_{cp}`
 computations objects:
 
+-   :func:`colour.temperature.mired_to_CCT`: Micro reciprocal degree to
+    correlated colour temperature :math:`T_{cp}` computation.
+-   :func:`colour.temperature.CCT_to_mired`: Correlated colour
+    temperature :math:`T_{cp}` to micro reciprocal degree computation.
 -   :func:`colour.temperature.uv_to_CCT_Robertson1968`: Correlated colour
     temperature :math:`T_{cp}` and :math:`\\Delta_{uv}` computation of given
     *CIE UCS* colourspace *uv* chromaticity coordinates using *Robertson
@@ -53,6 +57,8 @@ __all__ = [
     "DATA_ISOTEMPERATURE_LINES_ROBERTSON1968",
     "ISOTemperatureLine_Specification_Robertson1968",
     "ISOTEMPERATURE_LINES_ROBERTSON1968",
+    "mired_to_CCT",
+    "CCT_to_mired",
     "uv_to_CCT_Robertson1968",
     "CCT_to_uv_Robertson1968",
 ]
@@ -141,6 +147,60 @@ ISOTEMPERATURE_LINES_ROBERTSON1968: list = [
 ]
 
 
+def mired_to_CCT(mired: ArrayLike) -> NDArrayFloat:
+    """
+    Convert given micro reciprocal degree to correlated colour temperature
+    :math:`T_{cp}`.
+
+    Parameters
+    ----------
+    mired
+         Micro reciprocal degree (mired).
+
+    Returns
+    -------
+    :class:`numpy.ndarray`
+        Correlated colour temperature :math:`T_{cp}`.
+
+    Examples
+    --------
+    >>> CCT_to_mired(153.84615384615384)  # doctest: +ELLIPSIS
+    6500.0
+    """
+
+    mired = as_float_array(mired)
+
+    with sdiv_mode():
+        return sdiv(1.0e6, mired)
+
+
+def CCT_to_mired(CCT: ArrayLike) -> NDArrayFloat:
+    """
+    Convert given correlated colour temperature :math:`T_{cp}` to micro
+    reciprocal degree (mired).
+
+    Parameters
+    ----------
+    CCT
+         Correlated colour temperature :math:`T_{cp}`.
+
+    Returns
+    -------
+    :class:`numpy.ndarray`
+        Micro reciprocal degree (mired).
+
+    Examples
+    --------
+    >>> CCT_to_mired(6500)  # doctest: +ELLIPSIS
+    153.8461538...
+    """
+
+    CCT = as_float_array(CCT)
+
+    with sdiv_mode():
+        return sdiv(1.0e6, CCT)
+
+
 def _uv_to_CCT_Robertson1968(uv: ArrayLike) -> NDArrayFloat:
     """
     Return the correlated colour temperature :math:`T_{cp}` and
@@ -188,7 +248,7 @@ def _uv_to_CCT_Robertson1968(uv: ArrayLike) -> NDArrayFloat:
 
             f = 0 if i == 1 else dt / (last_dt + dt)
 
-            T = 1.0e6 / (wr_ruvt_previous.r * f + wr_ruvt.r * (1 - f))
+            T = mired_to_CCT(wr_ruvt_previous.r * f + wr_ruvt.r * (1 - f))
 
             uu = u - (wr_ruvt_previous.u * f + wr_ruvt.u * (1 - f))
             vv = v - (wr_ruvt_previous.v * f + wr_ruvt.v * (1 - f))
@@ -265,8 +325,7 @@ def _CCT_to_uv_Robertson1968(CCT_D_uv: ArrayLike) -> NDArrayFloat:
 
     CCT, D_uv = tsplit(CCT_D_uv)
 
-    with sdiv_mode():
-        r = sdiv(1.0e6, CCT)
+    r = CCT_to_mired(CCT)
 
     u, v = 0, 0
     for i in range(30):

--- a/colour/temperature/tests/test_robertson1968.py
+++ b/colour/temperature/tests/test_robertson1968.py
@@ -7,7 +7,12 @@ import numpy as np
 import unittest
 from itertools import product
 
-from colour.temperature import CCT_to_uv_Robertson1968, uv_to_CCT_Robertson1968
+from colour.temperature import (
+    mired_to_CCT,
+    CCT_to_mired,
+    CCT_to_uv_Robertson1968,
+    uv_to_CCT_Robertson1968,
+)
 from colour.utilities import ignore_numpy_errors
 
 __author__ = "Colour Developers"
@@ -18,6 +23,8 @@ __email__ = "colour-developers@colour-science.org"
 __status__ = "Production"
 
 __all__ = [
+    "TestMired_to_CCT",
+    "TestCCT_to_mired",
     "TestUv_to_CCT_Robertson1968",
     "TestCCT_to_uv_Robertson1968",
 ]
@@ -124,6 +131,112 @@ TEMPERATURE_DUV_TO_UV: dict = {
     (49500, 0.0250): np.array([0.157203932244369, 0.275011422146831]),
     (49500, 0.0500): np.array([0.133062712973587, 0.281507692778510]),
 }
+
+
+class TestMired_to_CCT(unittest.TestCase):
+    """
+    Define :func:`colour.temperature.robertson1968.mired_to_CCT`
+    definition unit tests methods.
+    """
+
+    def test_mired_to_CCT(self):
+        """
+        Test :func:`colour.temperature.robertson1968.mired_to_CCT`
+        definition.
+        """
+
+        self.assertAlmostEqual(CCT_to_mired(312.5), 3200, places=7)
+
+        self.assertAlmostEqual(CCT_to_mired(153.846153846154), 6500, places=7)
+
+        self.assertAlmostEqual(
+            CCT_to_mired(66.666666666666667), 15000, places=7
+        )
+
+    def test_n_dimensional_mired_to_CCT(self):
+        """
+        Test :func:`colour.temperature.robertson1968.mired_to_CCT`
+        definition n-dimensional arrays support.
+        """
+
+        mired = 312.5
+        CCT = mired_to_CCT(mired)
+
+        mired = np.tile(mired, (6, 1))
+        CCT = np.tile(CCT, (6, 1))
+        np.testing.assert_array_almost_equal(
+            mired_to_CCT(mired), CCT, decimal=7
+        )
+
+        mired = np.reshape(mired, (2, 3, 1))
+        CCT = np.reshape(CCT, (2, 3, 1))
+        np.testing.assert_array_almost_equal(
+            mired_to_CCT(mired), CCT, decimal=7
+        )
+
+    @ignore_numpy_errors
+    def test_nan_mired_to_CCT(self):
+        """
+        Test :func:`colour.temperature.robertson1968.mired_to_CCT`
+        definition nan support.
+        """
+
+        cases = [-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan]
+        cases = np.array(list(set(product(cases, repeat=2))))
+        mired_to_CCT(cases)
+
+
+class TestCCT_to_mired(unittest.TestCase):
+    """
+    Define :func:`colour.temperature.robertson1968.CCT_to_mired`
+    definition unit tests methods.
+    """
+
+    def test_CCT_to_mired(self):
+        """
+        Test :func:`colour.temperature.robertson1968.CCT_to_mired`
+        definition.
+        """
+
+        self.assertAlmostEqual(CCT_to_mired(3200), 312.5, places=7)
+
+        self.assertAlmostEqual(CCT_to_mired(6500), 153.846153846154, places=7)
+
+        self.assertAlmostEqual(
+            CCT_to_mired(15000), 66.666666666666667, places=7
+        )
+
+    def test_n_dimensional_CCT_to_mired(self):
+        """
+        Test :func:`colour.temperature.robertson1968.CCT_to_mired`
+        definition n-dimensional arrays support.
+        """
+
+        CCT = 3200
+        mired = CCT_to_mired(CCT)
+
+        CCT = np.tile(CCT, (6, 1))
+        mired = np.tile(mired, (6, 1))
+        np.testing.assert_array_almost_equal(
+            CCT_to_mired(CCT), mired, decimal=7
+        )
+
+        CCT = np.reshape(CCT, (2, 3, 1))
+        mired = np.reshape(mired, (2, 3, 1))
+        np.testing.assert_array_almost_equal(
+            CCT_to_mired(CCT), mired, decimal=7
+        )
+
+    @ignore_numpy_errors
+    def test_nan_CCT_to_mired(self):
+        """
+        Test :func:`colour.temperature.robertson1968.CCT_to_mired`
+        definition nan support.
+        """
+
+        cases = [-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan]
+        cases = np.array(list(set(product(cases, repeat=2))))
+        CCT_to_mired(cases)
 
 
 class TestUv_to_CCT_Robertson1968(unittest.TestCase):

--- a/docs/colour.temperature.rst
+++ b/docs/colour.temperature.rst
@@ -30,6 +30,8 @@ Robertson (1968)
 .. autosummary::
     :toctree: generated/
 
+    mired_to_CCT
+    CCT_to_mired
     uv_to_CCT_Robertson1968
     CCT_to_uv_Robertson1968
 


### PR DESCRIPTION
<!--
Thank you for taking the time to create this pull request. If it is the first
time you are contributing to a colour-science repository, a contributing guide
is available to guide the process: https://www.colour-science.org/contributing/.
-->

# Summary

This PR adds the `colour.mired_to_CCT` and `colour.CCT_to_mired` definitions to support micro reciprocal degree conversion.

# Preflight

<!-- Please mark any checkboxes that do not apply to this pull request as [N/A]. -->

**Code Style and Quality**

- [x] Unit tests have been implemented and passed.
- [x] Pyright static checking has been run and passed.
- [x] Pre-commit hooks have been run and passed.
- [N/A] New transformations have been added to the *Automatic Colour Conversion Graph*.
- [N/A] New transformations have been exported to the relevant namespaces, e.g. `colour`, `colour.models`.

<!-- The unit tests can be invoked with `poetry run invoke tests` -->
<!-- Pyright can be started with `pyright --skipunannotated` -->

**Documentation**

- [x] New features are documented along with examples if relevant.
- [x] The documentation is [Sphinx](https://www.sphinx-doc.org/en/master/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant.

<!--
Thank you again!
-->
