### PR TITLE
PR: Ensure that LUT reading and writing can occur when path has no known extension.

### DIFF
--- a/colour/hints/__init__.py
+++ b/colour/hints/__init__.py
@@ -107,6 +107,8 @@ __all__ = [
     "LiteralCCTFDecoding",
     "LiteralOOTF",
     "LiteralOOTFInverse",
+    "LiteralLUTReadMethods",
+    "LiteralLUTWriteMethods",
 ]
 
 RegexFlag = NewType("RegexFlag", re.RegexFlag)
@@ -533,6 +535,22 @@ LiteralCCTFDecoding = Literal[
 ]
 LiteralOOTF = Literal["ITU-R BT.2100 HLG", "ITU-R BT.2100 PQ"]
 LiteralOOTFInverse = Literal["ITU-R BT.2100 HLG", "ITU-R BT.2100 PQ"]
+LiteralLUTReadMethods = Literal[
+    "Cinespace",
+    "Iridas Cube",
+    "Resolve Cube",
+    "Sony SPI1D",
+    "Sony SPI3D",
+    "Sony SPImtx",
+]
+LiteralLUTWriteMethods = Literal[
+    "Cinespace",
+    "Iridas Cube",
+    "Resolve Cube",
+    "Sony SPI1D",
+    "Sony SPI3D",
+    "Sony SPImtx",
+]
 # LITERALISE::END
 
 

--- a/colour/io/luts/__init__.py
+++ b/colour/io/luts/__init__.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import os
 
-from colour.hints import Any, Literal
+from colour.hints import Any, LiteralLUTReadMethods, LiteralLUTWriteMethods
 from colour.utilities import (
     CanonicalMapping,
     filter_kwargs,
@@ -103,16 +103,7 @@ References
 
 def read_LUT(
     path: str,
-    method: Literal[
-        "Cinespace",
-        "Iridas Cube",
-        "Resolve Cube",
-        "Sony SPI1D",
-        "Sony SPI3D",
-        "Sony SPImtx",
-    ]
-    | str
-    | None = None,
+    method: LiteralLUTReadMethods | str | None = None,
     **kwargs: Any,
 ) -> LUT1D | LUT3x1D | LUT3D | LUTSequence | LUTOperatorMatrix:
     """
@@ -260,16 +251,7 @@ def write_LUT(
     LUT: LUT1D | LUT3x1D | LUT3D | LUTSequence | LUTOperatorMatrix,
     path: str,
     decimals: int = 7,
-    method: Literal[
-        "Cinespace",
-        "Iridas Cube",
-        "Resolve Cube",
-        "Sony SPI1D",
-        "Sony SPI3D",
-        "Sony SPImtx",
-    ]
-    | str
-    | None = None,
+    method: LiteralLUTWriteMethods | str | None = None,
     **kwargs: Any,
 ) -> bool:
     """

--- a/colour/io/luts/__init__.py
+++ b/colour/io/luts/__init__.py
@@ -19,7 +19,6 @@ from colour.hints import Any, LiteralLUTReadMethods, LiteralLUTWriteMethods
 from colour.utilities import (
     CanonicalMapping,
     filter_kwargs,
-    optional,
     validate_method,
 )
 
@@ -208,11 +207,11 @@ or :class:`colour.LUTSequence` or :class:`colour.LUTOperatorMatrix`
     Offset     : [ 0.  0.  0.  0.]
     """
 
-    method = optional(
-        method, MAPPING_EXTENSION_TO_LUT_FORMAT[os.path.splitext(path)[-1]]
+    method = (
+        MAPPING_EXTENSION_TO_LUT_FORMAT[os.path.splitext(path)[-1]].lower()
+        if method is None
+        else validate_method(method, tuple(LUT_WRITE_METHODS))
     )
-
-    method = validate_method(method, tuple(LUT_READ_METHODS))
 
     function = LUT_READ_METHODS[method]
 
@@ -319,11 +318,11 @@ def write_LUT(
     >>> write_LUT(LUT, "My_LUT.cube")  # doctest: +SKIP
     """
 
-    method = optional(
-        method, MAPPING_EXTENSION_TO_LUT_FORMAT[os.path.splitext(path)[-1]]
+    method = (
+        MAPPING_EXTENSION_TO_LUT_FORMAT[os.path.splitext(path)[-1]].lower()
+        if method is None
+        else validate_method(method, tuple(LUT_WRITE_METHODS))
     )
-
-    method = validate_method(method, tuple(LUT_WRITE_METHODS))
 
     if method == "iridas cube" and isinstance(LUT, LUTSequence):
         method = "resolve cube"

--- a/colour/io/luts/tests/test__init__.py
+++ b/colour/io/luts/tests/test__init__.py
@@ -101,6 +101,16 @@ class TestReadLUT(unittest.TestCase):
         )
         self.assertEqual(LUT_2[1].size, 4)
 
+        self.assertEqual(
+            read_LUT(
+                os.path.join(ROOT_LUTS, "sony_spi1d", "eotf_sRGB_1D.spi1d")
+            ),
+            read_LUT(
+                os.path.join(ROOT_LUTS, "sony_spi1d", "eotf_sRGB_1D.spi1d"),
+                method="Sony SPI1D",
+            ),
+        )
+
     def test_raise_exception_read_LUT(self):
         """
         Test :func:`colour.io.luts.__init__.read_LUT` definition raised
@@ -179,6 +189,22 @@ class TestWriteLUT(unittest.TestCase):
         )
 
         self.assertEqual(LUT_2_r, LUT_2_t)
+
+        write_LUT(
+            LUT_1_r,
+            os.path.join(self._temporary_directory, "eotf_sRGB_1D"),
+            method="Sony SPI1D",
+        )
+
+        self.assertEqual(
+            read_LUT(
+                os.path.join(self._temporary_directory, "eotf_sRGB_1D.spi1d")
+            ),
+            read_LUT(
+                os.path.join(self._temporary_directory, "eotf_sRGB_1D"),
+                method="Sony SPI1D",
+            ),
+        )
 
 
 if __name__ == "__main__":

--- a/docs/colour.hints.rst
+++ b/docs/colour.hints.rst
@@ -69,3 +69,5 @@ Annotation Type Hints
     LiteralCCTFDecoding
     LiteralOOTF
     LiteralOOTFInverse
+    LiteralLUTReadMethods
+    LiteralLUTWriteMethods

--- a/utilities/literalise.py
+++ b/utilities/literalise.py
@@ -63,6 +63,8 @@ def literalise(path_module_hints: str = PATH_MODULE_HINTS):
             LiteralCCTFDecoding = Literal{sorted(colour.CCTF_DECODINGS)}
             LiteralOOTF = Literal{sorted(colour.OOTFS)}
             LiteralOOTFInverse = Literal{sorted(colour.OOTF_INVERSES)}
+            LiteralLUTReadMethods = Literal{sorted(colour.io.LUT_READ_METHODS)}
+            LiteralLUTWriteMethods = Literal{sorted(colour.io.LUT_WRITE_METHODS)}
             # LITERALISE::END
             """
         ).strip(),


### PR DESCRIPTION
<!--
Thank you for taking the time to create this pull request. If it is the first
time you are contributing to a colour-science repository, a contributing guide
is available to guide the process: https://www.colour-science.org/contributing/.
-->

# Summary

This PR ensures that a LUT can be read or written when the given path has no known extension.

References #1212.

# Preflight

<!-- Please mark any checkboxes that do not apply to this pull request as [N/A]. -->

**Code Style and Quality**

- [x] Unit tests have been implemented and passed.
- [x] Pyright static checking has been run and passed.
- [x] Pre-commit hooks have been run and passed.
- [N/A] New transformations have been added to the *Automatic Colour Conversion Graph*.
- [N/A] New transformations have been exported to the relevant namespaces, e.g. `colour`, `colour.models`.

<!-- The unit tests can be invoked with `poetry run invoke tests` -->
<!-- Pyright can be started with `pyright --skipunannotated` -->

**Documentation**

- [N/A] New features are documented along with examples if relevant.
- [N/A] The documentation is [Sphinx](https://www.sphinx-doc.org/en/master/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant.

<!--
Thank you again!
-->
