### PR TITLE
use packages from poetry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,8 @@
 [tool.poetry]
-name = "colour"
+name = "colour-science"
+packages = [
+    { include = "colour" },
+]
 version = "0.4.2"
 description = "Colour Science for Python"
 license = "BSD-3-Clause"


### PR DESCRIPTION
<!--
Thank you for taking the time to create this pull request. If it is the first
time you are contributing to a colour-science repository, a contributing guide
is available to guide the process: https://www.colour-science.org/contributing/.
-->

# Summary

<!-- Please write a summary describing the changes that this PR implements. -->

This PR uses a new poetry mechanism to define package name and package contents seperately. This is a huge improvement when using poetry to manage local path based dependencies. When adding a local dependency on a path based colour-science, using the old package name `colour` in the local poetry config file confuses the dependency manager and ends up over-writing the `colour` (local) package with a pip-installed `colour-science`

changing the package name to colour-science and adding an include helps the dependency manager recognize that the local path version of `colour-science` can fulfill `colour-science` requirements


# Preflight

<!-- Please mark any checkboxes that do not apply to this pull request as [N/A]. -->

**Code Style and Quality**

- [ ] Unit tests have been implemented and passed.
- [ ] Pyright static checking has been run and passed.
- [ ] Pre-commit hooks have been run and passed.
- [ ] New transformations have been added to the *Automatic Colour Conversion Graph*.
- [ ] New transformations have been exported to the relevant namespaces, e.g. `colour`, `colour.models`.

<!-- The unit tests can be invoked with `poetry run invoke tests` -->
<!-- Pyright can be started with `pyright --skipunannotated` -->

**Documentation**

- [ ] New features are documented along with examples if relevant.
- [ ] The documentation is [Sphinx](https://www.sphinx-doc.org/en/master/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant.

<!--
Thank you again!
-->
