### PR TITLE
PR: Numpy 2 Compatibility: Replace `np.float_` w/ `np.double`.

### DIFF
--- a/colour/constants/common.py
+++ b/colour/constants/common.py
@@ -48,7 +48,7 @@ Integer threshold value when checking if a float point number is almost an
 int.
 """
 
-EPSILON: float = cast(float, np.finfo(np.float_).eps)
+EPSILON: float = cast(float, np.finfo(np.double).eps)
 """
 Default epsilon value for tolerance and singularities avoidance in various
 computations.


### PR DESCRIPTION
<!--
Thank you for taking the time to create this pull request. If it is the first
time you are contributing to a colour-science repository, a contributing guide
is available to guide the process: https://www.colour-science.org/contributing/.
-->

# Summary

Replace np.float_ with np.double for numpy 2.0 compatibility. This allows importing the colour module without error again. ( #1273 )