### PR TITLE
PR: Update `colour.XYZ_to_RGB` and `colour.RGB_to_XYZ` and related definition signatures.

### DIFF
--- a/.github/workflows/continuous-integration-documentation.yml
+++ b/.github/workflows/continuous-integration-documentation.yml
@@ -30,6 +30,8 @@ jobs:
         sudo apt-get update
         sudo apt-get --yes install graphviz graphviz-dev latexmk texlive-full
     - name: Install Poetry
+      env:
+        POETRY_VERSION: 1.4.0
       run: |
         curl -sSL https://install.python-poetry.org | POETRY_HOME=$HOME/.poetry python3 -
         echo "$HOME/.poetry/bin" >> $GITHUB_PATH

--- a/.github/workflows/continuous-integration-quality-unit-tests.yml
+++ b/.github/workflows/continuous-integration-quality-unit-tests.yml
@@ -35,6 +35,8 @@ jobs:
         sudo apt-get update
         sudo apt-get --yes install graphviz graphviz-dev libboost-all-dev libilmbase-dev libopenexr-dev libpng-dev libtiff5-dev
     - name: Install Poetry
+      env:
+        POETRY_VERSION: 1.4.0
       run: |
         curl -sSL https://install.python-poetry.org | POETRY_HOME=$HOME/.poetry python3 -
         echo "$HOME/.poetry/bin" >> $GITHUB_PATH

--- a/colour/examples/characterisation/examples_colour_checkers.py
+++ b/colour/examples/characterisation/examples_colour_checkers.py
@@ -36,11 +36,10 @@ message_box(
 for name, xyY in data.items():
     RGB = colour.XYZ_to_RGB(
         colour.xyY_to_XYZ(xyY),
+        colour.RGB_COLOURSPACES["sRGB"],
         illuminant,
-        colour.CCS_ILLUMINANTS["CIE 1931 2 Degree Standard Observer"]["D65"],
-        colour.RGB_COLOURSPACES["sRGB"].matrix_XYZ_to_RGB,
         "Bradford",
-        colour.RGB_COLOURSPACES["sRGB"].cctf_encoding,
+        apply_cctf_encoding=True,
     )
 
     RGB_i = [int(round(x * 255)) if x >= 0 else 0 for x in np.ravel(RGB)]

--- a/colour/examples/models/examples_models.py
+++ b/colour/examples/models/examples_models.py
@@ -67,12 +67,7 @@ message_box(
 D65 = colour.CCS_ILLUMINANTS["CIE 1931 2 Degree Standard Observer"]["D65"]
 print(
     colour.XYZ_to_RGB(
-        XYZ,
-        D65,
-        colour.RGB_COLOURSPACES["sRGB"].whitepoint,
-        colour.RGB_COLOURSPACES["sRGB"].matrix_XYZ_to_RGB,
-        "Bradford",
-        colour.RGB_COLOURSPACES["sRGB"].cctf_encoding,
+        XYZ, colour.RGB_COLOURSPACES["sRGB"], D65, "Bradford", True
     )
 )
 
@@ -85,12 +80,7 @@ message_box(
 )
 print(
     colour.RGB_to_XYZ(
-        RGB,
-        colour.RGB_COLOURSPACES["sRGB"].whitepoint,
-        D65,
-        colour.RGB_COLOURSPACES["sRGB"].matrix_RGB_to_XYZ,
-        "Bradford",
-        colour.RGB_COLOURSPACES["sRGB"].cctf_decoding,
+        RGB, colour.RGB_COLOURSPACES["sRGB"], D65, "Bradford", True
     )
 )
 

--- a/colour/graph/conversion.py
+++ b/colour/graph/conversion.py
@@ -756,22 +756,12 @@ CONVERSION_SPECIFICATIONS_DATA: List[tuple] = [
     (
         "CIE XYZ",
         "RGB",
-        partial(
-            XYZ_to_RGB,
-            illuminant_XYZ=_RGB_COLOURSPACE_DEFAULT.whitepoint,
-            illuminant_RGB=_RGB_COLOURSPACE_DEFAULT.whitepoint,
-            matrix_XYZ_to_RGB=_RGB_COLOURSPACE_DEFAULT.matrix_XYZ_to_RGB,
-        ),
+        partial(XYZ_to_RGB, colourspace=_RGB_COLOURSPACE_DEFAULT),
     ),
     (
         "RGB",
         "CIE XYZ",
-        partial(
-            RGB_to_XYZ,
-            illuminant_RGB=_RGB_COLOURSPACE_DEFAULT.whitepoint,
-            illuminant_XYZ=_RGB_COLOURSPACE_DEFAULT.whitepoint,
-            matrix_RGB_to_XYZ=_RGB_COLOURSPACE_DEFAULT.matrix_RGB_to_XYZ,
-        ),
+        partial(RGB_to_XYZ, colourspace=_RGB_COLOURSPACE_DEFAULT),
     ),
     (
         "RGB",

--- a/colour/models/rgb/common.py
+++ b/colour/models/rgb/common.py
@@ -89,15 +89,12 @@ def XYZ_to_sRGB(
     array([ 0.7057393...,  0.1924826...,  0.2235416...])
     """
 
-    sRGB = RGB_COLOURSPACES["sRGB"]
-
     return XYZ_to_RGB(
         XYZ,
+        RGB_COLOURSPACES["sRGB"],
         illuminant,
-        sRGB.whitepoint,
-        sRGB.matrix_XYZ_to_RGB,
         chromatic_adaptation_transform,
-        sRGB.cctf_encoding if apply_cctf_encoding else None,
+        apply_cctf_encoding,
     )
 
 
@@ -166,13 +163,10 @@ def sRGB_to_XYZ(
     array([ 0.2065429...,  0.1219794...,  0.0513714...])
     """
 
-    sRGB = RGB_COLOURSPACES["sRGB"]
-
     return RGB_to_XYZ(
         RGB,
-        sRGB.whitepoint,
+        RGB_COLOURSPACES["sRGB"],
         illuminant,
-        sRGB.matrix_RGB_to_XYZ,
         chromatic_adaptation_transform,
-        sRGB.cctf_decoding if apply_cctf_decoding else None,
+        apply_cctf_decoding,
     )

--- a/colour/models/rgb/ictcp.py
+++ b/colour/models/rgb/ictcp.py
@@ -519,13 +519,10 @@ def XYZ_to_ICtCp(
     array([ 0.5924279..., -0.0374073...,  0.2512267...])
     """
 
-    BT2020 = RGB_COLOURSPACES["ITU-R BT.2020"]
-
     RGB = XYZ_to_RGB(
         XYZ,
+        RGB_COLOURSPACES["ITU-R BT.2020"],
         illuminant,
-        BT2020.whitepoint,
-        BT2020.matrix_XYZ_to_RGB,
         chromatic_adaptation_transform,
     )
 
@@ -655,13 +652,10 @@ def ICtCp_to_XYZ(
 
     RGB = ICtCp_to_RGB(ICtCp, method, L_p)
 
-    BT2020 = RGB_COLOURSPACES["ITU-R BT.2020"]
-
     XYZ = RGB_to_XYZ(
         RGB,
-        BT2020.whitepoint,
+        RGB_COLOURSPACES["ITU-R BT.2020"],
         illuminant,
-        BT2020.matrix_RGB_to_XYZ,
         chromatic_adaptation_transform,
     )
 

--- a/colour/models/rgb/rgb_colourspace.py
+++ b/colour/models/rgb/rgb_colourspace.py
@@ -1238,8 +1238,8 @@ def RGB_to_XYZ(
 
 
 def matrix_RGB_to_RGB(
-    input_colourspace: RGB_Colourspace,
-    output_colourspace: RGB_Colourspace,
+    input_colourspace: RGB_Colourspace | str,
+    output_colourspace: RGB_Colourspace | str,
     chromatic_adaptation_transform: Literal[
         "Bianco 2010",
         "Bianco PC 2010",
@@ -1288,7 +1288,34 @@ def matrix_RGB_to_RGB(
     array([[ 0.5288241...,  0.3340609...,  0.1373616...],
            [ 0.0975294...,  0.8790074...,  0.0233981...],
            [ 0.0163599...,  0.1066124...,  0.8772485...]])
+    >>> matrix_RGB_to_RGB("sRGB", "ProPhoto RGB")
+    ... # doctest: +ELLIPSIS
+    array([[ 0.5288241...,  0.3340609...,  0.1373616...],
+           [ 0.0975294...,  0.8790074...,  0.0233981...],
+           [ 0.0163599...,  0.1066124...,  0.8772485...]])
     """
+
+    from colour.models import RGB_COLOURSPACES
+
+    if isinstance(input_colourspace, str):
+        input_colourspace = validate_method(
+            input_colourspace,
+            RGB_COLOURSPACES,
+            '"{0}" "RGB" colourspace is invalid, it must be one of {1}!',
+        )
+        input_colourspace = cast(
+            RGB_Colourspace, RGB_COLOURSPACES[input_colourspace]
+        )
+
+    if isinstance(output_colourspace, str):
+        output_colourspace = validate_method(
+            output_colourspace,
+            RGB_COLOURSPACES,
+            '"{0}" "RGB" colourspace is invalid, it must be one of {1}!',
+        )
+        output_colourspace = cast(
+            RGB_Colourspace, RGB_COLOURSPACES[output_colourspace]
+        )
 
     M = input_colourspace.matrix_RGB_to_XYZ
 
@@ -1308,8 +1335,8 @@ def matrix_RGB_to_RGB(
 
 def RGB_to_RGB(
     RGB: ArrayLike,
-    input_colourspace: RGB_Colourspace,
-    output_colourspace: RGB_Colourspace,
+    input_colourspace: RGB_Colourspace | str,
+    output_colourspace: RGB_Colourspace | str,
     chromatic_adaptation_transform: Literal[
         "Bianco 2010",
         "Bianco PC 2010",
@@ -1386,7 +1413,32 @@ def RGB_to_RGB(
     >>> RGB_to_RGB(RGB, RGB_COLOURSPACE_sRGB, RGB_COLOURSPACE_PROPHOTO_RGB)
     ... # doctest: +ELLIPSIS
     array([ 0.2568891...,  0.0721446...,  0.0465553...])
+    >>> RGB_to_RGB(RGB, "sRGB", "ProPhoto RGB")
+    ... # doctest: +ELLIPSIS
+    array([ 0.2568891...,  0.0721446...,  0.0465553...])
     """
+
+    from colour.models import RGB_COLOURSPACES
+
+    if isinstance(input_colourspace, str):
+        input_colourspace = validate_method(
+            input_colourspace,
+            RGB_COLOURSPACES,
+            '"{0}" "RGB" colourspace is invalid, it must be one of {1}!',
+        )
+        input_colourspace = cast(
+            RGB_Colourspace, RGB_COLOURSPACES[input_colourspace]
+        )
+
+    if isinstance(output_colourspace, str):
+        output_colourspace = validate_method(
+            output_colourspace,
+            RGB_COLOURSPACES,
+            '"{0}" "RGB" colourspace is invalid, it must be one of {1}!',
+        )
+        output_colourspace = cast(
+            RGB_Colourspace, RGB_COLOURSPACES[output_colourspace]
+        )
 
     RGB = to_domain_1(RGB)
 

--- a/colour/models/rgb/rgb_colourspace.py
+++ b/colour/models/rgb/rgb_colourspace.py
@@ -80,7 +80,7 @@ class RGB_Colourspace:
     Colour science literature related to *RGB* colourspaces and encodings
     defines their dataset using different degree of precision or rounding.
     While instances where a whitepoint is being defined with a value
-    different than its canonical agreed one are rare, it is however very
+    different from its canonical agreed one are rare, it is however very
     common to have normalised primary matrices rounded at different
     decimals. This can yield large discrepancies in computations.
 

--- a/colour/models/rgb/tests/test_rgb_colourspace.py
+++ b/colour/models/rgb/tests/test_rgb_colourspace.py
@@ -761,6 +761,12 @@ class TestMatrix_RGB_to_RGB(unittest.TestCase):
             decimal=7,
         )
 
+        np.testing.assert_array_almost_equal(
+            matrix_RGB_to_RGB(aces_2065_1_colourspace, sRGB_colourspace),
+            matrix_RGB_to_RGB("ACES2065-1", "sRGB"),
+            decimal=7,
+        )
+
 
 class TestRGB_to_RGB(unittest.TestCase):
     """
@@ -852,6 +858,20 @@ class TestRGB_to_RGB(unittest.TestCase):
                 out_int=True,
             ),
             np.array([120, 59, 46]),
+        )
+
+        np.testing.assert_array_almost_equal(
+            RGB_to_RGB(
+                np.array([0.21931722, 0.06950287, 0.04694832]),
+                aces_2065_1_colourspace,
+                sRGB_colourspace,
+            ),
+            RGB_to_RGB(
+                np.array([0.21931722, 0.06950287, 0.04694832]),
+                "ACES2065-1",
+                "sRGB",
+            ),
+            decimal=7,
         )
 
     def test_n_dimensional_RGB_to_RGB(self):

--- a/colour/models/rgb/tests/test_rgb_colourspace.py
+++ b/colour/models/rgb/tests/test_rgb_colourspace.py
@@ -1,5 +1,7 @@
 # !/usr/bin/env python
-"""Define the unit tests for the :mod:`colour.models.rgb.rgb_colourspace` module."""
+"""
+Define the unit tests for the :mod:`colour.models.rgb.rgb_colourspace` module.
+"""
 
 import numpy as np
 import re
@@ -8,6 +10,8 @@ import unittest
 from itertools import product
 
 from colour.models import (
+    RGB_COLOURSPACE_ACES2065_1,
+    RGB_COLOURSPACE_sRGB,
     RGB_COLOURSPACES,
     RGB_Colourspace,
     XYZ_to_RGB,
@@ -284,8 +288,62 @@ class TestXYZ_to_RGB(unittest.TestCase):
     """
 
     def test_XYZ_to_RGB(self):
-        """Test :func:`colour.models.rgb.rgb_colourspace.XYZ_to_RGB` definition."""
+        """
+        Test :func:`colour.models.rgb.rgb_colourspace.XYZ_to_RGB`
+        definition.
+        """
 
+        np.testing.assert_array_almost_equal(
+            XYZ_to_RGB(
+                np.array([0.21638819, 0.12570000, 0.03847493]),
+                RGB_COLOURSPACE_sRGB,
+                np.array([0.34570, 0.35850]),
+                "Bradford",
+                True,
+            ),
+            np.array([0.70556403, 0.19112904, 0.22341005]),
+            decimal=7,
+        )
+
+        np.testing.assert_array_almost_equal(
+            XYZ_to_RGB(
+                np.array([0.21638819, 0.12570000, 0.03847493]),
+                RGB_COLOURSPACE_sRGB,
+                apply_cctf_encoding=True,
+            ),
+            np.array([0.72794351, 0.18184112, 0.17951801]),
+            decimal=7,
+        )
+
+        np.testing.assert_array_almost_equal(
+            XYZ_to_RGB(
+                np.array([0.21638819, 0.12570000, 0.03847493]),
+                RGB_COLOURSPACE_ACES2065_1,
+                np.array([0.34570, 0.35850]),
+            ),
+            np.array([0.21959099, 0.06985815, 0.04703704]),
+            decimal=7,
+        )
+
+        np.testing.assert_array_almost_equal(
+            XYZ_to_RGB(
+                np.array([0.21638819, 0.12570000, 0.03847493]),
+                "sRGB",
+                np.array([0.34570, 0.35850]),
+                "Bradford",
+                True,
+            ),
+            XYZ_to_RGB(
+                np.array([0.21638819, 0.12570000, 0.03847493]),
+                RGB_COLOURSPACE_sRGB,
+                np.array([0.34570, 0.35850]),
+                "Bradford",
+                True,
+            ),
+            decimal=7,
+        )
+
+        # TODO: Remove tests when dropping deprecated signature support.
         np.testing.assert_array_almost_equal(
             XYZ_to_RGB(
                 np.array([0.21638819, 0.12570000, 0.03847493]),
@@ -366,38 +424,28 @@ class TestXYZ_to_RGB(unittest.TestCase):
 
         XYZ = np.array([0.21638819, 0.12570000, 0.03847493])
         W_R = np.array([0.34570, 0.35850])
-        W_T = np.array([0.31270, 0.32900])
-        M = np.array(
-            [
-                [3.24062548, -1.53720797, -0.49862860],
-                [-0.96893071, 1.87575606, 0.04151752],
-                [0.05571012, -0.20402105, 1.05699594],
-            ]
-        )
-        RGB = XYZ_to_RGB(XYZ, W_R, W_T, M, "Bradford", eotf_inverse_sRGB)
+        RGB = XYZ_to_RGB(XYZ, "sRGB", W_R, "Bradford", True)
 
         XYZ = np.tile(XYZ, (6, 1))
         RGB = np.tile(RGB, (6, 1))
         np.testing.assert_array_almost_equal(
-            XYZ_to_RGB(XYZ, W_R, W_T, M, "Bradford", eotf_inverse_sRGB),
+            XYZ_to_RGB(XYZ, "sRGB", W_R, "Bradford", True),
             RGB,
             decimal=7,
         )
 
         W_R = np.tile(W_R, (6, 1))
-        W_T = np.tile(W_T, (6, 1))
         np.testing.assert_array_almost_equal(
-            XYZ_to_RGB(XYZ, W_R, W_T, M, "Bradford", eotf_inverse_sRGB),
+            XYZ_to_RGB(XYZ, "sRGB", W_R, "Bradford", True),
             RGB,
             decimal=7,
         )
 
         XYZ = np.reshape(XYZ, (2, 3, 3))
         W_R = np.reshape(W_R, (2, 3, 2))
-        W_T = np.reshape(W_T, (2, 3, 2))
         RGB = np.reshape(RGB, (2, 3, 3))
         np.testing.assert_array_almost_equal(
-            XYZ_to_RGB(XYZ, W_R, W_T, M, "Bradford", eotf_inverse_sRGB),
+            XYZ_to_RGB(XYZ, "sRGB", W_R, "Bradford", True),
             RGB,
             decimal=7,
         )
@@ -410,21 +458,13 @@ class TestXYZ_to_RGB(unittest.TestCase):
 
         XYZ = np.array([0.21638819, 0.12570000, 0.03847493])
         W_R = np.array([0.34570, 0.35850])
-        W_T = np.array([0.31270, 0.32900])
-        M = np.array(
-            [
-                [3.24062548, -1.53720797, -0.49862860],
-                [-0.96893071, 1.87575606, 0.04151752],
-                [0.05571012, -0.20402105, 1.05699594],
-            ]
-        )
-        RGB = XYZ_to_RGB(XYZ, W_R, W_T, M)
+        RGB = XYZ_to_RGB(XYZ, "sRGB", W_R)
 
         d_r = (("reference", 1), ("1", 1), ("100", 100))
         for scale, factor in d_r:
             with domain_range_scale(scale):
                 np.testing.assert_array_almost_equal(
-                    XYZ_to_RGB(XYZ * factor, W_R, W_T, M),
+                    XYZ_to_RGB(XYZ * factor, "sRGB", W_R),
                     RGB * factor,
                     decimal=7,
                 )
@@ -451,8 +491,62 @@ class TestRGB_to_XYZ(unittest.TestCase):
     """
 
     def test_RGB_to_XYZ(self):
-        """Test :func:`colour.models.rgb.rgb_colourspace.RGB_to_XYZ` definition."""
+        """
+        Test :func:`colour.models.rgb.rgb_colourspace.RGB_to_XYZ`
+        definition.
+        """
 
+        np.testing.assert_array_almost_equal(
+            RGB_to_XYZ(
+                np.array([0.70556403, 0.19112904, 0.22341005]),
+                RGB_COLOURSPACE_sRGB,
+                np.array([0.34570, 0.35850]),
+                "Bradford",
+                True,
+            ),
+            np.array([0.21639121, 0.12570714, 0.03847642]),
+            decimal=7,
+        )
+
+        np.testing.assert_array_almost_equal(
+            RGB_to_XYZ(
+                np.array([0.72794351, 0.18184112, 0.17951801]),
+                RGB_COLOURSPACE_sRGB,
+                apply_cctf_decoding=True,
+            ),
+            np.array([0.21639100, 0.12570754, 0.03847682]),
+            decimal=7,
+        )
+
+        np.testing.assert_array_almost_equal(
+            RGB_to_XYZ(
+                np.array([0.21959099, 0.06985815, 0.04703704]),
+                RGB_COLOURSPACE_ACES2065_1,
+                np.array([0.34570, 0.35850]),
+            ),
+            np.array([0.21638819, 0.12570000, 0.03847493]),
+            decimal=7,
+        )
+
+        np.testing.assert_array_almost_equal(
+            RGB_to_XYZ(
+                np.array([0.21638819, 0.12570000, 0.03847493]),
+                "sRGB",
+                np.array([0.34570, 0.35850]),
+                "Bradford",
+                True,
+            ),
+            RGB_to_XYZ(
+                np.array([0.21638819, 0.12570000, 0.03847493]),
+                RGB_COLOURSPACE_sRGB,
+                np.array([0.34570, 0.35850]),
+                "Bradford",
+                True,
+            ),
+            decimal=7,
+        )
+
+        # TODO: Remove tests when dropping deprecated signature support.
         np.testing.assert_array_almost_equal(
             RGB_to_XYZ(
                 np.array([0.70556599, 0.19109268, 0.22340812]),
@@ -533,34 +627,24 @@ class TestRGB_to_XYZ(unittest.TestCase):
 
         RGB = np.array([0.70556599, 0.19109268, 0.22340812])
         W_R = np.array([0.31270, 0.32900])
-        W_T = np.array([0.34570, 0.35850])
-        M = np.array(
-            [
-                [0.41240000, 0.35760000, 0.18050000],
-                [0.21260000, 0.71520000, 0.07220000],
-                [0.01930000, 0.11920000, 0.95050000],
-            ]
-        )
-        XYZ = RGB_to_XYZ(RGB, W_R, W_T, M, "Bradford", eotf_sRGB)
+        XYZ = RGB_to_XYZ(RGB, "sRGB", W_R, "Bradford", True)
 
         RGB = np.tile(RGB, (6, 1))
         XYZ = np.tile(XYZ, (6, 1))
         np.testing.assert_array_almost_equal(
-            RGB_to_XYZ(RGB, W_R, W_T, M, "Bradford", eotf_sRGB), XYZ, decimal=7
+            RGB_to_XYZ(RGB, "sRGB", W_R, "Bradford", True), XYZ, decimal=7
         )
 
         W_R = np.tile(W_R, (6, 1))
-        W_T = np.tile(W_T, (6, 1))
         np.testing.assert_array_almost_equal(
-            RGB_to_XYZ(RGB, W_R, W_T, M, "Bradford", eotf_sRGB), XYZ, decimal=7
+            RGB_to_XYZ(RGB, "sRGB", W_R, "Bradford", True), XYZ, decimal=7
         )
 
         RGB = np.reshape(RGB, (2, 3, 3))
         W_R = np.reshape(W_R, (2, 3, 2))
-        W_T = np.reshape(W_T, (2, 3, 2))
         XYZ = np.reshape(XYZ, (2, 3, 3))
         np.testing.assert_array_almost_equal(
-            RGB_to_XYZ(RGB, W_R, W_T, M, "Bradford", eotf_sRGB), XYZ, decimal=7
+            RGB_to_XYZ(RGB, "sRGB", W_R, "Bradford", True), XYZ, decimal=7
         )
 
     def test_domain_range_scale_XYZ_to_RGB(self):
@@ -571,21 +655,13 @@ class TestRGB_to_XYZ(unittest.TestCase):
 
         RGB = np.array([0.45620801, 0.03079991, 0.04091883])
         W_R = np.array([0.31270, 0.32900])
-        W_T = np.array([0.34570, 0.35850])
-        M = np.array(
-            [
-                [3.24062548, -1.53720797, -0.49862860],
-                [-0.96893071, 1.87575606, 0.04151752],
-                [0.05571012, -0.20402105, 1.05699594],
-            ]
-        )
-        XYZ = RGB_to_XYZ(RGB, W_R, W_T, M)
+        XYZ = RGB_to_XYZ(RGB, "sRGB", W_R)
 
         d_r = (("reference", 1), ("1", 1), ("100", 100))
         for scale, factor in d_r:
             with domain_range_scale(scale):
                 np.testing.assert_array_almost_equal(
-                    RGB_to_XYZ(RGB * factor, W_R, W_T, M),
+                    RGB_to_XYZ(RGB * factor, "sRGB", W_R),
                     XYZ * factor,
                     decimal=7,
                 )

--- a/colour/plotting/common.py
+++ b/colour/plotting/common.py
@@ -386,13 +386,10 @@ def XYZ_to_plotting_colourspace(
 
     return XYZ_to_RGB(
         XYZ,
+        CONSTANTS_COLOUR_STYLE.colour.colourspace,
         illuminant,
-        CONSTANTS_COLOUR_STYLE.colour.colourspace.whitepoint,
-        CONSTANTS_COLOUR_STYLE.colour.colourspace.matrix_XYZ_to_RGB,
         chromatic_adaptation_transform,
-        CONSTANTS_COLOUR_STYLE.colour.colourspace.cctf_encoding
-        if apply_cctf_encoding
-        else None,
+        apply_cctf_encoding,
     )
 
 

--- a/colour/plotting/models.py
+++ b/colour/plotting/models.py
@@ -1057,12 +1057,7 @@ Plot_RGB_Chromaticities_In_Chromaticity_Diagram.png
             1,
         )
 
-    XYZ = RGB_to_XYZ(
-        RGB,
-        colourspace.whitepoint,
-        colourspace.whitepoint,
-        colourspace.matrix_RGB_to_XYZ,
-    )
+    XYZ = RGB_to_XYZ(RGB, colourspace)
 
     if method == "cie 1931":
         ij = XYZ_to_xy(XYZ, colourspace.whitepoint)
@@ -2058,23 +2053,12 @@ def plot_constant_hue_loci(
         )
 
         if use_RGB_colours:
-
-            def _XYZ_to_RGB(XYZ: NDArrayFloat) -> NDArrayFloat:
-                """
-                Convert given *CIE XYZ* tristimulus values to
-                ``colour.plotting`` *RGB* colourspace.
-                """
-
-                return XYZ_to_RGB(
-                    XYZ,
-                    xy_r,  # noqa: B023
-                    colourspace.whitepoint,
-                    colourspace.matrix_XYZ_to_RGB,
-                    cctf_encoding=colourspace.cctf_encoding,
-                )
-
-            RGB_ct = _XYZ_to_RGB(XYZ_ct)
-            RGB_cr = _XYZ_to_RGB(XYZ_cr)
+            RGB_ct = XYZ_to_RGB(
+                XYZ_ct, colourspace, xy_r, apply_cctf_encoding=True
+            )
+            RGB_cr = XYZ_to_RGB(
+                XYZ_cr, colourspace, xy_r, apply_cctf_encoding=True
+            )
 
             scatter_settings["c"] = np.clip(RGB_ct, 0, 1)
 

--- a/colour/plotting/section.py
+++ b/colour/plotting/section.py
@@ -754,12 +754,7 @@ def plot_RGB_colourspace_section(
     )
 
     vertices, faces, _outline = primitive_cube(1, 1, 1, 64, 64, 64)
-    XYZ_vertices = RGB_to_XYZ(
-        vertices["position"] + 0.5,
-        colourspace.whitepoint,
-        colourspace.whitepoint,
-        colourspace.matrix_RGB_to_XYZ,
-    )
+    XYZ_vertices = RGB_to_XYZ(vertices["position"] + 0.5, colourspace)
     hull = trimesh.Trimesh(XYZ_vertices, faces, process=False)
 
     if show_section_colours:

--- a/colour/plotting/tests/test_section.py
+++ b/colour/plotting/tests/test_section.py
@@ -50,10 +50,7 @@ class TestPlotHullSectionColours(unittest.TestCase):
 
         vertices, faces, _outline = primitive_cube(1, 1, 1, 64, 64, 64)
         XYZ_vertices = RGB_to_XYZ(
-            vertices["position"] + 0.5,
-            RGB_COLOURSPACE_sRGB.whitepoint,
-            RGB_COLOURSPACE_sRGB.whitepoint,
-            RGB_COLOURSPACE_sRGB.matrix_RGB_to_XYZ,
+            vertices["position"] + 0.5, RGB_COLOURSPACE_sRGB
         )
         hull = trimesh.Trimesh(XYZ_vertices, faces, process=False)
 
@@ -92,10 +89,7 @@ class TestPlotHullSectionContour(unittest.TestCase):
 
         vertices, faces, _outline = primitive_cube(1, 1, 1, 64, 64, 64)
         XYZ_vertices = RGB_to_XYZ(
-            vertices["position"] + 0.5,
-            RGB_COLOURSPACE_sRGB.whitepoint,
-            RGB_COLOURSPACE_sRGB.whitepoint,
-            RGB_COLOURSPACE_sRGB.matrix_RGB_to_XYZ,
+            vertices["position"] + 0.5, RGB_COLOURSPACE_sRGB
         )
         hull = trimesh.Trimesh(XYZ_vertices, faces, process=False)
 

--- a/colour/plotting/volume.py
+++ b/colour/plotting/volume.py
@@ -600,7 +600,6 @@ def plot_RGB_colourspaces_gamuts(
     RGB_cf: list = []
     RGB_ce: list = []
     for i, colourspace in enumerate(colourspaces):
-
         if chromatically_adapt and not np.array_equal(
             colourspace.whitepoint, plotting_colourspace.whitepoint
         ):
@@ -615,12 +614,7 @@ def plot_RGB_colourspaces_gamuts(
             depth_segments=segments,
         )
 
-        XYZ = RGB_to_XYZ(
-            quads_cb,
-            colourspace.whitepoint,
-            colourspace.whitepoint,
-            colourspace.matrix_RGB_to_XYZ,
-        )
+        XYZ = RGB_to_XYZ(quads_cb, colourspace)
 
         convert_settings = {"illuminant": colourspace.whitepoint}
         convert_settings.update(convert_kwargs)
@@ -836,12 +830,7 @@ def plot_RGB_scatter(
         **settings,
     )
 
-    XYZ = RGB_to_XYZ(
-        RGB,
-        colourspace.whitepoint,
-        colourspace.whitepoint,
-        colourspace.matrix_RGB_to_XYZ,
-    )
+    XYZ = RGB_to_XYZ(RGB, colourspace)
 
     convert_settings = {"illuminant": colourspace.whitepoint}
     convert_settings.update(convert_kwargs)

--- a/colour/recovery/jakob2019.py
+++ b/colour/recovery/jakob2019.py
@@ -201,9 +201,10 @@ def error_function(
     illuminant: SpectralDistribution,
     max_error: float | None = None,
     additional_data: bool = False,
-) -> Tuple[float, NDArrayFloat] | Tuple[
-    float, NDArrayFloat, NDArrayFloat, NDArrayFloat, NDArrayFloat
-]:
+) -> (
+    Tuple[float, NDArrayFloat]
+    | Tuple[float, NDArrayFloat, NDArrayFloat, NDArrayFloat, NDArrayFloat]
+):
     """
     Compute :math:`\\Delta E_{76}` between the target colour and the colour
     defined by given spectral model, along with its gradient.
@@ -922,12 +923,7 @@ class LUT3D_Jakob2019:
 
             RGB = self._lightness_scale[L] * chroma
 
-            XYZ = RGB_to_XYZ(
-                RGB,
-                colourspace.whitepoint,
-                xy_n,
-                colourspace.matrix_RGB_to_XYZ,
-            )
+            XYZ = RGB_to_XYZ(RGB, colourspace, xy_n)
 
             coefficients, _error = find_coefficients_Jakob2019(
                 XYZ, cmfs, illuminant, coefficients_0, dimensionalise=False

--- a/colour/recovery/smits1999.py
+++ b/colour/recovery/smits1999.py
@@ -13,13 +13,11 @@ References
 
 from __future__ import annotations
 
-import numpy as np
-
 from colour.colorimetry import CCS_ILLUMINANTS, SpectralDistribution
 from colour.hints import ArrayLike, NDArrayFloat
 from colour.models import (
     XYZ_to_RGB,
-    normalised_primary_matrix,
+    RGB_Colourspace,
     RGB_COLOURSPACE_sRGB,
 )
 from colour.recovery import SDS_SMITS1999
@@ -34,26 +32,36 @@ __status__ = "Production"
 
 __all__ = [
     "PRIMARIES_SMITS1999",
+    "WHITEPOINT_NAME_SMITS1999",
     "CCS_WHITEPOINT_SMITS1999",
-    "MATRIX_XYZ_TO_RGB_SMITS1999",
+    "RGB_COLOURSPACE_SMITS1999",
     "XYZ_to_RGB_Smits1999",
     "RGB_to_sd_Smits1999",
 ]
 
 PRIMARIES_SMITS1999: NDArrayFloat = RGB_COLOURSPACE_sRGB.primaries
-"""Current *Smits (1999)* method implementation colourspace primaries."""
+"""*Smits (1999)* method implementation colourspace primaries."""
+
+WHITEPOINT_NAME_SMITS1999 = "E"
+"""*Smits (1999)* method implementation colourspace whitepoint name."""
 
 CCS_WHITEPOINT_SMITS1999: NDArrayFloat = CCS_ILLUMINANTS[
     "CIE 1931 2 Degree Standard Observer"
-]["E"]
-"""Current *Smits (1999)* method implementation colourspace whitepoint."""
+][WHITEPOINT_NAME_SMITS1999]
+"""*Smits (1999)* method implementation colourspace whitepoint."""
 
-MATRIX_XYZ_TO_RGB_SMITS1999: NDArrayFloat = np.linalg.inv(
-    normalised_primary_matrix(PRIMARIES_SMITS1999, CCS_WHITEPOINT_SMITS1999)
+RGB_COLOURSPACE_SMITS1999 = RGB_Colourspace(
+    "Smits 1999",
+    PRIMARIES_SMITS1999,
+    CCS_WHITEPOINT_SMITS1999,
+    WHITEPOINT_NAME_SMITS1999,
 )
-"""
-Current *Smits (1999)* method implementation *RGB* colourspace to
-*CIE XYZ* tristimulus values matrix.
+RGB_COLOURSPACE_sRGB.__doc__ = """
+*Smits (1999)* colourspace.
+
+References
+----------
+:cite:`Smits1999a`,
 """
 
 
@@ -74,17 +82,13 @@ def XYZ_to_RGB_Smits1999(XYZ: ArrayLike) -> NDArrayFloat:
 
     Examples
     --------
+    >>> import numpy as np
     >>> XYZ = np.array([0.21781186, 0.12541048, 0.04697113])
     >>> XYZ_to_RGB_Smits1999(XYZ)  # doctest: +ELLIPSIS
     array([ 0.4063959...,  0.0275289...,  0.0398219...])
     """
 
-    return XYZ_to_RGB(
-        XYZ,
-        CCS_WHITEPOINT_SMITS1999,
-        CCS_WHITEPOINT_SMITS1999,
-        MATRIX_XYZ_TO_RGB_SMITS1999,
-    )
+    return XYZ_to_RGB(XYZ, RGB_COLOURSPACE_SMITS1999)
 
 
 def RGB_to_sd_Smits1999(RGB: ArrayLike) -> SpectralDistribution:
@@ -116,6 +120,7 @@ def RGB_to_sd_Smits1999(RGB: ArrayLike) -> SpectralDistribution:
 
     Examples
     --------
+    >>> import numpy as np
     >>> from colour import MSDS_CMFS, SDS_ILLUMINANTS, SpectralShape
     >>> from colour.colorimetry import sd_to_XYZ_integration
     >>> from colour.utilities import numpy_print_options

--- a/colour/recovery/tests/test_jakob2019.py
+++ b/colour/recovery/tests/test_jakob2019.py
@@ -323,12 +323,7 @@ class TestLUT3D_Jakob2019(unittest.TestCase):
             full(3, 0.5),
             ones(3),
         ]:
-            XYZ = RGB_to_XYZ(
-                RGB,
-                self._RGB_colourspace.whitepoint,
-                self._xy_D65,
-                self._RGB_colourspace.matrix_RGB_to_XYZ,
-            )
+            XYZ = RGB_to_XYZ(RGB, self._RGB_colourspace, self._xy_D65)
             Lab = XYZ_to_Lab(XYZ, self._xy_D65)
 
             recovered_sd = LUT.RGB_to_sd(RGB)

--- a/colour/recovery/tests/test_mallett2019.py
+++ b/colour/recovery/tests/test_mallett2019.py
@@ -82,12 +82,7 @@ class TestMixinMallett2019:
         for name, sd in SDS_COLOURCHECKERS["ColorChecker N Ohta"].items():
             XYZ = sd_to_XYZ(sd, self._cmfs, self._sd_D65) / 100
             Lab = XYZ_to_Lab(XYZ, self._xy_D65)
-            RGB = XYZ_to_RGB(
-                XYZ,
-                self._RGB_colourspace.whitepoint,
-                self._xy_D65,
-                self._RGB_colourspace.matrix_XYZ_to_RGB,
-            )
+            RGB = XYZ_to_RGB(XYZ, self._RGB_colourspace, self._xy_D65)
 
             recovered_sd = RGB_to_sd_Mallett2019(RGB, self._basis)
             recovered_XYZ = (

--- a/colour/volume/rgb.py
+++ b/colour/volume/rgb.py
@@ -152,10 +152,9 @@ reproducibility-of-python-pseudo-random-numbers-across-systems-and-versions
     Lab = random_generator(DEFAULT_INT_DTYPE(samples), limits, random_state)
     RGB = XYZ_to_RGB(
         Lab_to_XYZ(Lab, illuminant_Lab),
+        colourspace,
         illuminant_Lab,
-        colourspace.whitepoint,
-        colourspace.matrix_XYZ_to_RGB,
-        chromatic_adaptation_transform=chromatic_adaptation_transform,
+        chromatic_adaptation_transform,
     )
     RGB_w = RGB[
         np.logical_and(np.min(RGB, axis=-1) >= 0, np.max(RGB, axis=-1) <= 1)
@@ -200,12 +199,7 @@ def RGB_colourspace_limits(colourspace: RGB_Colourspace) -> NDArrayFloat:
     for combination in list(itertools.product([0, 1], repeat=3)):
         Lab_c.append(
             XYZ_to_Lab(
-                RGB_to_XYZ(
-                    combination,
-                    colourspace.whitepoint,
-                    colourspace.whitepoint,
-                    colourspace.matrix_RGB_to_XYZ,
-                ),
+                RGB_to_XYZ(combination, colourspace),
                 colourspace.whitepoint,
             )
         )
@@ -372,12 +366,7 @@ def RGB_colourspace_volume_coverage_MonteCarlo(
     )
     XYZ_vs = XYZ[coverage_sampler(XYZ)]
 
-    RGB = XYZ_to_RGB(
-        XYZ_vs,
-        colourspace.whitepoint,
-        colourspace.whitepoint,
-        colourspace.matrix_XYZ_to_RGB,
-    )
+    RGB = XYZ_to_RGB(XYZ_vs, colourspace)
 
     RGB_c = RGB[
         np.logical_and(np.min(RGB, axis=-1) >= 0, np.max(RGB, axis=-1) <= 1)

--- a/utilities/generate_plots.py
+++ b/utilities/generate_plots.py
@@ -874,12 +874,7 @@ def generate_documentation_plots(output_directory: str):
         output_directory, "Plotting_Plot_Hull_Section_Colours.png"
     )
     vertices, faces, _outline = primitive_cube(1, 1, 1, 64, 64, 64)
-    XYZ_vertices = RGB_to_XYZ(
-        vertices["position"] + 0.5,
-        RGB_COLOURSPACE_sRGB.whitepoint,
-        RGB_COLOURSPACE_sRGB.whitepoint,
-        RGB_COLOURSPACE_sRGB.matrix_RGB_to_XYZ,
-    )
+    XYZ_vertices = RGB_to_XYZ(vertices["position"] + 0.5, RGB_COLOURSPACE_sRGB)
     hull = trimesh.Trimesh(XYZ_vertices, faces, process=False)
     plt.close(
         plot_hull_section_colours(hull, section_colours="RGB", **arguments)[0]


### PR DESCRIPTION
<!--
Thank you for taking the time to create this pull request. If it is the first
time you are contributing to a colour-science repository, a contributing guide
is available to guide the process: https://www.colour-science.org/contributing/.
-->

# Summary

<!-- Please write a summary describing the changes that this PR implements. -->

This PR updates the following definition signatures according to #1127:

- `colour.XYZ_to_RGB`
- `colour.RGB_to_XYZ`
- `colour.matrix_RGB_to_RGB`
- `colour.RGB_to_RGB`

# Preflight

<!-- Please mark any checkboxes that do not apply to this pull request as [N/A]. -->

**Code Style and Quality**

- [x] Unit tests have been implemented and passed.
- [x] Pyright static checking has been run and passed.
- [x] Pre-commit hooks have been run and passed.
- [N/A] New transformations have been added to the *Automatic Colour Conversion Graph*.
- [N/A] New transformations have been exported to the relevant namespaces, e.g. `colour`, `colour.models`.

<!-- The unit tests can be invoked with `poetry run invoke tests` -->
<!-- Pyright can be started with `pyright --skipunannotated` -->

**Documentation**

- [N/A] New features are documented along with examples if relevant.
- [x] The documentation is [Sphinx](https://www.sphinx-doc.org/en/master/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant.

<!--
Thank you again!
-->
