### PR TITLE
PR: Add new `copy` argument to `colour.colorimetry.reshape_sd` definition.

### DIFF
--- a/colour/blindness/machado2009.py
+++ b/colour/blindness/machado2009.py
@@ -115,6 +115,7 @@ def matrix_RGB_to_WSYBRG(
     primaries = reshape_msds(
         primaries,
         cmfs.shape,
+        copy=False,
         extrapolator_kwargs={"method": "Constant", "left": 0, "right": 0},
     )
 
@@ -308,6 +309,7 @@ def matrix_anomalous_trichromacy_Machado2009(
             cmfs,
             SpectralShape(cmfs.shape.start, cmfs.shape.end, 1),
             "Interpolate",
+            copy=False,
         )
 
     M_n = matrix_RGB_to_WSYBRG(cmfs, primaries)

--- a/colour/characterisation/aces_it.py
+++ b/colour/characterisation/aces_it.py
@@ -229,10 +229,10 @@ def sd_to_aces_relative_exposure_values(
 
     shape = MSDS_ACES_RICD.shape
     if sd.shape != MSDS_ACES_RICD.shape:
-        sd = reshape_sd(sd, shape)
+        sd = reshape_sd(sd, shape, copy=False)
 
     if illuminant.shape != MSDS_ACES_RICD.shape:
-        illuminant = reshape_sd(illuminant, shape)
+        illuminant = reshape_sd(illuminant, shape, copy=False)
 
     s_v = sd.values
     i_v = illuminant.values
@@ -453,7 +453,7 @@ def white_balance_multipliers(
         runtime_warning(
             f'Aligning "{illuminant.name}" illuminant shape to "{shape}".'
         )
-        illuminant = reshape_sd(illuminant, shape)
+        illuminant = reshape_sd(illuminant, shape, copy=False)
 
     RGB_w = 1 / np.sum(
         sensitivities.values * illuminant.values[..., None], axis=0
@@ -624,14 +624,14 @@ def training_data_sds_to_RGB(
         runtime_warning(
             f'Aligning "{illuminant.name}" illuminant shape to "{shape}".'
         )
-        illuminant = reshape_sd(illuminant, shape)
+        illuminant = reshape_sd(illuminant, shape, copy=False)
 
     if training_data.shape != shape:
         runtime_warning(
             f'Aligning "{training_data.name}" training data shape to "{shape}".'
         )
         # pylint: disable=E1102
-        training_data = reshape_msds(training_data, shape)
+        training_data = reshape_msds(training_data, shape, copy=False)
 
     RGB_w = white_balance_multipliers(sensitivities, illuminant)
 
@@ -716,14 +716,14 @@ def training_data_sds_to_XYZ(
         runtime_warning(
             f'Aligning "{illuminant.name}" illuminant shape to "{shape}".'
         )
-        illuminant = reshape_sd(illuminant, shape)
+        illuminant = reshape_sd(illuminant, shape, copy=False)
 
     if training_data.shape != shape:
         runtime_warning(
             f'Aligning "{training_data.name}" training data shape to "{shape}".'
         )
         # pylint: disable=E1102
-        training_data = reshape_msds(training_data, shape)
+        training_data = reshape_msds(training_data, shape, copy=False)
 
     XYZ = np.dot(
         np.transpose(illuminant.values[..., None] * training_data.values),
@@ -961,14 +961,14 @@ def matrix_idt(
             f'Aligning "{sensitivities.name}" sensitivities shape to "{shape}".'
         )
         # pylint: disable=E1102
-        sensitivities = reshape_msds(sensitivities, shape)
+        sensitivities = reshape_msds(sensitivities, shape, copy=False)
 
     if training_data.shape != shape:
         runtime_warning(
             f'Aligning "{training_data.name}" training data shape to "{shape}".'
         )
         # pylint: disable=E1102
-        training_data = reshape_msds(training_data, shape)
+        training_data = reshape_msds(training_data, shape, copy=False)
 
     illuminant = normalise_illuminant(illuminant, sensitivities)
 

--- a/colour/colorimetry/photometry.py
+++ b/colour/colorimetry/photometry.py
@@ -82,6 +82,7 @@ def luminous_flux(
     lef = reshape_sd(
         lef,
         sd.shape,
+        copy=False,
         extrapolator_kwargs={"method": "Constant", "left": 0, "right": 0},
     )
 
@@ -129,6 +130,7 @@ def luminous_efficiency(
     lef = reshape_sd(
         lef,
         sd.shape,
+        copy=False,
         extrapolator_kwargs={"method": "Constant", "left": 0, "right": 0},
     )
 

--- a/colour/colorimetry/spectrum.py
+++ b/colour/colorimetry/spectrum.py
@@ -2763,6 +2763,7 @@ def reshape_sd(
     shape: SpectralShape = SPECTRAL_SHAPE_DEFAULT,
     method: Literal["Align", "Extrapolate", "Interpolate", "Trim"]
     | str = "Align",
+    copy: bool = True,
     **kwargs: Any,
 ) -> TypeSpectralDistribution:
     """
@@ -2779,6 +2780,9 @@ def reshape_sd(
         Spectral shape to reshape the spectral distribution with.
     method
         Reshape method.
+    copy
+        Whether to return a copy of the cached spectral distribution. Default
+        is *True*.
 
     Other Parameters
     ----------------
@@ -2812,7 +2816,9 @@ def reshape_sd(
         hash(arg) for arg in (sd, shape, method, tuple(kwargs_items))
     )
     if hash_key in _CACHE_RESHAPED_SDS_AND_MSDS:
-        return _CACHE_RESHAPED_SDS_AND_MSDS[hash_key].copy()
+        reshaped_sd = _CACHE_RESHAPED_SDS_AND_MSDS[hash_key]
+
+        return reshaped_sd.copy() if copy else reshaped_sd
 
     function = getattr(sd, method)
 
@@ -2835,6 +2841,7 @@ def reshape_msds(
     shape: SpectralShape = SPECTRAL_SHAPE_DEFAULT,
     method: Literal["Align", "Extrapolate", "Interpolate", "Trim"]
     | str = "Align",
+    copy: bool = True,
     **kwargs: Any,
 ) -> TypeMultiSpectralDistributions:
     """
@@ -2851,6 +2858,9 @@ def reshape_msds(
         Spectral shape to reshape the multi-spectral distributions with.
     method
         Reshape method.
+    copy
+        Whether to return a copy of the cached multi-spectra distributions.
+        Default is *True*.
 
     Other Parameters
     ----------------
@@ -2871,7 +2881,7 @@ def reshape_msds(
     data!
     """
 
-    return reshape_sd(msds, shape, method, **kwargs)  # pyright: ignore
+    return reshape_sd(msds, shape, method, copy, **kwargs)  # pyright: ignore
 
 
 def sds_and_msds_to_sds(

--- a/colour/colorimetry/tests/test_spectrum.py
+++ b/colour/colorimetry/tests/test_spectrum.py
@@ -1932,6 +1932,10 @@ class TestReshapeSd(unittest.TestCase):
         sd_reshaped = reshape_sd(sd, shape, method="Trim")
         self.assertEqual(sd_reshaped, sd.copy().trim(shape))
 
+        self.assertIs(
+            reshape_sd(sd, shape, method="Trim", copy=False), sd_reshaped
+        )
+
 
 class TestSdsAndMdsToSds(unittest.TestCase):
     """

--- a/colour/colorimetry/transformations.py
+++ b/colour/colorimetry/transformations.py
@@ -122,7 +122,9 @@ def RGB_2_degree_cmfs_to_XYZ_2_degree_cmfs(
     x, y, z = xyz[..., 0], xyz[..., 1], xyz[..., 2]
 
     V = reshape_sd(
-        SDS_LEFS_PHOTOPIC["CIE 1924 Photopic Standard Observer"], cmfs.shape
+        SDS_LEFS_PHOTOPIC["CIE 1924 Photopic Standard Observer"],
+        cmfs.shape,
+        copy=False,
     )
     L = V[wavelength]
 

--- a/colour/colorimetry/tristimulus_values.py
+++ b/colour/colorimetry/tristimulus_values.py
@@ -179,9 +179,14 @@ SpectralShape(400.0, 700.0, 20.0), 'D65', SpectralShape(400.0, 700.0, 20.0))
 
     from colour import MSDS_CMFS, SDS_ILLUMINANTS
 
-    cmfs = optional(cmfs, reshape_msds(MSDS_CMFS[cmfs_default], shape_default))
+    cmfs = optional(
+        cmfs, reshape_msds(MSDS_CMFS[cmfs_default], shape_default, copy=False)
+    )
     illuminant = optional(
-        illuminant, reshape_sd(SDS_ILLUMINANTS[illuminant_default], cmfs.shape)
+        illuminant,
+        reshape_sd(
+            SDS_ILLUMINANTS[illuminant_default], cmfs.shape, copy=False
+        ),
     )
 
     if illuminant.shape != cmfs.shape:
@@ -190,7 +195,7 @@ SpectralShape(400.0, 700.0, 20.0), 'D65', SpectralShape(400.0, 700.0, 20.0))
             f"colour matching functions shape."
         )
 
-        illuminant = reshape_sd(illuminant, cmfs.shape)
+        illuminant = reshape_sd(illuminant, cmfs.shape, copy=False)
 
     return cmfs, illuminant
 
@@ -674,9 +679,9 @@ def sd_to_XYZ_integration(
             )
 
             sd = (
-                reshape_sd(sd, shape)
+                reshape_sd(sd, shape, copy=False)
                 if isinstance(sd, SpectralDistribution)
-                else reshape_msds(sd, shape)
+                else reshape_msds(sd, shape, copy=False)
             )
 
         R = np.transpose(sd.values)
@@ -705,13 +710,13 @@ def sd_to_XYZ_integration(
         if cmfs.shape != shape:
             runtime_warning(f'Aligning "{cmfs.name}" cmfs shape to "{shape}".')
             # pylint: disable=E1102
-            cmfs = reshape_msds(cmfs, shape)
+            cmfs = reshape_msds(cmfs, shape, copy=False)
 
     if illuminant.shape != shape:
         runtime_warning(
             f'Aligning "{illuminant.name}" illuminant shape to "{shape}".'
         )
-        illuminant = reshape_sd(illuminant, shape)
+        illuminant = reshape_sd(illuminant, shape, copy=False)
 
     XYZ_b = cmfs.values
     S = illuminant.values
@@ -842,6 +847,7 @@ def sd_to_XYZ_tristimulus_weighting_factors_ASTME308(
             cmfs,
             SpectralShape(cmfs.shape.start, cmfs.shape.end, 1),
             "Interpolate",
+            copy=False,
         )
 
     if illuminant.shape != cmfs.shape:
@@ -849,14 +855,14 @@ def sd_to_XYZ_tristimulus_weighting_factors_ASTME308(
             f'Aligning "{illuminant.name}" illuminant shape to "{cmfs.name}" '
             f"colour matching functions shape."
         )
-        illuminant = reshape_sd(illuminant, cmfs.shape)
+        illuminant = reshape_sd(illuminant, cmfs.shape, copy=False)
 
     if sd.shape.boundaries != cmfs.shape.boundaries:
         runtime_warning(
             f'Trimming "{illuminant.name}" spectral distribution shape to '
             f'"{cmfs.name}" colour matching functions shape.'
         )
-        sd = reshape_sd(sd, cmfs.shape, "Trim")
+        sd = reshape_sd(sd, cmfs.shape, "Trim", copy=False)
 
     W = tristimulus_weighting_factors_ASTME2022(
         cmfs,
@@ -1006,7 +1012,7 @@ def sd_to_XYZ_ASTME308(
 
     if use_practice_range:
         # pylint: disable=E1102
-        cmfs = reshape_msds(cmfs, SPECTRAL_SHAPE_ASTME308, "Trim")
+        cmfs = reshape_msds(cmfs, SPECTRAL_SHAPE_ASTME308, "Trim", copy=False)
 
     method = sd_to_XYZ_tristimulus_weighting_factors_ASTME308
     if sd.shape.interval == 1:
@@ -1018,6 +1024,7 @@ def sd_to_XYZ_ASTME308(
                 cmfs,
                 SpectralShape(cmfs.shape.start, cmfs.shape.end, 5),
                 "Interpolate",
+                copy=False,
             )
         method = sd_to_XYZ_integration
     elif sd.shape.interval == 20 and mi_20nm_interpolation_method:

--- a/colour/plotting/section.py
+++ b/colour/plotting/section.py
@@ -585,7 +585,9 @@ def plot_visible_spectrum_section(
     cmfs = cast(
         MultiSpectralDistributions,
         reshape_msds(
-            first_item(filter_cmfs(cmfs).values()), SpectralShape(360, 780, 1)
+            first_item(filter_cmfs(cmfs).values()),
+            SpectralShape(360, 780, 1),
+            copy=False,
         ),
     )
     illuminant = cast(

--- a/colour/quality/cfi2017.py
+++ b/colour/quality/cfi2017.py
@@ -206,11 +206,11 @@ def colour_fidelity_index_CIE2017(
     # "CIE 1964 10 Degree Standard Observer".
     # pylint: disable=E1102
     cmfs_10 = reshape_msds(
-        MSDS_CMFS["CIE 1964 10 Degree Standard Observer"], shape
+        MSDS_CMFS["CIE 1964 10 Degree Standard Observer"], shape, copy=False
     )
 
     # pylint: disable=E1102
-    sds_tcs = reshape_msds(load_TCS_CIE2017(shape), shape)
+    sds_tcs = reshape_msds(load_TCS_CIE2017(shape), shape, copy=False)
 
     test_tcs_colorimetry_data = tcs_colorimetry_data(sd_test, sds_tcs, cmfs_10)
     reference_tcs_colorimetry_data = tcs_colorimetry_data(

--- a/colour/quality/cqs.py
+++ b/colour/quality/cqs.py
@@ -225,11 +225,15 @@ def colour_quality_scale(
     cmfs = reshape_msds(
         MSDS_CMFS["CIE 1931 2 Degree Standard Observer"],
         SPECTRAL_SHAPE_DEFAULT,
+        copy=False,
     )
 
     shape = cmfs.shape
-    sd_test = reshape_sd(sd_test, shape)
-    vs_sds = {sd.name: reshape_sd(sd, shape) for sd in SDS_VS[method].values()}
+    sd_test = reshape_sd(sd_test, shape, copy=False)
+    vs_sds = {
+        sd.name: reshape_sd(sd, shape, copy=False)
+        for sd in SDS_VS[method].values()
+    }
 
     with domain_range_scale("1"):
         XYZ = sd_to_XYZ(sd_test, cmfs)

--- a/colour/quality/cri.py
+++ b/colour/quality/cri.py
@@ -140,11 +140,14 @@ def colour_rendering_index(
     cmfs = reshape_msds(
         MSDS_CMFS["CIE 1931 2 Degree Standard Observer"],
         SPECTRAL_SHAPE_DEFAULT,
+        copy=False,
     )
 
     shape = cmfs.shape
-    sd_test = reshape_sd(sd_test, shape)
-    tcs_sds = {sd.name: reshape_sd(sd, shape) for sd in SDS_TCS.values()}
+    sd_test = reshape_sd(sd_test, shape, copy=False)
+    tcs_sds = {
+        sd.name: reshape_sd(sd, shape, copy=False) for sd in SDS_TCS.values()
+    }
 
     with domain_range_scale("1"):
         XYZ = sd_to_XYZ(sd_test, cmfs)

--- a/colour/quality/ssi.py
+++ b/colour/quality/ssi.py
@@ -100,9 +100,11 @@ def spectral_similarity_index(
         "extrapolator_kwargs": {"left": 0, "right": 0},
     }
 
-    sd_test = reshape_sd(sd_test, SPECTRAL_SHAPE_SSI, "Align", **settings)
+    sd_test = reshape_sd(
+        sd_test, SPECTRAL_SHAPE_SSI, "Align", copy=False, **settings
+    )
     sd_reference = reshape_sd(
-        sd_reference, SPECTRAL_SHAPE_SSI, "Align", **settings
+        sd_reference, SPECTRAL_SHAPE_SSI, "Align", copy=False, **settings
     )
 
     test_i = np.dot(_MATRIX_INTEGRATION, sd_test.values)

--- a/colour/recovery/jiang2013.py
+++ b/colour/recovery/jiang2013.py
@@ -248,14 +248,14 @@ def RGB_to_sd_camera_sensitivity_Jiang2013(
             f'Aligning "{illuminant.name}" illuminant shape to "{shape}".'
         )
         # pylint: disable=E1102
-        illuminant = reshape_sd(illuminant, shape)
+        illuminant = reshape_sd(illuminant, shape, copy=False)
 
     if reflectances.shape != shape:
         runtime_warning(
             f'Aligning "{reflectances.name}" reflectances shape to "{shape}".'
         )
         # pylint: disable=E1102
-        reflectances = reshape_msds(reflectances, shape)
+        reflectances = reshape_msds(reflectances, shape, copy=False)
 
     S = np.diag(illuminant.values)
     R = np.transpose(reflectances.values)
@@ -380,14 +380,14 @@ def RGB_to_msds_camera_sensitivities_Jiang2013(
             f'Aligning "{illuminant.name}" illuminant shape to "{shape}".'
         )
         # pylint: disable=E1102
-        illuminant = reshape_sd(illuminant, shape)
+        illuminant = reshape_sd(illuminant, shape, copy=False)
 
     if reflectances.shape != shape:
         runtime_warning(
             f'Aligning "{reflectances.name}" reflectances shape to "{shape}".'
         )
         # pylint: disable=E1102
-        reflectances = reshape_msds(reflectances, shape)
+        reflectances = reshape_msds(reflectances, shape, copy=False)
 
     S_R = RGB_to_sd_camera_sensitivity_Jiang2013(
         R, illuminant, reflectances, R_w, shape

--- a/colour/recovery/otsu2018.py
+++ b/colour/recovery/otsu2018.py
@@ -1333,7 +1333,7 @@ class Tree_Otsu2018(Node_Otsu2018):
         self._illuminant: SpectralDistribution = illuminant
 
         self._reflectances: NDArrayFloat = np.transpose(
-            reshape_msds(reflectances, self._cmfs.shape).values
+            reshape_msds(reflectances, self._cmfs.shape, copy=False).values
         )
 
         self.data: Data_Otsu2018 = Data_Otsu2018(


### PR DESCRIPTION
<!--
Thank you for taking the time to create this pull request. If it is the first
time you are contributing to a colour-science repository, a contributing guide
is available to guide the process: https://www.colour-science.org/contributing/.
-->

# Summary

This PR as discussed with @tjdcs, adds a new `copy` argument to the `colour.colorimetry.reshape_sd` definition to avoid paying a high copy cost when it is not required.

# Preflight

<!-- Please mark any checkboxes that do not apply to this pull request as [N/A]. -->

**Code Style and Quality**

- [x] Unit tests have been implemented and passed.
- [x] Pyright static checking has been run and passed.
- [x] Pre-commit hooks have been run and passed.
- [N/A] New transformations have been added to the *Automatic Colour Conversion Graph*.
- [N/A] New transformations have been exported to the relevant namespaces, e.g. `colour`, `colour.models`.

<!-- The unit tests can be invoked with `poetry run invoke tests` -->
<!-- Pyright can be started with `pyright --skipunannotated` -->

**Documentation**

- [N/A] New features are documented along with examples if relevant.
- [x] The documentation is [Sphinx](https://www.sphinx-doc.org/en/master/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant.

<!--
Thank you again!
-->
