### PR TITLE
Change fontsize to extra small for wavelength labels

### DIFF
--- a/colour/plotting/diagrams.py
+++ b/colour/plotting/diagrams.py
@@ -16,26 +16,22 @@ Defines the *CIE* chromaticity diagrams plotting objects:
 from __future__ import annotations
 
 import bisect
-import numpy as np
-from matplotlib.axes import Axes
-from matplotlib.collections import LineCollection
-from matplotlib.figure import Figure
-from matplotlib.patches import Polygon
 
+import numpy as np
 from colour.algebra import normalise_maximum, normalise_vector
-from colour.constants import DEFAULT_FLOAT_DTYPE
 from colour.colorimetry import (
-    MultiSpectralDistributions,
     SDS_ILLUMINANTS,
+    MultiSpectralDistributions,
     SpectralDistribution,
     sd_to_XYZ,
     sds_and_msds_to_sds,
 )
+from colour.constants import DEFAULT_FLOAT_DTYPE
 from colour.hints import (
     Any,
     ArrayLike,
-    Dict,
     Callable,
+    Dict,
     List,
     Literal,
     NDArray,
@@ -57,8 +53,8 @@ from colour.models import (
 )
 from colour.notation import HEX_to_RGB
 from colour.plotting import (
-    CONSTANTS_COLOUR_STYLE,
     CONSTANTS_ARROW_STYLE,
+    CONSTANTS_COLOUR_STYLE,
     XYZ_to_plotting_colourspace,
     artist,
     filter_cmfs,
@@ -78,6 +74,10 @@ from colour.utilities import (
     validate_method,
     zeros,
 )
+from matplotlib.axes import Axes
+from matplotlib.collections import LineCollection
+from matplotlib.figure import Figure
+from matplotlib.patches import Polygon
 
 __author__ = "Colour Developers"
 __copyright__ = "Copyright 2013 Colour Developers"
@@ -496,7 +496,7 @@ def plot_spectral_locus(
             clip_on=True,
             ha="left" if lines_w["normal"][::2][i, 0] >= 0 else "right",
             va="center",
-            fontdict={"size": "small"},
+            fontsize="x-small",
             zorder=CONSTANTS_COLOUR_STYLE.zorder.background_label,
         )
 


### PR DESCRIPTION
Just want to slightly improve the style for chromaticity plots. 

My dev tools automatically organized the imports. Hopefully doesn't have any disagreement with other dev tools. I can disable for future PRs. 