### PR TITLE
PR: Ensure that the`colour.utilities.as_float` definition do not reduce dimensionality

### DIFF
--- a/colour/algebra/common.py
+++ b/colour/algebra/common.py
@@ -482,14 +482,12 @@ def spow(a: ArrayLike, p: ArrayLike) -> NDArrayFloat:
     if not _SPOW_ENABLED:
         return np.power(a, p)
 
-    a = np.atleast_1d(a)
+    a = as_float_array(a)
     p = as_float_array(p)
 
     a_p = np.sign(a) * np.abs(a) ** p
 
-    a_p[np.isnan(a_p)] = 0
-
-    return as_float(a_p)
+    return as_float(0 if a_p.ndim == 0 and np.isnan(a_p) else a_p)
 
 
 def normalise_vector(a: ArrayLike) -> NDArrayFloat:

--- a/colour/algebra/extrapolation.py
+++ b/colour/algebra/extrapolation.py
@@ -31,9 +31,9 @@ from colour.hints import (
     ProtocolInterpolator,
     Real,
     Type,
-    cast,
 )
 from colour.utilities import (
+    as_float_array,
     as_float,
     attest,
     is_numeric,
@@ -301,7 +301,7 @@ class Extrapolator:
             Extrapolated points value(s).
         """
 
-        x = cast(NDArrayFloat, np.atleast_1d(x).astype(self._dtype))
+        x = as_float_array(x)
 
         xe = self._evaluate(x)
 

--- a/colour/algebra/interpolation.py
+++ b/colour/algebra/interpolation.py
@@ -658,7 +658,7 @@ class KernelInterpolator:
             Interpolated value(s).
         """
 
-        x = cast(NDArrayFloat, np.atleast_1d(x).astype(self._dtype))
+        x = as_float_array(x)
 
         xi = self._evaluate(x)
 
@@ -685,7 +685,9 @@ class KernelInterpolator:
         x_interval = interval(self._x)[0]
         x_f = np.floor(x / x_interval)
 
-        windows = x_f[:, None] + np.arange(-self._window + 1, self._window + 1)
+        windows = x_f[..., None] + np.arange(
+            -self._window + 1, self._window + 1
+        )
         clip_l = min(self._x_p) / x_interval
         clip_h = max(self._x_p) / x_interval
         windows = np.clip(windows, clip_l, clip_h) - clip_l
@@ -694,7 +696,7 @@ class KernelInterpolator:
         return np.sum(
             self._y_p[windows]
             * self._kernel(
-                x[:, None] / x_interval
+                x[..., None] / x_interval
                 - windows
                 - min(self._x_p) / x_interval,
                 **self._kernel_kwargs,
@@ -903,7 +905,7 @@ class LinearInterpolator:
             Interpolated value(s).
         """
 
-        x = cast(NDArrayFloat, np.atleast_1d(x).astype(self._dtype))
+        x = as_float_array(x)
 
         xi = self._evaluate(x)
 
@@ -1193,7 +1195,7 @@ class SpragueInterpolator:
             Interpolated value(s).
         """
 
-        x = cast(NDArrayFloat, np.atleast_1d(x).astype(self._dtype))
+        x = as_float_array(x)
 
         xi = self._evaluate(x)
 
@@ -1604,7 +1606,7 @@ class NullInterpolator:
             Interpolated value(s).
         """
 
-        x = cast(NDArrayFloat, np.atleast_1d(x).astype(self._dtype))
+        x = as_float_array(x)
 
         xi = self._evaluate(x)
 
@@ -1639,7 +1641,7 @@ class NullInterpolator:
             )
         ] = self._default
 
-        return values
+        return np.squeeze(values)
 
     def _validate_dimensions(self):
         """Validate that the variables dimensions are the same."""

--- a/colour/models/rgb/transfer_functions/itur_bt_2100.py
+++ b/colour/models/rgb/transfer_functions/itur_bt_2100.py
@@ -1126,9 +1126,11 @@ def ootf_BT2100_HLG_1(
     63.1051034...
     """
 
-    E = as_float_array(np.atleast_1d(to_domain_1(E)))
+    E = to_domain_1(E)
 
-    if E.shape[-1] != 3:
+    is_single_channel = np.atleast_1d(E).shape[-1] != 3
+
+    if is_single_channel:
         usage_warning(
             '"Recommendation ITU-R BT.2100" "Reference HLG OOTF" uses '
             "RGB Luminance in computations and expects a vector input, thus "
@@ -1150,7 +1152,7 @@ def ootf_BT2100_HLG_1(
     G_D = alpha * G_S * np.abs(Y_S) ** (gamma - 1) + beta
     B_D = alpha * B_S * np.abs(Y_S) ** (gamma - 1) + beta
 
-    if E.shape[-1] != 3:
+    if is_single_channel:
         return as_float(from_range_1(R_D))
     else:
         RGB_D = tstack([R_D, G_D, B_D])
@@ -1212,9 +1214,11 @@ def ootf_BT2100_HLG_2(
     63.0957344...
     """
 
-    E = as_float_array(np.atleast_1d(to_domain_1(E)))
+    E = to_domain_1(E)
 
-    if E.shape[-1] != 3:
+    is_single_channel = np.atleast_1d(E).shape[-1] != 3
+
+    if is_single_channel:
         usage_warning(
             '"Recommendation ITU-R BT.2100" "Reference HLG OOTF" uses '
             "RGB Luminance in computations and expects a vector input, thus "
@@ -1235,7 +1239,7 @@ def ootf_BT2100_HLG_2(
     G_D = alpha * G_S * np.abs(Y_S) ** (gamma - 1)
     B_D = alpha * B_S * np.abs(Y_S) ** (gamma - 1)
 
-    if E.shape[-1] != 3:
+    if is_single_channel:
         return as_float(from_range_1(R_D))
     else:
         RGB_D = tstack([R_D, G_D, B_D])
@@ -1392,9 +1396,11 @@ def ootf_inverse_BT2100_HLG_1(
     0.0999999...
     """
 
-    F_D = as_float_array(np.atleast_1d(to_domain_1(F_D)))
+    F_D = to_domain_1(F_D)
 
-    if F_D.shape[-1] != 3:
+    is_single_channel = np.atleast_1d(F_D).shape[-1] != 3
+
+    if is_single_channel:
         usage_warning(
             '"Recommendation ITU-R BT.2100" "Reference HLG OOTF" uses '
             "RGB Luminance in computations and expects a vector input, thus "
@@ -1430,7 +1436,7 @@ def ootf_inverse_BT2100_HLG_1(
         Y_D_beta * (B_D - beta) / alpha,
     )
 
-    if F_D.shape[-1] != 3:
+    if is_single_channel:
         return as_float(from_range_1(R_S))
     else:
         RGB_S = tstack([R_S, G_S, B_S])
@@ -1490,9 +1496,11 @@ def ootf_inverse_BT2100_HLG_2(
     0.1000000...
     """
 
-    F_D = as_float_array(np.atleast_1d(to_domain_1(F_D)))
+    F_D = to_domain_1(F_D)
 
-    if F_D.shape[-1] != 3:
+    is_single_channel = np.atleast_1d(F_D).shape[-1] != 3
+
+    if is_single_channel:
         usage_warning(
             '"Recommendation ITU-R BT.2100" "Reference HLG OOTF" uses '
             "RGB Luminance in computations and expects a vector input, thus "
@@ -1527,7 +1535,7 @@ def ootf_inverse_BT2100_HLG_2(
         Y_D_alpha * B_D / alpha,
     )
 
-    if F_D.shape[-1] != 3:
+    if is_single_channel:
         return as_float(from_range_1(R_S))
     else:
         RGB_S = tstack([R_S, G_S, B_S])

--- a/colour/notation/munsell.py
+++ b/colour/notation/munsell.py
@@ -1557,7 +1557,7 @@ def is_grey_munsell_colour(specification: ArrayLike) -> bool:
 
     specification = as_float_array(specification)
 
-    specification = specification[~np.isnan(specification)]
+    specification = np.squeeze(specification[~np.isnan(specification)])
 
     return is_numeric(as_float(specification))
 

--- a/colour/utilities/array.py
+++ b/colour/utilities/array.py
@@ -601,9 +601,11 @@ def as_int(a: ArrayLike, dtype: Type[DTypeInt] | None = None) -> NDArrayInt:
 
     Examples
     --------
-    >>> as_int(np.array([1]))
+    >>> as_int(np.array(1))
     1
-    >>> as_int(np.arange(10))  # doctest: +ELLIPSIS
+    >>> as_int(np.array([1]))  # doctest: +SKIP
+    array([1])
+    >>> as_int(np.arange(10))  # doctest: +SKIP
     array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]...)
     """
 
@@ -613,12 +615,6 @@ def as_int(a: ArrayLike, dtype: Type[DTypeInt] | None = None) -> NDArrayInt:
         dtype in DTypeInt.__args__,  # pyright: ignore
         _ASSERTION_MESSAGE_DTYPE_INT,
     )
-
-    try:
-        if len(a) == 1:  # pyright: ignore
-            a = np.squeeze(a)
-    except TypeError:
-        pass
 
     return dtype(a)  # pyright: ignore
 
@@ -647,8 +643,10 @@ def as_float(
 
     Examples
     --------
-    >>> as_float(np.array([1]))
+    >>> as_float(np.array(1))
     1.0
+    >>> as_float(np.array([1]))
+    array([ 1.])
     >>> as_float(np.arange(10))
     array([ 0.,  1.,  2.,  3.,  4.,  5.,  6.,  7.,  8.,  9.])
     """
@@ -660,11 +658,14 @@ def as_float(
         _ASSERTION_MESSAGE_DTYPE_FLOAT,
     )
 
-    try:
-        if len(a) == 1:  # pyright: ignore
-            a = np.squeeze(a)
-    except TypeError:
-        pass
+    # NOTE: "np.float64" reduces dimensionality:
+    # >>> np.int64(np.array([[1]]))
+    # array([[1]])
+    # >>> np.float64(np.array([[1]]))
+    # 1.0
+    # See for more information https://github.com/numpy/numpy/issues/24283
+    if isinstance(a, np.ndarray) and a.size == 1 and a.ndim != 0:
+        return as_float_array(a, dtype)
 
     return dtype(a)  # pyright: ignore
 

--- a/colour/utilities/tests/test_array.py
+++ b/colour/utilities/tests/test_array.py
@@ -502,7 +502,9 @@ class TestAsInt(unittest.TestCase):
 
         self.assertEqual(as_int(1), 1)
 
-        self.assertEqual(as_int(np.array([1])), 1)
+        self.assertEqual(as_int(np.array([1])).ndim, 1)
+
+        self.assertEqual(as_int(np.array([[1]])).ndim, 2)
 
         np.testing.assert_array_almost_equal(
             as_int(np.array([1.0, 2.0, 3.0])), np.array([1, 2, 3])
@@ -526,7 +528,9 @@ class TestAsFloat(unittest.TestCase):
 
         self.assertEqual(as_float(1), 1.0)
 
-        self.assertEqual(as_float(np.array([1])), 1.0)
+        self.assertEqual(as_float(np.array([1])).ndim, 1)
+
+        self.assertEqual(as_float(np.array([[1]])).ndim, 2)
 
         np.testing.assert_array_almost_equal(
             as_float(np.array([1, 2, 3])), np.array([1.0, 2.0, 3.0])


### PR DESCRIPTION
<!--
Thank you for taking the time to create this pull request. If it is the first
time you are contributing to a colour-science repository, a contributing guide
is available to guide the process: https://www.colour-science.org/contributing/.
-->

# Summary

This PR ensures that the `colour.utilities.as_float` definition do not reduce dimensionality. We piggy backed on some of its behaviour but it is inconsistent and caused issues when processing 1-pixel images.

References #1188.

# Preflight

<!-- Please mark any checkboxes that do not apply to this pull request as [N/A]. -->

**Code Style and Quality**

- [x] Unit tests have been implemented and passed.
- [x] Pyright static checking has been run and passed.
- [x] Pre-commit hooks have been run and passed.
- [N/A] New transformations have been added to the *Automatic Colour Conversion Graph*.
- [N/A] New transformations have been exported to the relevant namespaces, e.g. `colour`, `colour.models`.

<!-- The unit tests can be invoked with `poetry run invoke tests` -->
<!-- Pyright can be started with `pyright --skipunannotated` -->

**Documentation**

- [N/A] New features are documented along with examples if relevant.
- [N/A] The documentation is [Sphinx](https://www.sphinx-doc.org/en/master/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant.

<!--
Thank you again!
-->
