### PR TITLE
PR: Implement support for programmatic polar conversions.

### DIFF
--- a/colour/__init__.py
+++ b/colour/__init__.py
@@ -274,6 +274,7 @@ from .models import (
     CCTF_ENCODINGS,
     COLOUR_PRIMARIES_ITUTH273,
     COLOURSPACE_MODELS,
+    COLOURSPACE_MODELS_POLAR_CONVERSION,
     DATA_MACADAM_1942_ELLIPSES,
     EOTF_INVERSES,
     EOTFS,
@@ -330,11 +331,7 @@ from .models import (
     JMh_CIECAM02_to_CAM02UCS,
     Jzazbz_to_XYZ,
     Lab_to_DIN99,
-    Lab_to_LCHab,
     Lab_to_XYZ,
-    LCHab_to_Lab,
-    LCHuv_to_Luv,
-    Luv_to_LCHuv,
     Luv_to_uv,
     Luv_to_XYZ,
     Luv_uv_to_xy,
@@ -677,6 +674,7 @@ __all__ += [
     "CMY_to_CMYK",
     "CMY_to_RGB",
     "COLOURSPACE_MODELS",
+    "COLOURSPACE_MODELS_POLAR_CONVERSION",
     "COLOUR_PRIMARIES_ITUTH273",
     "CV_range",
     "DATA_MACADAM_1942_ELLIPSES",
@@ -706,14 +704,10 @@ __all__ += [
     "JMh_CIECAM02_to_CAM02SCD",
     "JMh_CIECAM02_to_CAM02UCS",
     "Jzazbz_to_XYZ",
-    "LCHab_to_Lab",
-    "LCHuv_to_Luv",
     "LOG_DECODINGS",
     "LOG_ENCODINGS",
     "Lab_to_DIN99",
-    "Lab_to_LCHab",
     "Lab_to_XYZ",
-    "Luv_to_LCHuv",
     "Luv_to_XYZ",
     "Luv_to_uv",
     "Luv_uv_to_xy",
@@ -898,6 +892,17 @@ __all__ += [
     "describe_conversion_path",
     "convert",
 ]
+
+# Programmatically defining the colourspace models polar conversions.
+for _Jab, _JCh in COLOURSPACE_MODELS_POLAR_CONVERSION:
+    for name in (f"{_Jab}_to_{_JCh}", f"{_JCh}_to_{_Jab}"):
+        _module = sys.modules["colour"]
+        _sub_module = sys.modules["colour.models"]
+        setattr(_module, name, getattr(_sub_module, name))
+        __all__.append(name)
+
+del _JCh, _Jab, _module, _sub_module
+
 
 __application_name__ = "Colour"
 

--- a/colour/examples/models/examples_models.py
+++ b/colour/examples/models/examples_models.py
@@ -185,7 +185,7 @@ message_box(
     f'Converting to "CIE L*C*Huv" colourspace from given "CIE L*u*v*" '
     f"colourspace values:\n\n\t{Luv}"
 )
-print(colour.Luv_to_LCHuv(Luv))
+print(colour.Luv_to_LCHuv(Luv))  # pyright: ignore
 
 print("\n")
 
@@ -194,7 +194,7 @@ message_box(
     f'Converting to "CIE L*u*v*" colourspace from given "CIE L*C*Huv" '
     f"colourspace values:\n\n\t{LCHuv}"
 )
-print(colour.LCHuv_to_Luv(LCHuv))
+print(colour.LCHuv_to_Luv(LCHuv))  # pyright: ignore
 
 print("\n")
 
@@ -219,7 +219,7 @@ message_box(
     f'Converting to "CIE L*C*Hab" colourspace from given "CIE L*a*b*" '
     f"colourspace values:\n\n\t{Lab}"
 )
-print(colour.Lab_to_LCHab(Lab))
+print(colour.Lab_to_LCHab(Lab))  # pyright: ignore
 
 print("\n")
 
@@ -228,7 +228,7 @@ message_box(
     f'Converting to "CIE L*a*b*" colourspace from given "CIE L*C*Hab" '
     f"colourspace values:\n\n\t{LCHab}"
 )
-print(colour.LCHab_to_Lab(LCHab))
+print(colour.LCHab_to_Lab(LCHab))  # pyright: ignore
 
 print("\n")
 

--- a/colour/models/__init__.py
+++ b/colour/models/__init__.py
@@ -1,5 +1,6 @@
 import sys
 
+from colour.utilities import copy_definition
 from colour.utilities.deprecation import ModuleAPI, build_API_changes
 from colour.utilities.documentation import is_documentation_building
 
@@ -50,7 +51,7 @@ from .cie_xyy import (
     xy_to_XYZ,
     XYZ_to_xy,
 )
-from .cie_lab import XYZ_to_Lab, Lab_to_XYZ, Lab_to_LCHab, LCHab_to_Lab
+from .cie_lab import XYZ_to_Lab, Lab_to_XYZ
 from .cie_luv import (
     XYZ_to_Luv,
     Luv_to_XYZ,
@@ -58,8 +59,6 @@ from .cie_luv import (
     uv_to_Luv,
     Luv_uv_to_xy,
     xy_to_Luv_uv,
-    Luv_to_LCHuv,
-    LCHuv_to_Luv,
     XYZ_to_CIE1976UCS,
     CIE1976UCS_to_XYZ,
 )
@@ -373,7 +372,125 @@ from .rgb import (
     describe_video_signal_matrix_coefficients,
 )
 
-__all__ = [
+__all__ = []
+
+# Programmatically defining the colourspace models polar conversions.
+COLOURSPACE_MODELS_POLAR_CONVERSION = (
+    ("Lab", "LCHab"),
+    ("Luv", "LCHuv"),
+    ("hdr_CIELab", "hdr_CIELCHab"),
+    ("Hunter_Lab", "Hunter_LCHab"),
+    ("Hunter_Rdab", "Hunter_RdCHab"),
+    ("ICaCb", "IaCH"),
+    ("ICtCp", "ItCH"),
+    ("IgPgTg", "IgCH"),
+    ("IPT", "ICH"),
+    ("Izazbz", "IzCH"),
+    ("Jzazbz", "JzCH"),
+    ("hdr_IPT", "hdr_ICH"),
+    ("Oklab", "Oklch"),
+    ("ProLab", "ProLCHab"),
+    ("IPT_Ragoo2021", "ICHPT_Ragoo2021"),
+)
+
+_DOCSTRING_JAB_TO_JCH = """
+Convert from *{Jab}* colourspace to *{JCh}* colourspace.
+
+This is a convenient definition wrapping :func:`colour.models.Jab_to_JCh`
+definition.
+
+Parameters
+----------
+Jab
+    *{Jab}* colourspace array.
+
+Returns
+-------
+:class:`numpy.ndarray`
+    *{JCh}* colourspace array.
+
+Notes
+-----
++------------+-----------------------+-----------------+
+| **Domain** | **Scale - Reference** | **Scale - 1**   |
++============+=======================+=================+
+| ``Jab``    | ``J`` : [0, 100]      | ``J`` : [0, 1]  |
+|            |                       |                 |
+|            | ``a`` : [-100, 100]   | ``a`` : [-1, 1] |
+|            |                       |                 |
+|            | ``b`` : [-100, 100]   | ``b`` : [-1, 1] |
++------------+-----------------------+-----------------+
+
++------------+-----------------------+-----------------+
+| **Range**  | **Scale - Reference** | **Scale - 1**   |
++============+=======================+=================+
+| ``JCh``    | ``J``  : [0, 100]     | ``J`` : [0, 1]  |
+|            |                       |                 |
+|            | ``C``  : [0, 100]     | ``C`` : [0, 1]  |
+|            |                       |                 |
+|            | ``h`` : [0, 360]      | ``h`` : [0, 1]  |
++------------+-----------------------+-----------------+
+"""
+
+_DOCSTRING_JCH_TO_JAB = """
+Convert from *{JCh}* colourspace to *{Jab}* colourspace.
+
+This is a convenient definition wrapping :func:`colour.models.JCh_to_Jab`
+definition.
+
+Parameters
+----------
+JCh
+    *{JCh}* colourspace array.
+
+Returns
+-------
+:class:`numpy.ndarray`
+    *{Jab}* colourspace array.
+
+Notes
+-----
++-------------+-----------------------+-----------------+
+| **Domain**  | **Scale - Reference** | **Scale - 1**   |
++=============+=======================+=================+
+| ``JCh``     | ``J``  : [0, 100]     | ``J``  : [0, 1] |
+|             |                       |                 |
+|             | ``C``  : [0, 100]     | ``C``  : [0, 1] |
+|             |                       |                 |
+|             | ``h`` : [0, 360]      | ``h`` : [0, 1]  |
++-------------+-----------------------+-----------------+
+
++-------------+-----------------------+-----------------+
+| **Range**   | **Scale - Reference** | **Scale - 1**   |
++=============+=======================+=================+
+| ``Jab``     | ``J`` : [0, 100]      | ``J`` : [0, 1]  |
+|             |                       |                 |
+|             | ``a`` : [-100, 100]   | ``a`` : [-1, 1] |
+|             |                       |                 |
+|             | ``b`` : [-100, 100]   | ``b`` : [-1, 1] |
++-------------+-----------------------+-----------------+
+"""
+
+for _Jab, _JCh in COLOURSPACE_MODELS_POLAR_CONVERSION:
+    name = f"{_Jab}_to_{_JCh}"
+    _callable = copy_definition(Jab_to_JCh, name)
+    _callable.__doc__ = _DOCSTRING_JAB_TO_JCH.format(Jab=_Jab, JCh=_JCh)
+    _module = sys.modules["colour.models"]
+    setattr(_module, name, _callable)
+    __all__.append(name)
+
+    name = f"{_JCh}_to_{_Jab}"
+    _callable = copy_definition(JCh_to_Jab, name)
+    _callable.__doc__ = _DOCSTRING_JCH_TO_JAB.format(JCh=_JCh, Jab=_Jab)
+    _module = sys.modules["colour.models"]
+    setattr(_module, name, _callable)
+    __all__.append(name)
+
+del _DOCSTRING_JAB_TO_JCH, _DOCSTRING_JCH_TO_JAB, _JCh, _Jab, _callable, _module
+
+__all__ += ["COLOURSPACE_MODELS_POLAR"]
+
+__all__ += [
     "COLOURSPACE_MODELS",
     "COLOURSPACE_MODELS_AXIS_LABELS",
     "COLOURSPACE_MODELS_DOMAIN_RANGE_SCALE_1_TO_REFERENCE",
@@ -421,8 +538,6 @@ __all__ += [
 __all__ += [
     "XYZ_to_Lab",
     "Lab_to_XYZ",
-    "Lab_to_LCHab",
-    "LCHab_to_Lab",
 ]
 __all__ += [
     "XYZ_to_Luv",
@@ -431,8 +546,6 @@ __all__ += [
     "uv_to_Luv",
     "Luv_uv_to_xy",
     "xy_to_Luv_uv",
-    "Luv_to_LCHuv",
-    "LCHuv_to_Luv",
     "XYZ_to_CIE1976UCS",
     "CIE1976UCS_to_XYZ",
 ]

--- a/colour/models/cie_lab.py
+++ b/colour/models/cie_lab.py
@@ -6,8 +6,6 @@ Define the *CIE L\\*a\\*b\\** colourspace transformations:
 
 -   :func:`colour.XYZ_to_Lab`
 -   :func:`colour.Lab_to_XYZ`
--   :func:`colour.Lab_to_LCHab`
--   :func:`colour.LCHab_to_Lab`
 
 References
 ----------
@@ -24,7 +22,7 @@ from colour.colorimetry import (
     intermediate_luminance_function_CIE1976,
 )
 from colour.hints import ArrayLike, NDArrayFloat
-from colour.models import Jab_to_JCh, JCh_to_Jab, xy_to_xyY, xyY_to_XYZ
+from colour.models import xy_to_xyY, xyY_to_XYZ
 from colour.utilities import (
     from_range_1,
     from_range_100,
@@ -44,8 +42,6 @@ __status__ = "Production"
 __all__ = [
     "XYZ_to_Lab",
     "Lab_to_XYZ",
-    "Lab_to_LCHab",
-    "LCHab_to_Lab",
 ]
 
 
@@ -190,107 +186,3 @@ def Lab_to_XYZ(
     XYZ = tstack([X, Y, Z])
 
     return from_range_1(XYZ)
-
-
-def Lab_to_LCHab(Lab: ArrayLike) -> NDArrayFloat:
-    """
-    Convert from *CIE L\\*a\\*b\\** colourspace to *CIE L\\*C\\*Hab*
-    colourspace.
-
-    Parameters
-    ----------
-    Lab
-        *CIE L\\*a\\*b\\** colourspace array.
-
-    Returns
-    -------
-    :class:`numpy.ndarray`
-        *CIE L\\*C\\*Hab* colourspace array.
-
-    Notes
-    -----
-    +------------+-----------------------+-----------------+
-    | **Domain** | **Scale - Reference** | **Scale - 1**   |
-    +============+=======================+=================+
-    | ``Lab``    | ``L`` : [0, 100]      | ``L`` : [0, 1]  |
-    |            |                       |                 |
-    |            | ``a`` : [-100, 100]   | ``a`` : [-1, 1] |
-    |            |                       |                 |
-    |            | ``b`` : [-100, 100]   | ``b`` : [-1, 1] |
-    +------------+-----------------------+-----------------+
-
-    +------------+-----------------------+------------------+
-    | **Range**  | **Scale - Reference** | **Scale - 1**    |
-    +============+=======================+==================+
-    | ``LCHab``  | ``L``   : [0, 100]    | ``L``   : [0, 1] |
-    |            |                       |                  |
-    |            | ``C``   : [0, 100]    | ``C``   : [0, 1] |
-    |            |                       |                  |
-    |            | ``Hab`` : [0, 360]    | ``Hab`` : [0, 1] |
-    +------------+-----------------------+------------------+
-
-    References
-    ----------
-    :cite:`CIETC1-482004m`
-
-    Examples
-    --------
-    >>> import numpy as np
-    >>> Lab = np.array([41.52787529, 52.63858304, 26.92317922])
-    >>> Lab_to_LCHab(Lab)  # doctest: +ELLIPSIS
-    array([ 41.5278752...,  59.1242590...,  27.0884878...])
-    """
-
-    return Jab_to_JCh(Lab)
-
-
-def LCHab_to_Lab(LCHab: ArrayLike) -> NDArrayFloat:
-    """
-    Convert from *CIE L\\*C\\*Hab* colourspace to *CIE L\\*a\\*b\\**
-    colourspace.
-
-    Parameters
-    ----------
-    LCHab
-        *CIE L\\*C\\*Hab* colourspace array.
-
-    Returns
-    -------
-    :class:`numpy.ndarray`
-        *CIE L\\*a\\*b\\** colourspace array.
-
-    Notes
-    -----
-    +-------------+-----------------------+------------------+
-    | **Domain**  | **Scale - Reference** | **Scale - 1**    |
-    +=============+=======================+==================+
-    | ``LCHab``   | ``L``   : [0, 100]    | ``L``   : [0, 1] |
-    |             |                       |                  |
-    |             | ``C``   : [0, 100]    | ``C``   : [0, 1] |
-    |             |                       |                  |
-    |             | ``Hab`` : [0, 360]    | ``Hab`` : [0, 1] |
-    +-------------+-----------------------+------------------+
-
-    +-------------+-----------------------+-----------------+
-    | **Range**   | **Scale - Reference** | **Scale - 1**   |
-    +=============+=======================+=================+
-    | ``Lab``     | ``L`` : [0, 100]      | ``L`` : [0, 1]  |
-    |             |                       |                 |
-    |             | ``a`` : [-100, 100]   | ``a`` : [-1, 1] |
-    |             |                       |                 |
-    |             | ``b`` : [-100, 100]   | ``b`` : [-1, 1] |
-    +-------------+-----------------------+-----------------+
-
-    References
-    ----------
-    :cite:`CIETC1-482004m`
-
-    Examples
-    --------
-    >>> import numpy as np
-    >>> LCHab = np.array([41.52787529, 59.12425901, 27.08848784])
-    >>> LCHab_to_Lab(LCHab)  # doctest: +ELLIPSIS
-    array([ 41.5278752...,  52.6385830...,  26.9231792...])
-    """
-
-    return JCh_to_Jab(LCHab)

--- a/colour/models/cie_luv.py
+++ b/colour/models/cie_luv.py
@@ -10,8 +10,6 @@ Define the *CIE L\\*u\\*v\\** colourspace transformations:
 -   :func:`colour.uv_to_Luv`
 -   :func:`colour.Luv_uv_to_xy`
 -   :func:`colour.xy_to_Luv_uv`
--   :func:`colour.Luv_to_LCHuv`
--   :func:`colour.LCHuv_to_Luv`
 -   :func:`colour.XYZ_to_CIE1976UCS`
 -   :func:`colour.CIE1976UCS_to_XYZ`
 
@@ -41,7 +39,7 @@ from colour.colorimetry import (
     luminance_CIE1976,
 )
 from colour.hints import ArrayLike, NDArrayFloat
-from colour.models import Jab_to_JCh, JCh_to_Jab, xy_to_xyY, xyY_to_XYZ
+from colour.models import xy_to_xyY, xyY_to_XYZ
 from colour.utilities import (
     domain_range_scale,
     from_range_1,
@@ -66,8 +64,6 @@ __all__ = [
     "uv_to_Luv",
     "Luv_uv_to_xy",
     "xy_to_Luv_uv",
-    "Luv_to_LCHuv",
-    "LCHuv_to_Luv",
     "XYZ_to_CIE1976UCS",
     "CIE1976UCS_to_XYZ",
 ]
@@ -434,110 +430,6 @@ def xy_to_Luv_uv(xy: ArrayLike) -> NDArrayFloat:
         uv = tstack([sdiv(4 * x, d), sdiv(9 * y, d)])
 
     return uv
-
-
-def Luv_to_LCHuv(Luv: ArrayLike) -> NDArrayFloat:
-    """
-    Convert from *CIE L\\*u\\*v\\** colourspace to *CIE L\\*C\\*Huv*
-    colourspace.
-
-    Parameters
-    ----------
-    Luv
-        *CIE L\\*u\\*v\\** colourspace array.
-
-    Returns
-    -------
-    :class:`numpy.ndarray`
-        *CIE L\\*C\\*Huv* colourspace array.
-
-    Notes
-    -----
-    +------------+-----------------------+-----------------+
-    | **Domain** | **Scale - Reference** | **Scale - 1**   |
-    +============+=======================+=================+
-    | ``Luv``    | ``L`` : [0, 100]      | ``L`` : [0, 1]  |
-    |            |                       |                 |
-    |            | ``u`` : [-100, 100]   | ``u`` : [-1, 1] |
-    |            |                       |                 |
-    |            | ``v`` : [-100, 100]   | ``v`` : [-1, 1] |
-    +------------+-----------------------+-----------------+
-
-    +------------+-----------------------+------------------+
-    | **Range**  | **Scale - Reference** | **Scale - 1**    |
-    +============+=======================+==================+
-    | ``LCHuv``  | ``L``   : [0, 100]    | ``L``   : [0, 1] |
-    |            |                       |                  |
-    |            | ``C``   : [0, 100]    | ``C``   : [0, 1] |
-    |            |                       |                  |
-    |            | ``Huv`` : [0, 360]    | ``Huv`` : [0, 1] |
-    +------------+-----------------------+------------------+
-
-    References
-    ----------
-    :cite:`CIETC1-482004m`
-
-    Examples
-    --------
-    >>> import numpy as np
-    >>> Luv = np.array([41.52787529, 96.83626054, 17.75210149])
-    >>> Luv_to_LCHuv(Luv)  # doctest: +ELLIPSIS
-    array([ 41.5278752...,  98.4499795...,  10.3881634...])
-    """
-
-    return Jab_to_JCh(Luv)
-
-
-def LCHuv_to_Luv(LCHuv: ArrayLike) -> NDArrayFloat:
-    """
-    Convert from *CIE L\\*C\\*Huv* colourspace to *CIE L\\*u\\*v\\**
-    colourspace.
-
-    Parameters
-    ----------
-    LCHuv
-        *CIE L\\*C\\*Huv* colourspace array.
-
-    Returns
-    -------
-    :class:`numpy.ndarray`
-        *CIE L\\*u\\*v\\** colourspace array.
-
-    Notes
-    -----
-    +------------+-----------------------+------------------+
-    | **Domain** | **Scale - Reference** | **Scale - 1**    |
-    +============+=======================+==================+
-    | ``LCHuv``  | ``L``   : [0, 100]    | ``L``   : [0, 1] |
-    |            |                       |                  |
-    |            | ``C``   : [0, 100]    | ``C``   : [0, 1] |
-    |            |                       |                  |
-    |            | ``Huv`` : [0, 360]    | ``Huv`` : [0, 1] |
-    +------------+-----------------------+------------------+
-
-    +------------+-----------------------+-----------------+
-    | **Range**  | **Scale - Reference** | **Scale - 1**   |
-    +============+=======================+=================+
-    | ``Luv``    | ``L`` : [0, 100]      | ``L`` : [0, 1]  |
-    |            |                       |                 |
-    |            | ``u`` : [-100, 100]   | ``u`` : [-1, 1] |
-    |            |                       |                 |
-    |            | ``v`` : [-100, 100]   | ``v`` : [-1, 1] |
-    +------------+-----------------------+-----------------+
-
-    References
-    ----------
-    :cite:`CIETC1-482004m`
-
-    Examples
-    --------
-    >>> import numpy as np
-    >>> LCHuv = np.array([41.52787529, 98.44997950, 10.38816348])
-    >>> LCHuv_to_Luv(LCHuv)  # doctest: +ELLIPSIS
-    array([ 41.5278752...,  96.8362605...,  17.7521014...])
-    """
-
-    return JCh_to_Jab(LCHuv)
 
 
 def XYZ_to_CIE1976UCS(

--- a/colour/models/tests/test_cie_lab.py
+++ b/colour/models/tests/test_cie_lab.py
@@ -5,7 +5,7 @@ from itertools import product
 import numpy as np
 
 from colour.constants import TOLERANCE_ABSOLUTE_TESTS
-from colour.models import Lab_to_LCHab, Lab_to_XYZ, LCHab_to_Lab, XYZ_to_Lab
+from colour.models import Lab_to_XYZ, XYZ_to_Lab
 from colour.utilities import domain_range_scale, ignore_numpy_errors
 
 __author__ = "Colour Developers"
@@ -18,8 +18,6 @@ __status__ = "Production"
 __all__ = [
     "TestXYZ_to_Lab",
     "TestLab_to_XYZ",
-    "TestLab_to_LCHab",
-    "TestLCHab_to_Lab",
 ]
 
 
@@ -241,167 +239,3 @@ class TestLab_to_XYZ:
         cases = [-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan]
         cases = np.array(list(set(product(cases, repeat=3))))
         Lab_to_XYZ(cases, cases[..., 0:2])
-
-
-class TestLab_to_LCHab:
-    """
-    Define :func:`colour.models.cie_lab.Lab_to_LCHab` definition unit tests
-    methods.
-    """
-
-    def test_Lab_to_LCHab(self):
-        """Test :func:`colour.models.cie_lab.Lab_to_LCHab` definition."""
-
-        np.testing.assert_allclose(
-            Lab_to_LCHab(np.array([41.52787529, 52.63858304, 26.92317922])),
-            np.array([41.52787529, 59.12425901, 27.08848784]),
-            atol=TOLERANCE_ABSOLUTE_TESTS,
-        )
-
-        np.testing.assert_allclose(
-            Lab_to_LCHab(np.array([55.11636304, -41.08791787, 30.91825778])),
-            np.array([55.11636304, 51.42135412, 143.03889556]),
-            atol=TOLERANCE_ABSOLUTE_TESTS,
-        )
-
-        np.testing.assert_allclose(
-            Lab_to_LCHab(np.array([29.80565520, 20.01830466, -48.34913874])),
-            np.array([29.80565520, 52.32945383, 292.49133666]),
-            atol=TOLERANCE_ABSOLUTE_TESTS,
-        )
-
-    def test_n_dimensional_Lab_to_LCHab(self):
-        """
-        Test :func:`colour.models.cie_lab.Lab_to_LCHab` definition
-        n-dimensional arrays support.
-        """
-
-        Lab = np.array([41.52787529, 52.63858304, 26.92317922])
-        LCHab = Lab_to_LCHab(Lab)
-
-        Lab = np.tile(Lab, (6, 1))
-        LCHab = np.tile(LCHab, (6, 1))
-        np.testing.assert_allclose(
-            Lab_to_LCHab(Lab), LCHab, atol=TOLERANCE_ABSOLUTE_TESTS
-        )
-
-        Lab = np.reshape(Lab, (2, 3, 3))
-        LCHab = np.reshape(LCHab, (2, 3, 3))
-        np.testing.assert_allclose(
-            Lab_to_LCHab(Lab), LCHab, atol=TOLERANCE_ABSOLUTE_TESTS
-        )
-
-    def test_domain_range_scale_Lab_to_LCHab(self):
-        """
-        Test :func:`colour.models.cie_lab.Lab_to_LCHab` definition domain and
-        range scale support.
-        """
-
-        Lab = np.array([41.52787529, 52.63858304, 26.92317922])
-        LCHab = Lab_to_LCHab(Lab)
-
-        d_r = (
-            ("reference", 1, 1),
-            ("1", 0.01, np.array([0.01, 0.01, 1 / 360])),
-            ("100", 1, np.array([1, 1, 1 / 3.6])),
-        )
-        for scale, factor_a, factor_b in d_r:
-            with domain_range_scale(scale):
-                np.testing.assert_allclose(
-                    Lab_to_LCHab(Lab * factor_a),
-                    LCHab * factor_b,
-                    atol=TOLERANCE_ABSOLUTE_TESTS,
-                )
-
-    @ignore_numpy_errors
-    def test_nan_Lab_to_LCHab(self):
-        """
-        Test :func:`colour.models.cie_lab.Lab_to_LCHab` definition nan
-        support.
-        """
-
-        cases = [-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan]
-        cases = np.array(list(set(product(cases, repeat=3))))
-        Lab_to_LCHab(cases)
-
-
-class TestLCHab_to_Lab:
-    """
-    Define :func:`colour.models.cie_lab.LCHab_to_Lab` definition unit tests
-    methods.
-    """
-
-    def test_LCHab_to_Lab(self):
-        """Test :func:`colour.models.cie_lab.LCHab_to_Lab` definition."""
-
-        np.testing.assert_allclose(
-            LCHab_to_Lab(np.array([41.52787529, 59.12425901, 27.08848784])),
-            np.array([41.52787529, 52.63858304, 26.92317922]),
-            atol=TOLERANCE_ABSOLUTE_TESTS,
-        )
-
-        np.testing.assert_allclose(
-            LCHab_to_Lab(np.array([55.11636304, 51.42135412, 143.03889556])),
-            np.array([55.11636304, -41.08791787, 30.91825778]),
-            atol=TOLERANCE_ABSOLUTE_TESTS,
-        )
-
-        np.testing.assert_allclose(
-            LCHab_to_Lab(np.array([29.80565520, 52.32945383, 292.49133666])),
-            np.array([29.80565520, 20.01830466, -48.34913874]),
-            atol=TOLERANCE_ABSOLUTE_TESTS,
-        )
-
-    def test_n_dimensional_LCHab_to_Lab(self):
-        """
-        Test :func:`colour.models.cie_lab.LCHab_to_Lab` definition
-        n-dimensional arrays support.
-        """
-
-        LCHab = np.array([41.52787529, 59.12425901, 27.08848784])
-        Lab = LCHab_to_Lab(LCHab)
-
-        LCHab = np.tile(LCHab, (6, 1))
-        Lab = np.tile(Lab, (6, 1))
-        np.testing.assert_allclose(
-            LCHab_to_Lab(LCHab), Lab, atol=TOLERANCE_ABSOLUTE_TESTS
-        )
-
-        LCHab = np.reshape(LCHab, (2, 3, 3))
-        Lab = np.reshape(Lab, (2, 3, 3))
-        np.testing.assert_allclose(
-            LCHab_to_Lab(LCHab), Lab, atol=TOLERANCE_ABSOLUTE_TESTS
-        )
-
-    def test_domain_range_scale_LCHab_to_Lab(self):
-        """
-        Test :func:`colour.models.cie_lab.LCHab_to_Lab` definition domain and
-        range scale support.
-        """
-
-        LCHab = np.array([41.52787529, 59.12425901, 27.08848784])
-        Lab = LCHab_to_Lab(LCHab)
-
-        d_r = (
-            ("reference", 1, 1),
-            ("1", np.array([0.01, 0.01, 1 / 360]), 0.01),
-            ("100", np.array([1, 1, 1 / 3.6]), 1),
-        )
-        for scale, factor_a, factor_b in d_r:
-            with domain_range_scale(scale):
-                np.testing.assert_allclose(
-                    LCHab_to_Lab(LCHab * factor_a),
-                    Lab * factor_b,
-                    atol=TOLERANCE_ABSOLUTE_TESTS,
-                )
-
-    @ignore_numpy_errors
-    def test_nan_LCHab_to_Lab(self):
-        """
-        Test :func:`colour.models.cie_lab.LCHab_to_Lab` definition nan
-        support.
-        """
-
-        cases = [-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan]
-        cases = np.array(list(set(product(cases, repeat=3))))
-        LCHab_to_Lab(cases)

--- a/colour/models/tests/test_cie_luv.py
+++ b/colour/models/tests/test_cie_luv.py
@@ -7,8 +7,6 @@ import numpy as np
 from colour.constants import TOLERANCE_ABSOLUTE_TESTS
 from colour.models import (
     CIE1976UCS_to_XYZ,
-    LCHuv_to_Luv,
-    Luv_to_LCHuv,
     Luv_to_uv,
     Luv_to_XYZ,
     Luv_uv_to_xy,
@@ -33,8 +31,6 @@ __all__ = [
     "Testuv_to_Luv",
     "TestLuv_uv_to_xy",
     "TestXy_to_Luv_uv",
-    "TestLuv_to_LCHuv",
-    "TestLCHuv_to_Luv",
     "TestXYZ_to_CIE1976UCS",
     "TestCIE1976UCS_to_XYZ",
 ]
@@ -597,170 +593,6 @@ class TestXy_to_Luv_uv:
         cases = [-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan]
         cases = np.array(list(set(product(cases, repeat=2))))
         xy_to_Luv_uv(cases)
-
-
-class TestLuv_to_LCHuv:
-    """
-    Define :func:`colour.models.cie_luv.Luv_to_LCHuv` definition unit tests
-    methods.
-    """
-
-    def test_Luv_to_LCHuv(self):
-        """Test :func:`colour.models.cie_luv.Luv_to_LCHuv` definition."""
-
-        np.testing.assert_allclose(
-            Luv_to_LCHuv(np.array([41.52787529, 96.83626054, 17.75210149])),
-            np.array([41.52787529, 98.44997950, 10.38816348]),
-            atol=TOLERANCE_ABSOLUTE_TESTS,
-        )
-
-        np.testing.assert_allclose(
-            Luv_to_LCHuv(np.array([55.11636304, -37.59308176, 44.13768458])),
-            np.array([55.11636304, 57.97736624, 130.42180076]),
-            atol=TOLERANCE_ABSOLUTE_TESTS,
-        )
-
-        np.testing.assert_allclose(
-            Luv_to_LCHuv(np.array([29.80565520, -10.96316802, -65.06751860])),
-            np.array([29.80565520, 65.98464238, 260.43611196]),
-            atol=TOLERANCE_ABSOLUTE_TESTS,
-        )
-
-    def test_n_dimensional_Luv_to_LCHuv(self):
-        """
-        Test :func:`colour.models.cie_luv.Luv_to_LCHuv` definition
-        n-dimensional arrays support.
-        """
-
-        Luv = np.array([41.52787529, 96.83626054, 17.75210149])
-        LCHuv = Luv_to_LCHuv(Luv)
-
-        Luv = np.tile(Luv, (6, 1))
-        LCHuv = np.tile(LCHuv, (6, 1))
-        np.testing.assert_allclose(
-            Luv_to_LCHuv(Luv), LCHuv, atol=TOLERANCE_ABSOLUTE_TESTS
-        )
-
-        Luv = np.reshape(Luv, (2, 3, 3))
-        LCHuv = np.reshape(LCHuv, (2, 3, 3))
-        np.testing.assert_allclose(
-            Luv_to_LCHuv(Luv), LCHuv, atol=TOLERANCE_ABSOLUTE_TESTS
-        )
-
-    def test_domain_range_scale_Luv_to_LCHuv(self):
-        """
-        Test :func:`colour.models.cie_luv.Luv_to_LCHuv` definition domain and
-        range scale support.
-        """
-
-        Luv = np.array([41.52787529, 96.83626054, 17.75210149])
-        LCHuv = Luv_to_LCHuv(Luv)
-
-        d_r = (
-            ("reference", 1, 1),
-            ("1", 0.01, np.array([0.01, 0.01, 1 / 360])),
-            ("100", 1, np.array([1, 1, 1 / 3.6])),
-        )
-        for scale, factor_a, factor_b in d_r:
-            with domain_range_scale(scale):
-                np.testing.assert_allclose(
-                    Luv_to_LCHuv(Luv * factor_a),
-                    LCHuv * factor_b,
-                    atol=TOLERANCE_ABSOLUTE_TESTS,
-                )
-
-    @ignore_numpy_errors
-    def test_nan_Luv_to_LCHuv(self):
-        """
-        Test :func:`colour.models.cie_luv.Luv_to_LCHuv` definition nan
-        support.
-        """
-
-        cases = [-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan]
-        cases = np.array(list(set(product(cases, repeat=3))))
-        Luv_to_LCHuv(cases)
-
-
-class TestLCHuv_to_Luv:
-    """
-    Define :func:`colour.models.cie_luv.LCHuv_to_Luv` definition unit tests
-    methods.
-    """
-
-    def test_LCHuv_to_Luv(self):
-        """Test :func:`colour.models.cie_luv.LCHuv_to_Luv` definition."""
-
-        np.testing.assert_allclose(
-            LCHuv_to_Luv(np.array([41.52787529, 98.44997950, 10.38816348])),
-            np.array([41.52787529, 96.83626054, 17.75210149]),
-            atol=TOLERANCE_ABSOLUTE_TESTS,
-        )
-
-        np.testing.assert_allclose(
-            LCHuv_to_Luv(np.array([55.11636304, 57.97736624, 130.42180076])),
-            np.array([55.11636304, -37.59308176, 44.13768458]),
-            atol=TOLERANCE_ABSOLUTE_TESTS,
-        )
-
-        np.testing.assert_allclose(
-            LCHuv_to_Luv(np.array([29.80565520, 65.98464238, 260.43611196])),
-            np.array([29.80565520, -10.96316802, -65.06751860]),
-            atol=TOLERANCE_ABSOLUTE_TESTS,
-        )
-
-    def test_n_dimensional_LCHuv_to_Luv(self):
-        """
-        Test :func:`colour.models.cie_luv.LCHuv_to_Luv` definition
-        n-dimensional arrays support.
-        """
-
-        LCHuv = np.array([41.52787529, 98.44997950, 10.38816348])
-        Luv = LCHuv_to_Luv(LCHuv)
-
-        Luv = np.tile(Luv, (6, 1))
-        LCHuv = np.tile(LCHuv, (6, 1))
-        np.testing.assert_allclose(
-            LCHuv_to_Luv(LCHuv), Luv, atol=TOLERANCE_ABSOLUTE_TESTS
-        )
-
-        Luv = np.reshape(Luv, (2, 3, 3))
-        LCHuv = np.reshape(LCHuv, (2, 3, 3))
-        np.testing.assert_allclose(
-            LCHuv_to_Luv(LCHuv), Luv, atol=TOLERANCE_ABSOLUTE_TESTS
-        )
-
-    def test_domain_range_scale_LCHuv_to_Lab(self):
-        """
-        Test :func:`colour.models.cie_luv.LCHuv_to_Luv` definition domain and
-        range scale support.
-        """
-
-        LCHuv = np.array([41.52787529, 98.44997950, 10.38816348])
-        Luv = LCHuv_to_Luv(LCHuv)
-
-        d_r = (
-            ("reference", 1, 1),
-            ("1", np.array([0.01, 0.01, 1 / 360]), 0.01),
-            ("100", np.array([1, 1, 1 / 3.6]), 1),
-        )
-        for scale, factor_a, factor_b in d_r:
-            with domain_range_scale(scale):
-                np.testing.assert_allclose(
-                    LCHuv_to_Luv(LCHuv * factor_a),
-                    Luv * factor_b,
-                    atol=TOLERANCE_ABSOLUTE_TESTS,
-                )
-
-    @ignore_numpy_errors
-    def test_nan_LCHuv_to_Luv(self):
-        """
-        Test :func:`colour.models.cie_luv.LCHuv_to_Luv` definition nan
-        support.
-        """
-
-        cases = [-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan]
-        cases = np.array(list(set(product(cases, repeat=3))))
-        LCHuv_to_Luv(cases)
 
 
 class TestXYZ_to_CIE1976UCS:

--- a/colour/notation/munsell.py
+++ b/colour/notation/munsell.py
@@ -144,7 +144,12 @@ from colour.hints import (
     Tuple,
     cast,
 )
-from colour.models import Lab_to_LCHab, XYZ_to_Lab, XYZ_to_xy, xyY_to_XYZ
+from colour.models import Lab_to_LCHab  # pyright: ignore
+from colour.models import (
+    XYZ_to_Lab,
+    XYZ_to_xy,
+    xyY_to_XYZ,
+)
 from colour.notation import MUNSELL_COLOURS_ALL
 from colour.utilities import (
     CACHE_REGISTRY,

--- a/colour/plotting/models.py
+++ b/colour/plotting/models.py
@@ -75,6 +75,7 @@ from colour.hints import (
     Tuple,
     cast,
 )
+from colour.models import LCHab_to_Lab  # pyright: ignore
 from colour.models import (
     CCS_ILLUMINANT_POINTER_GAMUT,
     CCS_POINTER_GAMUT_BOUNDARY,
@@ -85,7 +86,6 @@ from colour.models import (
     DATA_MACADAM_1942_ELLIPSES,
     DATA_POINTER_GAMUT_VOLUME,
     Lab_to_XYZ,
-    LCHab_to_Lab,
     RGB_Colourspace,
     RGB_to_RGB,
     RGB_to_XYZ,

--- a/colour/quality/cqs.py
+++ b/colour/quality/cqs.py
@@ -49,8 +49,8 @@ from colour.hints import (
     Tuple,
     cast,
 )
+from colour.models import Lab_to_LCHab  # pyright: ignore
 from colour.models import (
-    Lab_to_LCHab,
     UCS_to_uv,
     XYZ_to_Lab,
     XYZ_to_UCS,

--- a/colour/volume/pointer_gamut.py
+++ b/colour/volume/pointer_gamut.py
@@ -9,11 +9,11 @@ from __future__ import annotations
 
 from colour.constants import EPSILON
 from colour.hints import ArrayLike, NDArrayFloat
+from colour.models import LCHab_to_Lab  # pyright: ignore
 from colour.models import (
     CCS_ILLUMINANT_POINTER_GAMUT,
     DATA_POINTER_GAMUT_VOLUME,
     Lab_to_XYZ,
-    LCHab_to_Lab,
 )
 from colour.volume import is_within_mesh_volume
 

--- a/docs/colour.models.rst
+++ b/docs/colour.models.rst
@@ -54,8 +54,6 @@ CIE L*a*b* Colourspace
 
     XYZ_to_Lab
     Lab_to_XYZ
-    Lab_to_LCHab
-    LCHab_to_Lab
 
 CIE L*u*v* Colourspace
 ----------------------
@@ -73,8 +71,6 @@ CIE L*u*v* Colourspace
     uv_to_Luv
     Luv_uv_to_xy
     xy_to_Luv_uv
-    Luv_to_LCHuv
-    LCHuv_to_Luv
     XYZ_to_CIE1976UCS
     CIE1976UCS_to_XYZ
 
@@ -366,6 +362,47 @@ Yrg Colourspace - Kirk (2019)
     IZAZBZ_METHODS
     XYZ_to_Izazbz
     Izazbz_to_XYZ
+
+Polar Conversions
+-----------------
+
+``colour``
+
+.. currentmodule:: colour
+
+.. autosummary::
+    :toctree: generated/
+
+    Lab_to_LCHab
+    LCHab_to_Lab
+    Luv_to_LCHuv
+    LCHuv_to_Luv
+    hdr_CIELab_to_hdr_CIELCHab
+    hdr_CIELCHab_to_hdr_CIELab
+    Hunter_Lab_to_Hunter_LCHab
+    Hunter_LCHab_to_Hunter_Lab
+    Hunter_Rdab_to_Hunter_RdCHab
+    Hunter_RdCHab_to_Hunter_Rdab
+    ICaCb_to_IaCH
+    IaCH_to_ICaCb
+    ICtCp_to_ItCH
+    ItCH_to_ICtCp
+    IgPgTg_to_IgCH
+    IgCH_to_IgPgTg
+    IPT_to_ICH
+    ICH_to_IPT
+    Izazbz_to_IzCH
+    IzCH_to_Izazbz
+    Jzazbz_to_JzCH
+    JzCH_to_Jzazbz
+    hdr_IPT_to_hdr_ICH
+    hdr_ICH_to_hdr_IPT
+    Oklab_to_Oklch
+    Oklch_to_Oklab
+    ProLab_to_ProLCHab
+    ProLCHab_to_ProLab
+    IPT_Ragoo2021_to_ICHPT_Ragoo2021
+    ICHPT_Ragoo2021_to_IPT_Ragoo2021
 
 RGB Colourspace and Transformations
 -----------------------------------


### PR DESCRIPTION
<!--
Thank you for taking the time to create this pull request. If it is the first
time you are contributing to a colour-science repository, a contributing guide
is available to guide the process: https://www.colour-science.org/contributing/.
-->

# Summary

This PR implements support for programmatic polar conversions and adds the following definitions:

- `colour.Lab_to_LCHab` *
- `colour.LCHab_to_Lab` *
- `colour.Luv_to_LCHuv` *
- `colour.LCHuv_to_Luv` *
- `colour.hdr_CIELab_to_hdr_CIELCHab`
- `colour.hdr_CIELCHab_to_hdr_CIELab`
- `colour.Hunter_Lab_to_Hunter_LCHab`
- `colour.Hunter_LCHab_to_Hunter_Lab`
- `colour.Hunter_Rdab_to_Hunter_RdCHab`
- `colour.Hunter_RdCHab_to_Hunter_Rdab`
- `colour.ICaCb_to_IaCH`
- `colour.IaCH_to_ICaCb`
- `colour.ICtCp_to_ItCH`
- `colour.ItCH_to_ICtCp`
- `colour.IgPgTg_to_IgCH`
- `colour.IgCH_to_IgPgTg`
- `colour.IPT_to_ICH`
- `colour.ICH_to_IPT`
- `colour.Izazbz_to_IzCH`
- `colour.IzCH_to_Izazbz`
- `colour.Jzazbz_to_JzCH`
- `colour.JzCH_to_Jzazbz`
- `colour.hdr_IPT_to_hdr_ICH`
- `colour.hdr_ICH_to_hdr_IPT`
- `colour.Oklab_to_Oklch`
- `colour.Oklch_to_Oklab`
- `colour.ProLab_to_ProLCHab`
- `colour.ProLCHab_to_ProLab`
- `colour.IPT_Ragoo2021_to_ICHPT_Ragoo2021`
- `colour.ICHPT_Ragoo2021_to_IPT_Ragoo2021`

\* Now programmatically defined.

References #1183.

# Preflight

<!-- Please mark any checkboxes that do not apply to this pull request as [N/A]. -->

**Code Style and Quality**

- [x] Unit tests have been implemented and passed.
- [x] Pyright static checking has been run and passed.
- [x] Pre-commit hooks have been run and passed.
- [x] New transformations have been added to the _Automatic Colour Conversion Graph_.
- [x] New transformations have been exported to the relevant namespaces, e.g. `colour`, `colour.models`.

<!-- The unit tests can be invoked with `poetry run invoke tests` -->
<!-- Pyright can be started with `pyright --skipunannotated` -->

**Documentation**

- [x] New features are documented along with examples if relevant.
- [x] The documentation is [Sphinx](https://www.sphinx-doc.org/en/master/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant.

<!--
Thank you again!
-->
