### PR TITLE
PR: Use `colour.algebra.spow` in *ITU-R BT.1886* colour component transfer functions

### DIFF
--- a/colour/models/rgb/transfer_functions/itur_bt_1886.py
+++ b/colour/models/rgb/transfer_functions/itur_bt_1886.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import numpy as np
 
+from colour.algebra import spow
 from colour.hints import ArrayLike, NDArrayFloat
 from colour.utilities import as_float, from_range_1, to_domain_1
 
@@ -91,7 +92,7 @@ def eotf_inverse_BT1886(L: ArrayLike, L_B: float = 0, L_W: float = 1) -> NDArray
     a = n**gamma
     b = L_B**gamma_d / n
 
-    V = (L / a) ** gamma_d - b
+    V = spow(L / a, gamma_d) - b
 
     return as_float(from_range_1(V))
 
@@ -151,6 +152,6 @@ def eotf_BT1886(V: ArrayLike, L_B: float = 0, L_W: float = 1) -> NDArrayFloat:
     n = L_W**gamma_d - L_B**gamma_d
     a = n**gamma
     b = L_B**gamma_d / n
-    L = a * np.maximum(V + b, 0) ** gamma
+    L = a * spow(np.maximum(V + b, 0), gamma)
 
     return as_float(from_range_1(L))


### PR DESCRIPTION
<!--
Thank you for taking the time to create this pull request. If it is the first
time you are contributing to a colour-science repository, a contributing guide
is available to guide the process: https://www.colour-science.org/contributing/.
-->

# Summary

This PR ensures that `colour.algebra.spow` is used in *ITU-R BT.1886* colour component transfer functions to avoid NaN generation when negative values are passed.

References #1295

# Preflight

<!-- Please mark any checkboxes that do not apply to this pull request as [N/A]. -->

**Code Style and Quality**

- [x] Unit tests have been implemented and passed.
- [x] Pyright static checking has been run and passed.
- [x] Pre-commit hooks have been run and passed.
- [N/A] New transformations have been added to the _Automatic Colour Conversion Graph_.
- [N/A] New transformations have been exported to the relevant namespaces, e.g. `colour`, `colour.models`.

<!-- The unit tests can be invoked with `poetry run invoke tests` -->
<!-- Pyright can be started with `pyright --skipunannotated` -->

**Documentation**

- [N/A] New features are documented along with examples if relevant.
- [N/A] The documentation is [Sphinx](https://www.sphinx-doc.org/en/master/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant.

<!--
Thank you again!
-->
