### PR TITLE
PR: Remove ability to pass illuminant in "CIE XYZ" to "CIE xyY" related transformations.

### DIFF
--- a/colour/characterisation/datasets/colour_checkers/chromaticity_coordinates.py
+++ b/colour/characterisation/datasets/colour_checkers/chromaticity_coordinates.py
@@ -464,10 +464,7 @@ DATA_TE226_V2_CIE_XYZ: dict = {
 DATA_TE226_V2: dict = dict(
     zip(
         tuple(DATA_TE226_V2_CIE_XYZ.keys()),
-        XYZ_to_xyY(
-            list(DATA_TE226_V2_CIE_XYZ.values()),
-            CCS_ILLUMINANTS["CIE 1931 2 Degree Standard Observer"]["D65"],
-        ),
+        XYZ_to_xyY(list(DATA_TE226_V2_CIE_XYZ.values())),
     )
 )
 
@@ -481,7 +478,7 @@ CCS_TE226_V2: ColourChecker = ColourChecker(
 )
 """
 Reference data from *TE226 V2*. Transparent color rendition test chart
-for HDTV cameras, in addition to known colors from “ColorChecker”, the test
+for HDTV cameras, in addition to known colors from "ColorChecker", the test
 chart contains colors which are critical in reproduction.
 """
 

--- a/colour/examples/models/examples_models.py
+++ b/colour/examples/models/examples_models.py
@@ -24,14 +24,6 @@ print(colour.XYZ_to_xyY(np.array([0.00000000, 0.00000000, 0.00000000])))
 
 print("\n")
 
-message_box("Using an alternative illuminant.")
-print(
-    colour.XYZ_to_xyY(
-        np.array([0.00000000, 0.00000000, 0.00000000]),
-        colour.CCS_ILLUMINANTS["CIE 1931 2 Degree Standard Observer"]["ACES"],
-    )
-)
-
 print("\n")
 
 xyY = np.array([0.26414772, 0.37770001, 0.10080000])

--- a/colour/graph/tests/test_conversion.py
+++ b/colour/graph/tests/test_conversion.py
@@ -138,9 +138,9 @@ class TestConvert(unittest.TestCase):
         ]
         np.testing.assert_array_almost_equal(
             convert(
-                a, "CIE XYZ", "CIE xyY", XYZ_to_xyY={"illuminant": illuminant}
+                a, "CIE XYZ", "CIE UVW", XYZ_to_UVW={"illuminant": illuminant}
             ),
-            convert(a, "CIE XYZ", "CIE xyY", illuminant=illuminant),
+            convert(a, "CIE XYZ", "CIE UVW", illuminant=illuminant),
             decimal=7,
         )
 

--- a/colour/models/cie_xyy.py
+++ b/colour/models/cie_xyy.py
@@ -13,10 +13,9 @@ Defines the *CIE xyY* colourspace transformations:
 
 References
 ----------
--   :cite:`Lindbloom2003e` : Lindbloom, B. (2003). XYZ to xyY. Retrieved
-    February 24, 2014, from http://www.brucelindbloom.com/Eqn_XYZ_to_xyY.html
--   :cite:`Lindbloom2009d` : Lindbloom, B. (2009). xyY to XYZ. Retrieved
-    February 24, 2014, from http://www.brucelindbloom.com/Eqn_xyY_to_XYZ.html
+-   :cite:`CIETC1-482004h` : CIE TC 1-48. (2004). CIE 015:2004 Colorimetry,
+    3rd Edition. In CIE 015:2004 Colorimetry, 3rd Edition. Commission
+    Internationale de l'Eclairage. ISBN:978-3-901906-33-6
 -   :cite:`Wikipedia2005` : Wikipedia. (2005). CIE 1931 color space. Retrieved
     February 24, 2014, from http://en.wikipedia.org/wiki/CIE_1931_color_space
 """
@@ -25,7 +24,6 @@ from __future__ import annotations
 
 import numpy as np
 
-from colour.colorimetry import CCS_ILLUMINANTS
 from colour.hints import ArrayLike, NDArrayFloat
 from colour.utilities import (
     as_float_array,
@@ -55,22 +53,14 @@ __all__ = [
 ]
 
 
-def XYZ_to_xyY(
-    XYZ: ArrayLike,
-    illuminant: ArrayLike = CCS_ILLUMINANTS[
-        "CIE 1931 2 Degree Standard Observer"
-    ]["D65"],
-) -> NDArrayFloat:
+def XYZ_to_xyY(XYZ: ArrayLike) -> NDArrayFloat:
     """
-    Convert from *CIE XYZ* tristimulus values to *CIE xyY* colourspace and
-    reference *illuminant*.
+    Convert from *CIE XYZ* tristimulus values to *CIE xyY* colourspace.
 
     Parameters
     ----------
     XYZ
         *CIE XYZ* tristimulus values.
-    illuminant
-        Reference *illuminant* chromaticity coordinates.
 
     Returns
     -------
@@ -93,7 +83,7 @@ def XYZ_to_xyY(
 
     References
     ----------
-    :cite:`Lindbloom2003e`, :cite:`Wikipedia2005`
+    :cite:`CIETC1-482004h`, :cite:`Wikipedia2005`
 
     Examples
     --------
@@ -103,12 +93,11 @@ def XYZ_to_xyY(
     """
 
     XYZ = to_domain_1(XYZ)
-    xy_w = as_float_array(illuminant)
 
     X, Y, Z = tsplit(XYZ)
 
     xyY = zeros(XYZ.shape)
-    xyY[..., 0:2] = xy_w
+    xyY[..., 0:2] = 0
 
     m_xyY = ~np.all(XYZ == 0, axis=-1)
     X_Y_Z = (X + Y + Z)[m_xyY]
@@ -156,7 +145,7 @@ def xyY_to_XYZ(xyY: ArrayLike) -> NDArrayFloat:
 
     References
     ----------
-    :cite:`Lindbloom2009d`, :cite:`Wikipedia2005`
+    :cite:`CIETC1-482004h`, :cite:`Wikipedia2005`
 
     Examples
     --------
@@ -210,7 +199,7 @@ def xyY_to_xy(xyY: ArrayLike) -> NDArrayFloat:
 
     References
     ----------
-    :cite:`Wikipedia2005`
+    :cite:`CIETC1-482004h`, :cite:`Wikipedia2005`
 
     Examples
     --------
@@ -277,7 +266,7 @@ def xy_to_xyY(xy: ArrayLike, Y: float = 1) -> NDArrayFloat:
 
     References
     ----------
-    :cite:`Wikipedia2005`
+    :cite:`CIETC1-482004h`, :cite:`Wikipedia2005`
 
     Examples
     --------
@@ -307,12 +296,7 @@ def xy_to_xyY(xy: ArrayLike, Y: float = 1) -> NDArrayFloat:
     return from_range_1(xyY, np.array([1, 1, 100]))
 
 
-def XYZ_to_xy(
-    XYZ: ArrayLike,
-    illuminant: ArrayLike = CCS_ILLUMINANTS[
-        "CIE 1931 2 Degree Standard Observer"
-    ]["D65"],
-) -> NDArrayFloat:
+def XYZ_to_xy(XYZ: ArrayLike) -> NDArrayFloat:
     """
     Return the *CIE xy* chromaticity coordinates from given *CIE XYZ*
     tristimulus values.
@@ -321,8 +305,6 @@ def XYZ_to_xy(
     ----------
     XYZ
         *CIE XYZ* tristimulus values.
-    illuminant
-        Reference *illuminant* chromaticity coordinates.
 
     Returns
     -------
@@ -339,7 +321,7 @@ def XYZ_to_xy(
 
     References
     ----------
-    :cite:`Wikipedia2005`
+    :cite:`CIETC1-482004h`, :cite:`Wikipedia2005`
 
     Examples
     --------
@@ -348,7 +330,7 @@ def XYZ_to_xy(
     array([ 0.5436955...,  0.3210794...])
     """
 
-    return xyY_to_xy(XYZ_to_xyY(XYZ, illuminant))
+    return xyY_to_xy(XYZ_to_xyY(XYZ))
 
 
 def xy_to_XYZ(xy: ArrayLike) -> NDArrayFloat:
@@ -382,7 +364,7 @@ def xy_to_XYZ(xy: ArrayLike) -> NDArrayFloat:
 
     References
     ----------
-    :cite:`Wikipedia2005`
+    :cite:`CIETC1-482004h`, :cite:`Wikipedia2005`
 
     Examples
     --------

--- a/colour/models/tests/test_cie_xyy.py
+++ b/colour/models/tests/test_cie_xyy.py
@@ -78,7 +78,7 @@ class TestXYZ_to_xyY(unittest.TestCase):
             np.array(
                 [
                     [0.54369557, 0.32107944, 0.12197225],
-                    [0.31270000, 0.32900000, 0.00000000],
+                    [0.00000000, 0.00000000, 0.00000000],
                     [0.00000000, 1.00000000, 1.00000000],
                 ]
             ),
@@ -92,26 +92,15 @@ class TestXYZ_to_xyY(unittest.TestCase):
         """
 
         XYZ = np.array([0.20654008, 0.12197225, 0.05136952])
-        illuminant = np.array([0.31270, 0.32900])
-        xyY = XYZ_to_xyY(XYZ, illuminant)
+        xyY = XYZ_to_xyY(XYZ)
 
         XYZ = np.tile(XYZ, (6, 1))
         xyY = np.tile(xyY, (6, 1))
-        np.testing.assert_array_almost_equal(
-            XYZ_to_xyY(XYZ, illuminant), xyY, decimal=7
-        )
-
-        illuminant = np.tile(illuminant, (6, 1))
-        np.testing.assert_array_almost_equal(
-            XYZ_to_xyY(XYZ, illuminant), xyY, decimal=7
-        )
+        np.testing.assert_array_almost_equal(XYZ_to_xyY(XYZ), xyY, decimal=7)
 
         XYZ = np.reshape(XYZ, (2, 3, 3))
-        illuminant = np.reshape(illuminant, (2, 3, 2))
         xyY = np.reshape(xyY, (2, 3, 3))
-        np.testing.assert_array_almost_equal(
-            XYZ_to_xyY(XYZ, illuminant), xyY, decimal=7
-        )
+        np.testing.assert_array_almost_equal(XYZ_to_xyY(XYZ), xyY, decimal=7)
 
     def test_domain_range_scale_XYZ_to_xyY(self):
         """
@@ -141,7 +130,7 @@ class TestXYZ_to_xyY(unittest.TestCase):
 
         cases = [-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan]
         cases = np.array(list(set(product(cases, repeat=3))))
-        XYZ_to_xyY(cases, cases[..., 0:2])
+        XYZ_to_xyY(cases)
 
 
 class TestxyY_to_XYZ(unittest.TestCase):
@@ -446,7 +435,7 @@ class TestXYZ_to_xy(unittest.TestCase):
 
         np.testing.assert_array_almost_equal(
             XYZ_to_xy(np.array([0.00000000, 0.00000000, 0.00000000])),
-            np.array([0.31270000, 0.32900000]),
+            np.array([0.00000000, 0.00000000]),
             decimal=7,
         )
 
@@ -457,26 +446,15 @@ class TestXYZ_to_xy(unittest.TestCase):
         """
 
         XYZ = np.array([0.20654008, 0.12197225, 0.05136952])
-        illuminant = np.array([0.31270, 0.32900])
-        xy = XYZ_to_xy(XYZ, illuminant)
+        xy = XYZ_to_xy(XYZ)
 
         XYZ = np.tile(XYZ, (6, 1))
         xy = np.tile(xy, (6, 1))
-        np.testing.assert_array_almost_equal(
-            XYZ_to_xy(XYZ, illuminant), xy, decimal=7
-        )
-
-        illuminant = np.tile(illuminant, (6, 1))
-        np.testing.assert_array_almost_equal(
-            XYZ_to_xy(XYZ, illuminant), xy, decimal=7
-        )
+        np.testing.assert_array_almost_equal(XYZ_to_xy(XYZ), xy, decimal=7)
 
         XYZ = np.reshape(XYZ, (2, 3, 3))
-        illuminant = np.reshape(xy, (2, 3, 2))
         xy = np.reshape(xy, (2, 3, 2))
-        np.testing.assert_array_almost_equal(
-            XYZ_to_xy(XYZ, illuminant), xy, decimal=7
-        )
+        np.testing.assert_array_almost_equal(XYZ_to_xy(XYZ), xy, decimal=7)
 
     def test_domain_range_scale_XYZ_to_xy(self):
         """
@@ -502,7 +480,7 @@ class TestXYZ_to_xy(unittest.TestCase):
 
         cases = [-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan]
         cases = np.array(list(set(product(cases, repeat=3))))
-        XYZ_to_xy(cases, cases[..., 0:2])
+        XYZ_to_xy(cases)
 
 
 class Testxy_to_XYZ(unittest.TestCase):

--- a/colour/plotting/diagrams.py
+++ b/colour/plotting/diagrams.py
@@ -175,7 +175,7 @@ def plot_spectral_locus(
 
     labels = ()
     if method == "cie 1931":
-        ij = XYZ_to_xy(cmfs.values, illuminant)
+        ij = XYZ_to_xy(cmfs.values)
         labels = optional(
             spectral_locus_labels,
             (
@@ -452,7 +452,7 @@ def plot_chromaticity_diagram_colours(
     illuminant = CONSTANTS_COLOUR_STYLE.colour.colourspace.whitepoint
 
     if method == "cie 1931":
-        spectral_locus = XYZ_to_xy(cmfs.values, illuminant)
+        spectral_locus = XYZ_to_xy(cmfs.values)
     elif method == "cie 1960 ucs":
         spectral_locus = UCS_to_uv(XYZ_to_UCS(cmfs.values))
     elif method == "cie 1976 ucs":

--- a/colour/plotting/models.py
+++ b/colour/plotting/models.py
@@ -335,13 +335,15 @@ def plot_pointer_gamut(
 
     if method == "cie 1931":
 
-        def XYZ_to_ij(XYZ: NDArrayFloat, *args: Any) -> NDArrayFloat:
+        def XYZ_to_ij(
+            XYZ: NDArrayFloat, *args: Any  # noqa: ARG001
+        ) -> NDArrayFloat:
             """
             Convert given *CIE XYZ* tristimulus values to *ij* chromaticity
             coordinates.
             """
 
-            return XYZ_to_xy(XYZ, *args)
+            return XYZ_to_xy(XYZ)
 
         def xy_to_ij(xy: NDArrayFloat) -> NDArrayFloat:
             """
@@ -1062,7 +1064,7 @@ Plot_RGB_Chromaticities_In_Chromaticity_Diagram.png
     XYZ = RGB_to_XYZ(RGB, colourspace)
 
     if method == "cie 1931":
-        ij = XYZ_to_xy(XYZ, colourspace.whitepoint)
+        ij = XYZ_to_xy(XYZ)
 
     elif method == "cie 1960 ucs":
         ij = UCS_to_uv(XYZ_to_UCS(XYZ))


### PR DESCRIPTION
<!--
Thank you for taking the time to create this pull request. If it is the first
time you are contributing to a colour-science repository, a contributing guide
is available to guide the process: https://www.colour-science.org/contributing/.
-->

# Summary

<!-- Please write a summary describing the changes that this PR implements. -->

This one has been itching me for a while, it is a very old behaviour that is very strongly opinionated but not recommended by CIE during the computation of chromaticity coordinates: When the tristimulus values are null, we do set the chromaticity coordinates to the passed illuminant ones and the luminance to zero. This is what Bruce Lindbloom is doing. It is quite useful as it means that the achromatic colours are all on the same axis but I reckon that this is a behaviour that should be controlled by the user post-conversion. We do not do that with any other space for that matter.

![image](https://github.com/colour-science/colour/assets/99779/47c098dc-f5c8-4504-88ca-3aa614dfe42a)

# Preflight

<!-- Please mark any checkboxes that do not apply to this pull request as [N/A]. -->

**Code Style and Quality**

- [x] Unit tests have been implemented and passed.
- [] Pyright static checking has been run and passed.
- [x] Pre-commit hooks have been run and passed.
- [N/A] New transformations have been added to the *Automatic Colour Conversion Graph*.
- [N/A] New transformations have been exported to the relevant namespaces, e.g. `colour`, `colour.models`.

<!-- The unit tests can be invoked with `poetry run invoke tests` -->
<!-- Pyright can be started with `pyright --skipunannotated` -->

**Documentation**

- [N/A] New features are documented along with examples if relevant.
- [x] The documentation is [Sphinx](https://www.sphinx-doc.org/en/master/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant.

<!--
Thank you again!
-->
