### PR TITLE
PR: Implement support for fast integer digest using "xxhash".

### DIFF
--- a/colour/utilities/__init__.py
+++ b/colour/utilities/__init__.py
@@ -50,6 +50,7 @@ from .common import (
     validate_method,
     optional,
     slugify,
+    int_digest,
 )
 from .verbose import (
     ColourWarning,
@@ -167,6 +168,7 @@ __all__ += [
     "validate_method",
     "optional",
     "slugify",
+    "int_digest",
 ]
 __all__ += [
     "ColourWarning",

--- a/colour/utilities/tests/test_common.py
+++ b/colour/utilities/tests/test_common.py
@@ -505,7 +505,7 @@ class TestSlugify(unittest.TestCase):
     """
 
     def test_slugify(self):
-        """Test :func:`colour.utilities.common.optional` definition."""
+        """Test :func:`colour.utilities.common.slugify` definition."""
 
         self.assertEqual(
             slugify(

--- a/colour/utilities/tests/test_common.py
+++ b/colour/utilities/tests/test_common.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import numpy as np
+import platform
 import unittest
 import unicodedata
 from functools import partial
@@ -26,6 +27,7 @@ from colour.utilities import (
     validate_method,
     optional,
     slugify,
+    int_digest,
 )
 
 __author__ = "Colour Developers"
@@ -534,6 +536,29 @@ class TestSlugify(unittest.TestCase):
         )
 
         self.assertEqual(slugify(123), "123")
+
+
+class TestIntDigest(unittest.TestCase):
+    """
+    Define :func:`colour.utilities.common.int_digest` definition unit tests
+    methods.
+    """
+
+    def test_int_digest(self):
+        """Test :func:`colour.utilities.common.int_digest` definition."""
+
+        self.assertEqual(int_digest("Foo"), 7467386374397815550)
+
+        if platform.system() in ("Windows", "Microsoft"):  # pragma: no cover
+            self.assertEqual(
+                int_digest(np.array([1, 2, 3]).tobytes()), 7764052002911021640
+            )
+        else:
+            self.assertEqual(
+                int_digest(np.array([1, 2, 3]).tobytes()), 8964613590703056768
+            )
+
+        self.assertEqual(int_digest(repr((1, 2, 3))), 5069958125469218295)
 
 
 if __name__ == "__main__":

--- a/colour/utilities/verbose.py
+++ b/colour/utilities/verbose.py
@@ -13,7 +13,7 @@ import sys
 import traceback
 import warnings
 from collections import defaultdict
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from itertools import chain
 from textwrap import TextWrapper
 from warnings import filterwarnings, formatwarning, warn
@@ -655,18 +655,19 @@ def describe_environment(
             "tqdm",
             "trimesh",
         ]:
-            try:
+            with suppress(ImportError):
                 namespace = __import__(package)
                 environment["Runtime"][package] = namespace.__version__
-            except ImportError:
-                continue
 
         # OpenImageIO
-        try:  # pragma: no cover
+        with suppress(ImportError):  # pragma: no cover
             namespace = __import__("OpenImageIO")
             environment["Runtime"]["OpenImageIO"] = namespace.VERSION_STRING
-        except ImportError:  # pragma: no cover
-            pass
+
+        # xxhash
+        with suppress(ImportError):  # pragma: no cover
+            namespace = __import__("xxhash")
+            environment["Runtime"]["xxhash"] = namespace.version.VERSION
 
         environment["Runtime"].update(ANCILLARY_RUNTIME_PACKAGES)
 

--- a/docs/colour.utilities.rst
+++ b/docs/colour.utilities.rst
@@ -68,6 +68,7 @@ Common
     is_pandas_installed
     is_tqdm_installed
     is_trimesh_installed
+    is_xxhash_installed
     required
     is_iterable
     is_string
@@ -81,6 +82,7 @@ Common
     validate_method
     optional
     slugify
+    int_digest
 
 Array
 -----

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ pandas = { version = ">= 1.3, < 2", optional = true }
 pygraphviz = { version = ">= 1, < 2", optional = true }
 tqdm = { version = ">= 4, < 5", optional = true }
 trimesh = { version = ">= 3, < 4", optional = true }
+xxhash = { version = ">= 3.2, < 4", optional = true }
 
 biblib-simple = { version = "*", optional = true }  # Development dependency.
 black = { version = "*", optional = true }  # Development dependency.
@@ -124,7 +125,7 @@ development = [
 ]
 graphviz = [ "pygraphviz" ]
 meshing = [ "trimesh" ]
-optional = [ "networkx", "pandas", "scikit-learn", "tqdm" ]
+optional = [ "networkx", "pandas", "scikit-learn", "tqdm", "xxhash" ]
 plotting = [ "matplotlib" ]
 read-the-docs = [
     "matplotlib",


### PR DESCRIPTION
<!--
Thank you for taking the time to create this pull request. If it is the first
time you are contributing to a colour-science repository, a contributing guide
is available to guide the process: https://www.colour-science.org/contributing/.
-->

# Summary

<!-- Please write a summary describing the changes that this PR implements. -->

This PR implements support for fast integer digest using [xxhash](https://pypi.org/project/xxhash/) with the `colour.utilities.int_digest` definition. If `xxhash` is not available it falls back to the builtin `hash` definition.

The main use case is hashing of the `ndarray` as highlighted in PR #1120.

# Preflight

<!-- Please mark any checkboxes that do not apply to this pull request as [N/A]. -->

**Code Style and Quality**

- [x] Unit tests have been implemented and passed.
- [x] Pyright static checking has been run and passed.
- [x] Pre-commit hooks have been run and passed.
- [N/A] New transformations have been added to the *Automatic Colour Conversion Graph*.
- [N/A] New transformations have been exported to the relevant namespaces, e.g. `colour`, `colour.models`.

<!-- The unit tests can be invoked with `poetry run invoke tests` -->
<!-- Pyright can be started with `pyright --skipunannotated` -->

**Documentation**

- [x] New features are documented along with examples if relevant.
- [x] The documentation is [Sphinx](https://www.sphinx-doc.org/en/master/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant.

<!--
Thank you again!
-->
