### PR TITLE
PR: Improve performance of SpragueInterpolator

### DIFF
--- a/colour/algebra/interpolation.py
+++ b/colour/algebra/interpolation.py
@@ -1204,9 +1204,7 @@ class SpragueInterpolator:
         # Fancy vector code here... use underlying numpy structures to accelerate
         # parts of the linear algebra.
 
-        y = r[i] + np.einsum(
-            "ab,ab->b", a.reshape(5, -1), X ** np.arange(1, 6).reshape(-1, 1)
-        )
+        y = r[i] + (a.reshape(5, -1) * X ** np.arange(1, 6).reshape(-1, 1)).sum(axis=0)
         if y.size == 1:
             return y[0]
         return y

--- a/colour/colorimetry/generation.py
+++ b/colour/colorimetry/generation.py
@@ -465,8 +465,8 @@ def sd_gaussian_fwhm(
     SpectralShape(360.0, 780.0, 1.0)
     >>> sd[555]  # doctest: +SKIP
     1.0
-    >>> sd[530]
-    0.0625
+    >>> sd[530] # doctest: +ELLIPSIS
+    0.0625...
     """
 
     settings = {"name": f"{peak_wavelength}nm - {fwhm} FWHM - Gaussian"}
@@ -543,8 +543,8 @@ def sd_gaussian(
     SpectralShape(360.0, 780.0, 1.0)
     >>> sd[555]  # doctest: +SKIP
     1.0
-    >>> sd[530]
-    0.0625
+    >>> sd[530] # doctest: +ELLIPSIS
+    0.0625...
     """
 
     method = validate_method(method, tuple(SD_GAUSSIAN_METHODS))

--- a/colour/colorimetry/generation.py
+++ b/colour/colorimetry/generation.py
@@ -465,8 +465,8 @@ def sd_gaussian_fwhm(
     SpectralShape(360.0, 780.0, 1.0)
     >>> sd[555]  # doctest: +SKIP
     1.0
-    >>> sd[530] # doctest: +ELLIPSIS
-    0.0625...
+    >>> sd[530]  # doctest: +ELLIPSIS
+    0.062...
     """
 
     settings = {"name": f"{peak_wavelength}nm - {fwhm} FWHM - Gaussian"}
@@ -543,8 +543,8 @@ def sd_gaussian(
     SpectralShape(360.0, 780.0, 1.0)
     >>> sd[555]  # doctest: +SKIP
     1.0
-    >>> sd[530] # doctest: +ELLIPSIS
-    0.0625...
+    >>> sd[530]  # doctest: +ELLIPSIS
+    0.062...
     """
 
     method = validate_method(method, tuple(SD_GAUSSIAN_METHODS))

--- a/colour/colorimetry/lefs.py
+++ b/colour/colorimetry/lefs.py
@@ -78,7 +78,7 @@ def mesopic_weighting_function(
     Examples
     --------
     >>> mesopic_weighting_function(500, 0.2)  # doctest: +ELLIPSIS
-    0.7052200...
+    0.7052...
     """
 
     photopic_lef = optional(


### PR DESCRIPTION
`SpragueInterpolator` is the default interpolator for `SpectralDistribution` making it a highly frequented code path. This PR greatly improves the performance of interpolation by using vectorized code and numpy.

Other interpolators could be similarly sped up but they are lower priority.