### PR TITLE
Change xyY_to_XYZ function to prevent negative floating point error in some cases

### DIFF
--- a/colour/models/cie_xyy.py
+++ b/colour/models/cie_xyy.py
@@ -149,7 +149,7 @@ def xyY_to_XYZ(xyY: ArrayLike) -> NDArrayFloat:
     with sdiv_mode():
         Y_y = sdiv(Y, y)
 
-    XYZ = tstack([x * Y_y, Y, (1 - x - y) * Y_y])
+    XYZ = tstack([x * Y_y, Y, (1 - (x + y)) * Y_y])
 
     return from_range_1(XYZ)
 


### PR DESCRIPTION
Python Example:
1 - 0.680 - 0.320 = -5.551115123125783e-17;
1 - (0.680 + 0.320) = 0.0

<!--
Thank you for taking the time to create this pull request. If it is the first
time you are contributing to a colour-science repository, a contributing guide
is available to guide the process: https://www.colour-science.org/contributing/.
-->

# Summary

<!-- Please write a summary describing the changes that this PR implements. -->

# Preflight

<!-- Please mark any checkboxes that do not apply to this pull request as [N/A]. -->

**Code Style and Quality**

- [x] Unit tests have been implemented and passed.
- [x] Pyright static checking has been run and passed.
- [ ] Pre-commit hooks have been run and passed.
- [ ] New transformations have been added to the _Automatic Colour Conversion Graph_.
- [ ] New transformations have been exported to the relevant namespaces, e.g. `colour`, `colour.models`.

<!-- The unit tests can be invoked with `uv run invoke tests` -->
<!-- Pyright can be started with `uv run pyright --threads --skipunannotated` -->

**Documentation**

- [ ] New features are documented along with examples if relevant.
- [ ] The documentation is [Sphinx](https://www.sphinx-doc.org/en/master/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant.

<!--
Thank you again!
-->
