### PR TITLE
PR: Implement support for Python 3.13.

### DIFF
--- a/.github/workflows/continuous-integration-documentation.yml
+++ b/.github/workflows/continuous-integration-documentation.yml
@@ -22,7 +22,7 @@ jobs:
           echo "COLOUR_SCIENCE__DOCUMENTATION_BUILD=True" >> $GITHUB_ENV
         shell: bash
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Dependencies

--- a/.github/workflows/continuous-integration-quality-unit-tests.yml
+++ b/.github/workflows/continuous-integration-quality-unit-tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: ["3.10", 3.11, 3.12]
+        python-version: ["3.10", 3.11, 3.12, 3.13]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -24,11 +24,11 @@ jobs:
           echo "OMP_NUM_THREADS=1" >> $GITHUB_ENV
         shell: bash
       - name: Set up Python 3.10 for Pre-Commit
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Dependencies (macOS)

--- a/.github/workflows/continuous-integration-static-type-checking.yml
+++ b/.github/workflows/continuous-integration-static-type-checking.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest]
-        python-version: [3.12]
+        python-version: [3.13]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -18,7 +18,7 @@ jobs:
           echo "CI_PACKAGE=colour" >> $GITHUB_ENV
         shell: bash
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Dependencies (macOS)
@@ -30,7 +30,7 @@ jobs:
           echo "IMAGEIO_FREEIMAGE_LIB=/opt/homebrew/Cellar/freeimage/3.18.0/lib/libfreeimage.3.18.0.dylib" >> $GITHUB_ENV
       - name: Install Package Dependencies
         run: |
-          pip install -r requirements.txt
+          cat requirements.txt | grep -Eo '(^[^#]+)' | xargs -n 1 pip install || true
       - name: Static Type Checking
         run: |
           pyright --threads --skipunannotated

--- a/colour/examples/io/examples_ctl.py
+++ b/colour/examples/io/examples_ctl.py
@@ -4,66 +4,46 @@ import os
 import tempfile
 
 import colour
-from colour.utilities import message_box
+from colour.utilities import is_ctlrender_installed, message_box
 
-ROOT_RESOURCES = os.path.join(
-    os.path.dirname(__file__), "..", "..", "io", "tests", "resources"
-)
+if is_ctlrender_installed():
+    ROOT_RESOURCES = os.path.join(
+        os.path.dirname(__file__), "..", "..", "io", "tests", "resources"
+    )
 
-message_box("Color Transformation Language (CTL)")
+    message_box("Color Transformation Language (CTL)")
 
-message_box('Using a "CTL" string and the "float" template to transform an image.')
+    message_box('Using a "CTL" string and the "float" template to transform an image.')
 
-ctl_adjust_exposure_float = colour.io.template_ctl_transform_float(
-    "rIn * pow(2, exposure)",
-    "gIn * pow(2, exposure)",
-    "bIn * pow(2, exposure)",
-    description="Adjust Exposure",
-    parameters=["input float exposure = 0.0"],
-)
-print(ctl_adjust_exposure_float)
-path_input = os.path.join(ROOT_RESOURCES, "CMS_Test_Pattern.exr")
-_descriptor, path_output = tempfile.mkstemp(suffix=".exr")
-colour.io.ctl_render(
-    path_input,
-    path_output,
-    {ctl_adjust_exposure_float: ["-param1 exposure 3.0"]},
-    "-verbose",
-    "-force",
-)
-print(colour.read_image(path_output)[:3])
+    ctl_adjust_exposure_float = colour.io.template_ctl_transform_float(
+        "rIn * pow(2, exposure)",
+        "gIn * pow(2, exposure)",
+        "bIn * pow(2, exposure)",
+        description="Adjust Exposure",
+        parameters=["input float exposure = 0.0"],
+    )
+    print(ctl_adjust_exposure_float)
+    path_input = os.path.join(ROOT_RESOURCES, "CMS_Test_Pattern.exr")
+    _descriptor, path_output = tempfile.mkstemp(suffix=".exr")
+    colour.io.ctl_render(
+        path_input,
+        path_output,
+        {ctl_adjust_exposure_float: ["-param1 exposure 3.0"]},
+        "-verbose",
+        "-force",
+    )
+    print(colour.read_image(path_output)[:3])
 
-print("\n")
+    print("\n")
 
-message_box(
-    'Using a "CTL" "float" template based transform file to transform an image.'
-)
+    message_box(
+        'Using a "CTL" "float" template based transform file to transform an image.'
+    )
 
-path_input = os.path.join(ROOT_RESOURCES, "CMS_Test_Pattern.exr")
-colour.io.ctl_render(
-    path_input,
-    path_output,
-    {
-        os.path.join(ROOT_RESOURCES, "Adjust_Exposure_Float.ctl"): [
-            "-param1 exposure 3.0"
-        ]
-    },
-    "-verbose",
-    "-force",
-)
-print(colour.read_image(path_output)[:3])
-
-print("\n")
-
-message_box(
-    'Using a "CTL" "float" template based transform file to transform an array.'
-)
-
-print(os.path.join(ROOT_RESOURCES, "Adjust_Exposure_Float.ctl"))
-a = colour.utilities.full((4, 2, 3), 0.18)  # pyright: ignore
-print(
-    colour.io.process_image_ctl(
-        a,
+    path_input = os.path.join(ROOT_RESOURCES, "CMS_Test_Pattern.exr")
+    colour.io.ctl_render(
+        path_input,
+        path_output,
         {
             os.path.join(ROOT_RESOURCES, "Adjust_Exposure_Float.ctl"): [
                 "-param1 exposure 3.0"
@@ -72,72 +52,73 @@ print(
         "-verbose",
         "-force",
     )
-)
+    print(colour.read_image(path_output)[:3])
 
-print("\n")
+    print("\n")
 
-message_box('Using a "CTL" string and the "float3" template to transform an image.')
+    message_box(
+        'Using a "CTL" "float" template based transform file to transform an array.'
+    )
 
-ctl_adjust_exposure_float3 = colour.io.template_ctl_transform_float3(
-    "adjust_exposure(rgbIn, exposure)",
-    description="Adjust Exposure",
-    header="""
-float[3] adjust_exposure(float rgbIn[3], float exposureIn)
-{
-    float rgbOut[3];
+    print(os.path.join(ROOT_RESOURCES, "Adjust_Exposure_Float.ctl"))
+    a = colour.utilities.full((4, 2, 3), 0.18)  # pyright: ignore
+    print(
+        colour.io.process_image_ctl(
+            a,
+            {
+                os.path.join(ROOT_RESOURCES, "Adjust_Exposure_Float.ctl"): [
+                    "-param1 exposure 3.0"
+                ]
+            },
+            "-verbose",
+            "-force",
+        )
+    )
 
-    float exposure = pow(2, exposureIn);
+    print("\n")
 
-    rgbOut[0] = rgbIn[0] * exposure;
-    rgbOut[1] = rgbIn[1] * exposure;
-    rgbOut[2] = rgbIn[2] * exposure;
+    message_box('Using a "CTL" string and the "float3" template to transform an image.')
 
-    return rgbOut;
-}\n"""[1:],
-    parameters=["input float exposure = 0.0"],
-)
-print(ctl_adjust_exposure_float3)
-path_input = os.path.join(ROOT_RESOURCES, "CMS_Test_Pattern.exr")
-colour.io.ctl_render(
-    path_input,
-    path_output,
-    {ctl_adjust_exposure_float3: ["-param1 exposure 3.0"]},
-    "-verbose",
-    "-force",
-)
-print(colour.read_image(path_output)[:3])
-
-print("\n")
-
-message_box(
-    'Using a "CTL" "float3" template based transform file to transform an image.'
-)
-
-path_input = os.path.join(ROOT_RESOURCES, "CMS_Test_Pattern.exr")
-_descriptor, path_output = tempfile.mkstemp(suffix=".exr")
-colour.io.ctl_render(
-    path_input,
-    path_output,
+    ctl_adjust_exposure_float3 = colour.io.template_ctl_transform_float3(
+        "adjust_exposure(rgbIn, exposure)",
+        description="Adjust Exposure",
+        header="""
+    float[3] adjust_exposure(float rgbIn[3], float exposureIn)
     {
-        os.path.join(ROOT_RESOURCES, "Adjust_Exposure_Float3.ctl"): [
-            "-param1 exposure 3.0"
-        ]
-    },
-    "-verbose",
-    "-force",
-)
-print(colour.read_image(path_output)[:3])
-os.remove(path_output)
+        float rgbOut[3];
 
-print("\n")
+        float exposure = pow(2, exposureIn);
 
-message_box(
-    'Using a "CTL" "float3" template based transform file to transform an array.'
-)
+        rgbOut[0] = rgbIn[0] * exposure;
+        rgbOut[1] = rgbIn[1] * exposure;
+        rgbOut[2] = rgbIn[2] * exposure;
 
-print(
-    colour.io.process_image_ctl(
-        a,
+        return rgbOut;
+    }\n"""[1:],
+        parameters=["input float exposure = 0.0"],
+    )
+    print(ctl_adjust_exposure_float3)
+    path_input = os.path.join(ROOT_RESOURCES, "CMS_Test_Pattern.exr")
+    colour.io.ctl_render(
+        path_input,
+        path_output,
+        {ctl_adjust_exposure_float3: ["-param1 exposure 3.0"]},
+        "-verbose",
+        "-force",
+    )
+    print(colour.read_image(path_output)[:3])
+
+    print("\n")
+
+    message_box(
+        'Using a "CTL" "float3" template based transform file to transform an image.'
+    )
+
+    path_input = os.path.join(ROOT_RESOURCES, "CMS_Test_Pattern.exr")
+    _descriptor, path_output = tempfile.mkstemp(suffix=".exr")
+    colour.io.ctl_render(
+        path_input,
+        path_output,
         {
             os.path.join(ROOT_RESOURCES, "Adjust_Exposure_Float3.ctl"): [
                 "-param1 exposure 3.0"
@@ -146,102 +127,126 @@ print(
         "-verbose",
         "-force",
     )
-)
+    print(colour.read_image(path_output)[:3])
+    os.remove(path_output)
 
-print("\n")
+    print("\n")
 
-ROOT_ACES_DEV_TRANSFORMS = os.path.abspath(
-    os.path.join(
-        os.path.dirname(__file__),
-        "..",
-        "..",
-        "..",
-        "..",
-        "..",
-        "ampas",
-        "aces-dev",
-        "transforms",
-        "ctl",
+    message_box(
+        'Using a "CTL" "float3" template based transform file to transform an array.'
     )
-)
 
-if os.path.exists(ROOT_ACES_DEV_TRANSFORMS):
-    message_box('Running the "aces-dev" "RRT" "CTL" function to transform an array.')
-
-    CTL_MODULE_PATH = (
-        f"{ROOT_ACES_DEV_TRANSFORMS}:"
-        f"{ROOT_ACES_DEV_TRANSFORMS}/lib:"
-        f"{ROOT_ACES_DEV_TRANSFORMS}/utilities"
-    )
     print(
         colour.io.process_image_ctl(
             a,
-            {f"{ROOT_ACES_DEV_TRANSFORMS}/rrt/RRT.ctl": ["-param1 aIn 1.0"]},
-            env=dict(
-                os.environ,
-                CTL_MODULE_PATH=CTL_MODULE_PATH,
-            ),
+            {
+                os.path.join(ROOT_RESOURCES, "Adjust_Exposure_Float3.ctl"): [
+                    "-param1 exposure 3.0"
+                ]
+            },
+            "-verbose",
+            "-force",
         )
     )
 
     print("\n")
 
-    message_box(
-        'Running the "aces-dev" "Y_2_linCV" "CTL" function to transform an array.'
-    )
-
-    def format_imports(imports):
-        """Format given imports."""
-        return [f'import "{i}";' for i in imports]
-
-    ctl_Y_2_linCV_float = colour.io.template_ctl_transform_float(
-        "Y_2_linCV(rIn, CINEMA_WHITE, CINEMA_BLACK)",
-        "Y_2_linCV(gIn, CINEMA_WHITE, CINEMA_BLACK)",
-        "Y_2_linCV(bIn, CINEMA_WHITE, CINEMA_BLACK)",
-        imports=format_imports(
-            [
-                "ACESlib.Utilities",
-                "ACESlib.Transform_Common",
-                "ACESlib.ODT_Common",
-            ]
-        ),
-    )
-    print(ctl_Y_2_linCV_float)
-    print(
-        colour.io.process_image_ctl(
-            a,
-            [ctl_Y_2_linCV_float],
-            env=dict(
-                os.environ,
-                CTL_MODULE_PATH=CTL_MODULE_PATH,
-            ),
+    ROOT_ACES_DEV_TRANSFORMS = os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "..",
+            "..",
+            "..",
+            "..",
+            "ampas",
+            "aces-dev",
+            "transforms",
+            "ctl",
         )
     )
 
-    print("\n")
+    if os.path.exists(ROOT_ACES_DEV_TRANSFORMS):
+        message_box(
+            'Running the "aces-dev" "RRT" "CTL" function to transform an array.'
+        )
 
-    message_box(
-        'Running the "aces-dev" "darkSurround_to_dimSurround" "CTL" function '
-        "to transform an array."
-    )
-    ctl_darkSurround_to_dimSurround_float3 = colour.io.template_ctl_transform_float3(
-        "darkSurround_to_dimSurround(rgbIn)",
-        imports=format_imports(
-            [
-                "ACESlib.Utilities",
-                "ACESlib.Transform_Common",
-                "ACESlib.ODT_Common",
-            ]
-        ),
-    )
-    print(ctl_darkSurround_to_dimSurround_float3)
-    print(
-        colour.io.process_image_ctl(
-            a,
-            [ctl_darkSurround_to_dimSurround_float3],
-            env=dict(
-                os.environ,
-                CTL_MODULE_PATH=CTL_MODULE_PATH,
+        CTL_MODULE_PATH = (
+            f"{ROOT_ACES_DEV_TRANSFORMS}:"
+            f"{ROOT_ACES_DEV_TRANSFORMS}/lib:"
+            f"{ROOT_ACES_DEV_TRANSFORMS}/utilities"
+        )
+        print(
+            colour.io.process_image_ctl(
+                a,
+                {f"{ROOT_ACES_DEV_TRANSFORMS}/rrt/RRT.ctl": ["-param1 aIn 1.0"]},
+                env=dict(
+                    os.environ,
+                    CTL_MODULE_PATH=CTL_MODULE_PATH,
+                ),
+            )
+        )
+
+        print("\n")
+
+        message_box(
+            'Running the "aces-dev" "Y_2_linCV" "CTL" function to transform an array.'
+        )
+
+        def format_imports(imports):
+            """Format given imports."""
+            return [f'import "{i}";' for i in imports]
+
+        ctl_Y_2_linCV_float = colour.io.template_ctl_transform_float(
+            "Y_2_linCV(rIn, CINEMA_WHITE, CINEMA_BLACK)",
+            "Y_2_linCV(gIn, CINEMA_WHITE, CINEMA_BLACK)",
+            "Y_2_linCV(bIn, CINEMA_WHITE, CINEMA_BLACK)",
+            imports=format_imports(
+                [
+                    "ACESlib.Utilities",
+                    "ACESlib.Transform_Common",
+                    "ACESlib.ODT_Common",
+                ]
             ),
         )
-    )
+        print(ctl_Y_2_linCV_float)
+        print(
+            colour.io.process_image_ctl(
+                a,
+                [ctl_Y_2_linCV_float],
+                env=dict(
+                    os.environ,
+                    CTL_MODULE_PATH=CTL_MODULE_PATH,
+                ),
+            )
+        )
+
+        print("\n")
+
+        message_box(
+            'Running the "aces-dev" "darkSurround_to_dimSurround" "CTL" function '
+            "to transform an array."
+        )
+        ctl_darkSurround_to_dimSurround_float3 = (
+            colour.io.template_ctl_transform_float3(
+                "darkSurround_to_dimSurround(rgbIn)",
+                imports=format_imports(
+                    [
+                        "ACESlib.Utilities",
+                        "ACESlib.Transform_Common",
+                        "ACESlib.ODT_Common",
+                    ]
+                ),
+            )
+        )
+        print(ctl_darkSurround_to_dimSurround_float3)
+        print(
+            colour.io.process_image_ctl(
+                a,
+                [ctl_darkSurround_to_dimSurround_float3],
+                env=dict(
+                    os.environ,
+                    CTL_MODULE_PATH=CTL_MODULE_PATH,
+                ),
+            )
+        )

--- a/colour/examples/io/examples_fichet2021.py
+++ b/colour/examples/io/examples_fichet2021.py
@@ -7,26 +7,29 @@ import os
 import tempfile
 
 import colour
-from colour.utilities import message_box
+from colour.utilities import is_openimageio_installed, message_box
 
-ROOT_RESOURCES = os.path.join(
-    os.path.dirname(__file__), "..", "..", "io", "tests", "resources"
-)
+if is_openimageio_installed():
+    ROOT_RESOURCES = os.path.join(
+        os.path.dirname(__file__), "..", "..", "io", "tests", "resources"
+    )
 
-message_box('"Fichet, Pacanowski and Wilkie (2021)" Spectral Image Reading and Writing')
+    message_box(
+        '"Fichet, Pacanowski and Wilkie (2021)" Spectral Image Reading and Writing'
+    )
 
-message_box("Reading a spectral image.")
-path = os.path.join(ROOT_RESOURCES, "Ohta1997.exr")
-components, specification = colour.read_spectral_image_Fichet2021(
-    path, additional_data=True
-)
-print(components)
-print(specification)
+    message_box("Reading a spectral image.")
+    path = os.path.join(ROOT_RESOURCES, "Ohta1997.exr")
+    components, specification = colour.read_spectral_image_Fichet2021(
+        path, additional_data=True
+    )
+    print(components)
+    print(specification)
 
-print("\n")
+    print("\n")
 
-message_box("Writing a spectral image.")
-_descriptor, path = tempfile.mkstemp(suffix=".exr")
-colour.write_spectral_image_Fichet2021(components, path)  # pyright: ignore
-components = colour.read_spectral_image_Fichet2021(path)
-print(components)
+    message_box("Writing a spectral image.")
+    _descriptor, path = tempfile.mkstemp(suffix=".exr")
+    colour.write_spectral_image_Fichet2021(components, path)  # pyright: ignore
+    components = colour.read_spectral_image_Fichet2021(path)
+    print(components)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,7 +6,7 @@ babel==2.16.0
 beautifulsoup4==4.12.3
 biblib-simple==0.1.2
 certifi==2024.8.30
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
 colorama==0.4.6 ; sys_platform == 'win32' or platform_system == 'Windows'
 contourpy==1.3.0
 cycler==0.12.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "colour-science"
 version = "0.4.4"
 description = "Colour Science for Python"
 readme = "README.rst"
-requires-python = ">=3.10,<3.13"
+requires-python = ">=3.10,<3.14"
 authors = [
     { name = "Colour Developers", email = "colour-developers@colour-science.org" },
 ]
@@ -48,16 +48,16 @@ dependencies = [
     "imageio>=2,<3",
     "numpy>=1.24,<3",
     "scipy>=1.10,<2",
-    "trimesh>=1.16.1",
+    "trimesh>=4",
     "typing-extensions>=4,<5",
 ]
 
 [project.optional-dependencies]
 optional = [
-    "matplotlib>=3.6",
+    "matplotlib>=3.7",
     "networkx>=3,<4",
     "opencolorio>=2,<3",
-    "pandas>=1.5,<3",
+    "pandas>=2,<3",
     "pydot>=3,<4",
     "tqdm>=4,<5",
     "xxhash>=3,<4",
@@ -83,13 +83,13 @@ Changelog = "https://github.com/colour-science/colour/releases"
 [tool.uv]
 package = true
 dev-dependencies = [
-    "coverage>=6,<7",
+    "coverage",
     "coveralls",
     "hatch",
     "invoke",
     "jupyter",
-    "pre-commit>=3.5",
-    "pyright!=1.1.383",
+    "pre-commit",
+    "pyright",
     "pytest",
     "pytest-cov",
     "pytest-xdist",

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,19 +18,19 @@ bleach==6.1.0
 certifi==2024.8.30
 cffi==1.17.1
 cfgv==3.4.0
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
 click==8.1.7
 colorama==0.4.6 ; sys_platform == 'win32' or platform_system == 'Windows'
 comm==0.2.2
 contourpy==1.3.0
-coverage==6.5.0
+coverage==7.6.2
 coveralls==4.0.1
 cryptography==43.0.1 ; sys_platform == 'linux'
 cycler==0.12.1
 debugpy==1.8.6
 decorator==5.1.1
 defusedxml==0.7.1
-distlib==0.3.8
+distlib==0.3.9
 docopt==0.6.2
 docutils==0.21.2
 exceptiongroup==1.2.2 ; python_full_version < '3.11'
@@ -124,7 +124,7 @@ pydata-sphinx-theme==0.15.4
 pydot==3.0.2
 pygments==2.18.0
 pyparsing==3.1.4
-pyright==1.1.382.post1
+pyright==1.1.384
 pytest==8.3.3
 pytest-cov==5.0.0
 pytest-xdist==3.6.1


### PR DESCRIPTION
<!--
Thank you for taking the time to create this pull request. If it is the first
time you are contributing to a colour-science repository, a contributing guide
is available to guide the process: https://www.colour-science.org/contributing/.
-->

# Summary

This PR implements support for Python 3.13.

# Preflight

<!-- Please mark any checkboxes that do not apply to this pull request as [N/A]. -->

**Code Style and Quality**

- [x] Unit tests have been implemented and passed.
- [x] Pyright static checking has been run and passed.
- [x] Pre-commit hooks have been run and passed.
- [N/A] New transformations have been added to the _Automatic Colour Conversion Graph_.
- [N/A] New transformations have been exported to the relevant namespaces, e.g. `colour`, `colour.models`.

<!-- The unit tests can be invoked with `uv run invoke tests` -->
<!-- Pyright can be started with `uv run pyright --threads --skipunannotated` -->

**Documentation**

- [N/A] New features are documented along with examples if relevant.
- [N/A] The documentation is [Sphinx](https://www.sphinx-doc.org/en/master/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant.

<!--
Thank you again!
-->
