### PR TITLE
PR: Implement support for injecting `vaab/colour` objects  into our namespace.

### DIFF
--- a/colour/__init__.py
+++ b/colour/__init__.py
@@ -45,6 +45,7 @@ Sub-packages
 """
 
 import contextlib
+import os
 import sys
 
 import numpy as np
@@ -948,7 +949,7 @@ if not is_documentation_building():
         sys.modules["colour"], build_API_changes(API_CHANGES)
     )
 
-    del ModuleAPI, is_documentation_building, build_API_changes, sys
+    del ModuleAPI, is_documentation_building, build_API_changes
 
 colour.__disable_lazy_load__ = True  # pyright: ignore
 __disable_lazy_load__ = colour.__disable_lazy_load__  # pyright: ignore
@@ -956,3 +957,71 @@ __disable_lazy_load__ = colour.__disable_lazy_load__  # pyright: ignore
 Ensures that the lazy loaded datasets are not transformed during import.
 See :class:`colour.utilities.LazyCanonicalMapping` for more information.
 """
+
+# NOTE: We are solving the clash with https://github.com/vaab/colour by loading
+# a known subset of the objects given by vaab/colour-0.1.5 into our namespace.
+# There haven't been many clashes over the  years but people using
+# https://www.manim.community are experiencing problems:
+# - https://github.com/colour-science/colour/issues/958
+# - https://github.com/colour-science/colour/issues/1221
+if not os.environ.get(
+    "COLOUR_SCIENCE__COLOUR__SKIP_VAAB_COLOUR_INJECTION"
+):  # pragma: no cover
+    for _path in sys.path:
+        _module_path = os.path.join(_path, "colour.py")
+        if os.path.exists(_module_path):
+            import importlib.machinery
+
+            import colour  # pyright: ignore
+
+            _module = importlib.machinery.SourceFileLoader(
+                "__vaab_colour__", _module_path
+            ).load_module()
+
+            for name in [
+                "COLOR_NAME_TO_RGB",
+                "C_HEX",
+                "C_HSL",
+                "C_RGB",
+                "Color",
+                "HEX",
+                "HSL",
+                "HSL_equivalence",
+                "LONG_HEX_COLOR",
+                "RGB",
+                "RGB_TO_COLOR_NAMES",
+                "RGB_color_picker",
+                "RGB_equivalence",
+                "SHORT_HEX_COLOR",
+                "color_scale",
+                "hash_or_str",
+                "hex2hsl",
+                "hex2rgb",
+                "hex2web",
+                "hsl2hex",
+                "hsl2rgb",
+                "hsl2web",
+                "make_color_factory",
+                "rgb2hex",
+                "rgb2hsl",
+                "rgb2web",
+                "web2hex",
+                "web2hsl",
+                "web2rgb",
+            ]:
+                if name in dir(_module):
+                    colour.utilities.warning(  # pyright: ignore
+                        f'Injecting "vaab/colour" "{name}" object into '
+                        f'"Colour"\'s namespace!'
+                    )
+                    setattr(
+                        sys.modules["colour"], name, getattr(_module, name)
+                    )
+
+            del importlib, _module
+
+            break
+
+        del _module_path, _path
+
+del os, sys

--- a/colour/__init__.py
+++ b/colour/__init__.py
@@ -959,69 +959,75 @@ See :class:`colour.utilities.LazyCanonicalMapping` for more information.
 """
 
 # NOTE: We are solving the clash with https://github.com/vaab/colour by loading
-# a known subset of the objects given by vaab/colour-0.1.5 into our namespace.
-# There haven't been many clashes over the  years but people using
-# https://www.manim.community are experiencing problems:
+# a known subset of the objects given by vaab/colour-0.1.5 into our namespace
+# if the *COLOUR_SCIENCE__COLOUR__IMPORT_VAAB_COLOUR=True* environment variable
+# is defined.
+#
+# See the following issues for more information:
 # - https://github.com/colour-science/colour/issues/958
 # - https://github.com/colour-science/colour/issues/1221
-if not os.environ.get(
-    "COLOUR_SCIENCE__COLOUR__SKIP_VAAB_COLOUR_INJECTION"
-):  # pragma: no cover
-    for _path in sys.path:
-        _module_path = os.path.join(_path, "colour.py")
-        if os.path.exists(_module_path):
-            import importlib.machinery
+# - https://github.com/vaab/colour/issues/62
+for _path in sys.path:
+    _module_path = os.path.join(_path, "colour.py")
+    if os.path.exists(_module_path):
+        import colour  # pyright: ignore
 
-            import colour  # pyright: ignore
-
-            _module = importlib.machinery.SourceFileLoader(
-                "__vaab_colour__", _module_path
-            ).load_module()
-
-            for name in [
-                "COLOR_NAME_TO_RGB",
-                "C_HEX",
-                "C_HSL",
-                "C_RGB",
-                "Color",
-                "HEX",
-                "HSL",
-                "HSL_equivalence",
-                "LONG_HEX_COLOR",
-                "RGB",
-                "RGB_TO_COLOR_NAMES",
-                "RGB_color_picker",
-                "RGB_equivalence",
-                "SHORT_HEX_COLOR",
-                "color_scale",
-                "hash_or_str",
-                "hex2hsl",
-                "hex2rgb",
-                "hex2web",
-                "hsl2hex",
-                "hsl2rgb",
-                "hsl2web",
-                "make_color_factory",
-                "rgb2hex",
-                "rgb2hsl",
-                "rgb2web",
-                "web2hex",
-                "web2hsl",
-                "web2rgb",
-            ]:
-                if name in dir(_module):
-                    colour.utilities.warning(  # pyright: ignore
-                        f'Injecting "vaab/colour" "{name}" object into '
-                        f'"Colour"\'s namespace!'
-                    )
-                    setattr(
-                        sys.modules["colour"], name, getattr(_module, name)
-                    )
-
-            del importlib, _module
-
+        if not os.environ.get("COLOUR_SCIENCE__COLOUR__IMPORT_VAAB_COLOUR"):
+            colour.utilities.warning(  # pyright: ignore
+                '"vaab/colour" was detected in "sys.path", please define a '
+                '"COLOUR_SCIENCE__COLOUR__IMPORT_VAAB_COLOUR=True" environment '
+                'variable to import its objects into "colour" namespace!'
+            )
             break
 
-        del _module_path, _path
+        import importlib.machinery
+
+        _module = importlib.machinery.SourceFileLoader(
+            "__vaab_colour__", _module_path
+        ).load_module()
+
+        for name in [
+            "COLOR_NAME_TO_RGB",
+            "C_HEX",
+            "C_HSL",
+            "C_RGB",
+            "Color",
+            "HEX",
+            "HSL",
+            "HSL_equivalence",
+            "LONG_HEX_COLOR",
+            "RGB",
+            "RGB_TO_COLOR_NAMES",
+            "RGB_color_picker",
+            "RGB_equivalence",
+            "SHORT_HEX_COLOR",
+            "color_scale",
+            "hash_or_str",
+            "hex2hsl",
+            "hex2rgb",
+            "hex2web",
+            "hsl2hex",
+            "hsl2rgb",
+            "hsl2web",
+            "make_color_factory",
+            "rgb2hex",
+            "rgb2hsl",
+            "rgb2web",
+            "web2hex",
+            "web2hsl",
+            "web2rgb",
+        ]:
+            if name in dir(_module):
+                colour.utilities.warning(  # pyright: ignore
+                    f'Importing "vaab/colour" "{name}" object into '
+                    f'"Colour"\'s namespace!'
+                )
+                setattr(sys.modules["colour"], name, getattr(_module, name))
+
+        del importlib, _module
+
+        break
+
+    del _module_path, _path
 
 del os, sys

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -22,10 +22,11 @@ runtime:
     :func:`warnings.showwarning` definition to be replaced with the
     :func:`colour.utilities.show_warning` definition and thus providing
     complete traceback from the point where the warning occurred.
--   `COLOUR_SCIENCE__COLOUR__SKIP_VAAB_COLOUR_INJECTION`: Skip
-    `vaab/colour <https://github.com/vaab/colour>`__ objects injection into
-    **Colour** namespace. See the bottom of the core `__init__.py` module for
-    more information.
+-   `COLOUR_SCIENCE__COLOUR__IMPORT_VAAB_COLOUR`: Import
+    `vaab/colour <https://github.com/vaab/colour>`__ injection into
+    **Colour** namespace. This solves the clash with
+    `vaab/colour <https://github.com/vaab/colour>`__ by loading a known subset
+    of the objects given by vaab/colour-0.1.5 into our namespace.
 
 Caching
 -------

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -22,6 +22,10 @@ runtime:
     :func:`warnings.showwarning` definition to be replaced with the
     :func:`colour.utilities.show_warning` definition and thus providing
     complete traceback from the point where the warning occurred.
+-   `COLOUR_SCIENCE__COLOUR__SKIP_VAAB_COLOUR_INJECTION`: Skip
+    `vaab/colour <https://github.com/vaab/colour>`__ objects injection into
+    **Colour** namespace. See the bottom of the core `__init__.py` module for
+    more information.
 
 Caching
 -------


### PR DESCRIPTION
<!--
Thank you for taking the time to create this pull request. If it is the first
time you are contributing to a colour-science repository, a contributing guide
is available to guide the process: https://www.colour-science.org/contributing/.
-->

# Summary

This PR injects `vaab/colour` objects into our namespace to address #1221,  #958 and https://github.com/vaab/colour/issues/62.

This is really gross but it will help users so...

```python
from colour import Color, web2rgb

print(Color, web2rgb)
```

```
/Users/kelsolaar/Library/Caches/pypoetry/virtualenvs/colour-science-49B8_mty-py3.11/bin/python /Users/kelsolaar/Applications/PyCharm Professional Edition.app/Contents/plugins/python/helpers/pydev/pydevconsole.py --mode=client --host=127.0.0.1 --port=56376 
import sys; print('Python %s on %s' % (sys.version, sys.platform))
sys.path.extend(['/Users/kelsolaar/Documents/Development/colour-science/colour'])
Python 3.11.6 (main, Oct  2 2023, 20:46:14) [Clang 14.0.3 (clang-1403.0.22.14.1)]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.16.1 -- An enhanced Interactive Python. Type '?' for help.
PyDev console: using IPython 8.16.1
Python 3.11.6 (main, Oct  2 2023, 20:46:14) [Clang 14.0.3 (clang-1403.0.22.14.1)] on darwin
runfile('/Users/kelsolaar/Library/Application Support/JetBrains/PyCharm2023.2/scratches/scratch_127.py', wdir='/Users/kelsolaar/Library/Application Support/JetBrains/PyCharm2023.2/scratches')
/Users/kelsolaar/Documents/Development/colour-science/colour/colour/utilities/verbose.py:265: ColourWarning: Injecting "vaab/colour" "COLOR_NAME_TO_RGB" object into "Colour"'s namespace!
  warn(*args, **kwargs)  # noqa: B028
/Users/kelsolaar/Documents/Development/colour-science/colour/colour/utilities/verbose.py:265: ColourWarning: Injecting "vaab/colour" "C_HEX" object into "Colour"'s namespace!
  warn(*args, **kwargs)  # noqa: B028
/Users/kelsolaar/Documents/Development/colour-science/colour/colour/utilities/verbose.py:265: ColourWarning: Injecting "vaab/colour" "C_HSL" object into "Colour"'s namespace!
  warn(*args, **kwargs)  # noqa: B028
/Users/kelsolaar/Documents/Development/colour-science/colour/colour/utilities/verbose.py:265: ColourWarning: Injecting "vaab/colour" "C_RGB" object into "Colour"'s namespace!
  warn(*args, **kwargs)  # noqa: B028
/Users/kelsolaar/Documents/Development/colour-science/colour/colour/utilities/verbose.py:265: ColourWarning: Injecting "vaab/colour" "Color" object into "Colour"'s namespace!
  warn(*args, **kwargs)  # noqa: B028
/Users/kelsolaar/Documents/Development/colour-science/colour/colour/utilities/verbose.py:265: ColourWarning: Injecting "vaab/colour" "HEX" object into "Colour"'s namespace!
  warn(*args, **kwargs)  # noqa: B028
/Users/kelsolaar/Documents/Development/colour-science/colour/colour/utilities/verbose.py:265: ColourWarning: Injecting "vaab/colour" "HSL" object into "Colour"'s namespace!
  warn(*args, **kwargs)  # noqa: B028
/Users/kelsolaar/Documents/Development/colour-science/colour/colour/utilities/verbose.py:265: ColourWarning: Injecting "vaab/colour" "HSL_equivalence" object into "Colour"'s namespace!
  warn(*args, **kwargs)  # noqa: B028
/Users/kelsolaar/Documents/Development/colour-science/colour/colour/utilities/verbose.py:265: ColourWarning: Injecting "vaab/colour" "LONG_HEX_COLOR" object into "Colour"'s namespace!
  warn(*args, **kwargs)  # noqa: B028
/Users/kelsolaar/Documents/Development/colour-science/colour/colour/utilities/verbose.py:265: ColourWarning: Injecting "vaab/colour" "RGB" object into "Colour"'s namespace!
  warn(*args, **kwargs)  # noqa: B028
/Users/kelsolaar/Documents/Development/colour-science/colour/colour/utilities/verbose.py:265: ColourWarning: Injecting "vaab/colour" "RGB_TO_COLOR_NAMES" object into "Colour"'s namespace!
  warn(*args, **kwargs)  # noqa: B028
/Users/kelsolaar/Documents/Development/colour-science/colour/colour/utilities/verbose.py:265: ColourWarning: Injecting "vaab/colour" "RGB_color_picker" object into "Colour"'s namespace!
  warn(*args, **kwargs)  # noqa: B028
/Users/kelsolaar/Documents/Development/colour-science/colour/colour/utilities/verbose.py:265: ColourWarning: Injecting "vaab/colour" "RGB_equivalence" object into "Colour"'s namespace!
  warn(*args, **kwargs)  # noqa: B028
/Users/kelsolaar/Documents/Development/colour-science/colour/colour/utilities/verbose.py:265: ColourWarning: Injecting "vaab/colour" "SHORT_HEX_COLOR" object into "Colour"'s namespace!
  warn(*args, **kwargs)  # noqa: B028
/Users/kelsolaar/Documents/Development/colour-science/colour/colour/utilities/verbose.py:265: ColourWarning: Injecting "vaab/colour" "color_scale" object into "Colour"'s namespace!
  warn(*args, **kwargs)  # noqa: B028
/Users/kelsolaar/Documents/Development/colour-science/colour/colour/utilities/verbose.py:265: ColourWarning: Injecting "vaab/colour" "hash_or_str" object into "Colour"'s namespace!
  warn(*args, **kwargs)  # noqa: B028
/Users/kelsolaar/Documents/Development/colour-science/colour/colour/utilities/verbose.py:265: ColourWarning: Injecting "vaab/colour" "hex2hsl" object into "Colour"'s namespace!
  warn(*args, **kwargs)  # noqa: B028
/Users/kelsolaar/Documents/Development/colour-science/colour/colour/utilities/verbose.py:265: ColourWarning: Injecting "vaab/colour" "hex2rgb" object into "Colour"'s namespace!
  warn(*args, **kwargs)  # noqa: B028
/Users/kelsolaar/Documents/Development/colour-science/colour/colour/utilities/verbose.py:265: ColourWarning: Injecting "vaab/colour" "hex2web" object into "Colour"'s namespace!
  warn(*args, **kwargs)  # noqa: B028
/Users/kelsolaar/Documents/Development/colour-science/colour/colour/utilities/verbose.py:265: ColourWarning: Injecting "vaab/colour" "hsl2hex" object into "Colour"'s namespace!
  warn(*args, **kwargs)  # noqa: B028
/Users/kelsolaar/Documents/Development/colour-science/colour/colour/utilities/verbose.py:265: ColourWarning: Injecting "vaab/colour" "hsl2rgb" object into "Colour"'s namespace!
  warn(*args, **kwargs)  # noqa: B028
/Users/kelsolaar/Documents/Development/colour-science/colour/colour/utilities/verbose.py:265: ColourWarning: Injecting "vaab/colour" "hsl2web" object into "Colour"'s namespace!
  warn(*args, **kwargs)  # noqa: B028
/Users/kelsolaar/Documents/Development/colour-science/colour/colour/utilities/verbose.py:265: ColourWarning: Injecting "vaab/colour" "make_color_factory" object into "Colour"'s namespace!
  warn(*args, **kwargs)  # noqa: B028
/Users/kelsolaar/Documents/Development/colour-science/colour/colour/utilities/verbose.py:265: ColourWarning: Injecting "vaab/colour" "rgb2hex" object into "Colour"'s namespace!
  warn(*args, **kwargs)  # noqa: B028
/Users/kelsolaar/Documents/Development/colour-science/colour/colour/utilities/verbose.py:265: ColourWarning: Injecting "vaab/colour" "rgb2hsl" object into "Colour"'s namespace!
  warn(*args, **kwargs)  # noqa: B028
/Users/kelsolaar/Documents/Development/colour-science/colour/colour/utilities/verbose.py:265: ColourWarning: Injecting "vaab/colour" "rgb2web" object into "Colour"'s namespace!
  warn(*args, **kwargs)  # noqa: B028
/Users/kelsolaar/Documents/Development/colour-science/colour/colour/utilities/verbose.py:265: ColourWarning: Injecting "vaab/colour" "web2hex" object into "Colour"'s namespace!
  warn(*args, **kwargs)  # noqa: B028
/Users/kelsolaar/Documents/Development/colour-science/colour/colour/utilities/verbose.py:265: ColourWarning: Injecting "vaab/colour" "web2hsl" object into "Colour"'s namespace!
  warn(*args, **kwargs)  # noqa: B028
/Users/kelsolaar/Documents/Development/colour-science/colour/colour/utilities/verbose.py:265: ColourWarning: Injecting "vaab/colour" "web2rgb" object into "Colour"'s namespace!
  warn(*args, **kwargs)  # noqa: B028
<class '__vaab_colour__.Color'> <function <lambda> at 0x16f085da0>
```

# Preflight

<!-- Please mark any checkboxes that do not apply to this pull request as [N/A]. -->

**Code Style and Quality**

- [N/A] Unit tests have been implemented and passed.
- [x] Pyright static checking has been run and passed.
- [x] Pre-commit hooks have been run and passed.
- [N/A] New transformations have been added to the *Automatic Colour Conversion Graph*.
- [N/A] New transformations have been exported to the relevant namespaces, e.g. `colour`, `colour.models`.

<!-- The unit tests can be invoked with `poetry run invoke tests` -->
<!-- Pyright can be started with `pyright --skipunannotated` -->

**Documentation**

- [x] New features are documented along with examples if relevant.
- [x] The documentation is [Sphinx](https://www.sphinx-doc.org/en/master/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant.

<!--
Thank you again!
-->
