### PR TITLE
PR: Add `scipy-stubs` as development dependency.

### DIFF
--- a/colour/adaptation/cie1994.py
+++ b/colour/adaptation/cie1994.py
@@ -24,7 +24,7 @@ from colour.adaptation import CAT_VON_KRIES
 from colour.algebra import sdiv, sdiv_mode, spow, vecmul
 
 if typing.TYPE_CHECKING:
-    from colour.hints import ArrayLike, NDArrayFloat
+    from colour.hints import ArrayLike, DTypeFloat, NDArray, NDArrayFloat
 
 from colour.utilities import (
     as_float_array,
@@ -290,7 +290,13 @@ def effective_adapting_responses(
     return ((Y_o[..., None] * E_o[..., None]) / (100 * np.pi)) * xez
 
 
-def beta_1(x: ArrayLike) -> NDArrayFloat:
+@typing.overload
+def beta_1(x: float | DTypeFloat) -> DTypeFloat: ...
+@typing.overload
+def beta_1(x: NDArray) -> NDArrayFloat: ...
+@typing.overload
+def beta_1(x: ArrayLike) -> DTypeFloat | NDArrayFloat: ...
+def beta_1(x: ArrayLike) -> DTypeFloat | NDArrayFloat:
     """
     Compute the exponent :math:`\\beta_1` for the middle and long-wavelength
     sensitive cones.
@@ -316,7 +322,13 @@ def beta_1(x: ArrayLike) -> NDArrayFloat:
     return (6.469 + 6.362 * x_p) / (6.469 + x_p)
 
 
-def beta_2(x: ArrayLike) -> NDArrayFloat:
+@typing.overload
+def beta_2(x: float | DTypeFloat) -> DTypeFloat: ...
+@typing.overload
+def beta_2(x: NDArray) -> NDArrayFloat: ...
+@typing.overload
+def beta_2(x: ArrayLike) -> DTypeFloat | NDArrayFloat: ...
+def beta_2(x: ArrayLike) -> DTypeFloat | NDArrayFloat:
     """
     Compute the exponent :math:`\\beta_2` for the short-wavelength sensitive
     cones.

--- a/colour/adaptation/cie1994.py
+++ b/colour/adaptation/cie1994.py
@@ -319,7 +319,7 @@ def beta_1(x: ArrayLike) -> DTypeFloat | NDArrayFloat:
 
     x_p = spow(x, 0.4495)
 
-    return (6.469 + 6.362 * x_p) / (6.469 + x_p)
+    return (x_p * 6.362 + 6.469) / (x_p + 6.469)
 
 
 @typing.overload
@@ -351,7 +351,7 @@ def beta_2(x: ArrayLike) -> DTypeFloat | NDArrayFloat:
 
     x_p = spow(x, 0.5128)
 
-    return 0.7844 * (8.414 + 8.091 * x_p) / (8.414 + x_p)
+    return (x_p * 8.091 + 8.414) * 0.7844 / (x_p + 8.414)
 
 
 def exponential_factors(RGB_o: ArrayLike) -> NDArrayFloat:

--- a/colour/algebra/common.py
+++ b/colour/algebra/common.py
@@ -18,6 +18,8 @@ if typing.TYPE_CHECKING:
         Any,
         ArrayLike,
         Callable,
+        DTypeFloat,
+        NDArray,
         NDArrayFloat,
         Self,
         Tuple,
@@ -436,8 +438,15 @@ class spow_enable:
 
         return wrapper
 
-
-def spow(a: ArrayLike, p: ArrayLike) -> NDArrayFloat:
+@typing.overload
+def spow(a:  float | DTypeFloat, p:  float | DTypeFloat) -> DTypeFloat: ...
+@typing.overload
+def spow(a: NDArray, p: ArrayLike) -> NDArrayFloat: ...
+@typing.overload
+def spow(a: ArrayLike, p: NDArray) -> NDArrayFloat: ...
+@typing.overload
+def spow(a: ArrayLike, p: ArrayLike) -> DTypeFloat | NDArrayFloat: ...
+def spow(a: ArrayLike, p: ArrayLike) -> DTypeFloat | NDArrayFloat:
     """
     Raise given array :math:`a` to the power :math:`p` as follows:
     :math:`sign(a) * |a|^p`.

--- a/colour/algebra/common.py
+++ b/colour/algebra/common.py
@@ -438,8 +438,9 @@ class spow_enable:
 
         return wrapper
 
+
 @typing.overload
-def spow(a:  float | DTypeFloat, p:  float | DTypeFloat) -> DTypeFloat: ...
+def spow(a: float | DTypeFloat, p: float | DTypeFloat) -> DTypeFloat: ...
 @typing.overload
 def spow(a: NDArray, p: ArrayLike) -> NDArrayFloat: ...
 @typing.overload

--- a/colour/algebra/interpolation.py
+++ b/colour/algebra/interpolation.py
@@ -1292,7 +1292,7 @@ class PchipInterpolator(scipy.interpolate.PchipInterpolator):
     """
 
     def __init__(self, x: ArrayLike, y: ArrayLike, *args: Any, **kwargs: Any) -> None:
-        super().__init__(x, y, *args, **kwargs)
+        super().__init__(as_float_array(x), as_float_array(y), *args, **kwargs)
 
         self._y: NDArrayFloat = as_float_array(y)
 

--- a/colour/algebra/tests/test_interpolation.py
+++ b/colour/algebra/tests/test_interpolation.py
@@ -1438,7 +1438,7 @@ class TestPchipInterpolator:
 
         interpolator.y = np.linspace(0, 1, 10)
 
-        assert interpolator(5) == 5
+        assert interpolator(np.array(5)) == 5
 
 
 class TestNullInterpolator:

--- a/colour/appearance/ciecam02.py
+++ b/colour/appearance/ciecam02.py
@@ -1438,10 +1438,10 @@ def temporary_magnitude_quantity_inverse(
     """
 
     C = as_float_array(C)
-    J = np.maximum(J, EPSILON)
+    J_prime = np.maximum(J, EPSILON)
     n = as_float_array(n)
 
-    return spow(C / (np.sqrt(J / 100) * spow(1.64 - 0.29**n, 0.73)), 1 / 0.9)
+    return spow(C / (np.sqrt(J_prime / 100) * spow(1.64 - 0.29**n, 0.73)), 1 / 0.9)
 
 
 def chroma_correlate(

--- a/colour/appearance/hke.py
+++ b/colour/appearance/hke.py
@@ -237,6 +237,7 @@ def coefficient_q_Nayatani1997(
         - 0.00764 * np.sin(theta_4)
     )
 
+
 @typing.overload
 def coefficient_K_Br_Nayatani1997(L_a: float | DTypeFloat) -> DTypeFloat: ...
 @typing.overload

--- a/colour/appearance/hke.py
+++ b/colour/appearance/hke.py
@@ -32,7 +32,7 @@ import numpy as np
 from colour.algebra import spow
 
 if typing.TYPE_CHECKING:
-    from colour.hints import ArrayLike, Literal, NDArrayFloat
+    from colour.hints import ArrayLike, DTypeFloat, Literal, NDArray, NDArrayFloat
 
 from colour.utilities import CanonicalMapping, as_float_array, tsplit, validate_method
 
@@ -237,10 +237,13 @@ def coefficient_q_Nayatani1997(
         - 0.00764 * np.sin(theta_4)
     )
 
-
-def coefficient_K_Br_Nayatani1997(
-    L_a: ArrayLike,
-) -> NDArrayFloat:
+@typing.overload
+def coefficient_K_Br_Nayatani1997(L_a: float | DTypeFloat) -> DTypeFloat: ...
+@typing.overload
+def coefficient_K_Br_Nayatani1997(L_a: NDArray) -> NDArrayFloat: ...
+@typing.overload
+def coefficient_K_Br_Nayatani1997(L_a: ArrayLike) -> DTypeFloat | NDArrayFloat: ...
+def coefficient_K_Br_Nayatani1997(L_a: ArrayLike) -> DTypeFloat | NDArrayFloat:
     """
     Return the :math:`K_{Br}` coefficient for *Nayatani (1997)* *HKE*
     computations.

--- a/colour/appearance/hke.py
+++ b/colour/appearance/hke.py
@@ -280,4 +280,4 @@ def coefficient_K_Br_Nayatani1997(L_a: ArrayLike) -> DTypeFloat | NDArrayFloat:
 
     L_a_4495 = spow(L_a, 0.4495)
 
-    return 0.2717 * (6.469 + 6.362 * L_a_4495) / (6.469 + L_a_4495)
+    return (L_a_4495 * 6.362 + 6.469) * 0.2717 / (L_a_4495 + 6.469)

--- a/colour/appearance/rlab.py
+++ b/colour/appearance/rlab.py
@@ -273,6 +273,7 @@ b=-52.6142956...)
     M = np.matmul(np.matmul(MATRIX_R, row_as_diagonal(LMS_a_L)), MATRIX_XYZ_TO_HPE)
     XYZ_ref = vecmul(M, XYZ)
 
+    Y_ref: NDArrayFloat
     X_ref, Y_ref, Z_ref = tsplit(XYZ_ref)
 
     # Computing the correlate of *Lightness* :math:`L^R`.

--- a/colour/characterisation/aces_it.py
+++ b/colour/characterisation/aces_it.py
@@ -831,9 +831,7 @@ finaliser_function at 0x...>)
 
     x_0 = as_float_array([1, 0, 0, 1, 0, 0])
 
-    def objective_function(
-        M: ArrayLike, RGB: ArrayLike, Jab: ArrayLike
-    ) -> DTypeFloat:
+    def objective_function(M: ArrayLike, RGB: ArrayLike, Jab: ArrayLike) -> DTypeFloat:
         """:math:`J_za_zb_z` colourspace based objective function."""
 
         M = finaliser_function(M)
@@ -902,9 +900,7 @@ finaliser_function at 0x...>)
 
     x_0 = as_float_array([1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1])
 
-    def objective_function(
-        M: ArrayLike, RGB: ArrayLike, Jab: ArrayLike
-    ) -> DTypeFloat:
+    def objective_function(M: ArrayLike, RGB: ArrayLike, Jab: ArrayLike) -> DTypeFloat:
         """*Oklab* colourspace based objective function."""
 
         M = finaliser_function(M)

--- a/colour/characterisation/aces_it.py
+++ b/colour/characterisation/aces_it.py
@@ -87,6 +87,7 @@ if typing.TYPE_CHECKING:
         Any,
         ArrayLike,
         Callable,
+        DTypeFloat,
         Literal,
         LiteralChromaticAdaptationTransform,
         Mapping,
@@ -768,7 +769,7 @@ def optimisation_factory_rawtoaces_v1() -> (
 
     def objective_function(
         M: NDArrayFloat, RGB: NDArrayFloat, Lab: NDArrayFloat
-    ) -> NDArrayFloat:
+    ) -> DTypeFloat:
         """Objective function according to *RAW to ACES* v1."""
 
         M = finaliser_function(M)
@@ -832,7 +833,7 @@ finaliser_function at 0x...>)
 
     def objective_function(
         M: ArrayLike, RGB: ArrayLike, Jab: ArrayLike
-    ) -> NDArrayFloat:
+    ) -> DTypeFloat:
         """:math:`J_za_zb_z` colourspace based objective function."""
 
         M = finaliser_function(M)
@@ -903,7 +904,7 @@ finaliser_function at 0x...>)
 
     def objective_function(
         M: ArrayLike, RGB: ArrayLike, Jab: ArrayLike
-    ) -> NDArrayFloat:
+    ) -> DTypeFloat:
         """*Oklab* colourspace based objective function."""
 
         M = finaliser_function(M)
@@ -1124,7 +1125,8 @@ def matrix_idt(
         XYZ_to_optimization_colour_model,
         finaliser_function,
     ) = optimisation_factory()
-    optimisation_settings = {
+
+    optimisation_settings: dict[str, Any] = {
         "method": "BFGS",
         "jac": "2-point",
     }

--- a/colour/examples/contrast/examples_contrast.py
+++ b/colour/examples/contrast/examples_contrast.py
@@ -76,7 +76,7 @@ def maximise_spatial_frequency(L: ArrayLike) -> NDArrayFloat:
                         **settings_BT2246,
                     )
                 ).item(),
-                0,
+                [0],
                 disp=False,
             )[0]
         )

--- a/colour/examples/contrast/examples_contrast.py
+++ b/colour/examples/contrast/examples_contrast.py
@@ -75,7 +75,7 @@ def maximise_spatial_frequency(L: ArrayLike) -> NDArrayFloat:
                         E=E,  # noqa: B023
                         **settings_BT2246,
                     )
-                ),
+                ).item(),
                 0,
                 disp=False,
             )[0]

--- a/colour/hints/__init__.py
+++ b/colour/hints/__init__.py
@@ -149,18 +149,18 @@ class ProtocolInterpolator(Protocol):  # noqa: D101  # pragma: no cover
         ...
 
     @x.setter
-    def x(self, value: ArrayLike) -> None: ...
+    def x(self, value: ArrayLike, /) -> None: ...
 
     @property
     def y(self) -> NDArray:  # noqa: D102
         ...
 
     @y.setter
-    def y(self, value: ArrayLike) -> None: ...
+    def y(self, value: ArrayLike, /) -> None: ...
 
     def __init__(self, *args: Any, **kwargs: Any) -> None: ...  # pragma: no cover
 
-    def __call__(self, x: ArrayLike) -> NDArray:  # noqa: D102
+    def __call__(self, x: NDArrayFloat) -> NDArray:  # noqa: D102
         ...  # pragma: no cover
 
 
@@ -170,11 +170,11 @@ class ProtocolExtrapolator(Protocol):  # noqa: D101  # pragma: no cover
         ...
 
     @interpolator.setter
-    def interpolator(self, value: ProtocolInterpolator) -> None: ...
+    def interpolator(self, value: ProtocolInterpolator, /) -> None: ...
 
     def __init__(self, *args: Any, **kwargs: Any) -> None: ...  # pragma: no cover
 
-    def __call__(self, x: ArrayLike) -> NDArray:  # noqa: D102
+    def __call__(self, x: NDArrayFloat) -> NDArray:  # noqa: D102
         ...  # pragma: no cover
 
 

--- a/colour/io/luts/sony_spimtx.py
+++ b/colour/io/luts/sony_spimtx.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import typing
 
 if typing.TYPE_CHECKING:
-    from _typeshed import StrPath
+    from os import PathLike
 
 import numpy as np
 
@@ -34,7 +34,7 @@ __all__ = [
 ]
 
 
-def read_LUT_SonySPImtx(path: StrPath) -> LUTOperatorMatrix:
+def read_LUT_SonySPImtx(path: str | PathLike[str]) -> LUTOperatorMatrix:
     """
     Read given *Sony* *.spimtx* *LUT* file.
 
@@ -82,7 +82,9 @@ def read_LUT_SonySPImtx(path: StrPath) -> LUTOperatorMatrix:
 
 
 def write_LUT_SonySPImtx(
-    LUT: LUTOperatorMatrix, path: StrPath | typing.IO[typing.Any], decimals: int = 7
+    LUT: LUTOperatorMatrix,
+    path: str | PathLike[str] | typing.IO[typing.Any],
+    decimals: int = 7,
 ) -> bool:
     """
     Write given *LUT* to given *Sony* *.spimtx* *LUT* file.

--- a/colour/io/luts/sony_spimtx.py
+++ b/colour/io/luts/sony_spimtx.py
@@ -13,8 +13,7 @@ from __future__ import annotations
 import typing
 
 if typing.TYPE_CHECKING:
-    from pathlib import Path
-    from io import StringIO
+    from _typeshed import StrPath
 
 import numpy as np
 
@@ -35,7 +34,7 @@ __all__ = [
 ]
 
 
-def read_LUT_SonySPImtx(path: str | Path) -> LUTOperatorMatrix:
+def read_LUT_SonySPImtx(path: StrPath) -> LUTOperatorMatrix:
     """
     Read given *Sony* *.spimtx* *LUT* file.
 
@@ -83,7 +82,7 @@ def read_LUT_SonySPImtx(path: str | Path) -> LUTOperatorMatrix:
 
 
 def write_LUT_SonySPImtx(
-    LUT: LUTOperatorMatrix, path: str | Path | StringIO, decimals: int = 7
+    LUT: LUTOperatorMatrix, path: StrPath | typing.IO[typing.Any], decimals: int = 7
 ) -> bool:
     """
     Write given *LUT* to given *Sony* *.spimtx* *LUT* file.

--- a/colour/models/igpgtg.py
+++ b/colour/models/igpgtg.py
@@ -23,9 +23,8 @@ import numpy as np
 from colour.algebra import spow
 
 if typing.TYPE_CHECKING:
-    from colour.hints import ArrayLike
+    from colour.hints import ArrayLike, NDArrayFloat
 
-from colour.hints import NDArrayFloat, cast
 from colour.models import Iab_to_XYZ, XYZ_to_Iab
 
 __author__ = "Colour Developers"

--- a/colour/models/igpgtg.py
+++ b/colour/models/igpgtg.py
@@ -184,10 +184,7 @@ def IgPgTg_to_XYZ(IgPgTg: ArrayLike) -> NDArrayFloat:
         colourspace array.
         """
 
-        return cast(
-            NDArrayFloat,
-            spow(LMS_p, 1 / 0.427) * np.array([18.36, 21.46, 19435]),
-        )
+        return spow(LMS_p, 1 / 0.427) * np.array([18.36, 21.46, 19435])
 
     return Iab_to_XYZ(
         IgPgTg,

--- a/colour/models/osa_ucs.py
+++ b/colour/models/osa_ucs.py
@@ -28,7 +28,7 @@ from scipy.optimize import fmin
 from colour.algebra import sdiv, sdiv_mode, spow, vecmul
 
 if typing.TYPE_CHECKING:
-    from colour.hints import ArrayLike, NDArrayFloat
+    from colour.hints import ArrayLike, DTypeFloat, NDArrayFloat
 
 from colour.models import XYZ_to_xyY
 from colour.utilities import (
@@ -210,11 +210,11 @@ def OSA_UCS_to_XYZ(
     shape = Ljg.shape
     Ljg = np.atleast_1d(np.reshape(Ljg, (-1, 3)))
 
-    optimisation_settings = {"disp": False}
+    optimisation_settings: dict[str, typing.Any] = {"disp": False}
     if optimisation_kwargs is not None:
         optimisation_settings.update(optimisation_kwargs)
 
-    def error_function(XYZ: NDArrayFloat, Ljg: NDArrayFloat) -> NDArrayFloat:
+    def error_function(XYZ: NDArrayFloat, Ljg: NDArrayFloat) -> DTypeFloat:
         """Error function."""
 
         # Error must be computed in "reference" domain and range.

--- a/colour/models/rgb/transfer_functions/linear.py
+++ b/colour/models/rgb/transfer_functions/linear.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import typing
 
 if typing.TYPE_CHECKING:
-    from colour.hints import ArrayLike, NDArrayFloat
+    from colour.hints import ArrayLike, DTypeFloat, NDArray, NDArrayFloat
 
 from colour.utilities import as_float
 
@@ -29,7 +29,13 @@ __all__ = [
 ]
 
 
-def linear_function(a: ArrayLike) -> NDArrayFloat:
+@typing.overload
+def linear_function(a: float | DTypeFloat) -> DTypeFloat: ...
+@typing.overload
+def linear_function(a: NDArray) -> NDArrayFloat: ...
+@typing.overload
+def linear_function(a: ArrayLike) -> DTypeFloat | NDArrayFloat: ...
+def linear_function(a: ArrayLike) -> DTypeFloat | NDArrayFloat:
     """
     Define a typical linear encoding / decoding function, essentially a
     pass-through function.

--- a/colour/quality/ssi.py
+++ b/colour/quality/ssi.py
@@ -152,7 +152,7 @@ def spectral_similarity_index(
         3 / 15,
     ]
     c_wdr_i = convolve1d(wdr_i, [0.22, 0.56, 0.22], mode="constant", cval=0)
-    m_v = np.sum(c_wdr_i**2)
+    m_v = np.sum(np.square(c_wdr_i))
 
     SSI = 100 - 32 * np.sqrt(m_v)
 

--- a/colour/recovery/jakob2019.py
+++ b/colour/recovery/jakob2019.py
@@ -792,10 +792,10 @@ class LUT3D_Jakob2019:
                          {'method': 'Constant', 'left': None, 'right': None})
     """
 
+    _interpolator: RegularGridInterpolator[np.float64]
+
     def __init__(self) -> None:
-        self._interpolator: RegularGridInterpolator = RegularGridInterpolator(
-            np.array([]), np.array([])
-        )
+        self._interpolator = RegularGridInterpolator((), np.array([]))
 
         self._size: int = 0
         self._lightness_scale: NDArrayFloat = np.array([])

--- a/colour/recovery/jakob2019.py
+++ b/colour/recovery/jakob2019.py
@@ -212,8 +212,6 @@ def error_function(
     max_error: float | None = ...,
     additional_data: Literal[True] = True,
 ) -> Tuple[float, NDArrayFloat, NDArrayFloat, NDArrayFloat, NDArrayFloat]: ...
-
-
 @typing.overload
 def error_function(
     coefficients: ArrayLike,
@@ -224,8 +222,6 @@ def error_function(
     *,
     additional_data: Literal[False],
 ) -> Tuple[float, NDArrayFloat]: ...
-
-
 @typing.overload
 def error_function(
     coefficients: ArrayLike,
@@ -235,8 +231,6 @@ def error_function(
     max_error: float | None,
     additional_data: Literal[False],
 ) -> Tuple[float, NDArrayFloat]: ...
-
-
 def error_function(
     coefficients: ArrayLike,
     target: ArrayLike,
@@ -470,8 +464,8 @@ def find_coefficients_Jakob2019(
     )
 
     def optimize(
-        target_o: ArrayLike, coefficients_0_o: ArrayLike
-    ) -> Tuple[NDArrayFloat, float]:
+        target_o: NDArrayFloat, coefficients_0_o: NDArrayFloat
+    ) -> Tuple[NDArrayFloat, float | np.float64]:
         """Minimise the error function using *L-BFGS-B* method."""
 
         try:
@@ -522,7 +516,7 @@ def find_coefficients_Jakob2019(
     if dimensionalise:
         coefficients = dimensionalise_coefficients(coefficients, cmfs.shape)
 
-    return coefficients, error
+    return coefficients, float(error)
 
 
 @typing.overload

--- a/colour/recovery/meng2015.py
+++ b/colour/recovery/meng2015.py
@@ -31,9 +31,8 @@ from colour.colorimetry import (
 )
 
 if typing.TYPE_CHECKING:
-    from colour.hints import ArrayLike, DTypeFloat
+    from colour.hints import ArrayLike, DTypeFloat, NDArrayFloat
 
-from colour.hints import NDArrayFloat, cast
 from colour.utilities import from_range_100, to_domain_1
 
 __author__ = "Colour Developers"

--- a/colour/recovery/meng2015.py
+++ b/colour/recovery/meng2015.py
@@ -31,7 +31,7 @@ from colour.colorimetry import (
 )
 
 if typing.TYPE_CHECKING:
-    from colour.hints import ArrayLike
+    from colour.hints import ArrayLike, DTypeFloat
 
 from colour.hints import NDArrayFloat, cast
 from colour.utilities import from_range_100, to_domain_1
@@ -177,12 +177,12 @@ def XYZ_to_sd_Meng2015(
 
     sd = sd_ones(cmfs.shape)
 
-    def objective_function(a: ArrayLike) -> NDArrayFloat:
+    def objective_function(a: NDArrayFloat) -> DTypeFloat:
         """Define the objective function."""
 
-        return cast(NDArrayFloat, np.sum(np.diff(a) ** 2))
+        return np.sum(np.square(np.diff(a)))
 
-    def constraint_function(a: ArrayLike) -> NDArrayFloat:
+    def constraint_function(a: NDArrayFloat) -> NDArrayFloat:
         """Define the constraint function."""
 
         sd[:] = a

--- a/colour/temperature/cie_d.py
+++ b/colour/temperature/cie_d.py
@@ -109,7 +109,7 @@ def xy_to_CCT_CIE_D(
         [
             minimize(
                 objective_function,
-                x0=6500,
+                x0=[6500],
                 args=(xy_i,),
                 **optimisation_settings,
             ).x

--- a/colour/temperature/cie_d.py
+++ b/colour/temperature/cie_d.py
@@ -30,7 +30,7 @@ from scipy.optimize import minimize
 from colour.colorimetry import daylight_locus_function
 
 if typing.TYPE_CHECKING:
-    from colour.hints import ArrayLike, NDArrayFloat
+    from colour.hints import ArrayLike, DTypeFloat, NDArrayFloat
 
 from colour.utilities import as_float, as_float_array, tstack, usage_warning
 
@@ -89,7 +89,7 @@ def xy_to_CCT_CIE_D(
     shape = xy.shape
     xy = np.atleast_1d(np.reshape(xy, (-1, 2)))
 
-    def objective_function(CCT: NDArrayFloat, xy: NDArrayFloat) -> NDArrayFloat:
+    def objective_function(CCT: NDArrayFloat, xy: NDArrayFloat) -> DTypeFloat:
         """Objective function."""
 
         objective = np.linalg.norm(CCT_to_xy_CIE_D(CCT) - xy)

--- a/colour/temperature/hernandez1999.py
+++ b/colour/temperature/hernandez1999.py
@@ -31,7 +31,7 @@ from colour.algebra import sdiv, sdiv_mode
 from colour.colorimetry import CCS_ILLUMINANTS
 
 if typing.TYPE_CHECKING:
-    from colour.hints import ArrayLike, NDArrayFloat
+    from colour.hints import ArrayLike, DTypeFloat, NDArrayFloat
 
 from colour.utilities import as_float, as_float_array, tsplit, usage_warning
 
@@ -151,7 +151,7 @@ def CCT_to_xy_Hernandez1999(
     shape = list(CCT.shape)
     CCT = np.atleast_1d(np.reshape(CCT, (-1, 1)))
 
-    def objective_function(xy: NDArrayFloat, CCT: NDArrayFloat) -> NDArrayFloat:
+    def objective_function(xy: NDArrayFloat, CCT: NDArrayFloat) -> DTypeFloat:
         """Objective function."""
 
         objective = np.linalg.norm(xy_to_CCT_Hernandez1999(xy) - CCT)

--- a/colour/temperature/kang2002.py
+++ b/colour/temperature/kang2002.py
@@ -106,7 +106,7 @@ def xy_to_CCT_Kang2002(
         [
             minimize(
                 objective_function,
-                x0=6500,
+                x0=[6500],
                 args=(xy_i,),
                 **optimisation_settings,
             ).x

--- a/colour/temperature/kang2002.py
+++ b/colour/temperature/kang2002.py
@@ -27,7 +27,7 @@ import numpy as np
 from scipy.optimize import minimize
 
 if typing.TYPE_CHECKING:
-    from colour.hints import ArrayLike, NDArrayFloat
+    from colour.hints import ArrayLike, DTypeFloat, NDArrayFloat
 
 from colour.utilities import as_float, as_float_array, tstack, usage_warning
 
@@ -86,7 +86,7 @@ def xy_to_CCT_Kang2002(
     shape = xy.shape
     xy = np.atleast_1d(np.reshape(xy, (-1, 2)))
 
-    def objective_function(CCT: NDArrayFloat, xy: NDArrayFloat) -> NDArrayFloat:
+    def objective_function(CCT: NDArrayFloat, xy: NDArrayFloat) -> DTypeFloat:
         """Objective function."""
 
         objective = np.linalg.norm(CCT_to_xy_Kang2002(CCT) - xy)

--- a/colour/temperature/krystek1985.py
+++ b/colour/temperature/krystek1985.py
@@ -27,7 +27,7 @@ import numpy as np
 from scipy.optimize import minimize
 
 if typing.TYPE_CHECKING:
-    from colour.hints import ArrayLike, NDArrayFloat
+    from colour.hints import ArrayLike, DTypeFloat, NDArrayFloat
 
 from colour.utilities import as_float, as_float_array, tstack
 
@@ -92,7 +92,7 @@ def uv_to_CCT_Krystek1985(
     shape = uv.shape
     uv = np.atleast_1d(np.reshape(uv, (-1, 2)))
 
-    def objective_function(CCT: NDArrayFloat, uv: NDArrayFloat) -> NDArrayFloat:
+    def objective_function(CCT: NDArrayFloat, uv: NDArrayFloat) -> DTypeFloat:
         """Objective function."""
 
         objective = np.linalg.norm(CCT_to_uv_Krystek1985(CCT) - uv)

--- a/colour/temperature/krystek1985.py
+++ b/colour/temperature/krystek1985.py
@@ -112,7 +112,7 @@ def uv_to_CCT_Krystek1985(
         [
             minimize(
                 objective_function,
-                x0=6500,
+                x0=[6500],
                 args=(uv_i,),
                 **optimisation_settings,
             ).x

--- a/colour/temperature/mccamy1992.py
+++ b/colour/temperature/mccamy1992.py
@@ -29,7 +29,7 @@ from colour.algebra import sdiv, sdiv_mode
 from colour.colorimetry import CCS_ILLUMINANTS
 
 if typing.TYPE_CHECKING:
-    from colour.hints import ArrayLike, NDArrayFloat
+    from colour.hints import ArrayLike, DTypeFloat, NDArrayFloat
 
 from colour.utilities import as_float, as_float_array, tsplit, usage_warning
 
@@ -134,7 +134,7 @@ def CCT_to_xy_McCamy1992(
     shape = list(CCT.shape)
     CCT = np.atleast_1d(np.reshape(CCT, (-1, 1)))
 
-    def objective_function(xy: NDArrayFloat, CCT: NDArrayFloat) -> NDArrayFloat:
+    def objective_function(xy: NDArrayFloat, CCT: NDArrayFloat) -> DTypeFloat:
         """Objective function."""
 
         objective = np.linalg.norm(xy_to_CCT_McCamy1992(xy) - CCT)

--- a/colour/temperature/planck1900.py
+++ b/colour/temperature/planck1900.py
@@ -30,7 +30,7 @@ from colour.colorimetry import (
 )
 
 if typing.TYPE_CHECKING:
-    from colour.hints import ArrayLike, NDArrayFloat
+    from colour.hints import ArrayLike, DTypeFloat, NDArrayFloat
 
 from colour.models import UCS_to_uv, XYZ_to_UCS
 from colour.utilities import as_float, as_float_array
@@ -96,7 +96,7 @@ def uv_to_CCT_Planck1900(
     shape = uv.shape
     uv = np.atleast_1d(np.reshape(uv, (-1, 2)))
 
-    def objective_function(CCT: NDArrayFloat, uv: NDArrayFloat) -> NDArrayFloat:
+    def objective_function(CCT: NDArrayFloat, uv: NDArrayFloat) -> DTypeFloat:
         """Objective function."""
 
         objective = np.linalg.norm(CCT_to_uv_Planck1900(CCT, cmfs) - uv)

--- a/colour/temperature/planck1900.py
+++ b/colour/temperature/planck1900.py
@@ -116,7 +116,7 @@ def uv_to_CCT_Planck1900(
         [
             minimize(
                 objective_function,
-                x0=6500,
+                x0=[6500],
                 args=(uv_i,),
                 **optimisation_settings,
             ).x

--- a/colour/utilities/array.py
+++ b/colour/utilities/array.py
@@ -582,12 +582,17 @@ def as_array(
 
     return np.asarray(a, dtype)
 
+
 @typing.overload
 def as_int(a: float | DTypeFloat, dtype: Type[DTypeInt] | None = None) -> DTypeInt: ...
 @typing.overload
-def as_int(a: NDArray | Sequence[int], dtype: Type[DTypeInt] | None = None) -> NDArrayInt: ...
+def as_int(
+    a: NDArray | Sequence[int], dtype: Type[DTypeInt] | None = None
+) -> NDArrayInt: ...
 @typing.overload
-def as_int(a: ArrayLike, dtype: Type[DTypeInt] | None = None) -> DTypeInt | NDArrayInt: ...
+def as_int(
+    a: ArrayLike, dtype: Type[DTypeInt] | None = None
+) -> DTypeInt | NDArrayInt: ...
 def as_int(a: ArrayLike, dtype: Type[DTypeInt] | None = None) -> DTypeInt | NDArrayInt:
     """
     Attempt to convert given variable :math:`a` to :class:`numpy.integer`
@@ -627,13 +632,22 @@ def as_int(a: ArrayLike, dtype: Type[DTypeInt] | None = None) -> DTypeInt | NDAr
 
     return dtype(a)  # pyright: ignore
 
+
 @typing.overload
-def as_float(a: float | DTypeFloat, dtype: Type[DTypeFloat] | None = None) -> DTypeFloat: ...
+def as_float(
+    a: float | DTypeFloat, dtype: Type[DTypeFloat] | None = None
+) -> DTypeFloat: ...
 @typing.overload
-def as_float(a: NDArray | Sequence[float], dtype: Type[DTypeFloat] | None = None) -> NDArrayFloat: ...
+def as_float(
+    a: NDArray | Sequence[float], dtype: Type[DTypeFloat] | None = None
+) -> NDArrayFloat: ...
 @typing.overload
-def as_float(a: ArrayLike, dtype: Type[DTypeFloat] | None = None) -> DTypeFloat | NDArrayFloat: ...
-def as_float(a: ArrayLike, dtype: Type[DTypeFloat] | None = None) -> DTypeFloat | NDArrayFloat:
+def as_float(
+    a: ArrayLike, dtype: Type[DTypeFloat] | None = None
+) -> DTypeFloat | NDArrayFloat: ...
+def as_float(
+    a: ArrayLike, dtype: Type[DTypeFloat] | None = None
+) -> DTypeFloat | NDArrayFloat:
     """
     Attempt to convert given variable :math:`a` to :class:`numpy.floating`
     using given :class:`numpy.dtype`. If variable :math:`a` is not a scalar or

--- a/colour/utilities/array.py
+++ b/colour/utilities/array.py
@@ -582,8 +582,13 @@ def as_array(
 
     return np.asarray(a, dtype)
 
-
-def as_int(a: ArrayLike, dtype: Type[DTypeInt] | None = None) -> NDArrayInt:
+@typing.overload
+def as_int(a: float | DTypeFloat, dtype: Type[DTypeInt] | None = None) -> DTypeInt: ...
+@typing.overload
+def as_int(a: NDArray | Sequence[int], dtype: Type[DTypeInt] | None = None) -> NDArrayInt: ...
+@typing.overload
+def as_int(a: ArrayLike, dtype: Type[DTypeInt] | None = None) -> DTypeInt | NDArrayInt: ...
+def as_int(a: ArrayLike, dtype: Type[DTypeInt] | None = None) -> DTypeInt | NDArrayInt:
     """
     Attempt to convert given variable :math:`a` to :class:`numpy.integer`
     using given :class:`numpy.dtype`. If variable :math:`a` is not a scalar or
@@ -622,8 +627,13 @@ def as_int(a: ArrayLike, dtype: Type[DTypeInt] | None = None) -> NDArrayInt:
 
     return dtype(a)  # pyright: ignore
 
-
-def as_float(a: ArrayLike, dtype: Type[DTypeFloat] | None = None) -> NDArrayFloat:
+@typing.overload
+def as_float(a: float | DTypeFloat, dtype: Type[DTypeFloat] | None = None) -> DTypeFloat: ...
+@typing.overload
+def as_float(a: NDArray | Sequence[float], dtype: Type[DTypeFloat] | None = None) -> NDArrayFloat: ...
+@typing.overload
+def as_float(a: ArrayLike, dtype: Type[DTypeFloat] | None = None) -> DTypeFloat | NDArrayFloat: ...
+def as_float(a: ArrayLike, dtype: Type[DTypeFloat] | None = None) -> DTypeFloat | NDArrayFloat:
     """
     Attempt to convert given variable :math:`a` to :class:`numpy.floating`
     using given :class:`numpy.dtype`. If variable :math:`a` is not a scalar or
@@ -1399,7 +1409,7 @@ def to_domain_int(
 
     a = as_float_array(a, dtype).copy()
 
-    maximum_code_value = np.power(2, bit_depth) - 1
+    maximum_code_value: NDArray[DTypeInt] = np.power(2, bit_depth) - 1
     if _DOMAIN_RANGE_SCALE == "1":
         a *= maximum_code_value
 
@@ -1749,7 +1759,7 @@ def from_range_int(
 
     a = as_float_array(a, dtype)
 
-    maximum_code_value = np.power(2, bit_depth) - 1
+    maximum_code_value: NDArray[DTypeInt] = np.power(2, bit_depth) - 1
     if _DOMAIN_RANGE_SCALE == "1":
         a /= maximum_code_value
 

--- a/colour/volume/mesh.py
+++ b/colour/volume/mesh.py
@@ -13,6 +13,7 @@ import numpy as np
 from scipy.spatial import Delaunay
 
 from colour.constants import EPSILON
+from colour.utilities import as_float_array
 
 if typing.TYPE_CHECKING:
     from colour.hints import ArrayLike, NDArrayFloat
@@ -68,8 +69,8 @@ def is_within_mesh_volume(
     array([ True, False], dtype=bool)
     """
 
-    triangulation = Delaunay(mesh)
+    triangulation = Delaunay(as_float_array(mesh))
 
-    simplex = triangulation.find_simplex(points, tol=tolerance)
+    simplex = triangulation.find_simplex(as_float_array(points), tol=tolerance)
 
     return np.where(simplex >= 0, True, False)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ dev-dependencies = [
     "pytest",
     "pytest-cov",
     "pytest-xdist",
+    "scipy-stubs",
     "toml",
     "twine",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -147,6 +147,7 @@ rfc3986-validator==0.1.1
 rich==13.9.4
 rpds-py==0.22.3
 scipy==1.14.1
+scipy-stubs==1.14.1.6
 secretstorage==3.3.3 ; sys_platform == 'linux'
 send2trash==1.8.3
 setuptools==75.6.0


### PR DESCRIPTION
<!--
Thank you for taking the time to create this pull request. If it is the first
time you are contributing to a colour-science repository, a contributing guide
is available to guide the process: https://www.colour-science.org/contributing/.
-->

# Summary

This adds [scipy-stubs](https://github.com/scipy/scipy-stubs) as a development dependency. By doing so, 58 new pyright errors popped up. There were 18 that were caused by two bugs and two other issues in `scipy-stubs`, and I've fixed them. See https://github.com/scipy/scipy-stubs/issues/495 for details. 

The other 40 errors turned out to be typing issues in `colour` itself. I have included their fixes in this PR.

~I also noticed that an additional error pops up when the latest `numpy==2.2.4` release is installed (currently pinned at `2.2.0`). I've addressed this in https://github.com/numpy/numpy/pull/28660, and the fix will be included in the upcoming `2.2.5` (and `2.3.0`) NumPy release(s).~ (resolved in [numpy 2.2.5](https://github.com/numpy/numpy/releases/tag/v2.2.5))

This additionally improves the static-typing compatibility for different versions of pyright, numpy, scipy, and scipy-stubs.

# Preflight

<!-- Please mark any checkboxes that do not apply to this pull request as [N/A]. -->

**Code Style and Quality**

- [x] Pyright static checking has been run and passed.
- [x] Pre-commit hooks have been run and passed.

<!--
Thank you again!
-->
