### PR TITLE
Update the 'SSI' calculation to match the revised academy white paper.

### DIFF
--- a/colour/quality/ssi.py
+++ b/colour/quality/ssi.py
@@ -113,10 +113,10 @@ def spectral_similarity_index(
     with sdiv_mode():
         test_i = sdiv(test_i, np.sum(test_i))
         reference_i = sdiv(reference_i, np.sum(reference_i))
-        dr_i = sdiv(test_i - reference_i, reference_i + np.mean(reference_i))
+        dr_i = sdiv(test_i - reference_i, reference_i + 1 / 30)
 
     wdr_i = dr_i * [
-        12 / 45,
+        4 / 15,
         22 / 45,
         32 / 45,
         40 / 45,
@@ -147,7 +147,7 @@ def spectral_similarity_index(
         11 / 15,
         3 / 15,
     ]
-    c_wdr_i = convolve1d(np.hstack([0, wdr_i, 0]), [0.22, 0.56, 0.22])
+    c_wdr_i = convolve1d(wdr_i, [0.22, 0.56, 0.22], mode="constant", cval=0)
     m_v = np.sum(c_wdr_i**2)
 
     SSI = 100 - 32 * np.sqrt(m_v)

--- a/colour/quality/tests/test_ssi.py
+++ b/colour/quality/tests/test_ssi.py
@@ -589,7 +589,7 @@ class TestSpectralSimilarityIndex(unittest.TestCase):
                 SDS_ILLUMINANTS["D65"],
                 round_result=False,
             ),
-            94.178,
+            94.182,
             places=2,
         )
         self.assertAlmostEqual(
@@ -598,7 +598,7 @@ class TestSpectralSimilarityIndex(unittest.TestCase):
                 SDS_ILLUMINANTS["D50"],
                 round_result=False,
             ),
-            71.772,
+            71.775,
             places=2,
         )
 


### PR DESCRIPTION
Hey!

While implementing my own version of the 'Spectral Similarity Index' and comparing it to the 'colour-science' module I found some small discrepancies. It seems like there is a small error, probably stemming from an unclear wording in the original white paper by the academy [(link to the project page)](https://www.oscars.org/science-technology/projects/spectral-similarity-index-ssi) 

The [old white paper from 03/2019](https://www.oscars.org/sites/oscars/files/ssi_overview_2019-03-04.pdf) that was used for the original [PR#534](https://github.com/colour-science/colour/pull/534) stated:
> 8) Add zero to each end of weighted relative difference vector to have 32 values, then convolve
with {0.22, 0.56, 0.22} to create smoothed weighted relative difference vector.

The convolution step was clarified in the [revised version from 09/2020](https://www.oscars.org/sites/oscars/files/ssi_overview_2020-09-16.pdf)
> 7) Add zero to each end of weighted relative difference vector to have 32 values.
> 8) Convolve with {0.22, 0.56, 0.22} to create 30-element smoothed weighted relative difference
vector.

In the current implementation the vector is padded with zeros and the convolution is done with the default convolve1d mode 'reflect' which results in 32 values. That means this _slightly_ over emphazies the outer most wavelength bins. To correct this and match the new description this PR also pads with zeros, but does not extend the vector further to only get the 30 'valid' values.
In practice this should only lead to a very small (< 0.01) difference in the resulting SSI value for most spectra and will probably only be noticeable when disabling the  'round_result' option.

This also seems to match the [implementation](https://rdrr.io/cran/colorSpec/src/R/colorSpec.SSI.R) used for the 'SSI Calculator' on the academy site (but note that they use an external library and I could not find any official reference implementation).

The other two changes are just to match the newer description and do not affect the result (the mean of _reference_i_ is always 1/30 due to the scaling) .

It would be good to also update the citation to the revised white paper version, but as far as I understand these need to be updated externally in Zotero.

Hope I didn't miss anything :)

Cheers

# Preflight

**Code Style and Quality**

- [x] Unit tests have been implemented and passed.
- [x] Pyright static checking has been run and passed.
- [x] Pre-commit hooks have been run and passed.
- [ ] ~~New transformations have been added to the *Automatic Colour Conversion Graph*.~~
- [ ] ~~New transformations have been exported to the relevant namespaces, e.g. `colour`, `colour.models`.~~

<!-- The unit tests can be invoked with `poetry run invoke tests` -->
<!-- Pyright can be started with `pyright --skipunannotated` -->

**Documentation**

- [ ] ~~New features are documented along with examples if relevant.~~
- [ ] ~~The documentation is [Sphinx](https://www.sphinx-doc.org/en/master/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant.~~