### PR TITLE
PR: CRI: Test All Calculated Data

### DIFF
--- a/colour/quality/tests/test_cri.py
+++ b/colour/quality/tests/test_cri.py
@@ -340,7 +340,31 @@ class TestColourRenderingIndex:
         )
 
         np.testing.assert_allclose(
+            specification_r.Q_a, specification_t.Q_a, atol=TOLERANCE_ABSOLUTE_TESTS
+        )
+
+        np.testing.assert_allclose(
             [data.Q_a for _index, data in sorted(specification_r.Q_as.items())],
             [data.Q_a for _index, data in sorted(specification_t.Q_as.items())],
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+        np.testing.assert_allclose(
+            [
+                v
+                for s in specification_r.colorimetry_data
+                for tcs in s
+                for arr in [getattr(tcs, k) for k in ["XYZ", "uv", "UVW"]]
+                if isinstance(arr, np.ndarray)
+                for v in arr
+            ],
+            [
+                v
+                for s in specification_t.colorimetry_data
+                for tcs in s
+                for arr in [getattr(tcs, k) for k in ["XYZ", "uv", "UVW"]]
+                if isinstance(arr, np.ndarray)
+                for v in arr
+            ],
             atol=TOLERANCE_ABSOLUTE_TESTS,
         )


### PR DESCRIPTION
<!--
Thank you for taking the time to create this pull request. If it is the first
time you are contributing to a colour-science repository, a contributing guide
is available to guide the process: https://www.colour-science.org/contributing/.
-->

# Summary

Currently, the CRI test function only tests a subset of the calculated
data. The attribute `Q_a` and the colorimetry data are not tested,
although the reference data object has reference values.
This patch adds the missing tests.

# Preflight

<!-- Please mark any checkboxes that do not apply to this pull request as [N/A]. -->

**Code Style and Quality**

- [ ] Unit tests have been implemented and passed.
- [ ] Pyright static checking has been run and passed.
- [ ] Pre-commit hooks have been run and passed.
- [ ] New transformations have been added to the _Automatic Colour Conversion Graph_.
- [ ] New transformations have been exported to the relevant namespaces, e.g. `colour`, `colour.models`.

<!-- The unit tests can be invoked with `uv run invoke tests` -->
<!-- Pyright can be started with `uv run pyright --threads --skipunannotated` -->

**Documentation**

- [ ] New features are documented along with examples if relevant.
- [ ] The documentation is [Sphinx](https://www.sphinx-doc.org/en/master/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant.

<!--
Thank you again!
-->
