### PR TITLE
Fix Poetry package resolution when using local versions of colour-science in poetry projects

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,8 @@
 [tool.poetry]
-name = "colour"
+name = "colour-science"
+packages = [
+    { include = "colour" },
+]
 version = "0.4.2"
 description = "Colour Science for Python"
 license = "BSD-3-Clause"


### PR DESCRIPTION


Poetry complains: "The dependency name for colour-science does not match the actual package's name: colour" when using a path dependency in local projects. This is useful when a local project is dependent on a local version of color (like adding colour as a submodule dependency to a project)

Example:
```
[tool.poetry.dependencies]
python = ">=3.11,<3.12"
colour-science = {path = "submodules/colour-science", develop = true}
```