### PR TITLE
PR: Implement support for "Canon" v1.2 encodings.

### DIFF
--- a/colour/models/rgb/transfer_functions/__init__.py
+++ b/colour/models/rgb/transfer_functions/__init__.py
@@ -37,11 +37,17 @@ from .blackmagic_design import (
     oetf_inverse_BlackmagicFilmGeneration5,
 )
 from .canon import (
+    CANON_LOG_ENCODING_METHODS,
     log_encoding_CanonLog,
+    CANON_LOG_DECODING_METHODS,
     log_decoding_CanonLog,
+    CANON_LOG_2_ENCODING_METHODS,
     log_encoding_CanonLog2,
+    CANON_LOG_2_DECODING_METHODS,
     log_decoding_CanonLog2,
+    CANON_LOG_3_ENCODING_METHODS,
     log_encoding_CanonLog3,
+    CANON_LOG_3_DECODING_METHODS,
     log_decoding_CanonLog3,
 )
 from .cineon import log_encoding_Cineon, log_decoding_Cineon
@@ -177,11 +183,17 @@ __all__ += [
     "oetf_inverse_BlackmagicFilmGeneration5",
 ]
 __all__ += [
+    "CANON_LOG_ENCODING_METHODS",
     "log_encoding_CanonLog",
+    "CANON_LOG_DECODING_METHODS",
     "log_decoding_CanonLog",
+    "CANON_LOG_2_ENCODING_METHODS",
     "log_encoding_CanonLog2",
+    "CANON_LOG_2_DECODING_METHODS",
     "log_decoding_CanonLog2",
+    "CANON_LOG_3_ENCODING_METHODS",
     "log_encoding_CanonLog3",
+    "CANON_LOG_3_DECODING_METHODS",
     "log_decoding_CanonLog3",
 ]
 __all__ += [

--- a/colour/models/rgb/transfer_functions/canon.py
+++ b/colour/models/rgb/transfer_functions/canon.py
@@ -4,25 +4,36 @@ Canon Log Encodings
 
 Defines the *Canon Log* encodings:
 
+-   :attr:`colour.models.CANON_LOG_ENCODING_METHODS`
 -   :func:`colour.models.log_encoding_CanonLog`
+-   :attr:`colour.models.CANON_LOG_DECODING_METHODS`
 -   :func:`colour.models.log_decoding_CanonLog`
+-   :attr:`colour.models.CANON_LOG_2_ENCODING_METHODS`
 -   :func:`colour.models.log_encoding_CanonLog2`
+-   :attr:`colour.models.CANON_LOG_2_DECODING_METHODS`
 -   :func:`colour.models.log_decoding_CanonLog2`
+-   :attr:`colour.models.CANON_LOG_3_ENCODING_METHODS`
 -   :func:`colour.models.log_encoding_CanonLog3`
+-   :attr:`colour.models.CANON_LOG_3_DECODING_METHODS`
 -   :func:`colour.models.log_decoding_CanonLog3`
 
 Notes
 -----
--   :cite:`Canona` is available as a *Drivers & Downloads* *Software* for
-    Windows 10 (x64) *Operating System*, a copy of the archive is hosted at
+-   :cite:`Canon2016` is available as a *Drivers & Downloads* *Software* for
+    Windows 7 *Operating System*, a copy of the archive is hosted at
     this url: https://drive.google.com/open?id=0B_IQZQdc4Vy8ZGYyY29pMEVwZU0
+-   :cite:`Canon2020` is available as a *Drivers & Downloads* *Software* for
+    Windows 10 *Operating System*, a copy of the archive is hosted at
+    this url: https://drive.google.com/open?id=1Vcz8RVIXgXL54lhZsOwGUjjVZRObZSc5
 
 References
 ----------
--   :cite:`Canona` : Canon. (2016). EOS C300 Mark II - EOS C300 Mark II Input
-    Transform Version 2.0 (for Cinema Gamut / BT.2020). Retrieved August 23,
-    2016, from
-    https://www.usa.canon.com/internet/portal/us/home/support/details/cameras/cinema-eos/eos-c300-mark-ii
+-   :cite:`Canon2016` : Canon. (2016). Input Transform Version 201612 for EOS
+    C300 Mark II. Retrieved August 23, 2016, from https://www.usa.canon.com/\
+internet/portal/us/home/support/details/cameras/cinema-eos/eos-c300-mark-ii
+-   :cite:`Canon2020` : Canon. (2020). Input Transform Version 202007 for EOS
+    C300 Mark II. Retrieved July 16, 2023, from https://www.usa.canon.com/\
+internet/portal/us/home/support/details/cameras/cinema-eos/eos-c300-mark-ii
 -   :cite:`Thorpe2012a` : Thorpe, L. (2012). CANON-LOG TRANSFER CHARACTERISTIC.
     Retrieved September 25, 2014, from
     http://downloads.canon.com/CDLC/Canon-Log_Transfer_Characteristic_6-20-2012.pdf
@@ -32,13 +43,15 @@ from __future__ import annotations
 
 import numpy as np
 
-from colour.hints import ArrayLike, NDArrayFloat
+from colour.hints import ArrayLike, Literal, NDArrayFloat
 from colour.models.rgb.transfer_functions import full_to_legal, legal_to_full
 from colour.utilities import (
+    CanonicalMapping,
     as_float,
     domain_range_scale,
     from_range_1,
     to_domain_1,
+    validate_method,
 )
 
 __author__ = "Colour Developers"
@@ -49,23 +62,41 @@ __email__ = "colour-developers@colour-science.org"
 __status__ = "Production"
 
 __all__ = [
+    "log_encoding_CanonLog_v1",
+    "log_decoding_CanonLog_v1",
+    "log_encoding_CanonLog_v1_2",
+    "log_decoding_CanonLog_v1_2",
+    "CANON_LOG_ENCODING_METHODS",
     "log_encoding_CanonLog",
+    "CANON_LOG_DECODING_METHODS",
     "log_decoding_CanonLog",
+    "log_encoding_CanonLog2_v1",
+    "log_decoding_CanonLog2_v1",
+    "log_encoding_CanonLog2_v1_2",
+    "log_decoding_CanonLog2_v1_2",
+    "CANON_LOG_2_ENCODING_METHODS",
     "log_encoding_CanonLog2",
+    "CANON_LOG_2_DECODING_METHODS",
     "log_decoding_CanonLog2",
+    "log_encoding_CanonLog3_v1",
+    "log_decoding_CanonLog3_v1",
+    "log_encoding_CanonLog3_v1_2",
+    "log_decoding_CanonLog3_v1_2",
+    "CANON_LOG_3_ENCODING_METHODS",
     "log_encoding_CanonLog3",
+    "CANON_LOG_3_DECODING_METHODS",
     "log_decoding_CanonLog3",
 ]
 
 
-def log_encoding_CanonLog(
+def log_encoding_CanonLog_v1(
     x: ArrayLike,
     bit_depth: int = 10,
     out_normalised_code_value: bool = True,
     in_reflection: bool = True,
 ) -> NDArrayFloat:
     """
-    Define the *Canon Log* log encoding curve / opto-electronic transfer
+    Define the *Canon Log* v1 log encoding curve / opto-electronic transfer
     function.
 
     Parameters
@@ -87,7 +118,7 @@ def log_encoding_CanonLog(
 
     References
     ----------
-    :cite:`Thorpe2012a`
+    :cite:`Canon2016`, :cite:`Thorpe2012a`
 
     Notes
     -----
@@ -105,16 +136,16 @@ def log_encoding_CanonLog(
 
     Examples
     --------
-    >>> log_encoding_CanonLog(0.18) * 100  # doctest: +ELLIPSIS
+    >>> log_encoding_CanonLog_v1(0.18) * 100  # doctest: +ELLIPSIS
     34.3389651...
 
     The values of *Table 2 Canon-Log Code Values* table in :cite:`Thorpe2012a`
     are obtained as follows:
 
     >>> x = np.array([0, 2, 18, 90, 720]) / 100
-    >>> np.around(log_encoding_CanonLog(x) * (2**10 - 1)).astype(np.int_)
+    >>> np.around(log_encoding_CanonLog_v1(x) * (2**10 - 1)).astype(np.int_)
     array([ 128,  169,  351,  614, 1016])
-    >>> np.around(log_encoding_CanonLog(x, 10, False) * 100, 1)
+    >>> np.around(log_encoding_CanonLog_v1(x, 10, False) * 100, 1)
     array([   7.3,   12. ,   32.8,   62.7,  108.7])
     """
 
@@ -125,7 +156,7 @@ def log_encoding_CanonLog(
 
     with domain_range_scale("ignore"):
         clog = np.where(
-            x < log_decoding_CanonLog(0.0730597, bit_depth, False),
+            x < log_decoding_CanonLog_v1(0.0730597, bit_depth, False),
             -(0.529136 * (np.log10(-x * 10.1596 + 1)) - 0.0730597),
             0.529136 * np.log10(10.1596 * x + 1) + 0.0730597,
         )
@@ -137,14 +168,14 @@ def log_encoding_CanonLog(
     return as_float(from_range_1(clog_cv))
 
 
-def log_decoding_CanonLog(
+def log_decoding_CanonLog_v1(
     clog: ArrayLike,
     bit_depth: int = 10,
     in_normalised_code_value: bool = True,
     out_reflection: bool = True,
 ) -> NDArrayFloat:
     """
-    Define the *Canon Log* log decoding curve / electro-optical transfer
+    Define the *Canon Log* v1 log decoding curve / electro-optical transfer
     function.
 
     Parameters
@@ -180,11 +211,13 @@ def log_decoding_CanonLog(
 
     References
     ----------
-    :cite:`Thorpe2012a`
+    :cite:`Canon2016`, :cite:`Thorpe2012a`
 
     Examples
     --------
-    >>> log_decoding_CanonLog(34.338965172606912 / 100)  # doctest: +ELLIPSIS
+    >>> log_decoding_CanonLog_v1(
+    ...     34.338965172606912 / 100
+    ... )  # doctest: +ELLIPSIS
     0.17999999...
     """
 
@@ -204,14 +237,326 @@ def log_decoding_CanonLog(
     return as_float(from_range_1(x))
 
 
-def log_encoding_CanonLog2(
+def log_encoding_CanonLog_v1_2(
     x: ArrayLike,
     bit_depth: int = 10,
     out_normalised_code_value: bool = True,
     in_reflection: bool = True,
 ) -> NDArrayFloat:
     """
-    Define the *Canon Log 2* log encoding curve / opto-electronic transfer
+    Define the *Canon Log* v1.2 log encoding curve / opto-electronic transfer
+    function.
+
+    Parameters
+    ----------
+    x
+        Linear data :math:`x`.
+    bit_depth
+        Bit-depth used for conversion.
+    out_normalised_code_value
+        Whether the *Canon Log* non-linear data is encoded as normalised code
+        values.
+    in_reflection
+        Whether the light level :math:`x` to a camera is reflection.
+
+    Returns
+    -------
+    :class:`numpy.ndarray`
+        *Canon Log* non-linear data.
+
+    References
+    ----------
+    :cite:`Canon2020`
+
+    Notes
+    -----
+    +------------+-----------------------+---------------+
+    | **Domain** | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``x``      | [0, 1]                | [0, 1]        |
+    +------------+-----------------------+---------------+
+
+    +------------+-----------------------+---------------+
+    | **Range**  | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``clog``   | [0, 1]                | [0, 1]        |
+    +------------+-----------------------+---------------+
+
+    Examples
+    --------
+    >>> log_encoding_CanonLog_v1_2(0.18) * 100  # doctest: +ELLIPSIS
+    34.3389649...
+    """
+
+    x = to_domain_1(x)
+
+    if in_reflection:
+        x = x / 0.9
+
+    with domain_range_scale("ignore"):
+        clog = np.where(
+            x < (log_decoding_CanonLog_v1_2(0.12512248, bit_depth, True)),
+            -(0.45310179 * (np.log10(-x * 10.1596 + 1)) - 0.12512248),
+            0.45310179 * np.log10(10.1596 * x + 1) + 0.12512248,
+        )
+
+    # NOTE: *Canon Log* v1.2 constants are expressed in legal range
+    # (studio swing).
+    clog_cv = (
+        clog if out_normalised_code_value else legal_to_full(clog, bit_depth)
+    )
+
+    return as_float(from_range_1(clog_cv))
+
+
+def log_decoding_CanonLog_v1_2(
+    clog: ArrayLike,
+    bit_depth: int = 10,
+    in_normalised_code_value: bool = True,
+    out_reflection: bool = True,
+) -> NDArrayFloat:
+    """
+    Define the *Canon Log* v1.2 log decoding curve / electro-optical transfer
+    function.
+
+    Parameters
+    ----------
+    clog
+        *Canon Log* non-linear data.
+    bit_depth
+        Bit-depth used for conversion.
+    in_normalised_code_value
+        Whether the *Canon Log* non-linear data is encoded with normalised
+        code values.
+    out_reflection
+        Whether the light level :math:`x` to a camera is reflection.
+
+    Returns
+    -------
+    :class:`numpy.ndarray`
+        Linear data :math:`x`.
+
+    Notes
+    -----
+    +------------+-----------------------+---------------+
+    | **Domain** | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``clog``   | [0, 1]                | [0, 1]        |
+    +------------+-----------------------+---------------+
+
+    +------------+-----------------------+---------------+
+    | **Range**  | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``x``      | [0, 1]                | [0, 1]        |
+    +------------+-----------------------+---------------+
+
+    References
+    ----------
+    :cite:`Canon2020`
+
+    Examples
+    --------
+    >>> log_decoding_CanonLog_v1_2(34.338964929528061 / 100)
+    ... # doctest: +ELLIPSIS
+    0.17999999...
+    """
+
+    clog = to_domain_1(clog)
+
+    # NOTE: *Canon Log* v1.2 constants are expressed in legal range
+    # (studio swing).
+    clog = clog if in_normalised_code_value else full_to_legal(clog, bit_depth)
+
+    x = np.where(
+        clog < 0.12512248,
+        -(10 ** ((0.12512248 - clog) / 0.45310179) - 1) / 10.1596,
+        (10 ** ((clog - 0.12512248) / 0.45310179) - 1) / 10.1596,
+    )
+
+    if out_reflection:
+        x = x * 0.9
+
+    return as_float(from_range_1(x))
+
+
+CANON_LOG_ENCODING_METHODS: CanonicalMapping = CanonicalMapping(
+    {
+        "v1": log_encoding_CanonLog_v1,
+        "v1.2": log_encoding_CanonLog_v1_2,
+    }
+)
+CANON_LOG_ENCODING_METHODS.__doc__ = """
+Supported *CanonLog* log encoding curve / opto-electronic transfer function
+methods.
+
+References
+----------
+:cite:`Canon2016`, :cite:`Canon2020`
+"""
+
+
+def log_encoding_CanonLog(
+    x: ArrayLike,
+    bit_depth: int = 10,
+    out_normalised_code_value: bool = True,
+    in_reflection: bool = True,
+    method: Literal["v1", "v1.2"] | str = "v1.2",
+) -> NDArrayFloat:
+    """
+    Define the *Canon Log* log encoding curve / opto-electronic transfer
+    function.
+
+    Parameters
+    ----------
+    x
+        Linear data :math:`x`.
+    bit_depth
+        Bit-depth used for conversion.
+    out_normalised_code_value
+        Whether the *Canon Log* non-linear data is encoded as normalised code
+        values.
+    in_reflection
+        Whether the light level :math:`x` to a camera is reflection.
+    method
+        Computation method.
+
+    Returns
+    -------
+    :class:`numpy.ndarray`
+        *Canon Log* non-linear data.
+
+    References
+    ----------
+    :cite:`Canon2016`, :cite:`Canon2020`, :cite:`Thorpe2012a`
+
+    Notes
+    -----
+    +------------+-----------------------+---------------+
+    | **Domain** | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``x``      | [0, 1]                | [0, 1]        |
+    +------------+-----------------------+---------------+
+
+    +------------+-----------------------+---------------+
+    | **Range**  | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``clog``   | [0, 1]                | [0, 1]        |
+    +------------+-----------------------+---------------+
+
+    Examples
+    --------
+    >>> log_encoding_CanonLog(0.18) * 100  # doctest: +ELLIPSIS
+    34.3389649...
+    >>> log_encoding_CanonLog(0.18, method="v1") * 100  # doctest: +ELLIPSIS
+    34.3389651...
+
+    The values of *Table 2 Canon-Log Code Values* table in :cite:`Thorpe2012a`
+    are obtained as follows:
+
+    >>> x = np.array([0, 2, 18, 90, 720]) / 100
+    >>> np.around(
+    ...     log_encoding_CanonLog(x, method="v1") * (2**10 - 1)
+    ... ).astype(np.int_)
+    array([ 128,  169,  351,  614, 1016])
+    >>> np.around(log_encoding_CanonLog(x, 10, False, method="v1") * 100, 1)
+    array([   7.3,   12. ,   32.8,   62.7,  108.7])
+    """
+
+    method = validate_method(method, tuple(CANON_LOG_ENCODING_METHODS))
+
+    return CANON_LOG_ENCODING_METHODS[method](
+        x, bit_depth, out_normalised_code_value, in_reflection
+    )
+
+
+CANON_LOG_DECODING_METHODS: CanonicalMapping = CanonicalMapping(
+    {
+        "v1": log_decoding_CanonLog_v1,
+        "v1.2": log_decoding_CanonLog_v1_2,
+    }
+)
+CANON_LOG_DECODING_METHODS.__doc__ = """
+Supported *CanonLog* log decoding curve / electro-optical transfer function
+methods.
+
+References
+----------
+:cite:`Canon2016`, :cite:`Canon2020`
+"""
+
+
+def log_decoding_CanonLog(
+    clog: ArrayLike,
+    bit_depth: int = 10,
+    in_normalised_code_value: bool = True,
+    out_reflection: bool = True,
+    method: Literal["v1", "v1.2"] | str = "v1.2",
+) -> NDArrayFloat:
+    """
+    Define the *Canon Log* log decoding curve / electro-optical transfer
+    function.
+
+    Parameters
+    ----------
+    clog
+        *Canon Log* non-linear data.
+    bit_depth
+        Bit-depth used for conversion.
+    in_normalised_code_value
+        Whether the *Canon Log* non-linear data is encoded with normalised
+        code values.
+    out_reflection
+        Whether the light level :math:`x` to a camera is reflection.
+    method
+        Computation method.
+
+    Returns
+    -------
+    :class:`numpy.ndarray`
+        Linear data :math:`x`.
+
+    Notes
+    -----
+    +------------+-----------------------+---------------+
+    | **Domain** | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``clog``   | [0, 1]                | [0, 1]        |
+    +------------+-----------------------+---------------+
+
+    +------------+-----------------------+---------------+
+    | **Range**  | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``x``      | [0, 1]                | [0, 1]        |
+    +------------+-----------------------+---------------+
+
+    References
+    ----------
+    :cite:`Canon2016`, :cite:`Canon2020`, :cite:`Thorpe2012a`
+
+    Examples
+    --------
+    >>> log_decoding_CanonLog(34.338964929528061 / 100)  # doctest: +ELLIPSIS
+    0.17999999...
+    >>> log_decoding_CanonLog(34.338965172606912 / 100, method="v1")
+    ... # doctest: +ELLIPSIS
+    0.17999999...
+    """
+
+    method = validate_method(method, tuple(CANON_LOG_DECODING_METHODS))
+
+    return CANON_LOG_DECODING_METHODS[method](
+        clog, bit_depth, in_normalised_code_value, out_reflection
+    )
+
+
+def log_encoding_CanonLog2_v1(
+    x: ArrayLike,
+    bit_depth: int = 10,
+    out_normalised_code_value: bool = True,
+    in_reflection: bool = True,
+) -> NDArrayFloat:
+    """
+    Define the *Canon Log 2* v1 log encoding curve / opto-electronic transfer
     function.
 
     Parameters
@@ -247,11 +592,11 @@ def log_encoding_CanonLog2(
 
     References
     ----------
-    :cite:`Canona`
+    :cite:`Canon2016`
 
     Examples
     --------
-    >>> log_encoding_CanonLog2(0.18) * 100  # doctest: +ELLIPSIS
+    >>> log_encoding_CanonLog2_v1(0.18) * 100  # doctest: +ELLIPSIS
     39.8254694...
     """
 
@@ -262,7 +607,7 @@ def log_encoding_CanonLog2(
 
     with domain_range_scale("ignore"):
         clog2 = np.where(
-            x < log_decoding_CanonLog2(0.035388128, bit_depth, False),
+            x < log_decoding_CanonLog2_v1(0.035388128, bit_depth, False),
             -(0.281863093 * (np.log10(-x * 87.09937546 + 1)) - 0.035388128),
             0.281863093 * np.log10(x * 87.09937546 + 1) + 0.035388128,
         )
@@ -274,14 +619,14 @@ def log_encoding_CanonLog2(
     return as_float(from_range_1(clog2_cv))
 
 
-def log_decoding_CanonLog2(
+def log_decoding_CanonLog2_v1(
     clog2: ArrayLike,
     bit_depth: int = 10,
     in_normalised_code_value: bool = True,
     out_reflection: bool = True,
 ) -> NDArrayFloat:
     """
-    Define the *Canon Log 2* log decoding curve / electro-optical transfer
+    Define the *Canon Log 2* v1 log decoding curve / electro-optical transfer
     function.
 
     Parameters
@@ -317,11 +662,13 @@ def log_decoding_CanonLog2(
 
     References
     ----------
-    :cite:`Canona`
+    :cite:`Canon2016`
 
     Examples
     --------
-    >>> log_decoding_CanonLog2(39.825469498316735 / 100)  # doctest: +ELLIPSIS
+    >>> log_decoding_CanonLog2_v1(
+    ...     39.825469498316735 / 100
+    ... )  # doctest: +ELLIPSIS
     0.1799999...
     """
 
@@ -343,14 +690,312 @@ def log_decoding_CanonLog2(
     return as_float(from_range_1(x))
 
 
-def log_encoding_CanonLog3(
+def log_encoding_CanonLog2_v1_2(
     x: ArrayLike,
     bit_depth: int = 10,
     out_normalised_code_value: bool = True,
     in_reflection: bool = True,
 ) -> NDArrayFloat:
     """
-    Define the *Canon Log 3* log encoding curve / opto-electronic transfer
+    Define the *Canon Log 2* v1.2 log encoding curve / opto-electronic transfer
+    function.
+
+    Parameters
+    ----------
+    x
+        Linear data :math:`x`.
+    bit_depth
+        Bit-depth used for conversion.
+    out_normalised_code_value
+        Whether the *Canon Log 2* non-linear data is encoded as normalised
+        code values.
+    in_reflection
+        Whether the light level :math:`x` to a camera is reflection.
+
+    Returns
+    -------
+    :class:`numpy.ndarray`
+        *Canon Log 2* non-linear data.
+
+    Notes
+    -----
+    +------------+-----------------------+---------------+
+    | **Domain** | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``x``      | [0, 1]                | [0, 1]        |
+    +------------+-----------------------+---------------+
+
+    +------------+-----------------------+---------------+
+    | **Range**  | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``clog2``  | [0, 1]                | [0, 1]        |
+    +------------+-----------------------+---------------+
+
+    References
+    ----------
+    :cite:`Canon2020`
+
+    Examples
+    --------
+    >>> log_encoding_CanonLog2_v1_2(0.18) * 100  # doctest: +ELLIPSIS
+    39.8254692...
+    """
+
+    x = to_domain_1(x)
+
+    if in_reflection:
+        x = x / 0.9
+
+    with domain_range_scale("ignore"):
+        clog2 = np.where(
+            x < (log_decoding_CanonLog2_v1_2(0.092864125, bit_depth, True)),
+            -(0.24136077 * (np.log10(-x * 87.09937546 + 1)) - 0.092864125),
+            0.24136077 * np.log10(x * 87.09937546 + 1) + 0.092864125,
+        )
+
+    # NOTE: *Canon Log 2* v1.2 constants are expressed in legal range
+    # (studio swing).
+    clog2_cv = (
+        clog2 if out_normalised_code_value else legal_to_full(clog2, bit_depth)
+    )
+
+    return as_float(from_range_1(clog2_cv))
+
+
+def log_decoding_CanonLog2_v1_2(
+    clog2: ArrayLike,
+    bit_depth: int = 10,
+    in_normalised_code_value: bool = True,
+    out_reflection: bool = True,
+) -> NDArrayFloat:
+    """
+    Define the *Canon Log 2* v1.2 log decoding curve / electro-optical transfer
+    function.
+
+    Parameters
+    ----------
+    clog2
+        *Canon Log 2* non-linear data.
+    bit_depth
+        Bit-depth used for conversion.
+    in_normalised_code_value
+        Whether the *Canon Log 2* non-linear data is encoded with normalised
+        code values.
+    out_reflection
+        Whether the light level :math:`x` to a camera is reflection.
+
+    Returns
+    -------
+    :class:`numpy.ndarray`
+        Linear data :math:`x`.
+
+    Notes
+    -----
+    +------------+-----------------------+---------------+
+    | **Domain** | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``clog2``  | [0, 1]                | [0, 1]        |
+    +------------+-----------------------+---------------+
+
+    +------------+-----------------------+---------------+
+    | **Range**  | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``x``      | [0, 1]                | [0, 1]        |
+    +------------+-----------------------+---------------+
+
+    References
+    ----------
+    :cite:`Canon2020`
+
+    Examples
+    --------
+    >>> log_decoding_CanonLog2_v1_2(39.825469256149191 / 100)
+    ... # doctest: +ELLIPSIS
+    0.1799999...
+    """
+
+    clog2 = to_domain_1(clog2)
+
+    # NOTE: *Canon Log 2* v1.2 constants are expressed in legal range
+    # (studio swing).
+    clog2 = (
+        clog2 if in_normalised_code_value else full_to_legal(clog2, bit_depth)
+    )
+
+    x = np.where(
+        clog2 < 0.092864125,
+        -(10 ** ((0.092864125 - clog2) / 0.24136077) - 1) / 87.09937546,
+        (10 ** ((clog2 - 0.092864125) / 0.24136077) - 1) / 87.09937546,
+    )
+
+    if out_reflection:
+        x = x * 0.9
+
+    return as_float(from_range_1(x))
+
+
+CANON_LOG_2_ENCODING_METHODS: CanonicalMapping = CanonicalMapping(
+    {
+        "v1": log_encoding_CanonLog2_v1,
+        "v1.2": log_encoding_CanonLog2_v1_2,
+    }
+)
+CANON_LOG_2_ENCODING_METHODS.__doc__ = """
+Supported *Canon Log 2* log encoding curve / opto-electronic transfer function
+methods.
+
+References
+----------
+:cite:`Canon2016`, :cite:`Canon2020`
+"""
+
+
+def log_encoding_CanonLog2(
+    x: ArrayLike,
+    bit_depth: int = 10,
+    out_normalised_code_value: bool = True,
+    in_reflection: bool = True,
+    method: Literal["v1", "v1.2"] | str = "v1.2",
+) -> NDArrayFloat:
+    """
+    Define the *Canon Log 2* log encoding curve / opto-electronic transfer
+    function.
+
+    Parameters
+    ----------
+    x
+        Linear data :math:`x`.
+    bit_depth
+        Bit-depth used for conversion.
+    out_normalised_code_value
+        Whether the *Canon Log 2* non-linear data is encoded as normalised
+        code values.
+    in_reflection
+        Whether the light level :math:`x` to a camera is reflection.
+    method
+        Computation method.
+
+    Returns
+    -------
+    :class:`numpy.ndarray`
+        *Canon Log 2* non-linear data.
+
+    Notes
+    -----
+    +------------+-----------------------+---------------+
+    | **Domain** | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``x``      | [0, 1]                | [0, 1]        |
+    +------------+-----------------------+---------------+
+
+    +------------+-----------------------+---------------+
+    | **Range**  | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``clog2``  | [0, 1]                | [0, 1]        |
+    +------------+-----------------------+---------------+
+
+    References
+    ----------
+    :cite:`Canon2016`, :cite:`Canon2020`
+
+    Examples
+    --------
+    >>> log_encoding_CanonLog2(0.18) * 100  # doctest: +ELLIPSIS
+    39.8254692...
+    """
+
+    method = validate_method(method, tuple(CANON_LOG_2_ENCODING_METHODS))
+
+    return CANON_LOG_2_ENCODING_METHODS[method](
+        x, bit_depth, out_normalised_code_value, in_reflection
+    )
+
+
+CANON_LOG_2_DECODING_METHODS: CanonicalMapping = CanonicalMapping(
+    {
+        "v1": log_decoding_CanonLog2_v1,
+        "v1.2": log_decoding_CanonLog2_v1_2,
+    }
+)
+CANON_LOG_2_DECODING_METHODS.__doc__ = """
+Supported *Canon Log 2* log decoding curve / electro-optical transfer function
+methods.
+
+References
+----------
+:cite:`Canon2016`, :cite:`Canon2020`
+"""
+
+
+def log_decoding_CanonLog2(
+    clog2: ArrayLike,
+    bit_depth: int = 10,
+    in_normalised_code_value: bool = True,
+    out_reflection: bool = True,
+    method: Literal["v1", "v1.2"] | str = "v1.2",
+) -> NDArrayFloat:
+    """
+    Define the *Canon Log 2* log decoding curve / electro-optical transfer
+    function.
+
+    Parameters
+    ----------
+    clog2
+        *Canon Log 2* non-linear data.
+    bit_depth
+        Bit-depth used for conversion.
+    in_normalised_code_value
+        Whether the *Canon Log 2* non-linear data is encoded with normalised
+        code values.
+    out_reflection
+        Whether the light level :math:`x` to a camera is reflection.
+    method
+        Computation method.
+
+    Returns
+    -------
+    :class:`numpy.ndarray`
+        Linear data :math:`x`.
+
+    Notes
+    -----
+    +------------+-----------------------+---------------+
+    | **Domain** | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``clog2``  | [0, 1]                | [0, 1]        |
+    +------------+-----------------------+---------------+
+
+    +------------+-----------------------+---------------+
+    | **Range**  | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``x``      | [0, 1]                | [0, 1]        |
+    +------------+-----------------------+---------------+
+
+    References
+    ----------
+    :cite:`Canon2016`, :cite:`Canon2020`
+
+    Examples
+    --------
+    >>> log_decoding_CanonLog2(39.825469256149191 / 100)  # doctest: +ELLIPSIS
+    0.1799999...
+    """
+
+    method = validate_method(method, tuple(CANON_LOG_2_DECODING_METHODS))
+
+    return CANON_LOG_2_DECODING_METHODS[method](
+        clog2, bit_depth, in_normalised_code_value, out_reflection
+    )
+
+
+def log_encoding_CanonLog3_v1(
+    x: ArrayLike,
+    bit_depth: int = 10,
+    out_normalised_code_value: bool = True,
+    in_reflection: bool = True,
+) -> NDArrayFloat:
+    """
+    Define the *Canon Log 3* v1 log encoding curve / opto-electronic transfer
     function.
 
     Parameters
@@ -373,7 +1018,7 @@ def log_encoding_CanonLog3(
     Notes
     -----
     -   Introspection of the grafting points by Shaw, N. (2018) shows that the
-        *Canon Log 3* IDT was likely derived from its encoding curve as the
+        *Canon Log 3* v1 IDT was likely derived from its encoding curve as the
         latter is grafted at *+/-0.014*::
 
             >>> clog3 = 0.04076162
@@ -397,11 +1042,11 @@ def log_encoding_CanonLog3(
 
     References
     ----------
-    :cite:`Canona`
+    :cite:`Canon2016`
 
     Examples
     --------
-    >>> log_encoding_CanonLog3(0.18) * 100  # doctest: +ELLIPSIS
+    >>> log_encoding_CanonLog3_v1(0.18) * 100  # doctest: +ELLIPSIS
     34.3389369...
     """
 
@@ -414,13 +1059,17 @@ def log_encoding_CanonLog3(
         clog3 = np.select(
             (
                 x
-                < log_decoding_CanonLog3(0.04076162, bit_depth, False, False),
+                < log_decoding_CanonLog3_v1(
+                    0.04076162, bit_depth, False, False
+                ),
                 x
-                <= log_decoding_CanonLog3(
+                <= log_decoding_CanonLog3_v1(
                     0.105357102, bit_depth, False, False
                 ),
                 x
-                > log_decoding_CanonLog3(0.105357102, bit_depth, False, False),
+                > log_decoding_CanonLog3_v1(
+                    0.105357102, bit_depth, False, False
+                ),
             ),
             (
                 -0.42889912 * np.log10(-x * 14.98325 + 1) + 0.07623209,
@@ -436,14 +1085,14 @@ def log_encoding_CanonLog3(
     return as_float(from_range_1(clog3_cv))
 
 
-def log_decoding_CanonLog3(
+def log_decoding_CanonLog3_v1(
     clog3: ArrayLike,
     bit_depth: int = 10,
     in_normalised_code_value: bool = True,
     out_reflection: bool = True,
 ) -> NDArrayFloat:
     """
-    Define the *Canon Log 3* log decoding curve / electro-optical transfer
+    Define the *Canon Log 3* v1 log decoding curve / electro-optical transfer
     function.
 
     Parameters
@@ -479,11 +1128,13 @@ def log_decoding_CanonLog3(
 
     References
     ----------
-    :cite:`Canona`
+    :cite:`Canon2016`
 
     Examples
     --------
-    >>> log_decoding_CanonLog3(34.338936938868677 / 100)  # doctest: +ELLIPSIS
+    >>> log_decoding_CanonLog3_v1(
+    ...     34.338936938868677 / 100
+    ... )  # doctest: +ELLIPSIS
     0.1800000...
     """
 
@@ -506,3 +1157,331 @@ def log_decoding_CanonLog3(
         x = x * 0.9
 
     return as_float(from_range_1(x))
+
+
+def log_encoding_CanonLog3_v1_2(
+    x: ArrayLike,
+    bit_depth: int = 10,
+    out_normalised_code_value: bool = True,
+    in_reflection: bool = True,
+) -> NDArrayFloat:
+    """
+    Define the *Canon Log 3* v1.2 log encoding curve / opto-electronic transfer
+    function.
+
+    Parameters
+    ----------
+    x
+        Linear data :math:`x`.
+    bit_depth
+        Bit-depth used for conversion.
+    out_normalised_code_value
+        Whether the *Canon Log 3* non-linear data is encoded as normalised code
+        values.
+    in_reflection
+        Whether the light level :math:`x` to a camera is reflection.
+
+    Returns
+    -------
+    :class:`numpy.ndarray`
+        *Canon Log 3* non-linear data.
+
+    Notes
+    -----
+    +------------+-----------------------+---------------+
+    | **Domain** | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``x``      | [0, 1]                | [0, 1]        |
+    +------------+-----------------------+---------------+
+
+    +------------+-----------------------+---------------+
+    | **Range**  | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``clog3``  | [0, 1]                | [0, 1]        |
+    +------------+-----------------------+---------------+
+
+    References
+    ----------
+    :cite:`Canon2020`
+
+    Examples
+    --------
+    >>> log_encoding_CanonLog3_v1_2(0.18) * 100  # doctest: +ELLIPSIS
+    34.3389370...
+    """
+
+    x = to_domain_1(x)
+
+    if in_reflection:
+        x = x / 0.9
+
+    with domain_range_scale("ignore"):
+        clog3 = np.select(
+            (
+                x
+                < log_decoding_CanonLog3_v1_2(
+                    0.097465473, bit_depth, True, False
+                ),
+                x
+                <= log_decoding_CanonLog3_v1_2(
+                    0.15277891, bit_depth, True, False
+                ),
+                x
+                > log_decoding_CanonLog3_v1_2(
+                    0.15277891, bit_depth, True, False
+                ),
+            ),
+            (
+                -0.36726845 * np.log10(-x * 14.98325 + 1) + 0.12783901,
+                1.9754798 * x + 0.12512219,
+                0.36726845 * np.log10(x * 14.98325 + 1) + 0.12240537,
+            ),
+        )
+
+    # NOTE: *Canon Log 3* v1.2 constants are expressed in legal range
+    # (studio swing).
+    clog3_cv = (
+        clog3 if out_normalised_code_value else legal_to_full(clog3, bit_depth)
+    )
+
+    return as_float(from_range_1(clog3_cv))
+
+
+def log_decoding_CanonLog3_v1_2(
+    clog3: ArrayLike,
+    bit_depth: int = 10,
+    in_normalised_code_value: bool = True,
+    out_reflection: bool = True,
+) -> NDArrayFloat:
+    """
+    Define the *Canon Log 3* v1.2 log decoding curve / electro-optical transfer
+    function.
+
+    Parameters
+    ----------
+    clog3
+        *Canon Log 3* non-linear data.
+    bit_depth
+        Bit-depth used for conversion.
+    in_normalised_code_value
+        Whether the *Canon Log 3* non-linear data is encoded with normalised
+        code values.
+    out_reflection
+        Whether the light level :math:`x` to a camera is reflection.
+
+    Returns
+    -------
+    :class:`numpy.ndarray`
+        Linear data :math:`x`.
+
+    Notes
+    -----
+    +------------+-----------------------+---------------+
+    | **Domain** | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``clog3``  | [0, 1]                | [0, 1]        |
+    +------------+-----------------------+---------------+
+
+    +------------+-----------------------+---------------+
+    | **Range**  | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``x``      | [0, 1]                | [0, 1]        |
+    +------------+-----------------------+---------------+
+
+    References
+    ----------
+    :cite:`Canon2020`
+
+    Examples
+    --------
+    >>> log_decoding_CanonLog3_v1_2(34.338937037393549 / 100)
+    ... # doctest: +ELLIPSIS
+    0.1799999...
+    """
+
+    clog3 = to_domain_1(clog3)
+
+    # NOTE: *Canon Log 3* v1.2 constants are expressed in legal range
+    # (studio swing).
+    clog3 = (
+        clog3 if in_normalised_code_value else full_to_legal(clog3, bit_depth)
+    )
+
+    x = np.select(
+        (clog3 < 0.097465473, clog3 <= 0.15277891, clog3 > 0.15277891),
+        (
+            -(10 ** ((0.12783901 - clog3) / 0.36726845) - 1) / 14.98325,
+            (clog3 - 0.12512219) / 1.9754798,
+            (10 ** ((clog3 - 0.12240537) / 0.36726845) - 1) / 14.98325,
+        ),
+    )
+
+    if out_reflection:
+        x = x * 0.9
+
+    return as_float(from_range_1(x))
+
+
+CANON_LOG_3_ENCODING_METHODS: CanonicalMapping = CanonicalMapping(
+    {
+        "v1": log_encoding_CanonLog3_v1,
+        "v1.2": log_encoding_CanonLog3_v1_2,
+    }
+)
+CANON_LOG_3_ENCODING_METHODS.__doc__ = """
+Supported *Canon Log 3* log encoding curve / opto-electronic transfer function
+methods.
+
+References
+----------
+:cite:`Canon2016`, :cite:`Canon2020`
+"""
+
+
+def log_encoding_CanonLog3(
+    x: ArrayLike,
+    bit_depth: int = 10,
+    out_normalised_code_value: bool = True,
+    in_reflection: bool = True,
+    method: Literal["v1", "v1.2"] | str = "v1.2",
+) -> NDArrayFloat:
+    """
+    Define the *Canon Log 3* log encoding curve / opto-electronic transfer
+    function.
+
+    Parameters
+    ----------
+    x
+        Linear data :math:`x`.
+    bit_depth
+        Bit-depth used for conversion.
+    out_normalised_code_value
+        Whether the *Canon Log 3* non-linear data is encoded as normalised
+        code values.
+    in_reflection
+        Whether the light level :math:`x` to a camera is reflection.
+    method
+        Computation method.
+
+    Returns
+    -------
+    :class:`numpy.ndarray`
+        *Canon Log 3* non-linear data.
+
+    Notes
+    -----
+    -   Introspection of the grafting points by Shaw, N. (2018) shows that the
+        *Canon Log 3* v1 IDT was likely derived from its encoding curve as the
+        latter is grafted at *+/-0.014*::
+
+            >>> clog3 = 0.04076162
+            >>> (clog3 - 0.073059361) / 2.3069815
+            -0.014000000000000002
+            >>> clog3 = 0.105357102
+            >>> (clog3 - 0.073059361) / 2.3069815
+            0.013999999999999997
+
+    +------------+-----------------------+---------------+
+    | **Domain** | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``x``      | [0, 1]                | [0, 1]        |
+    +------------+-----------------------+---------------+
+
+    +------------+-----------------------+---------------+
+    | **Range**  | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``clog2``  | [0, 1]                | [0, 1]        |
+    +------------+-----------------------+---------------+
+
+    References
+    ----------
+    :cite:`Canon2016`, :cite:`Canon2020`
+
+    Examples
+    --------
+    >>> log_encoding_CanonLog3(0.18) * 100  # doctest: +ELLIPSIS
+    34.3389370...
+    """
+
+    method = validate_method(method, tuple(CANON_LOG_3_ENCODING_METHODS))
+
+    return CANON_LOG_3_ENCODING_METHODS[method](
+        x, bit_depth, out_normalised_code_value, in_reflection
+    )
+
+
+CANON_LOG_3_DECODING_METHODS: CanonicalMapping = CanonicalMapping(
+    {
+        "v1": log_decoding_CanonLog3_v1,
+        "v1.2": log_decoding_CanonLog3_v1_2,
+    }
+)
+CANON_LOG_3_DECODING_METHODS.__doc__ = """
+Supported *Canon Log 3* log decoding curve / electro-optical transfer function
+methods.
+
+References
+----------
+:cite:`Canon2016`, :cite:`Canon2020`
+"""
+
+
+def log_decoding_CanonLog3(
+    clog3: ArrayLike,
+    bit_depth: int = 10,
+    in_normalised_code_value: bool = True,
+    out_reflection: bool = True,
+    method: Literal["v1", "v1.2"] | str = "v1.2",
+) -> NDArrayFloat:
+    """
+    Define the *Canon Log 3* log decoding curve / electro-optical transfer
+    function.
+
+    Parameters
+    ----------
+    clog3
+        *Canon Log 3* non-linear data.
+    bit_depth
+        Bit-depth used for conversion.
+    in_normalised_code_value
+        Whether the *Canon Log 3* non-linear data is encoded with normalised
+        code values.
+    out_reflection
+        Whether the light level :math:`x` to a camera is reflection.
+    method
+        Computation method.
+
+    Returns
+    -------
+    :class:`numpy.ndarray`
+        Linear data :math:`x`.
+
+    Notes
+    -----
+    +------------+-----------------------+---------------+
+    | **Domain** | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``clog2``  | [0, 1]                | [0, 1]        |
+    +------------+-----------------------+---------------+
+
+    +------------+-----------------------+---------------+
+    | **Range**  | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``x``      | [0, 1]                | [0, 1]        |
+    +------------+-----------------------+---------------+
+
+    References
+    ----------
+    :cite:`Canon2016`, :cite:`Canon2020`
+
+    Examples
+    --------
+    >>> log_decoding_CanonLog3(34.338937037393549 / 100)  # doctest: +ELLIPSIS
+    0.1799999...
+    """
+
+    method = validate_method(method, tuple(CANON_LOG_3_DECODING_METHODS))
+
+    return CANON_LOG_3_DECODING_METHODS[method](
+        clog3, bit_depth, in_normalised_code_value, out_reflection
+    )

--- a/colour/models/rgb/transfer_functions/tests/test_canon.py
+++ b/colour/models/rgb/transfer_functions/tests/test_canon.py
@@ -6,13 +6,19 @@ Define the unit tests for the
 import numpy as np
 import unittest
 
-from colour.models.rgb.transfer_functions import (
-    log_encoding_CanonLog,
-    log_decoding_CanonLog,
-    log_encoding_CanonLog2,
-    log_decoding_CanonLog2,
-    log_encoding_CanonLog3,
-    log_decoding_CanonLog3,
+from colour.models.rgb.transfer_functions.canon import (
+    log_encoding_CanonLog_v1,
+    log_decoding_CanonLog_v1,
+    log_encoding_CanonLog_v1_2,
+    log_decoding_CanonLog_v1_2,
+    log_encoding_CanonLog2_v1,
+    log_decoding_CanonLog2_v1,
+    log_encoding_CanonLog2_v1_2,
+    log_decoding_CanonLog2_v1_2,
+    log_encoding_CanonLog3_v1,
+    log_decoding_CanonLog3_v1,
+    log_encoding_CanonLog3_v1_2,
+    log_decoding_CanonLog3_v1_2,
 )
 
 from colour.utilities import domain_range_scale, ignore_numpy_errors
@@ -25,609 +31,1419 @@ __email__ = "colour-developers@colour-science.org"
 __status__ = "Production"
 
 __all__ = [
-    "TestLogEncoding_CanonLog",
-    "TestLogDecoding_CanonLog",
-    "TestLogEncoding_CanonLog2",
-    "TestLogDecoding_CanonLog2",
-    "TestLogEncoding_CanonLog3",
-    "TestLogDecoding_CanonLog3",
+    "TestLogEncoding_CanonLog_v1",
+    "TestLogDecoding_CanonLog_v1",
+    "TestLogEncoding_CanonLog_v1_2",
+    "TestLogDecoding_CanonLog_v1_2",
+    "TestLogEncoding_CanonLog2_v1",
+    "TestLogDecoding_CanonLog2_v1",
+    "TestLogEncoding_CanonLog2_v1_2",
+    "TestLogDecoding_CanonLog2_v1_2",
+    "TestLogEncoding_CanonLog3_v1",
+    "TestLogDecoding_CanonLog3_v1",
+    "TestLogEncoding_CanonLog3_v1_2",
+    "TestLogDecoding_CanonLog3_v1_2",
 ]
 
 
-class TestLogEncoding_CanonLog(unittest.TestCase):
+class TestLogEncoding_CanonLog_v1(unittest.TestCase):
     """
     Define :func:`colour.models.rgb.transfer_functions.canon.\
-log_encoding_CanonLog` definition unit tests methods.
+log_encoding_CanonLog_v1` definition unit tests methods.
     """
 
-    def test_log_encoding_CanonLog(self):
+    def test_log_encoding_CanonLog_v1(self):
         """
         Test :func:`colour.models.rgb.transfer_functions.canon.\
-log_encoding_CanonLog` definition.
+log_encoding_CanonLog_v1` definition.
         """
 
         self.assertAlmostEqual(
-            log_encoding_CanonLog(-0.1), -0.023560122781997, places=7
+            log_encoding_CanonLog_v1(-0.1), -0.023560122781997, places=7
         )
 
         self.assertAlmostEqual(
-            log_encoding_CanonLog(0.0), 0.125122480156403, places=7
+            log_encoding_CanonLog_v1(0.0), 0.125122480156403, places=7
         )
 
         self.assertAlmostEqual(
-            log_encoding_CanonLog(0.18), 0.343389651726069, places=7
+            log_encoding_CanonLog_v1(0.18), 0.343389651726069, places=7
         )
 
         self.assertAlmostEqual(
-            log_encoding_CanonLog(0.18, 12), 0.343138084215647, places=7
+            log_encoding_CanonLog_v1(0.18, 12), 0.343138084215647, places=7
         )
 
         self.assertAlmostEqual(
-            log_encoding_CanonLog(0.18, 10, False), 0.327953896935809, places=7
+            log_encoding_CanonLog_v1(0.18, 10, False),
+            0.327953896935809,
+            places=7,
         )
 
         self.assertAlmostEqual(
-            log_encoding_CanonLog(0.18, 10, False, False),
+            log_encoding_CanonLog_v1(0.18, 10, False, False),
             0.312012855550395,
             places=7,
         )
 
         self.assertAlmostEqual(
-            log_encoding_CanonLog(1.0), 0.618775485598649, places=7
+            log_encoding_CanonLog_v1(1.0), 0.618775485598649, places=7
         )
 
-    def test_n_dimensional_log_encoding_CanonLog(self):
+    def test_n_dimensional_log_encoding_CanonLog_v1(self):
         """
         Test :func:`colour.models.rgb.transfer_functions.canon.\
-log_encoding_CanonLog` definition n-dimensional arrays support.
+log_encoding_CanonLog_v1` definition n-dimensional arrays support.
         """
 
         x = 0.18
-        clog = log_encoding_CanonLog(x)
+        clog = log_encoding_CanonLog_v1(x)
 
         x = np.tile(x, 6)
         clog = np.tile(clog, 6)
         np.testing.assert_array_almost_equal(
-            log_encoding_CanonLog(x), clog, decimal=7
+            log_encoding_CanonLog_v1(x), clog, decimal=7
         )
 
         x = np.reshape(x, (2, 3))
         clog = np.reshape(clog, (2, 3))
         np.testing.assert_array_almost_equal(
-            log_encoding_CanonLog(x), clog, decimal=7
+            log_encoding_CanonLog_v1(x), clog, decimal=7
         )
 
         x = np.reshape(x, (2, 3, 1))
         clog = np.reshape(clog, (2, 3, 1))
         np.testing.assert_array_almost_equal(
-            log_encoding_CanonLog(x), clog, decimal=7
+            log_encoding_CanonLog_v1(x), clog, decimal=7
         )
 
-    def test_domain_range_scale_log_encoding_CanonLog(self):
+    def test_domain_range_scale_log_encoding_CanonLog_v1(self):
         """
         Test :func:`colour.models.rgb.transfer_functions.canon.\
-log_encoding_CanonLog` definition domain and range scale support.
+log_encoding_CanonLog_v1` definition domain and range scale support.
         """
 
         x = 0.18
-        clog = log_encoding_CanonLog(x)
+        clog = log_encoding_CanonLog_v1(x)
 
         d_r = (("reference", 1), ("1", 1), ("100", 100))
         for scale, factor in d_r:
             with domain_range_scale(scale):
                 np.testing.assert_array_almost_equal(
-                    log_encoding_CanonLog(x * factor), clog * factor, decimal=7
+                    log_encoding_CanonLog_v1(x * factor),
+                    clog * factor,
+                    decimal=7,
                 )
 
     @ignore_numpy_errors
-    def test_nan_log_encoding_CanonLog(self):
+    def test_nan_log_encoding_CanonLog_v1(self):
         """
         Test :func:`colour.models.rgb.transfer_functions.canon.\
-log_encoding_CanonLog` definition nan support.
+log_encoding_CanonLog_v1` definition nan support.
         """
 
-        log_encoding_CanonLog(
+        log_encoding_CanonLog_v1(
             np.array([-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan])
         )
 
 
-class TestLogDecoding_CanonLog(unittest.TestCase):
+class TestLogDecoding_CanonLog_v1(unittest.TestCase):
     """
     Define :func:`colour.models.rgb.transfer_functions.canon.\
-log_decoding_CanonLog` definition unit tests methods.
+log_decoding_CanonLog_v1` definition unit tests methods.
     """
 
-    def test_log_decoding_CanonLog(self):
+    def test_log_decoding_CanonLog_v1(self):
         """
         Test :func:`colour.models.rgb.transfer_functions.canon.\
-log_decoding_CanonLog` definition.
+log_decoding_CanonLog_v1` definition.
         """
 
         self.assertAlmostEqual(
-            log_decoding_CanonLog(-0.023560122781997), -0.1, places=7
+            log_decoding_CanonLog_v1(-0.023560122781997), -0.1, places=7
         )
 
         self.assertAlmostEqual(
-            log_decoding_CanonLog(0.125122480156403), 0.0, places=7
+            log_decoding_CanonLog_v1(0.125122480156403), 0.0, places=7
         )
 
         self.assertAlmostEqual(
-            log_decoding_CanonLog(0.343389651726069), 0.18, places=7
+            log_decoding_CanonLog_v1(0.343389651726069), 0.18, places=7
         )
 
         self.assertAlmostEqual(
-            log_decoding_CanonLog(0.343138084215647, 12), 0.18, places=7
+            log_decoding_CanonLog_v1(0.343138084215647, 12), 0.18, places=7
         )
 
         self.assertAlmostEqual(
-            log_decoding_CanonLog(0.327953896935809, 10, False), 0.18, places=7
-        )
-
-        self.assertAlmostEqual(
-            log_decoding_CanonLog(0.312012855550395, 10, False, False),
+            log_decoding_CanonLog_v1(0.327953896935809, 10, False),
             0.18,
             places=7,
         )
 
         self.assertAlmostEqual(
-            log_decoding_CanonLog(0.618775485598649), 1.0, places=7
+            log_decoding_CanonLog_v1(0.312012855550395, 10, False, False),
+            0.18,
+            places=7,
         )
 
-    def test_n_dimensional_log_decoding_CanonLog(self):
+        self.assertAlmostEqual(
+            log_decoding_CanonLog_v1(0.618775485598649), 1.0, places=7
+        )
+
+    def test_n_dimensional_log_decoding_CanonLog_v1(self):
         """
         Test :func:`colour.models.rgb.transfer_functions.canon.\
-log_decoding_CanonLog` definition n-dimensional arrays support.
+log_decoding_CanonLog_v1` definition n-dimensional arrays support.
         """
 
         clog = 0.343389651726069
-        x = log_decoding_CanonLog(clog)
+        x = log_decoding_CanonLog_v1(clog)
 
         clog = np.tile(clog, 6)
         x = np.tile(x, 6)
         np.testing.assert_array_almost_equal(
-            log_decoding_CanonLog(clog), x, decimal=7
+            log_decoding_CanonLog_v1(clog), x, decimal=7
         )
 
         clog = np.reshape(clog, (2, 3))
         x = np.reshape(x, (2, 3))
         np.testing.assert_array_almost_equal(
-            log_decoding_CanonLog(clog), x, decimal=7
+            log_decoding_CanonLog_v1(clog), x, decimal=7
         )
 
         clog = np.reshape(clog, (2, 3, 1))
         x = np.reshape(x, (2, 3, 1))
         np.testing.assert_array_almost_equal(
-            log_decoding_CanonLog(clog), x, decimal=7
+            log_decoding_CanonLog_v1(clog), x, decimal=7
         )
 
-    def test_domain_range_scale_log_decoding_CanonLog(self):
+    def test_domain_range_scale_log_decoding_CanonLog_v1(self):
         """
         Test :func:`colour.models.rgb.transfer_functions.canon.\
-log_decoding_CanonLog` definition domain and range scale support.
+log_decoding_CanonLog_v1` definition domain and range scale support.
         """
 
         clog = 0.343389651726069
-        x = log_decoding_CanonLog(clog)
+        x = log_decoding_CanonLog_v1(clog)
 
         d_r = (("reference", 1), ("1", 1), ("100", 100))
         for scale, factor in d_r:
             with domain_range_scale(scale):
                 np.testing.assert_array_almost_equal(
-                    log_decoding_CanonLog(clog * factor), x * factor, decimal=7
+                    log_decoding_CanonLog_v1(clog * factor),
+                    x * factor,
+                    decimal=7,
                 )
 
     @ignore_numpy_errors
-    def test_nan_log_decoding_CanonLog(self):
+    def test_nan_log_decoding_CanonLog_v1(self):
         """
         Test :func:`colour.models.rgb.transfer_functions.canon.\
-log_decoding_CanonLog` definition nan support.
+log_decoding_CanonLog_v1` definition nan support.
         """
 
-        log_decoding_CanonLog(
+        log_decoding_CanonLog_v1(
             np.array([-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan])
         )
 
 
-class TestLogEncoding_CanonLog2(unittest.TestCase):
+class TestLogEncoding_CanonLog_v1_2(unittest.TestCase):
     """
     Define :func:`colour.models.rgb.transfer_functions.canon.\
-log_encoding_CanonLog2` definition unit tests methods.
+log_encoding_CanonLog_v1_2` definition unit tests methods.
     """
 
-    def test_log_encoding_CanonLog2(self):
+    def test_log_encoding_CanonLog_v1_2(self):
         """
         Test :func:`colour.models.rgb.transfer_functions.canon.\
-log_encoding_CanonLog2` definition.
+log_encoding_CanonLog_v1_2` definition.
         """
 
         self.assertAlmostEqual(
-            log_encoding_CanonLog2(-0.1), -0.155370131996824, places=7
+            log_encoding_CanonLog_v1_2(-0.1), -0.023560121389098, places=7
         )
 
         self.assertAlmostEqual(
-            log_encoding_CanonLog2(0.0), 0.092864125247312, places=7
+            log_encoding_CanonLog_v1_2(0.0), 0.125122480000000, places=7
         )
 
         self.assertAlmostEqual(
-            log_encoding_CanonLog2(0.18), 0.398254694983167, places=7
+            log_encoding_CanonLog_v1_2(0.18), 0.343389649295280, places=7
         )
 
         self.assertAlmostEqual(
-            log_encoding_CanonLog2(0.18, 12), 0.397962933301861, places=7
+            log_encoding_CanonLog_v1_2(0.18, 12), 0.343389649295281, places=7
         )
 
         self.assertAlmostEqual(
-            log_encoding_CanonLog2(0.18, 10, False),
+            log_encoding_CanonLog_v1_2(0.18, 10, False),
+            0.327953894097114,
+            places=7,
+        )
+
+        self.assertAlmostEqual(
+            log_encoding_CanonLog_v1_2(0.18, 10, False, False),
+            0.312012852877809,
+            places=7,
+        )
+
+        self.assertAlmostEqual(
+            log_encoding_CanonLog_v1_2(1.0), 0.618775480298287, places=7
+        )
+
+        samples = np.linspace(0, 1, 10000)
+
+        np.testing.assert_allclose(
+            log_encoding_CanonLog_v1(samples),
+            log_encoding_CanonLog_v1_2(samples),
+            rtol=0.0000001,
+            atol=0.0000001,
+        )
+
+        np.testing.assert_allclose(
+            log_encoding_CanonLog_v1(samples),
+            log_encoding_CanonLog_v1_2(samples),
+            rtol=0.0000001,
+            atol=0.0000001,
+        )
+
+        np.testing.assert_allclose(
+            log_encoding_CanonLog_v1(samples, out_normalised_code_value=False),
+            log_encoding_CanonLog_v1_2(
+                samples, out_normalised_code_value=False
+            ),
+            rtol=0.0000001,
+            atol=0.0000001,
+        )
+        np.testing.assert_allclose(
+            log_encoding_CanonLog_v1(samples, in_reflection=False),
+            log_encoding_CanonLog_v1_2(samples, in_reflection=False),
+            rtol=0.0000001,
+            atol=0.0000001,
+        )
+
+    def test_n_dimensional_log_encoding_CanonLog_v1_2(self):
+        """
+        Test :func:`colour.models.rgb.transfer_functions.canon.\
+log_encoding_CanonLog_v1_2` definition n-dimensional arrays support.
+        """
+
+        x = 0.18
+        clog = log_encoding_CanonLog_v1_2(x)
+
+        x = np.tile(x, 6)
+        clog = np.tile(clog, 6)
+        np.testing.assert_array_almost_equal(
+            log_encoding_CanonLog_v1_2(x), clog, decimal=7
+        )
+
+        x = np.reshape(x, (2, 3))
+        clog = np.reshape(clog, (2, 3))
+        np.testing.assert_array_almost_equal(
+            log_encoding_CanonLog_v1_2(x), clog, decimal=7
+        )
+
+        x = np.reshape(x, (2, 3, 1))
+        clog = np.reshape(clog, (2, 3, 1))
+        np.testing.assert_array_almost_equal(
+            log_encoding_CanonLog_v1_2(x), clog, decimal=7
+        )
+
+    def test_domain_range_scale_log_encoding_CanonLog_v1_2(self):
+        """
+        Test :func:`colour.models.rgb.transfer_functions.canon.\
+log_encoding_CanonLog_v1_2` definition domain and range scale support.
+        """
+
+        x = 0.18
+        clog = log_encoding_CanonLog_v1_2(x)
+
+        d_r = (("reference", 1), ("1", 1), ("100", 100))
+        for scale, factor in d_r:
+            with domain_range_scale(scale):
+                np.testing.assert_array_almost_equal(
+                    log_encoding_CanonLog_v1_2(x * factor),
+                    clog * factor,
+                    decimal=7,
+                )
+
+    @ignore_numpy_errors
+    def test_nan_log_encoding_CanonLog_v1_2(self):
+        """
+        Test :func:`colour.models.rgb.transfer_functions.canon.\
+log_encoding_CanonLog_v1_2` definition nan support.
+        """
+
+        log_encoding_CanonLog_v1_2(
+            np.array([-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan])
+        )
+
+
+class TestLogDecoding_CanonLog_v1_2(unittest.TestCase):
+    """
+    Define :func:`colour.models.rgb.transfer_functions.canon.\
+log_decoding_CanonLog_v1_2` definition unit tests methods.
+    """
+
+    def test_log_decoding_CanonLog_v1_2(self):
+        """
+        Test :func:`colour.models.rgb.transfer_functions.canon.\
+log_decoding_CanonLog_v1_2` definition.
+        """
+
+        self.assertAlmostEqual(
+            log_decoding_CanonLog_v1_2(-0.023560121389098), -0.1, places=7
+        )
+
+        self.assertAlmostEqual(
+            log_decoding_CanonLog_v1_2(0.125122480000000), 0.0, places=7
+        )
+
+        self.assertAlmostEqual(
+            log_decoding_CanonLog_v1_2(0.343389649295280), 0.18, places=7
+        )
+
+        self.assertAlmostEqual(
+            log_decoding_CanonLog_v1_2(0.343389649295281, 12), 0.18, places=7
+        )
+
+        self.assertAlmostEqual(
+            log_decoding_CanonLog_v1_2(0.327953894097114, 10, False),
+            0.18,
+            places=7,
+        )
+
+        self.assertAlmostEqual(
+            log_decoding_CanonLog_v1_2(0.312012852877809, 10, False, False),
+            0.18,
+            places=7,
+        )
+
+        self.assertAlmostEqual(
+            log_decoding_CanonLog_v1_2(0.618775480298287), 1.0, places=7
+        )
+
+        samples = np.linspace(0, 1, 10000)
+
+        np.testing.assert_allclose(
+            log_decoding_CanonLog_v1(samples),
+            log_decoding_CanonLog_v1_2(samples),
+            rtol=0.0000001,
+            atol=0.0000001,
+        )
+
+        np.testing.assert_allclose(
+            log_decoding_CanonLog_v1(samples),
+            log_decoding_CanonLog_v1_2(samples),
+            rtol=0.0000001,
+            atol=0.0000001,
+        )
+
+        np.testing.assert_allclose(
+            log_decoding_CanonLog_v1(samples, in_normalised_code_value=False),
+            log_decoding_CanonLog_v1_2(
+                samples, in_normalised_code_value=False
+            ),
+            rtol=0.0000001,
+            atol=0.0000001,
+        )
+        np.testing.assert_allclose(
+            log_decoding_CanonLog_v1(samples, out_reflection=False),
+            log_decoding_CanonLog_v1_2(samples, out_reflection=False),
+            rtol=0.0000001,
+            atol=0.0000001,
+        )
+
+    def test_n_dimensional_log_decoding_CanonLog_v1_2(self):
+        """
+        Test :func:`colour.models.rgb.transfer_functions.canon.\
+log_decoding_CanonLog_v1_2` definition n-dimensional arrays support.
+        """
+
+        clog = 0.343389649295280
+        x = log_decoding_CanonLog_v1_2(clog)
+
+        clog = np.tile(clog, 6)
+        x = np.tile(x, 6)
+        np.testing.assert_array_almost_equal(
+            log_decoding_CanonLog_v1_2(clog), x, decimal=7
+        )
+
+        clog = np.reshape(clog, (2, 3))
+        x = np.reshape(x, (2, 3))
+        np.testing.assert_array_almost_equal(
+            log_decoding_CanonLog_v1_2(clog), x, decimal=7
+        )
+
+        clog = np.reshape(clog, (2, 3, 1))
+        x = np.reshape(x, (2, 3, 1))
+        np.testing.assert_array_almost_equal(
+            log_decoding_CanonLog_v1_2(clog), x, decimal=7
+        )
+
+    def test_domain_range_scale_log_decoding_CanonLog_v1_2(self):
+        """
+        Test :func:`colour.models.rgb.transfer_functions.canon.\
+log_decoding_CanonLog_v1_2` definition domain and range scale support.
+        """
+
+        clog = 0.343389649295280
+        x = log_decoding_CanonLog_v1_2(clog)
+
+        d_r = (("reference", 1), ("1", 1), ("100", 100))
+        for scale, factor in d_r:
+            with domain_range_scale(scale):
+                np.testing.assert_array_almost_equal(
+                    log_decoding_CanonLog_v1_2(clog * factor),
+                    x * factor,
+                    decimal=7,
+                )
+
+    @ignore_numpy_errors
+    def test_nan_log_decoding_CanonLog_v1_2(self):
+        """
+        Test :func:`colour.models.rgb.transfer_functions.canon.\
+log_decoding_CanonLog_v1_2` definition nan support.
+        """
+
+        log_decoding_CanonLog_v1_2(
+            np.array([-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan])
+        )
+
+
+class TestLogEncoding_CanonLog2_v1(unittest.TestCase):
+    """
+    Define :func:`colour.models.rgb.transfer_functions.canon.\
+log_encoding_CanonLog2_v1` definition unit tests methods.
+    """
+
+    def test_log_encoding_CanonLog2_v1(self):
+        """
+        Test :func:`colour.models.rgb.transfer_functions.canon.\
+log_encoding_CanonLog2_v1` definition.
+        """
+
+        self.assertAlmostEqual(
+            log_encoding_CanonLog2_v1(-0.1), -0.155370131996824, places=7
+        )
+
+        self.assertAlmostEqual(
+            log_encoding_CanonLog2_v1(0.0), 0.092864125247312, places=7
+        )
+
+        self.assertAlmostEqual(
+            log_encoding_CanonLog2_v1(0.18), 0.398254694983167, places=7
+        )
+
+        self.assertAlmostEqual(
+            log_encoding_CanonLog2_v1(0.18, 12), 0.397962933301861, places=7
+        )
+
+        self.assertAlmostEqual(
+            log_encoding_CanonLog2_v1(0.18, 10, False),
             0.392025745397009,
             places=7,
         )
 
         self.assertAlmostEqual(
-            log_encoding_CanonLog2(0.18, 10, False, False),
+            log_encoding_CanonLog2_v1(0.18, 10, False, False),
             0.379864582222983,
             places=7,
         )
 
         self.assertAlmostEqual(
-            log_encoding_CanonLog2(1.0), 0.573229282897641, places=7
+            log_encoding_CanonLog2_v1(1.0), 0.573229282897641, places=7
         )
 
-    def test_n_dimensional_log_encoding_CanonLog2(self):
+    def test_n_dimensional_log_encoding_CanonLog2_v1(self):
         """
         Test :func:`colour.models.rgb.transfer_functions.canon.\
-log_encoding_CanonLog2` definition n-dimensional arrays support.
+log_encoding_CanonLog2_v1` definition n-dimensional arrays support.
         """
 
         x = 0.18
-        clog2 = log_encoding_CanonLog2(x)
+        clog2 = log_encoding_CanonLog2_v1(x)
 
         x = np.tile(x, 6)
         clog2 = np.tile(clog2, 6)
         np.testing.assert_array_almost_equal(
-            log_encoding_CanonLog2(x), clog2, decimal=7
+            log_encoding_CanonLog2_v1(x), clog2, decimal=7
         )
 
         x = np.reshape(x, (2, 3))
         clog2 = np.reshape(clog2, (2, 3))
         np.testing.assert_array_almost_equal(
-            log_encoding_CanonLog2(x), clog2, decimal=7
+            log_encoding_CanonLog2_v1(x), clog2, decimal=7
         )
 
         x = np.reshape(x, (2, 3, 1))
         clog2 = np.reshape(clog2, (2, 3, 1))
         np.testing.assert_array_almost_equal(
-            log_encoding_CanonLog2(x), clog2, decimal=7
+            log_encoding_CanonLog2_v1(x), clog2, decimal=7
         )
 
-    def test_domain_range_scale_log_encoding_CanonLog2(self):
+    def test_domain_range_scale_log_encoding_CanonLog2_v1(self):
         """
         Test :func:`colour.models.rgb.transfer_functions.canon.\
-log_encoding_CanonLog2` definition domain and range scale support.
+log_encoding_CanonLog2_v1` definition domain and range scale support.
         """
 
         x = 0.18
-        clog2 = log_encoding_CanonLog2(x)
+        clog2 = log_encoding_CanonLog2_v1(x)
 
         d_r = (("reference", 1), ("1", 1), ("100", 100))
         for scale, factor in d_r:
             with domain_range_scale(scale):
                 np.testing.assert_array_almost_equal(
-                    log_encoding_CanonLog2(x * factor),
+                    log_encoding_CanonLog2_v1(x * factor),
                     clog2 * factor,
                     decimal=7,
                 )
 
     @ignore_numpy_errors
-    def test_nan_log_encoding_CanonLog2(self):
+    def test_nan_log_encoding_CanonLog2_v1(self):
         """
         Test :func:`colour.models.rgb.transfer_functions.canon.\
-log_encoding_CanonLog2` definition nan support.
+log_encoding_CanonLog2_v1` definition nan support.
         """
 
-        log_encoding_CanonLog2(
+        log_encoding_CanonLog2_v1(
             np.array([-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan])
         )
 
 
-class TestLogDecoding_CanonLog2(unittest.TestCase):
+class TestLogDecoding_CanonLog2_v1(unittest.TestCase):
     """
     Define :func:`colour.models.rgb.transfer_functions.canon.\
-log_decoding_CanonLog2` definition unit tests methods.
+log_decoding_CanonLog2_v1` definition unit tests methods.
     """
 
-    def test_log_decoding_CanonLog2(self):
+    def test_log_decoding_CanonLog2_v1(self):
         """
         Test :func:`colour.models.rgb.transfer_functions.canon.\
-log_decoding_CanonLog2` definition.
+log_decoding_CanonLog2_v1` definition.
         """
 
         self.assertAlmostEqual(
-            log_decoding_CanonLog2(-0.155370131996824), -0.1, places=7
+            log_decoding_CanonLog2_v1(-0.155370131996824), -0.1, places=7
         )
 
         self.assertAlmostEqual(
-            log_decoding_CanonLog2(0.092864125247312), 0.0, places=7
+            log_decoding_CanonLog2_v1(0.092864125247312), 0.0, places=7
         )
 
         self.assertAlmostEqual(
-            log_decoding_CanonLog2(0.398254694983167), 0.18, places=7
+            log_decoding_CanonLog2_v1(0.398254694983167), 0.18, places=7
         )
 
         self.assertAlmostEqual(
-            log_decoding_CanonLog2(0.397962933301861, 12), 0.18, places=7
+            log_decoding_CanonLog2_v1(0.397962933301861, 12), 0.18, places=7
         )
 
         self.assertAlmostEqual(
-            log_decoding_CanonLog2(0.392025745397009, 10, False),
+            log_decoding_CanonLog2_v1(0.392025745397009, 10, False),
             0.18,
             places=7,
         )
 
         self.assertAlmostEqual(
-            log_decoding_CanonLog2(0.379864582222983, 10, False, False),
+            log_decoding_CanonLog2_v1(0.379864582222983, 10, False, False),
             0.18,
             places=7,
         )
 
         self.assertAlmostEqual(
-            log_decoding_CanonLog2(0.573229282897641), 1.0, places=7
+            log_decoding_CanonLog2_v1(0.573229282897641), 1.0, places=7
         )
 
-    def test_n_dimensional_log_decoding_CanonLog2(self):
+    def test_n_dimensional_log_decoding_CanonLog2_v1(self):
         """
         Test :func:`colour.models.rgb.transfer_functions.canon.\
-log_decoding_CanonLog2` definition n-dimensional arrays support.
+log_decoding_CanonLog2_v1` definition n-dimensional arrays support.
         """
 
         clog2 = 0.398254694983167
-        x = log_decoding_CanonLog2(clog2)
+        x = log_decoding_CanonLog2_v1(clog2)
 
         clog2 = np.tile(clog2, 6)
         x = np.tile(x, 6)
         np.testing.assert_array_almost_equal(
-            log_decoding_CanonLog2(clog2), x, decimal=7
+            log_decoding_CanonLog2_v1(clog2), x, decimal=7
         )
 
         clog2 = np.reshape(clog2, (2, 3))
         x = np.reshape(x, (2, 3))
         np.testing.assert_array_almost_equal(
-            log_decoding_CanonLog2(clog2), x, decimal=7
+            log_decoding_CanonLog2_v1(clog2), x, decimal=7
         )
 
         clog2 = np.reshape(clog2, (2, 3, 1))
         x = np.reshape(x, (2, 3, 1))
         np.testing.assert_array_almost_equal(
-            log_decoding_CanonLog2(clog2), x, decimal=7
+            log_decoding_CanonLog2_v1(clog2), x, decimal=7
         )
 
-    def test_domain_range_scale_log_decoding_CanonLog2(self):
+    def test_domain_range_scale_log_decoding_CanonLog2_v1(self):
         """
         Test :func:`colour.models.rgb.transfer_functions.canon.\
-log_decoding_CanonLog2` definition domain and range scale support.
+log_decoding_CanonLog2_v1` definition domain and range scale support.
         """
 
         clog = 0.398254694983167
-        x = log_decoding_CanonLog2(clog)
+        x = log_decoding_CanonLog2_v1(clog)
 
         d_r = (("reference", 1), ("1", 1), ("100", 100))
         for scale, factor in d_r:
             with domain_range_scale(scale):
                 np.testing.assert_array_almost_equal(
-                    log_decoding_CanonLog2(clog * factor),
+                    log_decoding_CanonLog2_v1(clog * factor),
                     x * factor,
                     decimal=7,
                 )
 
     @ignore_numpy_errors
-    def test_nan_log_decoding_CanonLog2(self):
+    def test_nan_log_decoding_CanonLog2_v1(self):
         """
         Test :func:`colour.models.rgb.transfer_functions.canon.\
-log_decoding_CanonLog2` definition nan support.
+log_decoding_CanonLog2_v1` definition nan support.
         """
 
-        log_decoding_CanonLog2(
+        log_decoding_CanonLog2_v1(
             np.array([-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan])
         )
 
 
-class TestLogEncoding_CanonLog3(unittest.TestCase):
+class TestLogEncoding_CanonLog2_v1_2(unittest.TestCase):
     """
     Define :func:`colour.models.rgb.transfer_functions.canon.\
-log_encoding_CanonLog3` definition unit tests methods.
+log_encoding_CanonLog2_v1_2` definition unit tests methods.
     """
 
-    def test_log_encoding_CanonLog3(self):
+    def test_log_encoding_CanonLog2_v1_2(self):
         """
         Test :func:`colour.models.rgb.transfer_functions.canon.\
-log_encoding_CanonLog3` definition.
+log_encoding_CanonLog2_v1_2` definition.
         """
 
         self.assertAlmostEqual(
-            log_encoding_CanonLog3(-0.1), -0.028494506076432, places=7
+            log_encoding_CanonLog2_v1_2(-0.1), -0.155370130476722, places=7
         )
 
         self.assertAlmostEqual(
-            log_encoding_CanonLog3(0.0), 0.125122189869013, places=7
+            log_encoding_CanonLog2_v1_2(0.0), 0.092864125000000, places=7
         )
 
         self.assertAlmostEqual(
-            log_encoding_CanonLog3(0.18), 0.343389369388687, places=7
+            log_encoding_CanonLog2_v1_2(0.18), 0.398254692561492, places=7
         )
 
         self.assertAlmostEqual(
-            log_encoding_CanonLog3(0.18, 12), 0.343137802085105, places=7
+            log_encoding_CanonLog2_v1_2(0.18, 12), 0.398254692561492, places=7
         )
 
         self.assertAlmostEqual(
-            log_encoding_CanonLog3(0.18, 10, False),
+            log_encoding_CanonLog2_v1_2(0.18, 10, False),
+            0.392025742568957,
+            places=7,
+        )
+
+        self.assertAlmostEqual(
+            log_encoding_CanonLog2_v1_2(0.18, 10, False, False),
+            0.379864579481518,
+            places=7,
+        )
+
+        self.assertAlmostEqual(
+            log_encoding_CanonLog2_v1_2(1.0), 0.573229279230156, places=7
+        )
+
+        samples = np.linspace(0, 1, 10000)
+
+        np.testing.assert_allclose(
+            log_encoding_CanonLog2_v1(samples),
+            log_encoding_CanonLog2_v1_2(samples),
+            rtol=0.0000001,
+            atol=0.0000001,
+        )
+
+        np.testing.assert_allclose(
+            log_encoding_CanonLog2_v1(samples),
+            log_encoding_CanonLog2_v1_2(samples),
+            rtol=0.0000001,
+            atol=0.0000001,
+        )
+
+        np.testing.assert_allclose(
+            log_encoding_CanonLog2_v1(
+                samples, out_normalised_code_value=False
+            ),
+            log_encoding_CanonLog2_v1_2(
+                samples, out_normalised_code_value=False
+            ),
+            rtol=0.0000001,
+            atol=0.0000001,
+        )
+        np.testing.assert_allclose(
+            log_encoding_CanonLog2_v1(samples, in_reflection=False),
+            log_encoding_CanonLog2_v1_2(samples, in_reflection=False),
+            rtol=0.0000001,
+            atol=0.0000001,
+        )
+
+    def test_n_dimensional_log_encoding_CanonLog2_v1_2(self):
+        """
+        Test :func:`colour.models.rgb.transfer_functions.canon.\
+log_encoding_CanonLog2_v1_2` definition n-dimensional arrays support.
+        """
+
+        x = 0.18
+        clog2 = log_encoding_CanonLog2_v1_2(x)
+
+        x = np.tile(x, 6)
+        clog2 = np.tile(clog2, 6)
+        np.testing.assert_array_almost_equal(
+            log_encoding_CanonLog2_v1_2(x), clog2, decimal=7
+        )
+
+        x = np.reshape(x, (2, 3))
+        clog2 = np.reshape(clog2, (2, 3))
+        np.testing.assert_array_almost_equal(
+            log_encoding_CanonLog2_v1_2(x), clog2, decimal=7
+        )
+
+        x = np.reshape(x, (2, 3, 1))
+        clog2 = np.reshape(clog2, (2, 3, 1))
+        np.testing.assert_array_almost_equal(
+            log_encoding_CanonLog2_v1_2(x), clog2, decimal=7
+        )
+
+    def test_domain_range_scale_log_encoding_CanonLog2_v1_2(self):
+        """
+        Test :func:`colour.models.rgb.transfer_functions.canon.\
+log_encoding_CanonLog2_v1_2` definition domain and range scale support.
+        """
+
+        x = 0.18
+        clog2 = log_encoding_CanonLog2_v1_2(x)
+
+        d_r = (("reference", 1), ("1", 1), ("100", 100))
+        for scale, factor in d_r:
+            with domain_range_scale(scale):
+                np.testing.assert_array_almost_equal(
+                    log_encoding_CanonLog2_v1_2(x * factor),
+                    clog2 * factor,
+                    decimal=7,
+                )
+
+    @ignore_numpy_errors
+    def test_nan_log_encoding_CanonLog2_v1_2(self):
+        """
+        Test :func:`colour.models.rgb.transfer_functions.canon.\
+log_encoding_CanonLog2_v1_2` definition nan support.
+        """
+
+        log_encoding_CanonLog2_v1_2(
+            np.array([-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan])
+        )
+
+
+class TestLogDecoding_CanonLog2_v1_2(unittest.TestCase):
+    """
+    Define :func:`colour.models.rgb.transfer_functions.canon.\
+log_decoding_CanonLog2_v1_2` definition unit tests methods.
+    """
+
+    def test_log_decoding_CanonLog2_v1_2(self):
+        """
+        Test :func:`colour.models.rgb.transfer_functions.canon.\
+log_decoding_CanonLog2_v1_2` definition.
+        """
+
+        self.assertAlmostEqual(
+            log_decoding_CanonLog2_v1_2(-0.155370130476722), -0.1, places=7
+        )
+
+        self.assertAlmostEqual(
+            log_decoding_CanonLog2_v1_2(0.092864125000000), 0.0, places=7
+        )
+
+        self.assertAlmostEqual(
+            log_decoding_CanonLog2_v1_2(0.398254692561492), 0.18, places=7
+        )
+
+        self.assertAlmostEqual(
+            log_decoding_CanonLog2_v1_2(0.398254692561492, 12), 0.18, places=7
+        )
+
+        self.assertAlmostEqual(
+            log_decoding_CanonLog2_v1_2(0.392025742568957, 10, False),
+            0.18,
+            places=7,
+        )
+
+        self.assertAlmostEqual(
+            log_decoding_CanonLog2_v1_2(0.379864579481518, 10, False, False),
+            0.18,
+            places=7,
+        )
+
+        self.assertAlmostEqual(
+            log_decoding_CanonLog2_v1_2(0.573229279230156), 1.0, places=7
+        )
+
+        samples = np.linspace(0, 1, 10000)
+
+        np.testing.assert_allclose(
+            log_decoding_CanonLog_v1(samples),
+            log_decoding_CanonLog_v1_2(samples),
+            rtol=0.0000001,
+            atol=0.0000001,
+        )
+
+        np.testing.assert_allclose(
+            log_decoding_CanonLog_v1(samples),
+            log_decoding_CanonLog_v1_2(samples),
+            rtol=0.0000001,
+            atol=0.0000001,
+        )
+
+        np.testing.assert_allclose(
+            log_decoding_CanonLog_v1(samples, in_normalised_code_value=False),
+            log_decoding_CanonLog_v1_2(
+                samples, in_normalised_code_value=False
+            ),
+            rtol=0.0000001,
+            atol=0.0000001,
+        )
+        np.testing.assert_allclose(
+            log_decoding_CanonLog_v1(samples, out_reflection=False),
+            log_decoding_CanonLog_v1_2(samples, out_reflection=False),
+            rtol=0.0000001,
+            atol=0.0000001,
+        )
+
+    def test_n_dimensional_log_decoding_CanonLog2_v1_2(self):
+        """
+        Test :func:`colour.models.rgb.transfer_functions.canon.\
+log_decoding_CanonLog2_v1_2` definition n-dimensional arrays support.
+        """
+
+        clog2 = 0.398254692561492
+        x = log_decoding_CanonLog2_v1_2(clog2)
+
+        clog2 = np.tile(clog2, 6)
+        x = np.tile(x, 6)
+        np.testing.assert_array_almost_equal(
+            log_decoding_CanonLog2_v1_2(clog2), x, decimal=7
+        )
+
+        clog2 = np.reshape(clog2, (2, 3))
+        x = np.reshape(x, (2, 3))
+        np.testing.assert_array_almost_equal(
+            log_decoding_CanonLog2_v1_2(clog2), x, decimal=7
+        )
+
+        clog2 = np.reshape(clog2, (2, 3, 1))
+        x = np.reshape(x, (2, 3, 1))
+        np.testing.assert_array_almost_equal(
+            log_decoding_CanonLog2_v1_2(clog2), x, decimal=7
+        )
+
+    def test_domain_range_scale_log_decoding_CanonLog2_v1_2(self):
+        """
+        Test :func:`colour.models.rgb.transfer_functions.canon.\
+log_decoding_CanonLog2_v1_2` definition domain and range scale support.
+        """
+
+        clog = 0.398254692561492
+        x = log_decoding_CanonLog2_v1_2(clog)
+
+        d_r = (("reference", 1), ("1", 1), ("100", 100))
+        for scale, factor in d_r:
+            with domain_range_scale(scale):
+                np.testing.assert_array_almost_equal(
+                    log_decoding_CanonLog2_v1_2(clog * factor),
+                    x * factor,
+                    decimal=7,
+                )
+
+    @ignore_numpy_errors
+    def test_nan_log_decoding_CanonLog2_v1_2(self):
+        """
+        Test :func:`colour.models.rgb.transfer_functions.canon.\
+log_decoding_CanonLog2_v1_2` definition nan support.
+        """
+
+        log_decoding_CanonLog2_v1_2(
+            np.array([-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan])
+        )
+
+
+class TestLogEncoding_CanonLog3_v1(unittest.TestCase):
+    """
+    Define :func:`colour.models.rgb.transfer_functions.canon.\
+log_encoding_CanonLog3_v1` definition unit tests methods.
+    """
+
+    def test_log_encoding_CanonLog3_v1(self):
+        """
+        Test :func:`colour.models.rgb.transfer_functions.canon.\
+log_encoding_CanonLog3_v1` definition.
+        """
+
+        self.assertAlmostEqual(
+            log_encoding_CanonLog3_v1(-0.1), -0.028494506076432, places=7
+        )
+
+        self.assertAlmostEqual(
+            log_encoding_CanonLog3_v1(0.0), 0.125122189869013, places=7
+        )
+
+        self.assertAlmostEqual(
+            log_encoding_CanonLog3_v1(0.18), 0.343389369388687, places=7
+        )
+
+        self.assertAlmostEqual(
+            log_encoding_CanonLog3_v1(0.18, 12), 0.343137802085105, places=7
+        )
+
+        self.assertAlmostEqual(
+            log_encoding_CanonLog3_v1(0.18, 10, False),
             0.327953567219893,
             places=7,
         )
 
         self.assertAlmostEqual(
-            log_encoding_CanonLog3(0.18, 10, False, False),
+            log_encoding_CanonLog3_v1(0.18, 10, False, False),
             0.313436005886328,
             places=7,
         )
 
         self.assertAlmostEqual(
-            log_encoding_CanonLog3(1.0), 0.580277796238604, places=7
+            log_encoding_CanonLog3_v1(1.0), 0.580277796238604, places=7
         )
 
-    def test_n_dimensional_log_encoding_CanonLog3(self):
+    def test_n_dimensional_log_encoding_CanonLog3_v1(self):
         """
         Test :func:`colour.models.rgb.transfer_functions.canon.\
-log_encoding_CanonLog3` definition n-dimensional arrays support.
+log_encoding_CanonLog3_v1` definition n-dimensional arrays support.
         """
 
         x = 0.18
-        clog3 = log_encoding_CanonLog3(x)
+        clog3 = log_encoding_CanonLog3_v1(x)
 
         x = np.tile(x, 6)
         clog3 = np.tile(clog3, 6)
         np.testing.assert_array_almost_equal(
-            log_encoding_CanonLog3(x), clog3, decimal=7
+            log_encoding_CanonLog3_v1(x), clog3, decimal=7
         )
 
         x = np.reshape(x, (2, 3))
         clog3 = np.reshape(clog3, (2, 3))
         np.testing.assert_array_almost_equal(
-            log_encoding_CanonLog3(x), clog3, decimal=7
+            log_encoding_CanonLog3_v1(x), clog3, decimal=7
         )
 
         x = np.reshape(x, (2, 3, 1))
         clog3 = np.reshape(clog3, (2, 3, 1))
         np.testing.assert_array_almost_equal(
-            log_encoding_CanonLog3(x), clog3, decimal=7
+            log_encoding_CanonLog3_v1(x), clog3, decimal=7
         )
 
-    def test_domain_range_scale_log_encoding_CanonLog3(self):
+    def test_domain_range_scale_log_encoding_CanonLog3_v1(self):
         """
         Test :func:`colour.models.rgb.transfer_functions.canon.\
-log_encoding_CanonLog3` definition domain and range scale support.
+log_encoding_CanonLog3_v1` definition domain and range scale support.
         """
 
         x = 0.18
-        clog3 = log_encoding_CanonLog3(x)
+        clog3 = log_encoding_CanonLog3_v1(x)
 
         d_r = (("reference", 1), ("1", 1), ("100", 100))
         for scale, factor in d_r:
             with domain_range_scale(scale):
                 np.testing.assert_array_almost_equal(
-                    log_encoding_CanonLog3(x * factor),
+                    log_encoding_CanonLog3_v1(x * factor),
                     clog3 * factor,
                     decimal=7,
                 )
 
     @ignore_numpy_errors
-    def test_nan_log_encoding_CanonLog3(self):
+    def test_nan_log_encoding_CanonLog3_v1(self):
         """
         Test :func:`colour.models.rgb.transfer_functions.canon.\
-log_encoding_CanonLog3` definition nan support.
+log_encoding_CanonLog3_v1` definition nan support.
         """
 
-        log_encoding_CanonLog3(
+        log_encoding_CanonLog3_v1(
             np.array([-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan])
         )
 
 
-class TestLogDecoding_CanonLog3(unittest.TestCase):
+class TestLogDecoding_CanonLog3_v1(unittest.TestCase):
     """
     Define :func:`colour.models.rgb.transfer_functions.canon.\
-log_decoding_CanonLog3` definition unit tests methods.
+log_decoding_CanonLog3_v1` definition unit tests methods.
     """
 
-    def test_log_decoding_CanonLog3(self):
+    def test_log_decoding_CanonLog3_v1(self):
         """
         Test :func:`colour.models.rgb.transfer_functions.canon.\
-log_decoding_CanonLog3` definition.
+log_decoding_CanonLog3_v1` definition.
         """
 
         self.assertAlmostEqual(
-            log_decoding_CanonLog3(-0.028494506076432), -0.1, places=7
+            log_decoding_CanonLog3_v1(-0.028494506076432), -0.1, places=7
         )
 
         self.assertAlmostEqual(
-            log_decoding_CanonLog3(0.125122189869013), 0.0, places=7
+            log_decoding_CanonLog3_v1(0.125122189869013), 0.0, places=7
         )
 
         self.assertAlmostEqual(
-            log_decoding_CanonLog3(0.343389369388687), 0.18, places=7
+            log_decoding_CanonLog3_v1(0.343389369388687), 0.18, places=7
         )
 
         self.assertAlmostEqual(
-            log_decoding_CanonLog3(0.343137802085105, 12), 0.18, places=7
+            log_decoding_CanonLog3_v1(0.343137802085105, 12), 0.18, places=7
         )
 
         self.assertAlmostEqual(
-            log_decoding_CanonLog3(0.327953567219893, 10, False),
+            log_decoding_CanonLog3_v1(0.327953567219893, 10, False),
             0.18,
             places=7,
         )
 
         self.assertAlmostEqual(
-            log_decoding_CanonLog3(0.313436005886328, 10, False, False),
+            log_decoding_CanonLog3_v1(0.313436005886328, 10, False, False),
             0.18,
             places=7,
         )
 
         self.assertAlmostEqual(
-            log_decoding_CanonLog3(0.580277796238604), 1.0, places=7
+            log_decoding_CanonLog3_v1(0.580277796238604), 1.0, places=7
         )
 
-    def test_n_dimensional_log_decoding_CanonLog3(self):
+    def test_n_dimensional_log_decoding_CanonLog3_v1(self):
         """
         Test :func:`colour.models.rgb.transfer_functions.canon.\
-log_decoding_CanonLog3` definition n-dimensional arrays support.
+log_decoding_CanonLog3_v1` definition n-dimensional arrays support.
         """
 
         clog3 = 0.343389369388687
-        x = log_decoding_CanonLog3(clog3)
+        x = log_decoding_CanonLog3_v1(clog3)
 
         clog3 = np.tile(clog3, 6)
         x = np.tile(x, 6)
         np.testing.assert_array_almost_equal(
-            log_decoding_CanonLog3(clog3), x, decimal=7
+            log_decoding_CanonLog3_v1(clog3), x, decimal=7
         )
 
         clog3 = np.reshape(clog3, (2, 3))
         x = np.reshape(x, (2, 3))
         np.testing.assert_array_almost_equal(
-            log_decoding_CanonLog3(clog3), x, decimal=7
+            log_decoding_CanonLog3_v1(clog3), x, decimal=7
         )
 
         clog3 = np.reshape(clog3, (2, 3, 1))
         x = np.reshape(x, (2, 3, 1))
         np.testing.assert_array_almost_equal(
-            log_decoding_CanonLog3(clog3), x, decimal=7
+            log_decoding_CanonLog3_v1(clog3), x, decimal=7
         )
 
-    def test_domain_range_scale_log_decoding_CanonLog3(self):
+    def test_domain_range_scale_log_decoding_CanonLog3_v1(self):
         """
         Test :func:`colour.models.rgb.transfer_functions.canon.\
-log_decoding_CanonLog3` definition domain and range scale support.
+log_decoding_CanonLog3_v1` definition domain and range scale support.
         """
 
         clog = 0.343389369388687
-        x = log_decoding_CanonLog3(clog)
+        x = log_decoding_CanonLog3_v1(clog)
 
         d_r = (("reference", 1), ("1", 1), ("100", 100))
         for scale, factor in d_r:
             with domain_range_scale(scale):
                 np.testing.assert_array_almost_equal(
-                    log_decoding_CanonLog3(clog * factor),
+                    log_decoding_CanonLog3_v1(clog * factor),
                     x * factor,
                     decimal=7,
                 )
 
     @ignore_numpy_errors
-    def test_nan_log_decoding_CanonLog3(self):
+    def test_nan_log_decoding_CanonLog3_v1(self):
         """
         Test :func:`colour.models.rgb.transfer_functions.canon.\
-log_decoding_CanonLog3` definition nan support.
+log_decoding_CanonLog3_v1` definition nan support.
         """
 
-        log_decoding_CanonLog3(
+        log_decoding_CanonLog3_v1(
+            np.array([-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan])
+        )
+
+
+class TestLogEncoding_CanonLog3_v1_2(unittest.TestCase):
+    """
+    Define :func:`colour.models.rgb.transfer_functions.canon.\
+log_encoding_CanonLog3_v1_2` definition unit tests methods.
+    """
+
+    def test_log_encoding_CanonLog3_v1_2(self):
+        """
+        Test :func:`colour.models.rgb.transfer_functions.canon.\
+log_encoding_CanonLog3_v1_2` definition.
+        """
+
+        self.assertAlmostEqual(
+            log_encoding_CanonLog3_v1_2(-0.1), -0.028494507620494, places=7
+        )
+
+        self.assertAlmostEqual(
+            log_encoding_CanonLog3_v1_2(0.0), 0.125122189999999, places=7
+        )
+
+        self.assertAlmostEqual(
+            log_encoding_CanonLog3_v1_2(0.18), 0.343389370373936, places=7
+        )
+
+        self.assertAlmostEqual(
+            log_encoding_CanonLog3_v1_2(0.18, 12), 0.343389370373936, places=7
+        )
+
+        self.assertAlmostEqual(
+            log_encoding_CanonLog3_v1_2(0.18, 10, False),
+            0.327953568370475,
+            places=7,
+        )
+
+        self.assertAlmostEqual(
+            log_encoding_CanonLog3_v1_2(0.18, 10, False, False),
+            0.313436007221221,
+            places=7,
+        )
+
+        self.assertAlmostEqual(
+            log_encoding_CanonLog3_v1_2(1.0), 0.580277794216371, places=7
+        )
+
+        samples = np.linspace(0, 1, 10000)
+
+        np.testing.assert_allclose(
+            log_encoding_CanonLog3_v1(samples),
+            log_encoding_CanonLog3_v1_2(samples),
+            rtol=0.0000001,
+            atol=0.0000001,
+        )
+
+        np.testing.assert_allclose(
+            log_encoding_CanonLog3_v1(samples),
+            log_encoding_CanonLog3_v1_2(samples),
+            rtol=0.0000001,
+            atol=0.0000001,
+        )
+
+        np.testing.assert_allclose(
+            log_encoding_CanonLog3_v1(
+                samples, out_normalised_code_value=False
+            ),
+            log_encoding_CanonLog3_v1_2(
+                samples, out_normalised_code_value=False
+            ),
+            rtol=0.0000001,
+            atol=0.0000001,
+        )
+        np.testing.assert_allclose(
+            log_encoding_CanonLog3_v1(samples, in_reflection=False),
+            log_encoding_CanonLog3_v1_2(samples, in_reflection=False),
+            rtol=0.0000001,
+            atol=0.0000001,
+        )
+
+    def test_n_dimensional_log_encoding_CanonLog3_v1_2(self):
+        """
+        Test :func:`colour.models.rgb.transfer_functions.canon.\
+log_encoding_CanonLog3_v1_2` definition n-dimensional arrays support.
+        """
+
+        x = 0.18
+        clog3 = log_encoding_CanonLog3_v1_2(x)
+
+        x = np.tile(x, 6)
+        clog3 = np.tile(clog3, 6)
+        np.testing.assert_array_almost_equal(
+            log_encoding_CanonLog3_v1_2(x), clog3, decimal=7
+        )
+
+        x = np.reshape(x, (2, 3))
+        clog3 = np.reshape(clog3, (2, 3))
+        np.testing.assert_array_almost_equal(
+            log_encoding_CanonLog3_v1_2(x), clog3, decimal=7
+        )
+
+        x = np.reshape(x, (2, 3, 1))
+        clog3 = np.reshape(clog3, (2, 3, 1))
+        np.testing.assert_array_almost_equal(
+            log_encoding_CanonLog3_v1_2(x), clog3, decimal=7
+        )
+
+    def test_domain_range_scale_log_encoding_CanonLog3_v1_2(self):
+        """
+        Test :func:`colour.models.rgb.transfer_functions.canon.\
+log_encoding_CanonLog3_v1_2` definition domain and range scale support.
+        """
+
+        x = 0.18
+        clog3 = log_encoding_CanonLog3_v1_2(x)
+
+        d_r = (("reference", 1), ("1", 1), ("100", 100))
+        for scale, factor in d_r:
+            with domain_range_scale(scale):
+                np.testing.assert_array_almost_equal(
+                    log_encoding_CanonLog3_v1_2(x * factor),
+                    clog3 * factor,
+                    decimal=7,
+                )
+
+    @ignore_numpy_errors
+    def test_nan_log_encoding_CanonLog3_v1_2(self):
+        """
+        Test :func:`colour.models.rgb.transfer_functions.canon.\
+log_encoding_CanonLog3_v1_2` definition nan support.
+        """
+
+        log_encoding_CanonLog3_v1_2(
+            np.array([-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan])
+        )
+
+
+class TestLogDecoding_CanonLog3_v1_2(unittest.TestCase):
+    """
+    Define :func:`colour.models.rgb.transfer_functions.canon.\
+log_decoding_CanonLog3_v1_2` definition unit tests methods.
+    """
+
+    def test_log_decoding_CanonLog3_v1_2(self):
+        """
+        Test :func:`colour.models.rgb.transfer_functions.canon.\
+log_decoding_CanonLog3_v1_2` definition.
+        """
+
+        self.assertAlmostEqual(
+            log_decoding_CanonLog3_v1_2(-0.028494507620494), -0.1, places=7
+        )
+
+        self.assertAlmostEqual(
+            log_decoding_CanonLog3_v1_2(0.125122189999999), 0.0, places=7
+        )
+
+        self.assertAlmostEqual(
+            log_decoding_CanonLog3_v1_2(0.343389370373936), 0.18, places=7
+        )
+
+        self.assertAlmostEqual(
+            log_decoding_CanonLog3_v1_2(0.343389370373936, 12), 0.18, places=7
+        )
+
+        self.assertAlmostEqual(
+            log_decoding_CanonLog3_v1_2(0.327953568370475, 10, False),
+            0.18,
+            places=7,
+        )
+
+        self.assertAlmostEqual(
+            log_decoding_CanonLog3_v1_2(0.313436007221221, 10, False, False),
+            0.18,
+            places=7,
+        )
+
+        self.assertAlmostEqual(
+            log_decoding_CanonLog3_v1_2(0.580277794216371), 1.0, places=7
+        )
+
+        samples = np.linspace(0, 1, 10000)
+
+        np.testing.assert_allclose(
+            log_decoding_CanonLog3_v1(samples),
+            log_decoding_CanonLog3_v1_2(samples),
+            rtol=0.0000001,
+            atol=0.0000001,
+        )
+
+        np.testing.assert_allclose(
+            log_decoding_CanonLog3_v1(samples),
+            log_decoding_CanonLog3_v1_2(samples),
+            rtol=0.0000001,
+            atol=0.0000001,
+        )
+
+        np.testing.assert_allclose(
+            log_decoding_CanonLog3_v1(samples, in_normalised_code_value=False),
+            log_decoding_CanonLog3_v1_2(
+                samples, in_normalised_code_value=False
+            ),
+            rtol=0.0000001,
+            atol=0.0000001,
+        )
+        np.testing.assert_allclose(
+            log_decoding_CanonLog3_v1(samples, out_reflection=False),
+            log_decoding_CanonLog3_v1_2(samples, out_reflection=False),
+            rtol=0.0000001,
+            atol=0.0000001,
+        )
+
+    def test_n_dimensional_log_decoding_CanonLog3_v1_2(self):
+        """
+        Test :func:`colour.models.rgb.transfer_functions.canon.\
+log_decoding_CanonLog3_v1_2` definition n-dimensional arrays support.
+        """
+
+        clog3 = 0.343389370373936
+        x = log_decoding_CanonLog3_v1_2(clog3)
+
+        clog3 = np.tile(clog3, 6)
+        x = np.tile(x, 6)
+        np.testing.assert_array_almost_equal(
+            log_decoding_CanonLog3_v1_2(clog3), x, decimal=7
+        )
+
+        clog3 = np.reshape(clog3, (2, 3))
+        x = np.reshape(x, (2, 3))
+        np.testing.assert_array_almost_equal(
+            log_decoding_CanonLog3_v1_2(clog3), x, decimal=7
+        )
+
+        clog3 = np.reshape(clog3, (2, 3, 1))
+        x = np.reshape(x, (2, 3, 1))
+        np.testing.assert_array_almost_equal(
+            log_decoding_CanonLog3_v1_2(clog3), x, decimal=7
+        )
+
+    def test_domain_range_scale_log_decoding_CanonLog3_v1_2(self):
+        """
+        Test :func:`colour.models.rgb.transfer_functions.canon.\
+log_decoding_CanonLog3_v1_2` definition domain and range scale support.
+        """
+
+        clog = 0.343389370373936
+        x = log_decoding_CanonLog3_v1_2(clog)
+
+        d_r = (("reference", 1), ("1", 1), ("100", 100))
+        for scale, factor in d_r:
+            with domain_range_scale(scale):
+                np.testing.assert_array_almost_equal(
+                    log_decoding_CanonLog3_v1_2(clog * factor),
+                    x * factor,
+                    decimal=7,
+                )
+
+    @ignore_numpy_errors
+    def test_nan_log_decoding_CanonLog3_v1_2(self):
+        """
+        Test :func:`colour.models.rgb.transfer_functions.canon.\
+log_decoding_CanonLog3_v1_2` definition nan support.
+        """
+
+        log_decoding_CanonLog3_v1_2(
             np.array([-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan])
         )
 


### PR DESCRIPTION
<!--
Thank you for taking the time to create this pull request. If it is the first
time you are contributing to a colour-science repository, a contributing guide
is available to guide the process: https://www.colour-science.org/contributing/.
-->

# Summary

<!-- Please write a summary describing the changes that this PR implements. -->

This PR implements support for **Canon** v1.2 encodings that define their constants in legal range. Minor numerical differences because of the rounding of the constants are expected.

References #1176.

# Preflight

<!-- Please mark any checkboxes that do not apply to this pull request as [N/A]. -->

**Code Style and Quality**

- [x] Unit tests have been implemented and passed.
- [x] Pyright static checking has been run and passed.
- [x] Pre-commit hooks have been run and passed.
- [N/A] New transformations have been added to the *Automatic Colour Conversion Graph*.
- [N/A] New transformations have been exported to the relevant namespaces, e.g. `colour`, `colour.models`.

<!-- The unit tests can be invoked with `poetry run invoke tests` -->
<!-- Pyright can be started with `pyright --skipunannotated` -->

**Documentation**

- [x] New features are documented along with examples if relevant.
- [x] The documentation is [Sphinx](https://www.sphinx-doc.org/en/master/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant.

<!--
Thank you again!
-->
