### PR TITLE
Update CTL examples and implementation against latest `ctlrender` built from source.

### DIFF
--- a/colour/io/ctl.py
+++ b/colour/io/ctl.py
@@ -341,14 +341,14 @@ def template_ctl_transform_float(
     <BLANKLINE>
     void main
     (
-        input varying float rIn,
-        input varying float gIn,
-        input varying float bIn,
-        input varying float aIn,
         output varying float rOut,
         output varying float gOut,
         output varying float bOut,
         output varying float aOut,
+        input varying float rIn,
+        input varying float gIn,
+        input varying float bIn,
+        input varying float aIn = 1.0,
         input float exposure = 0.0
     )
     {
@@ -380,14 +380,14 @@ def template_ctl_transform_float(
     <BLANKLINE>
     void main
     (
-        input varying float rIn,
-        input varying float gIn,
-        input varying float bIn,
-        input varying float aIn,
         output varying float rOut,
         output varying float gOut,
         output varying float bOut,
-        output varying float aOut)
+        output varying float aOut,
+        input varying float rIn,
+        input varying float gIn,
+        input varying float bIn,
+        input varying float aIn = 1.0)
     {
         rOut = Y_2_linCV(rIn, CINEMA_WHITE, CINEMA_BLACK);
         gOut = Y_2_linCV(gIn, CINEMA_WHITE, CINEMA_BLACK);
@@ -421,14 +421,14 @@ def template_ctl_transform_float(
     ctl_file_content += """
 void main
 (
-    input varying float rIn,
-    input varying float gIn,
-    input varying float bIn,
-    input varying float aIn,
     output varying float rOut,
     output varying float gOut,
     output varying float bOut,
-    output varying float aOut
+    output varying float aOut,
+    input varying float rIn,
+    input varying float gIn,
+    input varying float bIn,
+    input varying float aIn = 1.0
 """.strip()
 
     if parameters:
@@ -503,14 +503,14 @@ def template_ctl_transform_float3(
     <BLANKLINE>
     void main
     (
-        input varying float rIn,
-        input varying float gIn,
-        input varying float bIn,
-        input varying float aIn,
         output varying float rOut,
         output varying float gOut,
         output varying float bOut,
-        output varying float aOut)
+        output varying float aOut,
+        input varying float rIn,
+        input varying float gIn,
+        input varying float bIn,
+        input varying float aIn = 1.0)
     {
         float rgbIn[3] = {rIn, gIn, bIn};
     <BLANKLINE>
@@ -546,14 +546,14 @@ def template_ctl_transform_float3(
     ctl_file_content += """
 void main
 (
-    input varying float rIn,
-    input varying float gIn,
-    input varying float bIn,
-    input varying float aIn,
     output varying float rOut,
     output varying float gOut,
     output varying float bOut,
-    output varying float aOut
+    output varying float aOut,
+    input varying float rIn,
+    input varying float gIn,
+    input varying float bIn,
+    input varying float aIn = 1.0
 """.strip()
 
     if parameters:

--- a/colour/io/tests/resources/Adjust_Exposure_Float.ctl
+++ b/colour/io/tests/resources/Adjust_Exposure_Float.ctl
@@ -2,14 +2,14 @@
 
 void main
 (
-    input varying float rIn,
-    input varying float gIn,
-    input varying float bIn,
-    input varying float aIn,
     output varying float rOut,
     output varying float gOut,
     output varying float bOut,
     output varying float aOut,
+    input varying float rIn,
+    input varying float gIn,
+    input varying float bIn,
+    input varying float aIn = 1.0,
     input float exposure = 0.0
 )
 {

--- a/colour/io/tests/resources/Adjust_Exposure_Float3.ctl
+++ b/colour/io/tests/resources/Adjust_Exposure_Float3.ctl
@@ -15,14 +15,14 @@ float[3] adjust_exposure(float rgbIn[3], float exposureIn)
 
 void main
 (
-    input varying float rIn,
-    input varying float gIn,
-    input varying float bIn,
-    input varying float aIn,
     output varying float rOut,
     output varying float gOut,
     output varying float bOut,
     output varying float aOut,
+    input varying float rIn,
+    input varying float gIn,
+    input varying float bIn,
+    input varying float aIn = 1.0,
     input float exposure = 0.0
 )
 {

--- a/colour/io/tests/test_ctl.py
+++ b/colour/io/tests/test_ctl.py
@@ -219,43 +219,40 @@ class TestTemplateCtlTransformFloat(unittest.TestCase):
                 "input float foo[3] = {1.0, 1.0, 1.0}",
                 "input float bar = 1.0",
             ],
-            header="// Custom Header\n",
+            header="// Custom Header",
         )
 
-        self.assertEqual(
-            ctl_foo_bar_float,
-            textwrap.dedent(
-                """
-                // Foo & Bar
+        target = textwrap.dedent(
+            """
+            // Foo & Bar
 
-                import "Foo.ctl";
-                import "Bar.ctl";
-
-                // Custom Header
-
-                void main
-                (
-                    input varying float rIn,
-                    input varying float gIn,
-                    input varying float bIn,
-                    input varying float aIn,
-                    output varying float rOut,
-                    output varying float gOut,
-                    output varying float bOut,
-                    output varying float aOut,
-                    input float foo[3] = {1.0, 1.0, 1.0},
-                    input float bar = 1.0
-                )
-                {
-                    rOut = rIn + foo[0];
-                    gOut = gIn + foo[1];
-                    bOut = bIn + foo[2];
-                    aOut = aIn;
-                }"""[
-                    1:
-                ]
-            ),
+            import "Foo.ctl";
+            import "Bar.ctl";
+            
+            // Custom Header
+            void main
+            (
+                output varying float rOut,
+                output varying float gOut,
+                output varying float bOut,
+                output varying float aOut,
+                input varying float rIn,
+                input varying float gIn,
+                input varying float bIn,
+                input varying float aIn = 1.0,
+                input float foo[3] = {1.0, 1.0, 1.0},
+                input float bar = 1.0
+            )
+            {
+                rOut = rIn + foo[0];
+                gOut = gIn + foo[1];
+                bOut = bIn + foo[2];
+                aOut = aIn;
+            }"""[
+                1:
+            ]
         )
+        self.assertEqual(ctl_foo_bar_float, target)
 
 
 class TestTemplateCtlTransformFloat3(unittest.TestCase):
@@ -290,60 +287,59 @@ class TestTemplateCtlTransformFloat3(unittest.TestCase):
                     rgbOut[2] = rgbIn[2] * foo[2]* qux;
 
                     return rgbOut;
-                }\n"""[
-                    1:
-                ]
-            ),
-        )
-
-        self.assertEqual(
-            ctl_foo_bar_float3,
-            textwrap.dedent(
-                """
-                // Foo, Bar & Baz
-
-                // import "Foo.ctl";
-                // import "Bar.ctl";
-                // import "Baz.ctl";
-
-                float[3] baz(float rgbIn[3], float foo[3], float qux)
-                {
-                    float rgbOut[3];
-
-                    rgbOut[0] = rgbIn[0] * foo[0]* qux;
-                    rgbOut[1] = rgbIn[1] * foo[1]* qux;
-                    rgbOut[2] = rgbIn[2] * foo[2]* qux;
-
-                    return rgbOut;
                 }
-
-                void main
-                (
-                    input varying float rIn,
-                    input varying float gIn,
-                    input varying float bIn,
-                    input varying float aIn,
-                    output varying float rOut,
-                    output varying float gOut,
-                    output varying float bOut,
-                    output varying float aOut,
-                    input float foo[3] = {1.0, 1.0, 1.0},
-                    input float bar = 1.0
-                )
-                {
-                    float rgbIn[3] = {rIn, gIn, bIn};
-
-                    float rgbOut[3] = baz(rgbIn, foo, bar);
-
-                    rOut = rgbOut[0];
-                    gOut = rgbOut[1];
-                    bOut = rgbOut[2];
-                    aOut = aIn;
-                }"""[
+"""[
                     1:
                 ]
             ),
         )
+        # fmt: off
+        target = textwrap.dedent(
+            """
+            // Foo, Bar & Baz
+            
+            // import "Foo.ctl";
+            // import "Bar.ctl";
+            // import "Baz.ctl";
+
+            float[3] baz(float rgbIn[3], float foo[3], float qux)
+            {
+                float rgbOut[3];
+                
+                rgbOut[0] = rgbIn[0] * foo[0]* qux;
+                rgbOut[1] = rgbIn[1] * foo[1]* qux;
+                rgbOut[2] = rgbIn[2] * foo[2]* qux;
+
+                return rgbOut;
+            }
+            
+            void main
+            (
+                output varying float rOut,
+                output varying float gOut,
+                output varying float bOut,
+                output varying float aOut,
+                input varying float rIn,
+                input varying float gIn,
+                input varying float bIn,
+                input varying float aIn = 1.0,
+                input float foo[3] = {1.0, 1.0, 1.0},
+                input float bar = 1.0
+            )
+            {
+                float rgbIn[3] = {rIn, gIn, bIn};
+                
+                float rgbOut[3] = baz(rgbIn, foo, bar);
+
+                rOut = rgbOut[0];
+                gOut = rgbOut[1];
+                bOut = rgbOut[2];
+                aOut = aIn;
+            }"""[
+                1:
+            ]
+        )
+        self.assertEqual(ctl_foo_bar_float3, target)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
While trying to get set up for `invoke preflight` i couldn't run the CTL examples. Following install instructions from brew did not result in a working ctlrender script. After discussion on ampas/CTL/issues/134 I build CTL render from source and got a working implementation on my MacOS Apple Silicon laptop. 

It checks a few additional conditions. I believe these are backwards compatible with older versions of ctl render but do not know for sure.  

Reference discussion here: https://github.com/ampas/CTL/issues/134
Thank you @michaeldsmith