### PR TITLE
PR: Add `colour.SpectralShape.from_array` class method (constructor).

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,10 @@
+# The pre-commit steps used by colour are:
+# * codespell
+# * isort
+# * ruff-format
+# * ruff --fix
+# * blacken-docs
+# * prettier (with specific fixes)
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: "v5.0.0"

--- a/colour/colorimetry/spectrum.py
+++ b/colour/colorimetry/spectrum.py
@@ -158,6 +158,29 @@ class SpectralShape:
         self.end = end
         self.interval = interval
 
+    @classmethod
+    def from_array(cls, data: ArrayLike) -> SpectralShape:
+        """Alternate constructor, create a SpectralShape from an ArrayLike list
+        of values. Values must be evenly spaced.
+
+        Parameters
+        ----------
+        data : ArrayLike
+            The wavelength list
+
+        Returns
+        -------
+        SpectralShape
+        """
+        data = np.asarray(data)
+
+        spacing = (diff_intermediate := np.diff(data))[0]
+        if ~np.all(diff_intermediate == spacing):
+            error = "data values must have equal spacing"
+            raise RuntimeError(error)
+
+        return SpectralShape(data[0], data[-1], spacing)
+
     @property
     def start(self) -> Real:
         """

--- a/colour/colorimetry/tests/test_spectrum.py
+++ b/colour/colorimetry/tests/test_spectrum.py
@@ -1417,6 +1417,21 @@ class TestSpectralShape:
             np.arange(0, 10 + 0.1, 0.1),
         )
 
+    def test_from_data(self) -> None:
+        """Test :func:`colour.colorimetry.spectrum.SpectralShape.from_array`"""
+        data = np.arange(400, 700 + 1, 10)  # arange generates [start, stop)
+        shape = SpectralShape.from_array(data)
+
+        assert shape.start == 400
+        assert shape.end == 700
+        assert shape.interval == 10
+
+        assert shape == SpectralShape(400, 700, 10)
+
+        with pytest.raises(RuntimeError):
+            data = [400, 450, 500, 555, 600, 650, 700]
+            SpectralShape.from_array(data)
+
 
 class TestSpectralDistribution:
     """

--- a/colour/quality/cfi2017.py
+++ b/colour/quality/cfi2017.py
@@ -42,7 +42,8 @@ from colour.colorimetry import (
 if typing.TYPE_CHECKING:
     from colour.hints import ArrayLike, List, Literal, Tuple
 
-from colour.hints import NDArrayFloat, cast
+from colour.colorimetry.spectrum import SPECTRAL_SHAPE_DEFAULT
+from colour.hints import ArrayLike, List, NDArrayFloat, Tuple, cast
 from colour.models import JMh_CIECAM02_to_CAM02UCS, UCS_to_uv, XYZ_to_UCS
 from colour.temperature import CCT_to_xy_CIE_D, uv_to_CCT_Ohno2013
 from colour.utilities import (
@@ -66,16 +67,16 @@ __email__ = "colour-developers@colour-science.org"
 __status__ = "Production"
 
 __all__ = [
-    "SPECTRAL_SHAPE_CIE2017",
     "ROOT_RESOURCES_CIE2017",
-    "DataColorimetry_TCS_CIE2017",
-    "ColourRendering_Specification_CIE2017",
-    "colour_fidelity_index_CIE2017",
-    "load_TCS_CIE2017",
+    "SPECTRAL_SHAPE_CIE2017",
     "CCT_reference_illuminant",
+    "ColourRendering_Specification_CIE2017",
+    "DataColorimetry_TCS_CIE2017",
+    "colour_fidelity_index_CIE2017",
+    "delta_E_to_R_f",
+    "load_TCS_CIE2017",
     "sd_reference_illuminant",
     "tcs_colorimetry_data",
-    "delta_E_to_R_f",
 ]
 
 SPECTRAL_SHAPE_CIE2017: SpectralShape = SpectralShape(380, 780, 1)
@@ -346,7 +347,9 @@ def CCT_reference_illuminant(sd: SpectralDistribution) -> NDArrayFloat:
     return uv_to_CCT_Ohno2013(UCS_to_uv(XYZ_to_UCS(XYZ)), start=1000, end=25000)
 
 
-def sd_reference_illuminant(CCT: float, shape: SpectralShape) -> SpectralDistribution:
+def sd_reference_illuminant(
+    CCT: float, shape: SpectralShape = SPECTRAL_SHAPE_DEFAULT
+) -> SpectralDistribution:
     """
     Compute the reference illuminant for a given correlated colour temperature
     :math:`T_{cp}` for use in *CIE 2017 Colour Fidelity Index* (CFI)
@@ -357,7 +360,8 @@ def sd_reference_illuminant(CCT: float, shape: SpectralShape) -> SpectralDistrib
     CCT
         Correlated colour temperature :math:`T_{cp}`.
     shape
-        Desired shape of the returned spectral distribution.
+        Desired shape of the returned spectral distribution. Defaults to
+        SPECTRAL_SHAPE_DEFAULT
 
     Returns
     -------

--- a/colour/quality/tests/test_cfi2017.py
+++ b/colour/quality/tests/test_cfi2017.py
@@ -19,6 +19,7 @@ from colour.colorimetry import (
     reshape_sd,
     sd_blackbody,
 )
+from colour.colorimetry.spectrum import SPECTRAL_SHAPE_DEFAULT
 from colour.quality.cfi2017 import (
     CCT_reference_illuminant,
     colour_fidelity_index_CIE2017,
@@ -923,6 +924,14 @@ class TestSdReferenceIlluminant:
     Define :func:`colour.quality.CIE2017.sd_reference_illuminant`
     definition unit tests methods.
     """
+
+    def test_default_args(self) -> None:
+        """Test :func:`color.quality.CIE2017.sd_reference_illuminant` for
+        default shape argument.
+        """
+
+        sd = sd_reference_illuminant(5421)
+        assert sd.shape == SPECTRAL_SHAPE_DEFAULT
 
     def test_sd_reference_illuminant(self) -> None:
         """


### PR DESCRIPTION
This adds a utility constructor for constructing a SpectralShape directly from a list of values.

Not sure if this is already available elsewhere, but if it is then perhaps this organization (placing the method inside the definition of SpectralShape) is better?

‼️Ahead of #1321