### PR TITLE
PR: Implement support for callbacks in `colour.continuous.AbstractContinuousFunction` class.

### DIFF
--- a/colour/continuous/abstract.py
+++ b/colour/continuous/abstract.py
@@ -29,6 +29,7 @@ from colour.hints import (
     Type,
 )
 from colour.utilities import (
+    MixinCallback,
     as_float,
     attest,
     closest,
@@ -49,7 +50,7 @@ __all__ = [
 ]
 
 
-class AbstractContinuousFunction(ABC):
+class AbstractContinuousFunction(ABC, MixinCallback):
     """
     Define the base class for abstract continuous function.
 

--- a/colour/continuous/signal.py
+++ b/colour/continuous/signal.py
@@ -948,8 +948,7 @@ class Signal(AbstractContinuousFunction):
             variable.
         """
 
-        self._domain = fill_nan(self._domain, method, default)
-        self._function = None  # Invalidate the underlying continuous function.
+        self.domain = fill_nan(self.domain, method, default)
 
     def _fill_range_nan(
         self,
@@ -974,8 +973,7 @@ class Signal(AbstractContinuousFunction):
             variable.
         """
 
-        self._range = fill_nan(self._range, method, default)
-        self._function = None  # Invalidate the underlying continuous function.
+        self.range = fill_nan(self.range, method, default)
 
     def arithmetical_operation(
         self,

--- a/colour/utilities/__init__.py
+++ b/colour/utilities/__init__.py
@@ -11,6 +11,10 @@ from .data_structures import (
     LazyCanonicalMapping,
     Node,
 )
+from .callback import (
+    Callback,
+    MixinCallback,
+)
 from .common import (
     CacheRegistry,
     CACHE_REGISTRY,
@@ -123,6 +127,10 @@ __all__ = [
     "CanonicalMapping",
     "LazyCanonicalMapping",
     "Node",
+]
+__all__ += [
+    "Callback",
+    "MixinCallback",
 ]
 __all__ += [
     "CacheRegistry",

--- a/colour/utilities/callback.py
+++ b/colour/utilities/callback.py
@@ -1,0 +1,169 @@
+"""
+Callback Management
+===================
+
+Defines the callback management objects.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from colour.hints import (
+    Any,
+    Callable,
+    List,
+)
+
+__author__ = "Colour Developers"
+__copyright__ = "Copyright 2013 Colour Developers"
+__license__ = "New BSD License - https://opensource.org/licenses/BSD-3-Clause"
+__maintainer__ = "Colour Developers"
+__email__ = "colour-developers@colour-science.org"
+__status__ = "Production"
+
+__all__ = [
+    "Callback",
+    "MixinCallback",
+]
+
+
+@dataclass
+class Callback:
+    """
+    Define a callback.
+
+    Parameters
+    ----------
+    name
+        Callback name.
+    function
+        Callback callable.
+    """
+
+    name: str
+    function: Callable
+
+
+class MixinCallback:
+    """
+    A mixin providing support for callbacks.
+
+    Attributes
+    ----------
+    -   :attr:`~colour.utilities.MixinCallback.callbacks`
+    -   :attr:`~colour.utilities.MixinCallback.__setattr__`
+
+    Methods
+    -------
+    -   :meth:`~colour.utilities.MixinCallback.register_callback`
+    -   :meth:`~colour.utilities.MixinCallback.unregister_callback`
+
+    Examples
+    --------
+    >>> class WithCallback(MixinCallback):
+    ...     def __init__(self):
+    ...         super().__init__()
+    ...         self.attribute_a = "a"
+    ...
+    >>> with_callback = WithCallback()
+    >>> def _on_attribute_a_changed(self, name: str, value: str) -> str:
+    ...     if name == "attribute_a":
+    ...         value = value.upper()
+    ...     return value
+    >>> with_callback.register_callback(
+    ...     "on_attribute_a_changed", _on_attribute_a_changed
+    ... )
+    >>> with_callback.attribute_a = "a"
+    >>> with_callback.attribute_a
+    'A'
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+
+        self._callbacks: List = []
+
+    @property
+    def callbacks(self) -> List:
+        """
+        Getter property for the callbacks.
+
+        Returns
+        -------
+        :class:`list`
+            Callbacks.
+        """
+
+        return self._callbacks
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        """
+        Set given value to the attribute with given name.
+
+        Parameters
+        ----------
+        attribute
+            Attribute to set the value of.
+        value
+            Value to set the attribute with.
+        """
+
+        if hasattr(self, "_callbacks"):
+            for callback in self._callbacks:
+                value = callback.function(self, name, value)
+
+        super().__setattr__(name, value)
+
+    def register_callback(self, name: str, function: Callable) -> None:
+        """
+        Register the callback with given name.
+
+        Parameters
+        ----------
+        name
+            Callback name.
+        function
+            Callback callable.
+
+        Examples
+        --------
+        >>> class WithCallback(MixinCallback):
+        ...     def __init__(self):
+        ...         super().__init__()
+        ...
+        >>> with_callback = WithCallback()
+        >>> with_callback.register_callback("callback", lambda *args: None)
+        >>> with_callback.callbacks  # doctest: +SKIP
+        [Callback(name='callback', function=<function <lambda> at 0x10fcf3420>)]
+        """
+
+        self._callbacks.append(Callback(name, function))
+
+    def unregister_callback(self, name: str) -> None:
+        """
+        Unregister the callback with given name.
+
+        Parameters
+        ----------
+        name
+            Callback name.
+
+        Examples
+        --------
+        >>> class WithCallback(MixinCallback):
+        ...     def __init__(self):
+        ...         super().__init__()
+        ...
+        >>> with_callback = WithCallback()
+        >>> with_callback.register_callback("callback", lambda s, n, v: v)
+        >>> with_callback.callbacks  # doctest: +SKIP
+        [Callback(name='callback', function=<function <lambda> at 0x10fcf3420>)]
+        >>> with_callback.unregister_callback("callback")
+        >>> with_callback.callbacks
+        []
+        """
+
+        self._callbacks = [
+            callback for callback in self._callbacks if callback.name != name
+        ]

--- a/colour/utilities/tests/test_callback.py
+++ b/colour/utilities/tests/test_callback.py
@@ -1,0 +1,109 @@
+# !/usr/bin/env python
+"""Define the unit tests for the :mod:`colour.utilities.callback` module."""
+
+from __future__ import annotations
+
+import unittest
+
+from colour.utilities import MixinCallback
+
+__author__ = "Colour Developers"
+__copyright__ = "Copyright 2013 Colour Developers"
+__license__ = "New BSD License - https://opensource.org/licenses/BSD-3-Clause"
+__maintainer__ = "Colour Developers"
+__email__ = "colour-developers@colour-science.org"
+__status__ = "Production"
+
+__all__ = [
+    "TestMixinCallback",
+]
+
+
+class TestMixinCallback(unittest.TestCase):
+    """
+    Define :class:`colour.utilities.callback.MixinCallback` class unit
+    tests methods.
+    """
+
+    def setUp(self):
+        """Initialise the common tests attributes."""
+
+        class WithCallback(MixinCallback):
+            """Test :class:`MixinCallback` class."""
+
+            def __init__(self):
+                super().__init__()
+
+                self.attribute_a = "a"
+
+        self._with_callback = WithCallback()
+
+        def _on_attribute_a_changed(self, name: str, value: str) -> str:
+            """Transform *self._attribute_a* to uppercase."""
+
+            if name == "attribute_a":
+                value = value.upper()
+
+                if getattr(self, name) != "a":
+                    raise RuntimeError(
+                        '"self" was not able to retrieve class instance value!'
+                    )
+
+            return value
+
+        self._on_attribute_a_changed = _on_attribute_a_changed
+
+    def test_required_attributes(self):
+        """Test the presence of required attributes."""
+
+        required_attributes = ("callbacks",)
+
+        for attribute in required_attributes:
+            self.assertIn(attribute, dir(MixinCallback))
+
+    def test_required_methods(self):
+        """Test the presence of required methods."""
+
+        required_methods = (
+            "__init__",
+            "register_callback",
+            "unregister_callback",
+        )
+
+        for method in required_methods:
+            self.assertIn(method, dir(MixinCallback))
+
+    def test_register_callback(self):
+        """
+        Test :class:`colour.utilities.callback.MixinCallback.register_callback`
+        method.
+        """
+
+        self._with_callback.register_callback(
+            "on_attribute_a_changed", self._on_attribute_a_changed
+        )
+
+        self._with_callback.attribute_a = "a"
+        self.assertEqual(self._with_callback.attribute_a, "A")
+        self.assertEqual(len(self._with_callback.callbacks), 1)
+
+    def test_unregister_callback(self):
+        """
+        Test :class:`colour.utilities.callback.MixinCallback.unregister_callback`
+        method.
+        """
+
+        if len(self._with_callback.callbacks) == 0:
+            self._with_callback.register_callback(
+                "on_attribute_a_changed", self._on_attribute_a_changed
+            )
+
+        self.assertEqual(len(self._with_callback.callbacks), 1)
+        self._with_callback.unregister_callback("on_attribute_a_changed")
+        self.assertEqual(len(self._with_callback.callbacks), 0)
+        self._with_callback.attribute_a = "a"
+        self.assertEqual(self._with_callback.attribute_a, "a")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/colour.utilities.rst
+++ b/docs/colour.utilities.rst
@@ -1,6 +1,23 @@
 Utilities
 =========
 
+Callback Management
+-------------------
+
+``colour``
+
+
+``colour.utilities``
+
+.. currentmodule:: colour.utilities
+
+.. autosummary::
+    :toctree: generated/
+    :template: class.rst
+
+    Callback
+    MixinCallback
+
 Common
 ------
 


### PR DESCRIPTION
<!--
Thank you for taking the time to create this pull request. If it is the first
time you are contributing to a colour-science repository, a contributing guide
is available to guide the process: https://www.colour-science.org/contributing/.
-->

# Summary

<!-- Please write a summary describing the changes that this PR implements. -->

This PR implements support for callbacks in `colour.continuous.AbstractContinuousFunction` class. This allows concrete child classes to register many callback functions to use when an attribute is set. One use case highlighted in #1120 by @tjdcs is to be able to bypass the dynamic computation of the `colour.SpectralDistribution.shape` property which is expensive: One can now store the value of the *shape* during property access and have it reset whenever the underlying  `colour.Signal._domain` attribute is changed.

# Preflight

<!-- Please mark any checkboxes that do not apply to this pull request as [N/A]. -->

**Code Style and Quality**

- [x] Unit tests have been implemented and passed.
- [x] Pyright static checking has been run and passed.
- [x] Pre-commit hooks have been run and passed.
- [N/A] New transformations have been added to the *Automatic Colour Conversion Graph*.
- [N/A] New transformations have been exported to the relevant namespaces, e.g. `colour`, `colour.models`.

<!-- The unit tests can be invoked with `poetry run invoke tests` -->
<!-- Pyright can be started with `pyright --skipunannotated` -->

**Documentation**

- [x] New features are documented along with examples if relevant.
- [x] The documentation is [Sphinx](https://www.sphinx-doc.org/en/master/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant.

<!--
Thank you again!
-->
