### PR TITLE
PR: Add `RGB_Colorspace` comparisons

### DIFF
--- a/colour/models/rgb/rgb_colourspace.py
+++ b/colour/models/rgb/rgb_colourspace.py
@@ -26,6 +26,7 @@ References
 from __future__ import annotations
 
 from copy import deepcopy
+from functools import partial
 
 import numpy as np
 
@@ -276,6 +277,63 @@ class RGB_Colourspace:
         self.use_derived_matrix_RGB_to_XYZ = use_derived_matrix_RGB_to_XYZ
         self._use_derived_matrix_XYZ_to_RGB: bool = False
         self.use_derived_matrix_XYZ_to_RGB = use_derived_matrix_XYZ_to_RGB
+
+    def __eq__(self, other: object) -> bool:
+        """Return weather or not two RGB spaces are equivalent and would produce
+        the same results with XYZ_to_RGB and visa-versa. Can detect and compare
+        instances of `partial` for the cctf properties.
+
+        Parameters
+        ----------
+        other : object
+
+        Returns
+        -------
+        bool
+        """
+        if not isinstance(other, RGB_Colourspace):
+            return False
+
+        cctf_decoding_eq: bool
+        if isinstance(self.cctf_decoding, partial) and isinstance(
+            other.cctf_decoding, partial
+        ):
+            cctf_decoding_eq = np.all(
+                (
+                    self.cctf_decoding.func == other.cctf_decoding.func,
+                    np.all(self.cctf_decoding.args == other.cctf_decoding.args),
+                    np.all(self.cctf_decoding.keywords == other.cctf_decoding.keywords),
+                )
+            )
+        else:
+            cctf_decoding_eq = self.cctf_decoding == other.cctf_decoding
+
+        cctf_encoding_eq: bool
+        if isinstance(self.cctf_encoding, partial) and isinstance(
+            other.cctf_encoding, partial
+        ):
+            cctf_encoding_eq = np.all(
+                (
+                    self.cctf_encoding.func == other.cctf_encoding.func,
+                    np.all(self.cctf_encoding.args == other.cctf_encoding.args),
+                    np.all(self.cctf_encoding.keywords == other.cctf_encoding.keywords),
+                )
+            )
+        else:
+            cctf_encoding_eq = self.cctf_encoding == other.cctf_encoding
+
+        return np.all(
+            (
+                self.name == other.name,
+                np.all(self.primaries == other.primaries),
+                np.all(self.whitepoint == self.whitepoint),
+                self.whitepoint_name == self.whitepoint_name,
+                np.all(self.matrix_RGB_to_XYZ == other.matrix_RGB_to_XYZ),
+                np.all(self.matrix_XYZ_to_RGB == other.matrix_XYZ_to_RGB),
+                cctf_decoding_eq,
+                cctf_encoding_eq,
+            )
+        )
 
     @property
     def name(self) -> str:

--- a/colour/models/rgb/transfer_functions/gamma.py
+++ b/colour/models/rgb/transfer_functions/gamma.py
@@ -25,15 +25,87 @@ __status__ = "Production"
 
 __all__ = [
     "gamma_function",
+    "GammaFunction",
 ]
+
+NegativeNumberHandlingType = (
+    Literal["Clamp", "Indeterminate", "Mirror", "Preserve"] | str
+)
+
+
+class GammaFunction:
+    """Provides an object oriented interface to contain optional parameters for
+    an underlying :func:gamma_function call. Useful for providing both a simpler
+    and constructed api for gamma_function as well as allowing for control flow.
+    """
+
+    def __init__(
+        self,
+        exponent: float = 1,
+        negative_number_handling: NegativeNumberHandlingType = "Indeterminate",
+    ):
+        """
+        Construct an object oriented interface to contain optional parameters for
+        an underlying :func:gamma_function call. Useful for providing both a simpler
+        and constructed api for gamma_function as well as allowing for control flow.
+
+        Parameters
+        ----------
+        exponent : float, optional
+            The exponent value in a^b, by default 1
+        negative_number_handling : NegativeNumberHandlingType, optional
+            Defines the behavior for negative number handling, by default
+            "Indeterminate"
+
+        See Also
+        --------
+        :func:gamma_function
+        """
+        self._exponent = exponent
+        self._negative_number_handling = negative_number_handling
+
+    @property
+    def exponent(self) -> float:
+        """The exponent, b, in the function a^b
+
+        Returns
+        -------
+        float
+        """
+        return self._exponent
+
+    @property
+    def negative_number_handling(self) -> NegativeNumberHandlingType:
+        """How to treat negative numbers. See also :func:gamma_function
+
+        Returns
+        -------
+        NegativeNumberHandlingType
+            See also :func:gamma_function
+        """
+        return self._negative_number_handling
+
+    def __call__(self, a: ArrayLike):
+        """Calculate a typical encoding / decoding function on `a`. Representative
+        of the function a ^ b where b is determined by the instance value of
+        `exponent` and negative handling behavior is defined by the instance
+        value `negative_number_handling`. See also :func:gamma_function
+
+        Parameters
+        ----------
+        a : ArrayLike
+        """
+        return gamma_function(
+            a,
+            exponent=self.exponent,
+            negative_number_handling=self.negative_number_handling,
+        )
 
 
 def gamma_function(
     a: ArrayLike,
     exponent: ArrayLike = 1,
-    negative_number_handling: (
-        Literal["Clamp", "Indeterminate", "Mirror", "Preserve"] | str
-    ) = "Indeterminate",
+    negative_number_handling: NegativeNumberHandlingType = "Indeterminate",
 ) -> NDArrayFloat:
     """
     Define a typical gamma encoding / decoding function.

--- a/colour/models/rgb/transfer_functions/gamma.py
+++ b/colour/models/rgb/transfer_functions/gamma.py
@@ -101,6 +101,26 @@ class GammaFunction:
             negative_number_handling=self.negative_number_handling,
         )
 
+    def __eq__(self, other: object) -> bool:
+        """Return if two gamma functions have the same parameters and therefore
+        produce the same results
+
+        Parameters
+        ----------
+        other : object
+
+        Returns
+        -------
+        bool
+        """
+        if not isinstance(other, GammaFunction):
+            return False
+
+        return (
+            self.exponent == other.exponent
+            and self.negative_number_handling == other.negative_number_handling
+        )
+
 
 def gamma_function(
     a: ArrayLike,

--- a/colour/models/rgb/transfer_functions/tests/test_gamma.py
+++ b/colour/models/rgb/transfer_functions/tests/test_gamma.py
@@ -3,11 +3,11 @@ Define the unit tests for the
 :mod:`colour.models.rgb.transfer_functions.gamma` module.
 """
 
-
 import numpy as np
 
 from colour.constants import TOLERANCE_ABSOLUTE_TESTS
 from colour.models.rgb.transfer_functions import gamma_function
+from colour.models.rgb.transfer_functions.gamma import GammaFunction
 from colour.utilities import ignore_numpy_errors
 
 __author__ = "Colour Developers"
@@ -20,6 +20,199 @@ __status__ = "Production"
 __all__ = [
     "TestGammaFunction",
 ]
+
+
+class TestGammaFunctionClass:
+    def test_gamma_function_class(self):
+        """
+        Test :func:`colour.models.rgb.transfer_functions.gamma.\
+        gamma_function` definition.
+        """
+
+        np.testing.assert_allclose(
+            GammaFunction(2.2)(0.0), 0.0, atol=TOLERANCE_ABSOLUTE_TESTS
+        )
+
+        np.testing.assert_allclose(
+            GammaFunction(2.2)(0.18),
+            0.022993204992707,
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+        np.testing.assert_allclose(
+            GammaFunction(1.0 / 2.2)(0.022993204992707),
+            0.18,
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+        np.testing.assert_allclose(
+            GammaFunction(2.0)(-0.18),
+            0.0323999999999998,
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+        np.testing.assert_array_equal(GammaFunction(2.2)(-0.18), np.nan)
+
+        np.testing.assert_allclose(
+            GammaFunction(2.2, "Mirror")(-0.18),
+            -0.022993204992707,
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+        np.testing.assert_allclose(
+            GammaFunction(2.2, "Preserve")(-0.18),
+            -0.18,
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+        np.testing.assert_allclose(
+            GammaFunction(2.2, "Clamp")(-0.18),
+            0,
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+        np.testing.assert_array_equal(GammaFunction(-2.2)(-0.18), np.nan)
+
+        np.testing.assert_allclose(
+            GammaFunction(-2.2, "Mirror")(0.0),
+            0.0,
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+        np.testing.assert_allclose(
+            GammaFunction(2.2, "Preserve")(0.0),
+            0.0,
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+        np.testing.assert_allclose(
+            GammaFunction(2.2, "Clamp")(0.0), 0, atol=TOLERANCE_ABSOLUTE_TESTS
+        )
+
+    def test_n_dimensional_gamma_function(self):
+        """
+        Test :func:`colour.models.rgb.transfer_functions.gamma.\
+gamma_function` definition n-dimensional arrays support.
+        """
+
+        a = 0.18
+        a_p = GammaFunction(2.2)(a)
+
+        a = np.tile(a, 6)
+        a_p = np.tile(a_p, 6)
+        np.testing.assert_allclose(
+            GammaFunction(2.2)(a), a_p, atol=TOLERANCE_ABSOLUTE_TESTS
+        )
+
+        a = np.reshape(a, (2, 3))
+        a_p = np.reshape(a_p, (2, 3))
+        np.testing.assert_allclose(
+            GammaFunction(2.2)(a), a_p, atol=TOLERANCE_ABSOLUTE_TESTS
+        )
+
+        a = np.reshape(a, (2, 3, 1))
+        a_p = np.reshape(a_p, (2, 3, 1))
+        np.testing.assert_allclose(
+            GammaFunction(2.2)(a), a_p, atol=TOLERANCE_ABSOLUTE_TESTS
+        )
+
+        a = -0.18
+        a_p = -0.022993204992707
+        np.testing.assert_allclose(
+            GammaFunction(2.2, "Mirror")(a),
+            a_p,
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+        a = np.tile(a, 6)
+        a_p = np.tile(a_p, 6)
+        np.testing.assert_allclose(
+            GammaFunction(2.2, "Mirror")(a),
+            a_p,
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+        a = np.reshape(a, (2, 3))
+        a_p = np.reshape(a_p, (2, 3))
+        np.testing.assert_allclose(
+            GammaFunction(2.2, "Mirror")(a),
+            a_p,
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+        a = np.reshape(a, (2, 3, 1))
+        a_p = np.reshape(a_p, (2, 3, 1))
+        np.testing.assert_allclose(
+            GammaFunction(2.2, "Mirror")(a),
+            a_p,
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+        a = -0.18
+        a_p = -0.18
+        np.testing.assert_allclose(
+            GammaFunction(2.2, "Preserve")(a),
+            a_p,
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+        a = np.tile(a, 6)
+        a_p = np.tile(a_p, 6)
+        np.testing.assert_allclose(
+            GammaFunction(2.2, "Preserve")(a),
+            a_p,
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+        a = np.reshape(a, (2, 3))
+        a_p = np.reshape(a_p, (2, 3))
+        np.testing.assert_allclose(
+            GammaFunction(2.2, "Preserve")(a),
+            a_p,
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+        a = np.reshape(a, (2, 3, 1))
+        a_p = np.reshape(a_p, (2, 3, 1))
+        np.testing.assert_allclose(
+            GammaFunction(2.2, "Preserve")(a),
+            a_p,
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+        a = -0.18
+        a_p = 0.0
+        np.testing.assert_allclose(
+            GammaFunction(2.2, "Clamp")(a), a_p, atol=TOLERANCE_ABSOLUTE_TESTS
+        )
+
+        a = np.tile(a, 6)
+        a_p = np.tile(a_p, 6)
+        np.testing.assert_allclose(
+            GammaFunction(2.2, "Clamp")(a), a_p, atol=TOLERANCE_ABSOLUTE_TESTS
+        )
+
+        a = np.reshape(a, (2, 3))
+        a_p = np.reshape(a_p, (2, 3))
+        np.testing.assert_allclose(
+            GammaFunction(2.2, "Clamp")(a), a_p, atol=TOLERANCE_ABSOLUTE_TESTS
+        )
+
+        a = np.reshape(a, (2, 3, 1))
+        a_p = np.reshape(a_p, (2, 3, 1))
+        np.testing.assert_allclose(
+            GammaFunction(2.2, "Clamp")(a), a_p, atol=TOLERANCE_ABSOLUTE_TESTS
+        )
+
+    @ignore_numpy_errors
+    def test_nan_gamma_function(self):
+        """
+        Test :func:`colour.models.rgb.transfer_functions.gamma.\
+gamma_function` definition nan support.
+        """
+
+        cases = [-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan]
+        GammaFunction(cases)(cases)
 
 
 class TestGammaFunction:

--- a/colour/models/rgb/transfer_functions/tests/test_gamma.py
+++ b/colour/models/rgb/transfer_functions/tests/test_gamma.py
@@ -204,6 +204,16 @@ gamma_function` definition n-dimensional arrays support.
             GammaFunction(2.2, "Clamp")(a), a_p, atol=TOLERANCE_ABSOLUTE_TESTS
         )
 
+    def test__eq__(self):
+        g1 = GammaFunction(exponent=3, negative_number_handling="Clip")
+        g2 = GammaFunction(exponent=3, negative_number_handling="Clip")
+        g3 = GammaFunction(exponent=4, negative_number_handling="Clip")
+        g4 = GammaFunction(exponent=3, negative_number_handling="Mirror")
+
+        assert g1 == g2
+        assert g1 != g3
+        assert g1 != g4
+
     @ignore_numpy_errors
     def test_nan_gamma_function(self):
         """


### PR DESCRIPTION
<!--
Thank you for taking the time to create this pull request. If it is the first
time you are contributing to a colour-science repository, a contributing guide
is available to guide the process: https://www.colour-science.org/contributing/.
-->

# Summary

Adds a class to encapsulate initialized functionality of gamma_function. Useful for passing around gamma functions in a dynamic way.

Ahead of #1268, needs to be merged first

# Preflight

<!-- Please mark any checkboxes that do not apply to this pull request as [N/A]. -->

**Code Style and Quality**

- [x] Unit tests have been implemented and passed.
- [x] Pyright static checking has been run and passed.
- [x] Pre-commit hooks have been run and passed.
- [ ] ~New transformations have been added to the _Automatic Colour Conversion Graph_.~
- [ ] ~New transformations have been exported to the relevant namespaces, e.g. `colour`, `colour.models`.~

<!-- The unit tests can be invoked with `poetry run invoke tests` -->
<!-- Pyright can be started with `pyright --skipunannotated` -->

**Documentation**

- [x] New features are documented along with examples if relevant.
- [ ] The documentation is [Sphinx](https://www.sphinx-doc.org/en/master/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant.

<!--
Thank you again!
-->
