### PR TITLE
PR: Improve Docstrings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.pyo
 .DS_Store
 .coverage*
+CLAUDE.md
 uv.lock
 
 # Common Directories

--- a/colour/adaptation/__init__.py
+++ b/colour/adaptation/__init__.py
@@ -159,7 +159,7 @@ def chromatic_adaptation(
     **kwargs: Any,
 ) -> NDArrayFloat:
     """
-    Adapt given stimulus from test viewing conditions to reference viewing
+    Adapt the specified stimulus from test viewing conditions to reference viewing
     conditions.
 
     Parameters
@@ -187,8 +187,8 @@ def chromatic_adaptation(
         Noise component in fundamental primary system.
     Y_o
         {:func:`colour.adaptation.chromatic_adaptation_CIE1994`},
-        Luminance factor :math:`Y_o` of achromatic background normalised to
-        domain [0.18, 1] in **'Reference'** domain-range scale.
+        Luminance factor :math:`Y_o` of achromatic background normalised
+        to domain [0.18, 1] in **'Reference'** domain-range scale.
     direction
         {:func:`colour.adaptation.chromatic_adaptation_CMCCAT2000`},
         Chromatic adaptation direction.
@@ -197,7 +197,8 @@ def chromatic_adaptation(
         Luminance of test adapting field :math:`L_{A1}` in :math:`cd/m^2`.
     L_A2
         {:func:`colour.adaptation.chromatic_adaptation_CMCCAT2000`},
-        Luminance of reference adapting field :math:`L_{A2}` in :math:`cd/m^2`.
+        Luminance of reference adapting field :math:`L_{A2}` in
+        :math:`cd/m^2`.
     surround
         {:func:`colour.adaptation.chromatic_adaptation_CMCCAT2000`},
         Surround viewing conditions induction factors.

--- a/colour/adaptation/cie1994.py
+++ b/colour/adaptation/cie1994.py
@@ -80,7 +80,7 @@ def chromatic_adaptation_CIE1994(
     n: ArrayLike = 1,
 ) -> NDArrayFloat:
     """
-    Adapt given stimulus *CIE XYZ_1* tristimulus values from test viewing
+    Adapt the specified stimulus *CIE XYZ_1* tristimulus values from test viewing
     conditions to reference viewing conditions using *CIE 1994* chromatic
     adaptation model.
 
@@ -98,9 +98,9 @@ def chromatic_adaptation_CIE1994(
         Luminance factor :math:`Y_o` of achromatic background as percentage
         normalised to domain [18, 100] in **'Reference'** domain-range scale.
     E_o1
-        Test illuminance :math:`E_{o1}` in :math:`cd/m^2`.
+        Test illuminance :math:`E_{o1}` in lux.
     E_o2
-        Reference illuminance :math:`E_{o2}` in :math:`cd/m^2`.
+        Reference illuminance :math:`E_{o2}` in lux.
     n
         Noise component in fundamental primary system.
 
@@ -174,7 +174,7 @@ def chromatic_adaptation_CIE1994(
 
 def XYZ_to_RGB_CIE1994(XYZ: ArrayLike) -> NDArrayFloat:
     """
-    Convert from *CIE XYZ* tristimulus values to cone responses.
+    Convert *CIE XYZ* tristimulus values to cone responses.
 
     Parameters
     ----------
@@ -198,7 +198,7 @@ def XYZ_to_RGB_CIE1994(XYZ: ArrayLike) -> NDArrayFloat:
 
 def RGB_to_XYZ_CIE1994(RGB: ArrayLike) -> NDArrayFloat:
     """
-    Convert from cone responses to *CIE XYZ* tristimulus values.
+    Convert cone responses to *CIE XYZ* tristimulus values.
 
     Parameters
     ----------
@@ -222,7 +222,7 @@ def RGB_to_XYZ_CIE1994(RGB: ArrayLike) -> NDArrayFloat:
 
 def intermediate_values(xy_o: ArrayLike) -> NDArrayFloat:
     """
-    Return the intermediate values :math:`\\xi`, :math:`\\eta`,
+    Compute the intermediate values :math:`\\xi`, :math:`\\eta`,
     :math:`\\zeta`.
 
     Parameters
@@ -256,7 +256,7 @@ def effective_adapting_responses(
     xez: ArrayLike, Y_o: ArrayLike, E_o: ArrayLike
 ) -> NDArrayFloat:
     """
-    Derive the effective adapting responses in the fundamental primary system
+    Compute the effective adapting responses in the fundamental primary system
     of the test or reference field.
 
     Parameters
@@ -356,8 +356,9 @@ def beta_2(x: ArrayLike) -> DTypeFloat | NDArrayFloat:
 
 def exponential_factors(RGB_o: ArrayLike) -> NDArrayFloat:
     """
-    Return the chromatic adaptation exponential factors :math:`\\beta_1(R_o)`,
-    :math:`\\beta_1(G_o)` and :math:`\\beta_2(B_o)` of given cone responses.
+    Compute the chromatic adaptation exponential factors :math:`\\beta_1(R_o)`,
+    :math:`\\beta_1(G_o)` and :math:`\\beta_2(B_o)` of the specified cone
+    responses.
 
     Parameters
     ----------
@@ -464,8 +465,8 @@ def corresponding_colour(
     n: ArrayLike = 1,
 ) -> NDArrayFloat:
     """
-    Compute the corresponding colour cone responses of given test sample cone
-    responses :math:`RGB_1`.
+    Compute the corresponding colour cone responses of the specified test sample
+    cone responses :math:`RGB_1`.
 
     Parameters
     ----------
@@ -495,7 +496,7 @@ def corresponding_colour(
     Returns
     -------
     :class:`numpy.ndarray`
-        Corresponding colour cone responses of given test sample cone
+        Corresponding colour cone responses of specified test sample cone
         responses.
 
     Examples

--- a/colour/adaptation/cmccat2000.py
+++ b/colour/adaptation/cmccat2000.py
@@ -109,7 +109,7 @@ def chromatic_adaptation_forward_CMCCAT2000(
     surround: InductionFactors_CMCCAT2000 = VIEWING_CONDITIONS_CMCCAT2000["Average"],
 ) -> NDArrayFloat:
     """
-    Adapt given stimulus *CIE XYZ* tristimulus values from test viewing
+    Adapt the specified stimulus *CIE XYZ* tristimulus values from test viewing
     conditions to reference viewing conditions using *CMCCAT2000* forward
     chromatic adaptation model.
 
@@ -202,8 +202,8 @@ def chromatic_adaptation_inverse_CMCCAT2000(
     surround: InductionFactors_CMCCAT2000 = VIEWING_CONDITIONS_CMCCAT2000["Average"],
 ) -> NDArrayFloat:
     """
-    Adapt given stimulus corresponding colour *CIE XYZ* tristimulus values
-    from reference viewing conditions to test viewing conditions using
+    Adapt the specified stimulus corresponding colour *CIE XYZ* tristimulus
+    values from reference viewing conditions to test viewing conditions using
     *CMCCAT2000* inverse chromatic adaptation model.
 
     Parameters
@@ -296,8 +296,8 @@ def chromatic_adaptation_CMCCAT2000(
     direction: Literal["Forward", "Inverse"] | str = "Forward",
 ) -> NDArrayFloat:
     """
-    Adapt given stimulus *CIE XYZ* tristimulus values using given viewing
-    conditions.
+    Adapt the specified stimulus *CIE XYZ* tristimulus values using the specified
+    viewing conditions.
 
     This definition is a convenient wrapper around
     :func:`colour.adaptation.chromatic_adaptation_forward_CMCCAT2000` and

--- a/colour/adaptation/fairchild1990.py
+++ b/colour/adaptation/fairchild1990.py
@@ -73,7 +73,7 @@ def chromatic_adaptation_Fairchild1990(
     discount_illuminant: bool = False,
 ) -> NDArrayFloat:
     """
-    Adapt given stimulus *CIE XYZ_1* tristimulus values from test viewing
+    Adapt the specified stimulus *CIE XYZ_1* tristimulus values from test viewing
     conditions to reference viewing conditions using *Fairchild (1990)*
     chromatic adaptation model.
 
@@ -82,19 +82,20 @@ def chromatic_adaptation_Fairchild1990(
     XYZ_1
         *CIE XYZ_1* tristimulus values of test sample / stimulus.
     XYZ_n
-        Test viewing condition *CIE XYZ_n* tristimulus values of whitepoint.
+        Test viewing condition *CIE XYZ_n* tristimulus values of the
+        whitepoint.
     XYZ_r
-        Reference viewing condition *CIE XYZ_r* tristimulus values of
+        Reference viewing condition *CIE XYZ_r* tristimulus values of the
         whitepoint.
     Y_n
-        Luminance :math:`Y_n` of test adapting stimulus in :math:`cd/m^2`.
+        luminance :math:`Y_n` of test adapting stimulus in :math:`cd/m^2`.
     discount_illuminant
         Truth value indicating if the illuminant should be discounted.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Adapted *CIE XYZ_2* tristimulus values of stimulus.
+        Adapted *CIE XYZ_2* tristimulus values of the stimulus.
 
     Notes
     -----
@@ -162,7 +163,7 @@ def chromatic_adaptation_Fairchild1990(
 
 def XYZ_to_RGB_Fairchild1990(XYZ: ArrayLike) -> NDArrayFloat:
     """
-    Convert from *CIE XYZ* tristimulus values to cone responses.
+    Convert *CIE XYZ* tristimulus values to cone responses.
 
     Parameters
     ----------
@@ -186,7 +187,7 @@ def XYZ_to_RGB_Fairchild1990(XYZ: ArrayLike) -> NDArrayFloat:
 
 def RGB_to_XYZ_Fairchild1990(RGB: ArrayLike) -> NDArrayFloat:
     """
-    Convert from cone responses to *CIE XYZ* tristimulus values.
+    Convert cone responses to *CIE XYZ* tristimulus values.
 
     Parameters
     ----------
@@ -223,7 +224,7 @@ def degrees_of_adaptation(
     LMS
         Cone responses.
     Y_n
-        Luminance :math:`Y_n` of test adapting stimulus in :math:`cd/m^2`.
+        luminance :math:`Y_n` of test adapting stimulus in :math:`cd/m^2`.
     v
         Exponent :math:`v`.
     discount_illuminant

--- a/colour/adaptation/fairchild2020.py
+++ b/colour/adaptation/fairchild2020.py
@@ -136,17 +136,19 @@ def matrix_chromatic_adaptation_vk20(
     ),
 ) -> NDArrayFloat:
     """
-    Compute the *chromatic adaptation* matrix from previous viewing conditions
+    Compute the chromatic adaptation matrix from previous viewing conditions
     to adapting viewing conditions using *Von Kries 2020* (*vK20*) method.
 
     Parameters
     ----------
     XYZ_p
-        Previous viewing conditions *CIE XYZ* tristimulus values of whitepoint.
+        Previous viewing conditions *CIE XYZ* tristimulus values of the
+        whitepoint.
     XYZ_n
-        Adapting viewing conditions *CIE XYZ* tristimulus values of whitepoint.
+        Adapting viewing conditions *CIE XYZ* tristimulus values of the
+        whitepoint.
     XYZ_r
-        Reference viewing conditions *CIE XYZ* tristimulus values of
+        Reference viewing conditions *CIE XYZ* tristimulus values of the
         whitepoint.
     transform
         Chromatic adaptation transform.
@@ -247,19 +249,21 @@ def chromatic_adaptation_vK20(
     ),
 ) -> NDArrayFloat:
     """
-    Adapt given stimulus from previous viewing conditions to adapting viewing
-    conditions using *Von Kries 2020* (*vK20*) method.
+    Adapt the specified stimulus from previous viewing conditions to adapting
+    viewing conditions using *Von Kries 2020* (*vK20*) method.
 
     Parameters
     ----------
     XYZ
-        *CIE XYZ* tristimulus values of stimulus to adapt.
+        *CIE XYZ* tristimulus values of the stimulus to adapt.
     XYZ_p
-        Previous viewing conditions *CIE XYZ* tristimulus values of whitepoint.
+        Previous viewing conditions *CIE XYZ* tristimulus values of the
+        whitepoint.
     XYZ_n
-        Adapting viewing conditions *CIE XYZ* tristimulus values of whitepoint.
+        Adapting viewing conditions *CIE XYZ* tristimulus values of the
+        whitepoint.
     XYZ_r
-        Reference viewing conditions *CIE XYZ* tristimulus values of
+        Reference viewing conditions *CIE XYZ* tristimulus values of the
         whitepoint.
     transform
         Chromatic adaptation transform.

--- a/colour/adaptation/vonkries.py
+++ b/colour/adaptation/vonkries.py
@@ -57,15 +57,16 @@ def matrix_chromatic_adaptation_VonKries(
     transform: LiteralChromaticAdaptationTransform | str = "CAT02",
 ) -> NDArrayFloat:
     """
-    Compute the *chromatic adaptation* matrix from test viewing conditions
-    to reference viewing conditions.
+    Compute the chromatic adaptation matrix from test viewing conditions to
+    reference viewing conditions.
 
     Parameters
     ----------
     XYZ_w
-        Test viewing conditions *CIE XYZ* tristimulus values of whitepoint.
+        Test viewing conditions *CIE XYZ* tristimulus values of the
+        whitepoint.
     XYZ_wr
-        Reference viewing conditions *CIE XYZ* tristimulus values of
+        Reference viewing conditions *CIE XYZ* tristimulus values of the
         whitepoint.
     transform
         Chromatic adaptation transform.
@@ -142,17 +143,18 @@ def chromatic_adaptation_VonKries(
     transform: LiteralChromaticAdaptationTransform | str = "CAT02",
 ) -> NDArrayFloat:
     """
-    Adapt given stimulus from test viewing conditions to reference viewing
-    conditions.
+    Adapt the specified stimulus from test viewing conditions to reference
+    viewing conditions.
 
     Parameters
     ----------
     XYZ
-        *CIE XYZ* tristimulus values of stimulus to adapt.
+        *CIE XYZ* tristimulus values of the stimulus to adapt.
     XYZ_w
-        Test viewing conditions *CIE XYZ* tristimulus values of whitepoint.
+        Test viewing conditions *CIE XYZ* tristimulus values of the
+        whitepoint.
     XYZ_wr
-        Reference viewing conditions *CIE XYZ* tristimulus values of
+        Reference viewing conditions *CIE XYZ* tristimulus values of the
         whitepoint.
     transform
         Chromatic adaptation transform.

--- a/colour/adaptation/zhai2018.py
+++ b/colour/adaptation/zhai2018.py
@@ -54,22 +54,22 @@ def chromatic_adaptation_Zhai2018(
     transform: Literal["CAT02", "CAT16"] | str = "CAT02",
 ) -> NDArrayFloat:
     """
-    Adapt given sample colour :math:`XYZ_{\\beta}` tristimulus values from
-    input viewing conditions under :math:`\\beta` illuminant to output viewing
-    conditions under :math:`\\delta` illuminant using *Zhai and Luo (2018)*
-    chromatic adaptation model.
+    Adapt the specified sample colour :math:`XYZ_{\\beta}` tristimulus values
+    from input viewing conditions under :math:`\\beta` illuminant to output
+    viewing conditions under :math:`\\delta` illuminant using
+    *Zhai and Luo (2018)* chromatic adaptation model.
 
     According to the definition of :math:`D`, a one-step CAT such as CAT02 can
-    only be used to transform colors from an incomplete adapted field into a
+    only be used to transform colours from an incomplete adapted field into a
     complete adapted field. When CAT02 are used to transform an incomplete to
     incomplete case, :math:`D` has no baseline level to refer to.
     *Smet et al. (2017)* proposed a new concept of two-step CAT to replace the
     present CATs such as CAT02 with only one-step transform in order to define
     :math:`D` more clearly. A two-step CAT involves an illuminant representing
     the baseline states between the test and reference illuminants for the
-    calculation. In the first step the test color is transformed from test
+    calculation. In the first step, the test colour is transformed from test
     illuminant to the baseline illuminant (:math:`BI`), and it is then
-    transformed to the reference illuminant Degrees of adaptation under the
+    transformed to the reference illuminant. Degrees of adaptation under the
     other illuminants should be calculated relative to the adaptation under the
     :math:`BI`. When :math:`D` becomes lower towards zero, the adaptation point
     of the observer moves towards the :math:`BI`. Therefore, the chromaticity
@@ -100,7 +100,7 @@ def chromatic_adaptation_Zhai2018(
     -------
     :class:`numpy.ndarray`
         Sample corresponding colour :math:`XYZ_{\\delta}` tristimulus values
-        under output illuminant :math:`D_{\\delta}`.
+        under output illuminant :math:`\\delta`.
 
     Notes
     -----

--- a/colour/algebra/__init__.py
+++ b/colour/algebra/__init__.py
@@ -117,10 +117,10 @@ __all__ += [
 # ---                API Changes and Deprecation Management                ---#
 # ----------------------------------------------------------------------------#
 class algebra(ModuleAPI):
-    """Define a class acting like the *algebra* module."""
+    """A class acting like the *algebra* module."""
 
     def __getattr__(self, attribute: str) -> Any:
-        """Return the value from the attribute with given name."""
+        """Return the value from the attribute with specified name."""
 
         return super().__getattr__(attribute)
 
@@ -134,7 +134,7 @@ API_CHANGES: dict = {
         ],
     ]
 }
-"""Defines the *colour.algebra* sub-package API changes."""
+"""*colour.algebra* sub-package API changes."""
 
 
 API_CHANGES["ObjectRemoved"] = [  # pyright: ignore

--- a/colour/algebra/common.py
+++ b/colour/algebra/common.py
@@ -2,7 +2,7 @@
 Common Utilities
 ================
 
-Define the common algebra utilities objects that don't fall in any specific
+Common algebra utilities objects that don't fall in any specific
 category.
 """
 
@@ -172,7 +172,7 @@ def set_sdiv_mode(
 
 class sdiv_mode:
     """
-    Define a context manager and decorator temporarily setting *Colour* safe
+    A context manager and decorator temporarily setting *Colour* safe
     division function mode.
 
     Parameters
@@ -232,7 +232,7 @@ class sdiv_mode:
 
 def sdiv(a: ArrayLike, b: ArrayLike) -> NDArrayFloat:
     """
-    Divide given array :math:`b` with array :math:`b` while handling
+    Divide specified array :math:`b` with array :math:`b` while handling
     zero-division.
 
     This definition avoids NaNs and +/- infs generation when array :math:`b`
@@ -396,7 +396,7 @@ def set_spow_enable(enable: bool) -> None:
 
 class spow_enable:
     """
-    Define a context manager and decorator temporarily setting *Colour* safe /
+    A context manager and decorator temporarily setting *Colour* safe /
     symmetrical power function enabled state.
 
     Parameters
@@ -449,7 +449,7 @@ def spow(a: ArrayLike, p: NDArray) -> NDArrayFloat: ...
 def spow(a: ArrayLike, p: ArrayLike) -> DTypeFloat | NDArrayFloat: ...
 def spow(a: ArrayLike, p: ArrayLike) -> DTypeFloat | NDArrayFloat:
     """
-    Raise given array :math:`a` to the power :math:`p` as follows:
+    Raise specified array :math:`a` to the power :math:`p` as follows:
     :math:`sign(a) * |a|^p`.
 
     This definition avoids NaNs generation when array :math:`a` is negative and
@@ -492,7 +492,7 @@ def spow(a: ArrayLike, p: ArrayLike) -> DTypeFloat | NDArrayFloat:
 
 def normalise_vector(a: ArrayLike) -> NDArrayFloat:
     """
-    Normalise given vector :math:`a`.
+    Normalise specified vector :math:`a`.
 
     Parameters
     ----------
@@ -524,7 +524,7 @@ def normalise_maximum(
     clip: bool = True,
 ) -> NDArrayFloat:
     """
-    Normalise given array :math:`a` values by :math:`a` maximum value and
+    Normalise specified array :math:`a` values by :math:`a` maximum value and
     optionally clip them between.
 
     Parameters
@@ -674,7 +674,7 @@ def linear_conversion(
     a: ArrayLike, old_range: ArrayLike, new_range: ArrayLike
 ) -> NDArrayFloat:
     """
-    Perform a simple linear conversion of given array :math:`a` between the
+    Perform a simple linear conversion of specified array :math:`a` between the
     old and new ranges.
 
     Parameters
@@ -713,7 +713,7 @@ def linstep_function(
     clip: bool = False,
 ) -> NDArrayFloat:
     """
-    Perform a simple linear interpolation between given array :math:`a` and
+    Perform a simple linear interpolation between specified array :math:`a` and
     array :math:`b` using :math:`x` array.
 
     Parameters
@@ -829,8 +829,8 @@ def eigen_decomposition(
     covariance_matrix: bool = False,
 ) -> Tuple[NDArrayFloat, NDArrayFloat]:
     """
-    Return the eigen-values :math:`w` and eigen-vectors :math:`v` of given
-    array :math:`a` in given order.
+    Return the eigen-values :math:`w` and eigen-vectors :math:`v` of specified
+    array :math:`a` in specified order.
 
     Parameters
     ----------
@@ -851,7 +851,7 @@ def eigen_decomposition(
     -------
     :class:`tuple`
         Tuple of eigen-values :math:`w` and eigen-vectors :math:`v`. The
-        eigenv-alues are in given order, each repeated according to
+        eigenv-alues are in specified order, each repeated according to
         its multiplicity. The column ``v[:, i]`` is the normalized eigen-vector
         corresponding to the eige-nvalue ``w[i]``.
 

--- a/colour/algebra/coordinates/transformations.py
+++ b/colour/algebra/coordinates/transformations.py
@@ -2,7 +2,7 @@
 Coordinates System Transformations
 ==================================
 
-Define the objects to apply transformations on coordinates systems.
+Objects to apply transformations on coordinates systems.
 
 The following transformations are available:
 
@@ -60,7 +60,7 @@ __all__ = [
 
 def cartesian_to_spherical(a: ArrayLike) -> NDArrayFloat:
     """
-    Transform given cartesian coordinates array :math:`xyz` to spherical
+    Transform specified cartesian coordinates array :math:`xyz` to spherical
     coordinates array :math:`\\rho\\theta\\phi` (radial distance, inclination
     or elevation and azimuth).
 
@@ -100,7 +100,7 @@ def cartesian_to_spherical(a: ArrayLike) -> NDArrayFloat:
 
 def spherical_to_cartesian(a: ArrayLike) -> NDArrayFloat:
     """
-    Transform given spherical coordinates array :math:`\\rho\\theta\\phi`
+    Transform specified spherical coordinates array :math:`\\rho\\theta\\phi`
     (radial distance, inclination or elevation and azimuth) to cartesian
     coordinates array :math:`xyz`.
 
@@ -139,7 +139,7 @@ def spherical_to_cartesian(a: ArrayLike) -> NDArrayFloat:
 
 def cartesian_to_polar(a: ArrayLike) -> NDArrayFloat:
     """
-    Transform given cartesian coordinates array :math:`xy` to polar
+    Transform specified cartesian coordinates array :math:`xy` to polar
     coordinates array :math:`\\rho\\phi` (radial coordinate, angular
     coordinate).
 
@@ -176,7 +176,7 @@ def cartesian_to_polar(a: ArrayLike) -> NDArrayFloat:
 
 def polar_to_cartesian(a: ArrayLike) -> NDArrayFloat:
     """
-    Transform given polar coordinates array :math:`\\rho\\phi` (radial
+    Transform specified polar coordinates array :math:`\\rho\\phi` (radial
     coordinate, angular coordinate) to cartesian coordinates array :math:`xy`.
 
     Parameters
@@ -212,7 +212,7 @@ def polar_to_cartesian(a: ArrayLike) -> NDArrayFloat:
 
 def cartesian_to_cylindrical(a: ArrayLike) -> NDArrayFloat:
     """
-    Transform given cartesian coordinates array :math:`xyz` to cylindrical
+    Transform specified cartesian coordinates array :math:`xyz` to cylindrical
     coordinates array :math:`\\rho\\phi z` (radial distance, azimuth and
     height).
 
@@ -248,7 +248,7 @@ def cartesian_to_cylindrical(a: ArrayLike) -> NDArrayFloat:
 
 def cylindrical_to_cartesian(a: ArrayLike) -> NDArrayFloat:
     """
-    Transform given cylindrical coordinates array :math:`\\rho\\phi z`
+    Transform specified cylindrical coordinates array :math:`\\rho\\phi z`
     (radial distance, azimuth and height) to cartesian coordinates array
     :math:`xyz`.
 

--- a/colour/algebra/extrapolation.py
+++ b/colour/algebra/extrapolation.py
@@ -2,7 +2,7 @@
 Extrapolation
 =============
 
-Define the classes for extrapolating variables:
+Classes for extrapolating variables:
 
 -   :class:`colour.Extrapolator`: 1-D function extrapolation.
 
@@ -60,21 +60,21 @@ __all__ = [
 
 class Extrapolator:
     """
-    Extrapolate the 1-D function of given interpolator.
+    Extrapolate the 1-D function of specified interpolator.
 
     The :class:`colour.Extrapolator` class acts as a wrapper around a given
     *Colour* or *scipy* interpolator class instance with compatible signature.
     Two extrapolation methods are available:
 
-    -   *Linear*: Linearly extrapolates given points using the slope defined by
-        the interpolator boundaries (xi[0], xi[1]) if x < xi[0] and
+    -   *Linear*: Linearly extrapolates specified points using the slope defined
+        by the interpolator boundaries (xi[0], xi[1]) if x < xi[0] and
         (xi[-1], xi[-2]) if x > xi[-1].
-    -   *Constant*: Extrapolates given points by assigning the interpolator
+    -   *Constant*: Extrapolates specified points by assigning the interpolator
         boundaries values xi[0] if x < xi[0] and xi[-1] if x > xi[-1].
 
     Specifying the *left* and *right* arguments takes precedence on the chosen
     extrapolation method and will assign the respective *left* and *right*
-    values to the given points.
+    values to the specified points.
 
     Parameters
     ----------
@@ -292,7 +292,7 @@ class Extrapolator:
 
     def __call__(self, x: ArrayLike) -> NDArrayFloat:
         """
-        Evaluate the Extrapolator at given point(s).
+        Evaluate the Extrapolator at specified point(s).
 
         Parameters
         ----------
@@ -313,7 +313,7 @@ class Extrapolator:
 
     def _evaluate(self, x: NDArrayFloat) -> NDArrayFloat:
         """
-        Perform the extrapolating evaluation at given points.
+        Perform the extrapolating evaluation at specified points.
 
         Parameters
         ----------

--- a/colour/algebra/interpolation.py
+++ b/colour/algebra/interpolation.py
@@ -2,7 +2,7 @@
 Interpolation
 =============
 
-Define the classes and definitions for interpolating variables.
+Classes and definitions for interpolating variables.
 
 -   :class:`colour.KernelInterpolator`: 1-D function generic interpolation with
     arbitrary kernel.
@@ -24,8 +24,8 @@ Define the classes and definitions for interpolating variables.
     interpolation with table.
 -   :attr:`colour.TABLE_INTERPOLATION_METHODS`: Supported table interpolation
     methods.
--   :func:`colour.table_interpolation`: Interpolation with table using given
-    method.
+-   :func:`colour.table_interpolation`: Interpolation with table using
+    specified method.
 
 References
 ----------
@@ -134,7 +134,7 @@ __all__ = [
 
 def kernel_nearest_neighbour(x: ArrayLike) -> NDArrayFloat:
     """
-    Return the *nearest-neighbour* kernel evaluated at given samples.
+    Return the *nearest-neighbour* kernel evaluated at specified samples.
 
     Parameters
     ----------
@@ -144,7 +144,7 @@ def kernel_nearest_neighbour(x: ArrayLike) -> NDArrayFloat:
     Returns
     -------
     :class:`numpy.ndarray`
-        The *nearest-neighbour* kernel evaluated at given samples.
+        The *nearest-neighbour* kernel evaluated at specified samples.
 
     References
     ----------
@@ -161,7 +161,7 @@ def kernel_nearest_neighbour(x: ArrayLike) -> NDArrayFloat:
 
 def kernel_linear(x: ArrayLike) -> NDArrayFloat:
     """
-    Return the *linear* kernel evaluated at given samples.
+    Return the *linear* kernel evaluated at specified samples.
 
     Parameters
     ----------
@@ -171,7 +171,7 @@ def kernel_linear(x: ArrayLike) -> NDArrayFloat:
     Returns
     -------
     :class:`numpy.ndarray`
-        The *linear* kernel evaluated at given samples.
+        The *linear* kernel evaluated at specified samples.
 
     References
     ----------
@@ -191,7 +191,7 @@ def kernel_linear(x: ArrayLike) -> NDArrayFloat:
 
 def kernel_sinc(x: ArrayLike, a: float = 3) -> NDArrayFloat:
     """
-    Return the *sinc* kernel evaluated at given samples.
+    Return the *sinc* kernel evaluated at specified samples.
 
     Parameters
     ----------
@@ -203,7 +203,7 @@ def kernel_sinc(x: ArrayLike, a: float = 3) -> NDArrayFloat:
     Returns
     -------
     :class:`numpy.ndarray`
-        The *sinc* kernel evaluated at given samples.
+        The *sinc* kernel evaluated at specified samples.
 
     References
     ----------
@@ -227,7 +227,7 @@ def kernel_sinc(x: ArrayLike, a: float = 3) -> NDArrayFloat:
 
 def kernel_lanczos(x: ArrayLike, a: float = 3) -> NDArrayFloat:
     """
-    Return the *lanczos* kernel evaluated at given samples.
+    Return the *lanczos* kernel evaluated at specified samples.
 
     Parameters
     ----------
@@ -239,7 +239,7 @@ def kernel_lanczos(x: ArrayLike, a: float = 3) -> NDArrayFloat:
     Returns
     -------
     :class:`numpy.ndarray`
-        The *lanczos* kernel evaluated at given samples.
+        The *lanczos* kernel evaluated at specified samples.
 
     References
     ----------
@@ -265,7 +265,7 @@ def kernel_cardinal_spline(
     x: ArrayLike, a: float = 0.5, b: float = 0.0
 ) -> NDArrayFloat:
     """
-    Return the *cardinal spline* kernel evaluated at given samples.
+    Return the *cardinal spline* kernel evaluated at specified samples.
 
     Notable *cardinal spline* :math:`a` and :math:`b` parameterizations:
 
@@ -285,7 +285,7 @@ def kernel_cardinal_spline(
     Returns
     -------
     :class:`numpy.ndarray`
-        The *cardinal spline* kernel evaluated at given samples.
+        The *cardinal spline* kernel evaluated at specified samples.
 
     References
     ----------
@@ -323,7 +323,7 @@ class KernelInterpolator:
 
     The reconstruction of a continuous signal can be described as a linear
     convolution operation. Interpolation can be expressed as a convolution of
-    the given discrete function :math:`g(x)` with some continuous interpolation
+    the specified discrete function :math:`g(x)` with some continuous interpolation
     kernel :math:`k(w)`::
 
         :math:`\\hat{g}(w_0) = [k * g](w_0) = \
@@ -648,7 +648,7 @@ class KernelInterpolator:
 
     def __call__(self, x: ArrayLike) -> NDArrayFloat:
         """
-        Evaluate the interpolator at given point(s).
+        Evaluate the interpolator at specified point(s).
 
         Parameters
         ----------
@@ -669,7 +669,7 @@ class KernelInterpolator:
 
     def _evaluate(self, x: NDArrayFloat) -> NDArrayFloat:
         """
-        Perform the interpolator evaluation at given points.
+        Perform the interpolator evaluation at specified points.
 
         Parameters
         ----------
@@ -715,7 +715,7 @@ class KernelInterpolator:
             raise ValueError(error)
 
     def _validate_interpolation_range(self, x: NDArrayFloat) -> None:
-        """Validate given point to be in interpolation range."""
+        """Validate specified point to be in interpolation range."""
 
         below_interpolation_range = x < self._x[0]
         above_interpolation_range = x > self._x[-1]
@@ -894,7 +894,7 @@ class LinearInterpolator:
 
     def __call__(self, x: ArrayLike) -> NDArrayFloat:
         """
-        Evaluate the interpolating polynomial at given point(s).
+        Evaluate the interpolating polynomial at specified point(s).
 
 
         Parameters
@@ -916,7 +916,7 @@ class LinearInterpolator:
 
     def _evaluate(self, x: NDArrayFloat) -> NDArrayFloat:
         """
-        Perform the interpolating polynomial evaluation at given points.
+        Perform the interpolating polynomial evaluation at specified points.
 
         Parameters
         ----------
@@ -946,7 +946,7 @@ class LinearInterpolator:
             raise ValueError(error)
 
     def _validate_interpolation_range(self, x: NDArrayFloat) -> None:
-        """Validate given point to be in interpolation range."""
+        """Validate specified point to be in interpolation range."""
 
         below_interpolation_range = x < self._x[0]
         above_interpolation_range = x > self._x[-1]
@@ -1161,7 +1161,7 @@ class SpragueInterpolator:
 
     def __call__(self, x: ArrayLike) -> NDArrayFloat:
         """
-        Evaluate the interpolating polynomial at given point(s).
+        Evaluate the interpolating polynomial at specified point(s).
 
         Parameters
         ----------
@@ -1182,7 +1182,7 @@ class SpragueInterpolator:
 
     def _evaluate(self, x: NDArrayFloat) -> NDArrayFloat:
         """
-        Perform the interpolating polynomial evaluation at given point.
+        Perform the interpolating polynomial evaluation at specified point.
 
         Parameters
         ----------
@@ -1238,7 +1238,7 @@ class SpragueInterpolator:
             raise ValueError(error)
 
     def _validate_interpolation_range(self, x: NDArrayFloat) -> None:
-        """Validate given point to be in interpolation range."""
+        """Validate specified point to be in interpolation range."""
 
         below_interpolation_range = x < self._x[0]
         above_interpolation_range = x > self._x[-1]
@@ -1325,7 +1325,7 @@ class PchipInterpolator(scipy.interpolate.PchipInterpolator):
 
 class NullInterpolator:
     """
-    Perform 1-D function null interpolation, i.e., a call within given
+    Perform 1-D function null interpolation, i.e., a call within specified
     tolerances will return existing :math:`y` variable values and ``default``
     if outside tolerances.
 
@@ -1552,7 +1552,7 @@ class NullInterpolator:
 
     def __call__(self, x: ArrayLike) -> NDArrayFloat:
         """
-        Evaluate the interpolator at given point(s).
+        Evaluate the interpolator at specified point(s).
 
 
         Parameters
@@ -1574,7 +1574,7 @@ class NullInterpolator:
 
     def _evaluate(self, x: NDArrayFloat) -> NDArrayFloat:
         """
-        Perform the interpolator evaluation at given points.
+        Perform the interpolator evaluation at specified points.
 
         Parameters
         ----------
@@ -1615,7 +1615,7 @@ class NullInterpolator:
             raise ValueError(error)
 
     def _validate_interpolation_range(self, x: NDArrayFloat) -> None:
-        """Validate given point to be in interpolation range."""
+        """Validate specified point to be in interpolation range."""
 
         below_interpolation_range = x < self._x[0]
         above_interpolation_range = x > self._x[-1]
@@ -1633,7 +1633,7 @@ class NullInterpolator:
 
 def lagrange_coefficients(r: float, n: int = 4) -> NDArrayFloat:
     """
-    Compute the *Lagrange Coefficients* at given point :math:`r` for degree
+    Compute the *Lagrange Coefficients* at specified point :math:`r` for degree
     :math:`n`.
 
     Parameters
@@ -1671,7 +1671,7 @@ def vertices_and_relative_coordinates(
 ) -> Tuple[NDArrayFloat, NDArrayFloat]:
     """
     Compute the vertices coordinates and indexes relative :math:`V_{xyzr}`
-    coordinates from given :math:`V_{xyzr}` values and interpolation table.
+    coordinates from specified :math:`V_{xyzr}` values and interpolation table.
 
     Parameters
     ----------
@@ -1752,9 +1752,9 @@ def vertices_and_relative_coordinates(
 
     V_xyz = np.reshape(V_xyz, (-1, 3))
 
-    # Indexes computations where ``i_m`` is the maximum index value on a given
-    # table axis, ``i_f`` and ``i_c`` respectively the floor and ceiling
-    # indexes encompassing a given V_xyz value.
+    # Indexes computations where ``i_m`` is the maximum index value on a
+    # specified table axis, ``i_f`` and ``i_c`` respectively the floor and
+    # ceiling indexes encompassing a specified V_xyz value.
     i_m = np.array(table.shape[0:-1]) - 1
     i_f = as_int_array(np.floor(V_xyz * i_m))
     i_f = np.clip(i_f, 0, i_m)
@@ -1766,7 +1766,7 @@ def vertices_and_relative_coordinates(
     i_f_c = i_f, i_c
 
     # Vertices computations by indexing ``table`` with the ``i_f`` and ``i_c``
-    # indexes. 8 encompassing vertices are computed for a given V_xyz value
+    # indexes. 8 encompassing vertices are computed for a specified V_xyz value
     # forming a cube around it:
     vertices = np.array(
         [
@@ -1780,8 +1780,8 @@ def vertices_and_relative_coordinates(
 
 def table_interpolation_trilinear(V_xyz: ArrayLike, table: ArrayLike) -> NDArrayFloat:
     """
-    Perform the trilinear interpolation of given :math:`V_{xyz}` values using
-    given interpolation table.
+    Perform the trilinear interpolation of specified :math:`V_{xyz}` values
+    using specified interpolation table.
 
     Parameters
     ----------
@@ -1856,8 +1856,8 @@ def table_interpolation_trilinear(V_xyz: ArrayLike, table: ArrayLike) -> NDArray
 
 def table_interpolation_tetrahedral(V_xyz: ArrayLike, table: ArrayLike) -> NDArrayFloat:
     """
-    Perform the tetrahedral interpolation of given :math:`V_{xyz}` values using
-    given interpolation table.
+    Perform the tetrahedral interpolation of specified :math:`V_{xyz}` values
+    using specified interpolation table.
 
     Parameters
     ----------
@@ -1954,7 +1954,7 @@ def table_interpolation(
     method: Literal["Trilinear", "Tetrahedral"] | str = "Trilinear",
 ) -> NDArrayFloat:
     """
-    Perform interpolation of given :math:`V_{xyz}` values using given
+    Perform interpolation of specified :math:`V_{xyz}` values using specified
     interpolation table.
 
     Parameters

--- a/colour/algebra/prng.py
+++ b/colour/algebra/prng.py
@@ -2,7 +2,7 @@
 Random Numbers Utilities
 ========================
 
-Define the random number generator objects:
+Random number generator objects:
 
 -   :func:`colour.algebra.random_triplet_generator`
 

--- a/colour/algebra/regression.py
+++ b/colour/algebra/regression.py
@@ -2,7 +2,7 @@
 Regression
 ==========
 
-Define various objects to perform regression:
+Various objects to perform regression:
 
 -   :func:`colour.algebra.least_square_mapping_MoorePenrose`: *Least-squares*
     mapping using *Moore-Penrose* inverse.

--- a/colour/appearance/atd95.py
+++ b/colour/appearance/atd95.py
@@ -69,7 +69,7 @@ class CAM_ReferenceSpecification_ATD95(MixinDataclassArithmetic):
     """
     Define the *ATD (1995)* colour vision model reference specification.
 
-    This specification has field names consistent with *Fairchild (2013)*
+    This specification has field names consistent with the *Fairchild (2013)*
     reference.
 
     Parameters
@@ -77,11 +77,11 @@ class CAM_ReferenceSpecification_ATD95(MixinDataclassArithmetic):
     H
         *Hue* angle :math:`H` in degrees.
     C
-        Correlate of *saturation* :math:`C`. *Guth (1995)* incorrectly uses the
-        terms saturation and chroma interchangeably. However, :math:`C` is here
-        a measure of saturation rather than chroma since it is measured
-        relative to the achromatic response for the stimulus rather than that
-        of a similarly illuminated white.
+        Correlate of *saturation* :math:`C`. *Guth (1995)* incorrectly uses
+        the terms saturation and chroma interchangeably. However, :math:`C`
+        is here a measure of saturation rather than chroma since it is
+        measured relative to the achromatic response for the stimulus rather
+        than that of a similarly illuminated white.
     Br
         Correlate of *brightness* :math:`Br`.
     A_1
@@ -119,7 +119,7 @@ class CAM_Specification_ATD95(MixinDataclassArithmetic):
     Define the *ATD (1995)* colour vision model specification.
 
     This specification has field names consistent with the remaining colour
-    appearance models in :mod:`colour.appearance` but diverge from
+    appearance models in :mod:`colour.appearance` but diverge from the
     *Fairchild (2013)* reference.
 
     Parameters
@@ -127,11 +127,11 @@ class CAM_Specification_ATD95(MixinDataclassArithmetic):
     h
         *Hue* angle :math:`H` in degrees.
     C
-        Correlate of *saturation* :math:`C`. *Guth (1995)* incorrectly uses the
-        terms saturation and chroma interchangeably. However, :math:`C` is here
-        a measure of saturation rather than chroma since it is measured
-        relative to the achromatic response for the stimulus rather than that
-        of a similarly illuminated white.
+        Correlate of *saturation* :math:`C`. *Guth (1995)* incorrectly uses
+        the terms saturation and chroma interchangeably. However, :math:`C`
+        is here a measure of saturation rather than chroma since it is
+        measured relative to the achromatic response for the stimulus rather
+        than that of a similarly illuminated white.
     Q
         Correlate of *brightness* :math:`Br`.
     A_1
@@ -149,7 +149,8 @@ class CAM_Specification_ATD95(MixinDataclassArithmetic):
 
     Notes
     -----
-    -   This specification is the one used in the current model implementation.
+    -   This specification is the one used in the current model
+        implementation.
 
     References
     ----------
@@ -214,10 +215,10 @@ def XYZ_to_ATD95(
     | ``CAM_Specification_ATD95.h`` | [0, 360]              | [0, 1]        |
     +-------------------------------+-----------------------+---------------+
 
-    -   For unrelated colors, there is only self-adaptation and :math:`k_1` is
-        set to 1.0 while :math:`k_2` is set to 0.0. For related colors such as
-        typical colorimetric applications, :math:`k_1` is set to 0.0 and
-        :math:`k_2` is set to a value between 15 and 50 *(Guth, 1995)*.
+    -   For unrelated colors, there is only self-adaptation and :math:`k_1`
+        is set to 1.0 while :math:`k_2` is set to 0.0. For related colors
+        such as typical colorimetric applications, :math:`k_1` is set to 0.0
+        and :math:`k_2` is set to a value between 15 and 50 *(Guth, 1995)*.
 
     References
     ----------
@@ -281,8 +282,7 @@ T_2=0.0205377..., D_2=0.0107584...)
 
 def luminance_to_retinal_illuminance(XYZ: ArrayLike, Y_c: ArrayLike) -> NDArrayFloat:
     """
-    Convert from luminance in :math:`cd/m^2` to retinal illuminance in
-    trolands.
+    Convert luminance in :math:`cd/m^2` to retinal illuminance in trolands.
 
     Parameters
     ----------
@@ -312,7 +312,7 @@ def luminance_to_retinal_illuminance(XYZ: ArrayLike, Y_c: ArrayLike) -> NDArrayF
 
 def XYZ_to_LMS_ATD95(XYZ: ArrayLike) -> NDArrayFloat:
     """
-    Convert from *CIE XYZ* tristimulus values to *LMS* cone responses.
+    Convert *CIE XYZ* tristimulus values to *LMS* cone responses.
 
     Parameters
     ----------
@@ -349,12 +349,13 @@ def XYZ_to_LMS_ATD95(XYZ: ArrayLike) -> NDArrayFloat:
 
 def opponent_colour_dimensions(LMS_g: ArrayLike) -> NDArrayFloat:
     """
-    Return opponent colour dimensions from given post adaptation cone signals.
+    Compute opponent colour dimensions from the specified post-adaptation cone
+    signals.
 
     Parameters
     ----------
     LMS_g
-        Post adaptation cone signals.
+        Post-adaptation cone signals.
 
     Returns
     -------
@@ -389,12 +390,12 @@ def opponent_colour_dimensions(LMS_g: ArrayLike) -> NDArrayFloat:
 
 def final_response(value: ArrayLike) -> NDArrayFloat:
     """
-    Return the final response of given opponent colour dimension.
+    Compute the final response of the specified opponent colour dimension.
 
     Parameters
     ----------
     value
-         Opponent colour dimension.
+        Opponent colour dimension.
 
     Returns
     -------

--- a/colour/appearance/cam16.py
+++ b/colour/appearance/cam16.py
@@ -109,8 +109,8 @@ class InductionFactors_CAM16(MixinDataclassIterable):
 
     Notes
     -----
-    -   The *CAM16* colour appearance model induction factors are the same as
-        *CIECAM02* colour appearance model.
+    -   The *CAM16* colour appearance model induction factors are the same
+        as *CIECAM02* colour appearance model.
 
     References
     ----------
@@ -142,7 +142,7 @@ class CAM_Specification_CAM16(MixinDataclassArithmetic):
     Parameters
     ----------
     J
-        Correlate of *Lightness* :math:`J`.
+        Correlate of *lightness* :math:`J`.
     C
         Correlate of *chroma* :math:`C`.
     h
@@ -185,7 +185,7 @@ def XYZ_to_CAM16(
     compute_H: bool = True,
 ) -> CAM_Specification_CAM16:
     """
-    Compute the *CAM16* colour appearance model correlates from given
+    Compute the *CAM16* colour appearance model correlates from the specified
     *CIE XYZ* tristimulus values.
 
     Parameters
@@ -195,22 +195,22 @@ def XYZ_to_CAM16(
     XYZ_w
         *CIE XYZ* tristimulus values of reference white.
     L_A
-        Adapting field *luminance* :math:`L_A` in :math:`cd/m^2`, (often taken
-        to be 20% of the luminance of a white object in the scene).
+        Adapting field *luminance* :math:`L_A` in :math:`cd/m^2`, (often
+        taken to be 20% of the luminance of a white object in the scene).
     Y_b
         Luminous factor of background :math:`Y_b` such as
-        :math:`Y_b = 100 x L_b / L_w` where :math:`L_w` is the luminance of the
-        light source and :math:`L_b` is the luminance of the background. For
-        viewing images, :math:`Y_b` can be the average :math:`Y` value for the
-        pixels in the entire image, or frequently, a :math:`Y` value of 20,
-        approximate an :math:`L^*` of 50 is used.
+        :math:`Y_b = 100 x L_b / L_w` where :math:`L_w` is the luminance of
+        the light source and :math:`L_b` is the luminance of the background.
+        For viewing images, :math:`Y_b` can be the average :math:`Y` value
+        for the pixels in the entire image, or frequently, a :math:`Y` value
+        of 20, approximate an :math:`L^*` of 50 is used.
     surround
         Surround viewing conditions induction factors.
     discount_illuminant
         Truth value indicating if the illuminant should be discounted.
     compute_H
-        Whether to compute *Hue* :math:`h` quadrature :math:`H`. :math:`H` is
-        rarely used, and expensive to compute.
+        Whether to compute *Hue* :math:`h` quadrature :math:`H`. :math:`H`
+        is rarely used, and expensive to compute.
 
     Returns
     -------
@@ -361,27 +361,27 @@ def CAM16_to_XYZ(
     discount_illuminant: bool = False,
 ) -> NDArrayFloat:
     """
-    Convert from *CAM16* specification to *CIE XYZ* tristimulus values.
+    Convert *CAM16* specification to *CIE XYZ* tristimulus values.
 
     Parameters
     ----------
     specification
         *CAM16* colour appearance model specification. Correlate of
-        *Lightness* :math:`J`, correlate of *chroma* :math:`C` or correlate of
-        *colourfulness* :math:`M` and *hue* angle :math:`h` in degrees must be
-        specified, e.g., :math:`JCh` or :math:`JMh`.
+        *lightness* :math:`J`, correlate of *chroma* :math:`C` or correlate
+        of *colourfulness* :math:`M` and *hue* angle :math:`h` in degrees
+        must be specified, e.g., :math:`JCh` or :math:`JMh`.
     XYZ_w
         *CIE XYZ* tristimulus values of reference white.
     L_A
-        Adapting field *luminance* :math:`L_A` in :math:`cd/m^2`, (often taken
-        to be 20% of the luminance of a white object in the scene).
+        Adapting field *luminance* :math:`L_A` in :math:`cd/m^2`, (often
+        taken to be 20% of the luminance of a white object in the scene).
     Y_b
         Luminous factor of background :math:`Y_b` such as
-        :math:`Y_b = 100 x L_b / L_w` where :math:`L_w` is the luminance of the
-        light source and :math:`L_b` is the luminance of the background. For
-        viewing images, :math:`Y_b` can be the average :math:`Y` value for the
-        pixels in the entire image, or frequently, a :math:`Y` value of 20,
-        approximate an :math:`L^*` of 50 is used.
+        :math:`Y_b = 100 x L_b / L_w` where :math:`L_w` is the luminance of
+        the light source and :math:`L_b` is the luminance of the background.
+        For viewing images, :math:`Y_b` can be the average :math:`Y` value
+        for the pixels in the entire image, or frequently, a :math:`Y` value
+        of 20, approximate an :math:`L^*` of 50 is used.
     surround
         Surround viewing conditions.
     discount_illuminant
@@ -395,8 +395,8 @@ def CAM16_to_XYZ(
     Raises
     ------
     ValueError
-        If neither :math:`C` or :math:`M` correlates have been defined in the
-        ``specification`` argument.
+        If neither :math:`C` or :math:`M` correlates have been defined in
+        the ``specification`` argument.
 
     Notes
     -----

--- a/colour/appearance/ciecam02.py
+++ b/colour/appearance/ciecam02.py
@@ -194,7 +194,7 @@ class CAM_Specification_CIECAM02(MixinDataclassArithmetic):
     Parameters
     ----------
     J
-        Correlate of *Lightness* :math:`J`.
+        Correlate of *lightness* :math:`J`.
     C
         Correlate of *chroma* :math:`C`.
     h
@@ -236,7 +236,7 @@ def XYZ_to_CIECAM02(
     compute_H: bool = True,
 ) -> CAM_Specification_CIECAM02:
     """
-    Compute the *CIECAM02* colour appearance model correlates from given
+    Compute the *CIECAM02* colour appearance model correlates from the specified
     *CIE XYZ* tristimulus values.
 
     Parameters
@@ -416,7 +416,7 @@ def CIECAM02_to_XYZ(
     discount_illuminant: bool = False,
 ) -> NDArrayFloat:
     """
-    Convert from *CIECAM02* specification to *CIE XYZ* tristimulus values.
+    Convert *CIECAM02* specification to *CIE XYZ* tristimulus values.
 
     Parameters
     ----------
@@ -600,7 +600,8 @@ def CIECAM02_to_XYZ(
 
 def chromatic_induction_factors(n: ArrayLike) -> NDArrayFloat:
     """
-    Return the chromatic induction factors :math:`N_{bb}` and :math:`N_{cb}`.
+    Compute the chromatic induction factors :math:`N_{bb}` and
+    :math:`N_{cb}`.
 
     Parameters
     ----------
@@ -630,7 +631,7 @@ def base_exponential_non_linearity(
     n: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Return the base exponential non-linearity :math:`n`.
+    Compute the base exponential non-linearity :math:`n`.
 
     Parameters
     ----------
@@ -665,7 +666,7 @@ def viewing_conditions_dependent_parameters(
     NDArrayFloat,
 ]:
     """
-    Return the viewing condition dependent parameters.
+    Compute the viewing condition dependent parameters.
 
     Parameters
     ----------
@@ -703,9 +704,9 @@ def viewing_conditions_dependent_parameters(
 
 def degree_of_adaptation(F: ArrayLike, L_A: ArrayLike) -> NDArrayFloat:
     """
-    Return the degree of adaptation :math:`D` from given surround maximum
-    degree of adaptation :math:`F` and adapting field *luminance* :math:`L_A`
-    in :math:`cd/m^2`.
+    Compute the degree of adaptation :math:`D` from the specified surround
+    maximum degree of adaptation :math:`F` and adapting field *luminance*
+    :math:`L_A` in :math:`cd/m^2`.
 
     Parameters
     ----------
@@ -738,8 +739,8 @@ def full_chromatic_adaptation_forward(
     D: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Apply full chromatic adaptation to given *CMCCAT2000* transform sharpened
-    *RGB* array using given *CMCCAT2000* transform sharpened whitepoint
+    Apply full chromatic adaptation to specified *CMCCAT2000* transform sharpened
+    *RGB* array using specified *CMCCAT2000* transform sharpened whitepoint
     *RGB_w* array.
 
     Parameters
@@ -787,8 +788,8 @@ def full_chromatic_adaptation_inverse(
     D: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Revert full chromatic adaptation of given *CMCCAT2000* transform sharpened
-    *RGB* array using given *CMCCAT2000* transform sharpened whitepoint
+    Revert full chromatic adaptation of specified *CMCCAT2000* transform sharpened
+    *RGB* array using specified *CMCCAT2000* transform sharpened whitepoint
     *RGB_w* array.
 
     Parameters
@@ -830,7 +831,7 @@ def full_chromatic_adaptation_inverse(
 
 def RGB_to_rgb(RGB: ArrayLike) -> NDArrayFloat:
     """
-    Convert given *RGB* array to *Hunt-Pointer-Estevez*
+    Convert the specified *RGB* array to *Hunt-Pointer-Estevez*
     :math:`\\rho\\gamma\\beta` colourspace.
 
     Parameters
@@ -855,7 +856,7 @@ def RGB_to_rgb(RGB: ArrayLike) -> NDArrayFloat:
 
 def rgb_to_RGB(rgb: ArrayLike) -> NDArrayFloat:
     """
-    Convert given *Hunt-Pointer-Estevez* :math:`\\rho\\gamma\\beta`
+    Convert the specified *Hunt-Pointer-Estevez* :math:`\\rho\\gamma\\beta`
     colourspace array to *RGB* array.
 
     Parameters
@@ -882,8 +883,8 @@ def post_adaptation_non_linear_response_compression_forward(
     RGB: ArrayLike, F_L: ArrayLike
 ) -> NDArrayFloat:
     """
-    Return given *CMCCAT2000* transform sharpened *RGB* array with post
-    adaptation non-linear response compression.
+    Apply post adaptation non-linear response compression to the specified
+    *CMCCAT2000* transform sharpened *RGB* array.
 
     Parameters
     ----------
@@ -923,8 +924,8 @@ def post_adaptation_non_linear_response_compression_inverse(
     RGB: ArrayLike, F_L: ArrayLike
 ) -> NDArrayFloat:
     """
-    Return given *CMCCAT2000* transform sharpened *RGB* array without post
-    adaptation non-linear response compression.
+    Remove post adaptation non-linear response compression from the specified
+    *CMCCAT2000* transform sharpened *RGB* array.
 
     Parameters
     ----------
@@ -963,8 +964,9 @@ def post_adaptation_non_linear_response_compression_inverse(
 
 def opponent_colour_dimensions_forward(RGB: ArrayLike) -> NDArrayFloat:
     """
-    Return opponent colour dimensions from given compressed *CMCCAT2000*
-    transform sharpened *RGB* array for forward *CIECAM02* implementation.
+    Compute opponent colour dimensions from the specified compressed
+    *CMCCAT2000* transform sharpened *RGB* array for forward
+    *CIECAM02* implementation.
 
     Parameters
     ----------
@@ -993,8 +995,8 @@ def opponent_colour_dimensions_forward(RGB: ArrayLike) -> NDArrayFloat:
 
 def opponent_colour_dimensions_inverse(P_n: ArrayLike, h: ArrayLike) -> NDArrayFloat:
     """
-    Return opponent colour dimensions from given points :math:`P_n` and hue
-    :math:`h` in degrees for inverse *CIECAM02* implementation.
+    Compute opponent colour dimensions from the specified points :math:`P_n`
+    and hue :math:`h` in degrees for inverse *CIECAM02* implementation.
 
     Parameters
     ----------
@@ -1077,7 +1079,7 @@ def opponent_colour_dimensions_inverse(P_n: ArrayLike, h: ArrayLike) -> NDArrayF
 
 def hue_angle(a: ArrayLike, b: ArrayLike) -> NDArrayFloat:
     """
-    Return the *hue* angle :math:`h` in degrees.
+    Compute the *hue* angle :math:`h` in degrees.
 
     Parameters
     ----------
@@ -1109,7 +1111,8 @@ def hue_angle(a: ArrayLike, b: ArrayLike) -> NDArrayFloat:
 
 def hue_quadrature(h: ArrayLike) -> NDArrayFloat:
     """
-    Return the hue quadrature from given hue :math:`h` angle in degrees.
+    Compute the hue quadrature from the specified hue :math:`h` angle in
+    degrees.
 
     Parameters
     ----------
@@ -1161,8 +1164,8 @@ def hue_quadrature(h: ArrayLike) -> NDArrayFloat:
 
 def eccentricity_factor(h: ArrayLike) -> NDArrayFloat:
     """
-    Return the eccentricity factor :math:`e_t` from given hue :math:`h` angle
-    in degrees for forward *CIECAM02* implementation.
+    Compute the eccentricity factor :math:`e_t` from the specified hue
+    :math:`h` angle in degrees for forward *CIECAM02* implementation.
 
     Parameters
     ----------
@@ -1187,7 +1190,7 @@ def eccentricity_factor(h: ArrayLike) -> NDArrayFloat:
 
 def achromatic_response_forward(RGB: ArrayLike, N_bb: ArrayLike) -> NDArrayFloat:
     """
-    Return the achromatic response :math:`A` from given compressed
+    Compute the achromatic response :math:`A` from the specified compressed
     *CMCCAT2000* transform sharpened *RGB* array and :math:`N_{bb}` chromatic
     induction factor for forward *CIECAM02* implementation.
 
@@ -1223,7 +1226,8 @@ def achromatic_response_inverse(
     z: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Return the achromatic response :math:`A` from given achromatic response
+    Compute the achromatic response :math:`A` from the specified achromatic
+    response
     :math:`A_w` for the whitepoint, *Lightness* correlate :math:`J`, surround
     exponential non-linearity :math:`c` and base exponential non-linearity
     :math:`z` for inverse *CIECAM02* implementation.
@@ -1269,7 +1273,7 @@ def lightness_correlate(
     z: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Return the *Lightness* correlate :math:`J`.
+    Compute the *Lightness* correlate :math:`J`.
 
     Parameters
     ----------
@@ -1313,7 +1317,7 @@ def brightness_correlate(
     F_L: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Return the *brightness* correlate :math:`Q`.
+    Compute the *brightness* correlate :math:`Q`.
 
     Parameters
     ----------
@@ -1358,8 +1362,8 @@ def temporary_magnitude_quantity_forward(
     RGB_a: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Return the temporary magnitude quantity :math:`t`. for forward *CIECAM02*
-    implementation.
+    Compute the temporary magnitude quantity :math:`t`. for forward
+    *CIECAM02* implementation.
 
     Parameters
     ----------
@@ -1411,8 +1415,8 @@ def temporary_magnitude_quantity_inverse(
     C: ArrayLike, J: ArrayLike, n: ArrayLike
 ) -> NDArrayFloat:
     """
-    Return the temporary magnitude quantity :math:`t`. for inverse *CIECAM02*
-    implementation.
+    Compute the temporary magnitude quantity :math:`t`. for inverse
+    *CIECAM02* implementation.
 
     Parameters
     ----------
@@ -1455,7 +1459,7 @@ def chroma_correlate(
     RGB_a: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Return the *chroma* correlate :math:`C`.
+    Compute the *chroma* correlate :math:`C`.
 
     Parameters
     ----------
@@ -1506,7 +1510,7 @@ def chroma_correlate(
 
 def colourfulness_correlate(C: ArrayLike, F_L: ArrayLike) -> NDArrayFloat:
     """
-    Return the *colourfulness* correlate :math:`M`.
+    Compute the *colourfulness* correlate :math:`M`.
 
     Parameters
     ----------
@@ -1536,7 +1540,7 @@ def colourfulness_correlate(C: ArrayLike, F_L: ArrayLike) -> NDArrayFloat:
 
 def saturation_correlate(M: ArrayLike, Q: ArrayLike) -> NDArrayFloat:
     """
-    Return the *saturation* correlate :math:`s`.
+    Compute the *saturation* correlate :math:`s`.
 
     Parameters
     ----------
@@ -1574,7 +1578,7 @@ def P(
     N_bb: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Return the points :math:`P_1`, :math:`P_2` and :math:`P_3`.
+    Compute the points :math:`P_1`, :math:`P_2` and :math:`P_3`.
 
     Parameters
     ----------

--- a/colour/appearance/ciecam16.py
+++ b/colour/appearance/ciecam16.py
@@ -137,7 +137,7 @@ class CAM_Specification_CIECAM16(MixinDataclassArithmetic):
     Parameters
     ----------
     J
-        Correlate of *Lightness* :math:`J`.
+        Correlate of *lightness* :math:`J`.
     C
         Correlate of *chroma* :math:`C`.
     h
@@ -180,7 +180,7 @@ def XYZ_to_CIECAM16(
     compute_H: bool = True,
 ) -> CAM_Specification_CIECAM16:
     """
-    Compute the *CIECAM16* colour appearance model correlates from given
+    Compute the *CIECAM16* colour appearance model correlates from the specified
     *CIE XYZ* tristimulus values.
 
     Parameters
@@ -373,13 +373,13 @@ def CIECAM16_to_XYZ(
     discount_illuminant: bool = False,
 ) -> NDArrayFloat:
     """
-    Convert from *CIECAM16* specification to *CIE XYZ* tristimulus values.
+    Convert *CIECAM16* specification to *CIE XYZ* tristimulus values.
 
     Parameters
     ----------
     specification
         *CIECAM16* colour appearance model specification. Correlate of
-        *Lightness* :math:`J`, correlate of *chroma* :math:`C` or correlate of
+        *lightness* :math:`J`, correlate of *chroma* :math:`C` or correlate of
         *colourfulness* :math:`M` and *hue* angle :math:`h` in degrees must be
         specified, e.g., :math:`JCh` or :math:`JMh`.
     XYZ_w

--- a/colour/appearance/hellwig2022.py
+++ b/colour/appearance/hellwig2022.py
@@ -146,7 +146,7 @@ class CAM_Specification_Hellwig2022(MixinDataclassArithmetic):
     Parameters
     ----------
     J
-        Correlate of *Lightness* :math:`J`.
+        Correlate of *lightness* :math:`J`.
     C
         Correlate of *chroma* :math:`C`.
     h
@@ -162,7 +162,7 @@ class CAM_Specification_Hellwig2022(MixinDataclassArithmetic):
     HC
         *Hue* :math:`h` composition :math:`H^C`.
     J_HK
-        Correlate of *Lightness* :math:`J_{HK}` accounting for
+        Correlate of *lightness* :math:`J_{HK}` accounting for
         *Helmholtz-Kohlrausch* effect.
     Q_HK
         Correlate of *brightness* :math:`Q_{HK}` accounting for
@@ -198,7 +198,7 @@ def XYZ_to_Hellwig2022(
 ) -> CAM_Specification_Hellwig2022:
     """
     Compute the *Hellwig and Fairchild (2022)* colour appearance model
-    correlates from given *CIE XYZ* tristimulus values.
+    correlates from the specified *CIE XYZ* tristimulus values.
 
     This implementation supports the *Helmholtz-Kohlrausch* effect extension
     from :cite:`Hellwig2022a`.
@@ -408,7 +408,7 @@ def Hellwig2022_to_XYZ(
     discount_illuminant: bool = False,
 ) -> NDArrayFloat:
     """
-    Convert from *Hellwig and Fairchild (2022)* specification to *CIE XYZ*
+    Convert *Hellwig and Fairchild (2022)* specification to *CIE XYZ*
     tristimulus values.
 
     This implementation supports the *Helmholtz-Kohlrausch* effect extension
@@ -418,7 +418,7 @@ def Hellwig2022_to_XYZ(
     ----------
     specification
         *Hellwig and Fairchild (2022)* colour appearance model specification.
-        Correlate of *Lightness* :math:`J`, correlate of *chroma* :math:`C` or
+        Correlate of *lightness* :math:`J`, correlate of *chroma* :math:`C` or
         correlate of *colourfulness* :math:`M` and *hue* angle :math:`h` in
         degrees must be specified, e.g., :math:`JCh` or :math:`JMh`.
     XYZ_w
@@ -625,7 +625,7 @@ def viewing_conditions_dependent_parameters(
     L_A: ArrayLike,
 ) -> Tuple[NDArrayFloat, NDArrayFloat]:
     """
-    Return the viewing condition dependent parameters.
+    Compute the viewing condition dependent parameters.
 
     Parameters
     ----------
@@ -662,7 +662,7 @@ def viewing_conditions_dependent_parameters(
 
 def achromatic_response_forward(RGB: ArrayLike) -> NDArrayFloat:
     """
-    Return the achromatic response :math:`A` from given compressed
+    Compute the achromatic response :math:`A` from the specified compressed
     *CAM16* transform sharpened *RGB* array and :math:`N_{bb}` chromatic
     induction factor for forward *Hellwig and Fairchild (2022)* implementation.
 
@@ -692,7 +692,7 @@ def opponent_colour_dimensions_inverse(
     P_p_1: ArrayLike, h: ArrayLike, M: ArrayLike
 ) -> NDArrayFloat:
     """
-    Return opponent colour dimensions from given point :math:`P'_1`, hue
+    Compute opponent colour dimensions from the specified point :math:`P'_1`, hue
     :math:`h` in degrees and correlate of *colourfulness* :math:`M` for
     inverse *Hellwig and Fairchild (2022)* implementation.
 
@@ -735,7 +735,7 @@ def opponent_colour_dimensions_inverse(
 
 def eccentricity_factor(h: ArrayLike) -> NDArrayFloat:
     """
-    Return the eccentricity factor :math:`e_t` from given hue :math:`h` angle
+    Compute the eccentricity factor :math:`e_t` from the specified hue :math:`h` angle
     in degrees for forward *CIECAM02* implementation.
 
     Parameters
@@ -782,7 +782,7 @@ def brightness_correlate(
     A_w: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Return the *brightness* correlate :math:`Q`.
+    Compute the *brightness* correlate :math:`Q`.
 
     Parameters
     ----------
@@ -822,7 +822,7 @@ def colourfulness_correlate(
     b: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Return the *colourfulness* correlate :math:`M`.
+    Compute the *colourfulness* correlate :math:`M`.
 
     Parameters
     ----------
@@ -863,7 +863,7 @@ def chroma_correlate(
     A_w: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Return the *chroma* correlate :math:`C`.
+    Compute the *chroma* correlate :math:`C`.
 
     Parameters
     ----------
@@ -894,7 +894,7 @@ def chroma_correlate(
 
 def saturation_correlate(M: ArrayLike, Q: ArrayLike) -> NDArrayFloat:
     """
-    Return the *saturation* correlate :math:`s`.
+    Compute the *saturation* correlate :math:`s`.
 
     Parameters
     ----------
@@ -929,7 +929,7 @@ def P_p(
     A: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Return the points :math:`P'_1` and :math:`P'_2`.
+    Compute the points :math:`P'_1` and :math:`P'_2`.
 
     Parameters
     ----------

--- a/colour/appearance/hke.py
+++ b/colour/appearance/hke.py
@@ -58,8 +58,8 @@ HKE_NAYATANI1997_METHODS = CanonicalMapping(
     }
 )
 HKE_NAYATANI1997_METHODS.__doc__ = """
-*Nayatani (1997)* *HKE* computation methods, choice between variable achromatic
-colour ('VAC') and variable chromatic colour ('VCC')
+*Nayatani (1997)* *HKE* computation methods, choice between variable
+achromatic colour ('VAC') and variable chromatic colour ('VCC')
 
 References
 ----------
@@ -74,7 +74,7 @@ def HelmholtzKohlrausch_effect_object_Nayatani1997(
     method: Literal["VAC", "VCC"] | str = "VCC",
 ) -> NDArrayFloat:
     """
-    Return the *HKE* value for object colours using *Nayatani (1997)* method.
+    Compute the *HKE* value for object colours using *Nayatani (1997)* method.
 
     Parameters
     ----------
@@ -131,7 +131,7 @@ def HelmholtzKohlrausch_effect_luminous_Nayatani1997(
     method: Literal["VAC", "VCC"] | str = "VCC",
 ) -> NDArrayFloat:
     """
-    Return the *HKE* factor for luminous colours using *Nayatani (1997)* method.
+    Compute the *HKE* factor for luminous colours using *Nayatani (1997)* method.
 
     Parameters
     ----------
@@ -183,7 +183,7 @@ def coefficient_q_Nayatani1997(
     theta: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Return the :math:`q(\\theta)` coefficient for *Nayatani (1997)* *HKE*
+    Compute the :math:`q(\\theta)` coefficient for *Nayatani (1997)* *HKE*
     computations.
 
     The hue angle :math:`\\theta` can be computed as follows:
@@ -246,7 +246,7 @@ def coefficient_K_Br_Nayatani1997(L_a: NDArray) -> NDArrayFloat: ...
 def coefficient_K_Br_Nayatani1997(L_a: ArrayLike) -> DTypeFloat | NDArrayFloat: ...
 def coefficient_K_Br_Nayatani1997(L_a: ArrayLike) -> DTypeFloat | NDArrayFloat:
     """
-    Return the :math:`K_{Br}` coefficient for *Nayatani (1997)* *HKE*
+    Compute the :math:`K_{Br}` coefficient for *Nayatani (1997)* *HKE*
     computations.
 
     Parameters

--- a/colour/appearance/hunt.py
+++ b/colour/appearance/hunt.py
@@ -94,15 +94,16 @@ class InductionFactors_Hunt(MixinDataclassIterable):
     N_c
         Chromatic surround induction factor :math:`N_c`.
     N_b
-        *Brightness* surround induction factor :math:`N_b`.
+        Brightness surround induction factor :math:`N_b`.
     N_cb
         Chromatic background induction factor :math:`N_{cb}`, approximated
         using tristimulus values :math:`Y_w` and :math:`Y_b` of
         respectively the reference white and the background if not specified.
     N_bb
-        *Brightness* background induction factor :math:`N_{bb}`, approximated
+        Brightness background induction factor :math:`N_{bb}`, approximated
         using tristimulus values :math:`Y_w` and :math:`Y_b` of
-        respectively the reference white and the background if not specified.
+        respectively the reference white and the background if not
+        specified.
 
     References
     ----------
@@ -301,11 +302,11 @@ def XYZ_to_Hunt(
         Scotopic luminance :math:`L_{AS}` of the illuminant, approximated if
         not specified.
     CCT_w
-        Correlated color temperature :math:`T_{cp}`: of the illuminant, needed
-        to approximate :math:`L_{AS}`.
+        Correlated color temperature :math:`T_{cp}` of the illuminant,
+        needed to approximate :math:`L_{AS}`.
     XYZ_p
-        *CIE XYZ* tristimulus values of proximal field, assumed to be equal to
-        background if not specified.
+        *CIE XYZ* tristimulus values of proximal field, assumed to be equal
+        to background if not specified.
     p
         Simultaneous contrast / assimilation factor :math:`p` with value
         normalised to domain [-1, 0] when simultaneous contrast occurs and
@@ -315,13 +316,13 @@ def XYZ_to_Hunt(
         tristimulus values :math:`Y` of the stimulus if not specified.
     S_w
         Scotopic response :math:`S_w` for the reference white, approximated
-        using the tristimulus values :math:`Y_w` of the reference white if not
-        specified.
+        using the tristimulus values :math:`Y_w` of the reference white if
+        not specified.
     helson_judd_effect
         Truth value indicating whether the *Helson-Judd* effect should be
         accounted for.
     discount_illuminant
-       Truth value indicating if the illuminant should be discounted.
+        Truth value indicating if the illuminant should be discounted.
 
     Returns
     -------
@@ -544,7 +545,7 @@ def luminance_level_adaptation_factor(
     L_A: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Return the *luminance* level adaptation factor :math:`F_L`.
+    Compute the *luminance* level adaptation factor :math:`F_L`.
 
     Parameters
     ----------
@@ -554,7 +555,7 @@ def luminance_level_adaptation_factor(
     Returns
     -------
     :class:`numpy.ndarray`
-        *Luminance* level adaptation factor :math:`F_L`
+        *Luminance* level adaptation factor :math:`F_L`.
 
     Examples
     --------
@@ -573,7 +574,7 @@ def luminance_level_adaptation_factor(
 
 def illuminant_scotopic_luminance(L_A: ArrayLike, CCT: ArrayLike) -> NDArrayFloat:
     """
-    Return the approximate scotopic luminance :math:`L_{AS}` of the
+    Compute the approximate scotopic luminance :math:`L_{AS}` of the
     illuminant.
 
     Parameters
@@ -604,7 +605,7 @@ def illuminant_scotopic_luminance(L_A: ArrayLike, CCT: ArrayLike) -> NDArrayFloa
 
 def XYZ_to_rgb(XYZ: ArrayLike) -> NDArrayFloat:
     """
-    Convert from *CIE XYZ* tristimulus values to *Hunt-Pointer-Estevez*
+    Convert *CIE XYZ* tristimulus values to *Hunt-Pointer-Estevez*
     :math:`\\rho\\gamma\\beta` colourspace.
 
     Parameters
@@ -668,7 +669,7 @@ def chromatic_adaptation(
     discount_illuminant: bool = True,
 ) -> NDArrayFloat:
     """
-    Apply chromatic adaptation to given *CIE XYZ* tristimulus values.
+    Apply chromatic adaptation to the specified *CIE XYZ* tristimulus values.
 
     Parameters
     ----------
@@ -683,17 +684,17 @@ def chromatic_adaptation(
     F_L
         Luminance adaptation factor :math:`F_L`.
     XYZ_p
-        *CIE XYZ* tristimulus values of proximal field, assumed to be equal to
-        background if not specified.
+        *CIE XYZ* tristimulus values of proximal field, assumed to be equal
+        to background if not specified.
     p
         Simultaneous contrast / assimilation factor :math:`p` with value
-        normalised to  domain [-1, 0] when simultaneous contrast occurs and
+        normalised to domain [-1, 0] when simultaneous contrast occurs and
         normalised to domain [0, 1] when assimilation occurs.
     helson_judd_effect
         Truth value indicating whether the *Helson-Judd* effect should be
         accounted for.
     discount_illuminant
-       Truth value indicating if the illuminant should be discounted.
+        Truth value indicating if the illuminant should be discounted.
 
     Returns
     -------
@@ -783,8 +784,8 @@ def adjusted_reference_white_signals(
         Cone signals *Hunt-Pointer-Estevez* :math:`\\rho\\gamma\\beta`
         colourspace array of the background.
     rgb_w
-        Cone signals array *Hunt-Pointer-Estevez* :math:`\\rho\\gamma\\beta`
-        colourspace array of the reference white.
+        Cone signals array *Hunt-Pointer-Estevez*
+        :math:`\\rho\\gamma\\beta` colourspace array of the reference white.
     p
         Simultaneous contrast / assimilation factor :math:`p` with value
         normalised to domain [-1, 0] when simultaneous contrast occurs and
@@ -793,8 +794,8 @@ def adjusted_reference_white_signals(
     Returns
     -------
     :class:`numpy.ndarray`
-        Adjusted cone signals *Hunt-Pointer-Estevez* :math:`\\rho\\gamma\\beta`
-        colourspace array of the reference white.
+        Adjusted cone signals *Hunt-Pointer-Estevez*
+        :math:`\\rho\\gamma\\beta` colourspace array of the reference white.
 
     Examples
     --------
@@ -822,7 +823,7 @@ def adjusted_reference_white_signals(
 
 def achromatic_post_adaptation_signal(rgb: ArrayLike) -> NDArrayFloat:
     """
-    Return the achromatic post adaptation signal :math:`A` from given
+    Compute the achromatic post adaptation signal :math:`A` from the specified
     *Hunt-Pointer-Estevez* :math:`\\rho\\gamma\\beta` colourspace array.
 
     Parameters
@@ -849,9 +850,9 @@ def achromatic_post_adaptation_signal(rgb: ArrayLike) -> NDArrayFloat:
 
 def colour_difference_signals(rgb: ArrayLike) -> NDArrayFloat:
     """
-    Return the colour difference signals :math:`C_1`, :math:`C_2` and
-    :math:`C_3` from given *Hunt-Pointer-Estevez* :math:`\\rho\\gamma\\beta`
-    colourspace array.
+    Compute the colour difference signals :math:`C_1`, :math:`C_2` and
+    :math:`C_3` from the specified *Hunt-Pointer-Estevez*
+    :math:`\\rho\\gamma\\beta` colourspace array.
 
     Parameters
     ----------
@@ -881,8 +882,8 @@ def colour_difference_signals(rgb: ArrayLike) -> NDArrayFloat:
 
 def hue_angle(C: ArrayLike) -> NDArrayFloat:
     """
-    Return the *hue* angle :math:`h` in degrees from given colour difference
-    signals :math:`C`.
+    Compute the *hue* angle :math:`h` in degrees from the specified colour
+    difference signals :math:`C`.
 
     Parameters
     ----------
@@ -910,8 +911,8 @@ def hue_angle(C: ArrayLike) -> NDArrayFloat:
 
 def eccentricity_factor(hue: ArrayLike) -> NDArrayFloat:
     """
-    Return eccentricity factor :math:`e_s` from given hue angle :math:`h`
-    in degrees.
+    Compute eccentricity factor :math:`e_s` from the specified hue angle
+    :math:`h` in degrees.
 
     Parameters
     ----------
@@ -945,8 +946,8 @@ def low_luminance_tritanopia_factor(
     L_A: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Return the low luminance tritanopia factor :math:`F_t` from given adapting
-    field *luminance* :math:`L_A` in :math:`cd/m^2`.
+    Compute the low luminance tritanopia factor :math:`F_t` from the specified
+    adapting field *luminance* :math:`L_A` in :math:`cd/m^2`.
 
     Parameters
     ----------
@@ -979,7 +980,7 @@ def yellowness_blueness_response(
     F_t: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Return the yellowness / blueness response :math:`M_{yb}`.
+    Compute the yellowness / blueness response :math:`M_{yb}`.
 
     Parameters
     ----------
@@ -988,9 +989,9 @@ def yellowness_blueness_response(
     e_s
         Eccentricity factor :math:`e_s`.
     N_c
-         Chromatic surround induction factor :math:`N_c`.
+        Chromatic surround induction factor :math:`N_c`.
     N_cb
-         Chromatic background induction factor :math:`N_{cb}`.
+        Chromatic background induction factor :math:`N_{cb}`.
     F_t
         Low luminance tritanopia factor :math:`F_t`.
 
@@ -1029,7 +1030,7 @@ def redness_greenness_response(
     N_cb: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Return the redness / greenness response :math:`M_{yb}`.
+    Compute the redness / greenness response :math:`M_{rg}`.
 
     Parameters
     ----------
@@ -1038,9 +1039,9 @@ def redness_greenness_response(
     e_s
         Eccentricity factor :math:`e_s`.
     N_c
-         Chromatic surround induction factor :math:`N_c`.
+        Chromatic surround induction factor :math:`N_c`.
     N_cb
-         Chromatic background induction factor :math:`N_{cb}`.
+        Chromatic background induction factor :math:`N_{cb}`.
 
     Returns
     -------
@@ -1069,14 +1070,14 @@ def redness_greenness_response(
 
 def overall_chromatic_response(M_yb: ArrayLike, M_rg: ArrayLike) -> NDArrayFloat:
     """
-    Return the overall chromatic response :math:`M`.
+    Compute the overall chromatic response :math:`M`.
 
     Parameters
     ----------
     M_yb
-         Yellowness / blueness response :math:`M_{yb}`.
+        Yellowness / blueness response :math:`M_{yb}`.
     M_rg
-         Redness / greenness response :math:`M_{rg}`.
+        Redness / greenness response :math:`M_{rg}`.
 
     Returns
     -------
@@ -1099,15 +1100,15 @@ def overall_chromatic_response(M_yb: ArrayLike, M_rg: ArrayLike) -> NDArrayFloat
 
 def saturation_correlate(M: ArrayLike, rgb_a: ArrayLike) -> NDArrayFloat:
     """
-    Return the *saturation* correlate :math:`s`.
+    Compute the *saturation* correlate :math:`s`.
 
     Parameters
     ----------
     M
-         Overall chromatic response :math:`M`.
+        Overall chromatic response :math:`M`.
     rgb_a
-        Adapted *Hunt-Pointer-Estevez* :math:`\\rho\\gamma\\beta` colourspace
-        array.
+        Adapted *Hunt-Pointer-Estevez* :math:`\\rho\\gamma\\beta`
+        colourspace array.
 
     Returns
     -------
@@ -1138,7 +1139,7 @@ def achromatic_signal(
     A_a: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Return the achromatic signal :math:`A`.
+    Compute the achromatic signal :math:`A`.
 
     Parameters
     ----------
@@ -1205,7 +1206,7 @@ def brightness_correlate(
     N_b: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Return the *brightness* correlate :math:`Q`.
+    Compute the *brightness* correlate :math:`Q`.
 
     Parameters
     ----------
@@ -1251,7 +1252,7 @@ def lightness_correlate(
     Q_w: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Return the *Lightness* correlate :math:`J`.
+    Compute the *lightness* correlate :math:`J`.
 
     Parameters
     ----------
@@ -1297,7 +1298,7 @@ def chroma_correlate(
     Q_w: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Return the *chroma* correlate :math:`C_94`.
+    Compute the *chroma* correlate :math:`C_94`.
 
     Parameters
     ----------
@@ -1343,7 +1344,7 @@ def chroma_correlate(
 
 def colourfulness_correlate(F_L: ArrayLike, C_94: ArrayLike) -> NDArrayFloat:
     """
-    Return the *colourfulness* correlate :math:`M_94`.
+    Compute the *colourfulness* correlate :math:`M_94`.
 
     Parameters
     ----------

--- a/colour/appearance/kim2009.py
+++ b/colour/appearance/kim2009.py
@@ -226,7 +226,7 @@ def XYZ_to_Kim2009(
 ) -> CAM_Specification_Kim2009:
     """
     Compute the *Kim, Weyrich and Kautz (2009)* colour appearance model
-    correlates from given *CIE XYZ* tristimulus values.
+    correlates from the specified *CIE XYZ* tristimulus values.
 
     Parameters
     ----------
@@ -392,7 +392,7 @@ def Kim2009_to_XYZ(
     discount_illuminant: bool = False,
 ) -> NDArrayFloat:
     """
-    Convert from *Kim, Weyrich and Kautz (2009)* specification to *CIE XYZ*
+    Convert *Kim, Weyrich and Kautz (2009)* specification to *CIE XYZ*
     tristimulus values.
 
     Parameters

--- a/colour/appearance/llab.py
+++ b/colour/appearance/llab.py
@@ -384,7 +384,7 @@ s=0.0002395..., M=0.0190185..., HC=None, a=..., b=-0.0190185...)
 
 def XYZ_to_RGB_LLAB(XYZ: ArrayLike) -> NDArrayFloat:
     """
-    Convert from *CIE XYZ* tristimulus values to normalised cone responses.
+    Convert *CIE XYZ* tristimulus values to normalised cone responses.
 
     Parameters
     ----------
@@ -417,7 +417,7 @@ def chromatic_adaptation(
     D: ArrayLike = 1,
 ) -> NDArrayFloat:
     """
-    Apply chromatic adaptation to given *RGB* normalised cone responses
+    Apply chromatic adaptation to the specified *RGB* normalised cone responses
     array.
 
     Parameters
@@ -514,7 +514,7 @@ def opponent_colour_dimensions(
     F_L: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Return opponent colour dimensions from given adapted *CIE XYZ* tristimulus
+    Compute opponent colour dimensions from the specified adapted *CIE XYZ* tristimulus
     values.
 
     The opponent colour dimensions are based on a modified *CIE L\\*a\\*b\\**
@@ -564,7 +564,7 @@ def opponent_colour_dimensions(
 
 def hue_angle(a: ArrayLike, b: ArrayLike) -> NDArrayFloat:
     """
-    Return the *hue* angle :math:`h_L` in degrees.
+    Compute the *hue* angle :math:`h_L` in degrees.
 
     Parameters
     ----------
@@ -594,7 +594,7 @@ def hue_angle(a: ArrayLike, b: ArrayLike) -> NDArrayFloat:
 
 def chroma_correlate(a: ArrayLike, b: ArrayLike) -> NDArrayFloat:
     """
-    Return the correlate of *chroma* :math:`Ch_L`.
+    Compute the correlate of *chroma* :math:`Ch_L`.
 
     Parameters
     ----------
@@ -632,7 +632,7 @@ def colourfulness_correlate(
     F_C: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Return the correlate of *colourfulness* :math:`C_L`.
+    Compute the correlate of *colourfulness* :math:`C_L`.
 
     Parameters
     ----------
@@ -674,7 +674,7 @@ def colourfulness_correlate(
 
 def saturation_correlate(Ch_L: ArrayLike, L_L: ArrayLike) -> NDArrayFloat:
     """
-    Return the correlate of *saturation* :math:`S_L`.
+    Compute the correlate of *saturation* :math:`S_L`.
 
     Parameters
     ----------
@@ -704,7 +704,7 @@ def saturation_correlate(Ch_L: ArrayLike, L_L: ArrayLike) -> NDArrayFloat:
 
 def final_opponent_signals(C_L: ArrayLike, h_L: ArrayLike) -> NDArrayFloat:
     """
-    Return the final opponent signals :math:`A_L` and :math:`B_L`.
+    Compute the final opponent signals :math:`A_L` and :math:`B_L`.
 
     Parameters
     ----------

--- a/colour/appearance/nayatani95.py
+++ b/colour/appearance/nayatani95.py
@@ -340,7 +340,7 @@ H=None, HC=None, L_star_N=50.0039154...)
 
 def illuminance_to_luminance(E: ArrayLike, Y_f: ArrayLike) -> NDArrayFloat:
     """
-    Convert given *illuminance* :math:`E` value in lux to *luminance* in
+    Convert the specified *illuminance* :math:`E` value in lux to *luminance* in
     :math:`cd/m^2`.
 
     Parameters
@@ -369,7 +369,7 @@ def illuminance_to_luminance(E: ArrayLike, Y_f: ArrayLike) -> NDArrayFloat:
 
 def XYZ_to_RGB_Nayatani95(XYZ: ArrayLike) -> NDArrayFloat:
     """
-    Convert from *CIE XYZ* tristimulus values to cone responses.
+    Convert *CIE XYZ* tristimulus values to cone responses.
 
     Parameters
     ----------
@@ -393,7 +393,7 @@ def XYZ_to_RGB_Nayatani95(XYZ: ArrayLike) -> NDArrayFloat:
 
 def scaling_coefficient(x: ArrayLike, y: ArrayLike) -> NDArrayFloat:
     """
-    Return the scaling coefficient :math:`e(R)` or :math:`e(G)`.
+    Compute the scaling coefficient :math:`e(R)` or :math:`e(G)`.
 
     Parameters
     ----------
@@ -431,7 +431,7 @@ def achromatic_response(
     n: ArrayLike = 1,
 ) -> NDArrayFloat:
     """
-    Return the achromatic response :math:`Q` from given stimulus cone
+    Compute the achromatic response :math:`Q` from the specified stimulus cone
     responses.
 
     Parameters
@@ -490,7 +490,7 @@ def tritanopic_response(
     RGB: ArrayLike, bRGB_o: ArrayLike, xez: ArrayLike, n: ArrayLike
 ) -> NDArrayFloat:
     """
-    Return the tritanopic response :math:`t` from given stimulus cone
+    Compute the tritanopic response :math:`t` from the specified stimulus cone
     responses.
 
     Parameters
@@ -535,7 +535,7 @@ def protanopic_response(
     RGB: ArrayLike, bRGB_o: ArrayLike, xez: ArrayLike, n: ArrayLike
 ) -> NDArrayFloat:
     """
-    Return the protanopic response :math:`p` from given stimulus cone
+    Compute the protanopic response :math:`p` from the specified stimulus cone
     responses.
 
     Parameters
@@ -580,7 +580,7 @@ def brightness_correlate(
     bRGB_o: ArrayLike, bL_or: ArrayLike, Q: ArrayLike
 ) -> NDArrayFloat:
     """
-    Return the *brightness* correlate :math:`B_r`.
+    Compute the *brightness* correlate :math:`B_r`.
 
     Parameters
     ----------
@@ -623,7 +623,7 @@ def ideal_white_brightness_correlate(
     n: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Return the ideal white *brightness* correlate :math:`B_{rw}`.
+    Compute the ideal white *brightness* correlate :math:`B_{rw}`.
 
     Parameters
     ----------
@@ -671,7 +671,7 @@ def achromatic_lightness_correlate(
     Q: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Return the *achromatic Lightness* correlate :math:`L_p^\\star`.
+    Compute the *achromatic lightness* correlate :math:`L_p^\\star`.
 
     Parameters
     ----------
@@ -681,7 +681,7 @@ def achromatic_lightness_correlate(
     Returns
     -------
     :class:`numpy.ndarray`
-        *Achromatic Lightness* correlate :math:`L_p^\\star`.
+        *Achromatic lightness* correlate :math:`L_p^\\star`.
 
     Examples
     --------
@@ -699,7 +699,7 @@ def normalised_achromatic_lightness_correlate(
     B_r: ArrayLike, B_rw: ArrayLike
 ) -> NDArrayFloat:
     """
-    Return the *normalised achromatic Lightness* correlate :math:`L_n^\\star`.
+    Compute the *normalised achromatic lightness* correlate :math:`L_n^\\star`.
 
     Parameters
     ----------
@@ -711,7 +711,7 @@ def normalised_achromatic_lightness_correlate(
     Returns
     -------
     :class:`numpy.ndarray`
-        *Normalised achromatic Lightness* correlate :math:`L_n^\\star`.
+        *Normalised achromatic lightness* correlate :math:`L_n^\\star`.
 
     Examples
     --------
@@ -730,7 +730,7 @@ def normalised_achromatic_lightness_correlate(
 
 def hue_angle(p: ArrayLike, t: ArrayLike) -> NDArrayFloat:
     """
-    Return the *hue* angle :math:`h` in degrees.
+    Compute the *hue* angle :math:`h` in degrees.
 
     Parameters
     ----------
@@ -807,7 +807,7 @@ def saturation_components(
     p: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Return the *saturation* components :math:`S_{RG}` and :math:`S_{YB}`.
+    Compute the *saturation* components :math:`S_{RG}` and :math:`S_{YB}`.
 
     Parameters
     ----------
@@ -850,7 +850,7 @@ def saturation_components(
 
 def saturation_correlate(S_RG: ArrayLike, S_YB: ArrayLike) -> NDArrayFloat:
     """
-    Return the correlate of *saturation* :math:`S`.
+    Compute the correlate of *saturation* :math:`S`.
 
     Parameters
     ----------
@@ -886,12 +886,12 @@ def chroma_components(
     S_YB: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Return the *chroma* components :math:`C_{RG}` and :math:`C_{YB}`.
+    Compute the *chroma* components :math:`C_{RG}` and :math:`C_{YB}`.
 
     Parameters
     ----------
     L_star_P
-        *Achromatic Lightness* correlate :math:`L_p^\\star`.
+        *Achromatic lightness* correlate :math:`L_p^\\star`.
     S_RG
         *Saturation* component :math:`S_{RG}`.
     S_YB
@@ -923,12 +923,12 @@ def chroma_components(
 
 def chroma_correlate(L_star_P: ArrayLike, S: ArrayLike) -> NDArrayFloat:
     """
-    Return the correlate of *chroma* :math:`C`.
+    Compute the correlate of *chroma* :math:`C`.
 
     Parameters
     ----------
     L_star_P
-        *Achromatic Lightness* correlate :math:`L_p^\\star`.
+        *Achromatic lightness* correlate :math:`L_p^\\star`.
     S
         Correlate of *saturation* :math:`S`.
 
@@ -957,7 +957,7 @@ def colourfulness_components(
     B_rw: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Return the *colourfulness* components :math:`M_{RG}` and :math:`M_{YB}`.
+    Compute the *colourfulness* components :math:`M_{RG}` and :math:`M_{YB}`.
 
     Parameters
     ----------
@@ -994,7 +994,7 @@ def colourfulness_components(
 
 def colourfulness_correlate(C: ArrayLike, B_rw: ArrayLike) -> NDArrayFloat:
     """
-    Return the correlate of *colourfulness* :math:`M`.
+    Compute the correlate of *colourfulness* :math:`M`.
 
     Parameters
     ----------

--- a/colour/appearance/rlab.py
+++ b/colour/appearance/rlab.py
@@ -114,7 +114,7 @@ class CAM_ReferenceSpecification_RLAB(MixinDataclassArray):
     Parameters
     ----------
     LR
-        Correlate of *Lightness* :math:`L^R`.
+        Correlate of *lightness* :math:`L^R`.
     CR
         Correlate of *achromatic chroma* :math:`C^R`.
     hR
@@ -154,7 +154,7 @@ class CAM_Specification_RLAB(MixinDataclassArray):
     Parameters
     ----------
     J
-        Correlate of *Lightness* :math:`L^R`.
+        Correlate of *lightness* :math:`L^R`.
     C
         Correlate of *achromatic chroma* :math:`C^R`.
     h

--- a/colour/appearance/zcam.py
+++ b/colour/appearance/zcam.py
@@ -147,7 +147,7 @@ class CAM_ReferenceSpecification_ZCAM(MixinDataclassArithmetic):
     Parameters
     ----------
     J_z
-        Correlate of *Lightness* :math:`J_z`.
+        Correlate of *lightness* :math:`J_z`.
     C_z
         Correlate of *chroma* :math:`C_z`.
     h_z
@@ -318,7 +318,7 @@ def XYZ_to_ZCAM(
     compute_H: bool = True,
 ) -> CAM_Specification_ZCAM:
     """
-    Compute the *ZCAM* colour appearance model correlates from given *CIE XYZ*
+    Compute the *ZCAM* colour appearance model correlates from the specified *CIE XYZ*
     tristimulus values.
 
     Parameters
@@ -522,13 +522,13 @@ def ZCAM_to_XYZ(
     discount_illuminant: bool = False,
 ) -> NDArrayFloat:
     """
-    Convert from *ZCAM* specification to *CIE XYZ* tristimulus values.
+    Convert *ZCAM* specification to *CIE XYZ* tristimulus values.
 
     Parameters
     ----------
     specification
          *ZCAM* colour appearance model specification.
-         Correlate of *Lightness* :math:`J`, correlate of *chroma* :math:`C` or
+         Correlate of *lightness* :math:`J`, correlate of *chroma* :math:`C` or
          correlate of *colourfulness* :math:`M` and *hue* angle :math:`h` in
          degrees must be specified, e.g., :math:`JCh` or :math:`JMh`.
     XYZ_w
@@ -581,7 +581,7 @@ def ZCAM_to_XYZ(
         *Zhai and Luo (2018)* two-steps chromatic adaptation transform but then
         the *ZCAM* colour appearance model does not round-trip properly.
     -   *Step 4* of the inverse model uses a rounded exponent of 1.3514
-        preventing the model to round-trip properly. Given that this
+        preventing the model to round-trip properly. specified that this
         implementation takes some liberties with respect to the chromatic
         adaptation transform to use, it was deemed appropriate to use an
         exponent value that enables the *ZCAM* colour appearance model to
@@ -726,7 +726,7 @@ def ZCAM_to_XYZ(
 
 def hue_quadrature(h: ArrayLike) -> NDArrayFloat:
     """
-    Return the hue quadrature from given hue :math:`h` angle in degrees.
+    Compute the hue quadrature from the specified hue :math:`h` angle in degrees.
 
     Parameters
     ----------

--- a/colour/biochemistry/michaelis_menten.py
+++ b/colour/biochemistry/michaelis_menten.py
@@ -2,7 +2,7 @@
 Michaelis-Menten Kinetics
 =========================
 
-Implement support for *Michaelis-Menten* kinetics, a model of enzyme kinetics:
+Define *Michaelis-Menten* kinetics, a model of enzyme kinetics:
 
 -   :func:`colour.biochemistry.reaction_rate_MichaelisMenten_Michaelis1913`
 -   :func:`colour.biochemistry.reaction_rate_MichaelisMenten_Abebe2017`
@@ -65,15 +65,15 @@ def reaction_rate_MichaelisMenten_Michaelis1913(
     K_m: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Describe the rate of enzymatic reactions, by relating reaction rate
-    :math:`v` to concentration of a substrate :math:`S`.
+    Compute the rate of enzymatic reactions by relating reaction rate
+    :math:`v` to the concentration of a substrate :math:`S`.
 
     Parameters
     ----------
     S
         Concentration of a substrate :math:`S`.
     V_max
-        Maximum rate :math:`V_{max}` achieved by the system, at saturating
+        Maximum rate :math:`V_{max}` achieved by the system at saturating
         substrate concentration.
     K_m
         Substrate concentration :math:`K_m` at which the reaction rate is
@@ -110,9 +110,9 @@ def reaction_rate_MichaelisMenten_Abebe2017(
     b_m: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Describe the rate of enzymatic reactions, by relating reaction rate
-    :math:`v` to concentration of a substrate :math:`S` according to the
-    modified *Michaelis-Menten* kinetics equation as given by
+    Compute the rate of enzymatic reactions by relating reaction rate
+    :math:`v` to the concentration of a substrate :math:`S` according to the
+    modified *Michaelis-Menten* kinetics equation as specified by
     *Abebe, Pouli, Larabi and Reinhard (2017)*.
 
     Parameters
@@ -121,7 +121,7 @@ def reaction_rate_MichaelisMenten_Abebe2017(
         Concentration of a substrate :math:`S` (or
         :math:`(\\cfrac{Y}{Y_n})^{\\epsilon}`).
     V_max
-        Maximum rate :math:`V_{max}` (or :math:`a_m`) achieved by the system,
+        Maximum rate :math:`V_{max}` (or :math:`a_m`) achieved by the system
         at saturating substrate concentration.
     K_m
         Substrate concentration :math:`K_m` (or :math:`c_m`) at which the
@@ -179,16 +179,16 @@ def reaction_rate_MichaelisMenten(
     **kwargs: Any,
 ) -> NDArrayFloat:
     """
-    Describe the rate of enzymatic reactions, by relating reaction rate
-    :math:`v` to concentration of a substrate :math:`S` according to given
-    method.
+    Compute the rate of enzymatic reactions by relating reaction rate
+    :math:`v` to the concentration of a substrate :math:`S` according to the
+    specified method.
 
     Parameters
     ----------
     S
         Concentration of a substrate :math:`S`.
     V_max
-        Maximum rate :math:`V_{max}` achieved by the system, at saturating
+        Maximum rate :math:`V_{max}` achieved by the system at saturating
         substrate concentration.
     K_m
         Substrate concentration :math:`K_m` at which the reaction rate is
@@ -234,15 +234,15 @@ def substrate_concentration_MichaelisMenten_Michaelis1913(
     K_m: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Describe the rate of enzymatic reactions, by relating concentration of a
-    substrate :math:`S` to reaction rate :math:`v`.
+    Compute the substrate concentration by relating the concentration of a
+    substrate :math:`S` to the reaction rate :math:`v`.
 
     Parameters
     ----------
     v
         Reaction rate :math:`v`.
     V_max
-        Maximum rate :math:`V_{max}` achieved by the system, at saturating
+        Maximum rate :math:`V_{max}` achieved by the system at saturating
         substrate concentration.
     K_m
         Substrate concentration :math:`K_m` at which the reaction rate is
@@ -280,9 +280,9 @@ def substrate_concentration_MichaelisMenten_Abebe2017(
     b_m: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Describe the rate of enzymatic reactions, by relating concentration of a
-    substrate :math:`S` to reaction rate :math:`v` according to the modified
-    *Michaelis-Menten* kinetics equation as given by
+    Compute the substrate concentration by relating the concentration of a
+    substrate :math:`S` to the reaction rate :math:`v` according to the
+    modified *Michaelis-Menten* kinetics equation as specified by
     *Abebe, Pouli, Larabi and Reinhard (2017)*.
 
     Parameters
@@ -290,7 +290,7 @@ def substrate_concentration_MichaelisMenten_Abebe2017(
     v
         Reaction rate :math:`v`.
     V_max
-        Maximum rate :math:`V_{max}` (or :math:`a_m`) achieved by the system,
+        Maximum rate :math:`V_{max}` (or :math:`a_m`) achieved by the system
         at saturating substrate concentration.
     K_m
         Substrate concentration :math:`K_m` (or :math:`c_m`) at which the
@@ -349,15 +349,16 @@ def substrate_concentration_MichaelisMenten(
     **kwargs: Any,
 ) -> NDArrayFloat:
     """
-    Describe the rate of enzymatic reactions, by relating concentration of a
-    substrate :math:`S` to reaction rate :math:`v` according to given method.
+    Compute the substrate concentration by relating the concentration of a
+    substrate :math:`S` to the reaction rate :math:`v` according to the specified
+    method.
 
     Parameters
     ----------
     v
         Reaction rate :math:`v`.
     V_max
-        Maximum rate :math:`V_{max}` achieved by the system, at saturating
+        Maximum rate :math:`V_{max}` achieved by the system at saturating
         substrate concentration.
     K_m
         Substrate concentration :math:`K_m` at which the reaction rate is

--- a/colour/blindness/machado2009.py
+++ b/colour/blindness/machado2009.py
@@ -83,8 +83,8 @@ def matrix_RGB_to_WSYBRG(
     cmfs: LMS_ConeFundamentals, primaries: RGB_DisplayPrimaries
 ) -> NDArrayFloat:
     """
-    Compute the matrix transforming from *RGB* colourspace to opponent-colour
-    space using *Machado et al. (2009)* method.
+    Compute the matrix for transforming from *RGB* colourspace to
+    opponent-colour space using *Machado et al. (2009)* method.
 
     Parameters
     ----------
@@ -153,7 +153,7 @@ def msds_cmfs_anomalous_trichromacy_Machado2009(
     cmfs: LMS_ConeFundamentals, d_LMS: ArrayLike
 ) -> LMS_ConeFundamentals:
     """
-    Shift given *LMS* cone fundamentals colour matching functions with given
+    Shift specified *LMS* cone fundamentals colour matching functions with specified
     :math:`\\Delta_{LMS}` shift amount in nanometers to simulate anomalous
     trichromacy using *Machado et al. (2009)* method.
 
@@ -255,10 +255,10 @@ def matrix_anomalous_trichromacy_Machado2009(
     d_LMS: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Compute the *Machado et al. (2009)* *CVD* matrix for given *LMS* cone
-    fundamentals colour matching functions and display primaries tri-spectral
-    distributions with given :math:`\\Delta_{LMS}` shift amount in nanometers
-    to simulate anomalous trichromacy.
+    Compute the *Machado et al. (2009)* colour vision deficiency matrix for
+    specified *LMS* cone fundamentals colour matching functions and display
+    primaries tri-spectral distributions with specified :math:`\\Delta_{LMS}` shift
+    amount in nanometers to simulate anomalous trichromacy.
 
     Parameters
     ----------
@@ -320,8 +320,8 @@ def matrix_cvd_Machado2009(
     severity: float,
 ) -> NDArrayFloat:
     """
-    Compute *Machado et al. (2009)* *CVD* matrix for given deficiency and
-    severity using the pre-computed matrices dataset.
+    Compute *Machado et al. (2009)* colour vision deficiency matrix for specified
+    deficiency and severity using the pre-computed matrices dataset.
 
     Parameters
     ----------
@@ -334,7 +334,7 @@ def matrix_cvd_Machado2009(
         peak of sensitivity moved towards the red sensitive cones. The complete
         absence of M-cones is known as *Deuteranopia*.
         - *Tritanomaly* : defective short-wavelength cones (S-cones), an
-        alleviated form of blue-yellow color blindness. The complete absence of
+        alleviated form of blue-yellow colour blindness. The complete absence of
         S-cones is known as *Tritanopia*.
     severity
         Severity of the colour vision deficiency in domain [0, 1].
@@ -342,7 +342,7 @@ def matrix_cvd_Machado2009(
     Returns
     -------
     :class:`numpy.ndarray`
-        *CVD* matrix.
+        Colour vision deficiency matrix.
 
     References
     ----------
@@ -379,7 +379,7 @@ def matrix_cvd_Machado2009(
     m1, m2 = matrices[a], matrices[b]
 
     if a == b:
-        # 1.0 severity CVD matrix, returning directly.
+        # 1.0 severity colour vision deficiency matrix, returning directly.
         return m1
 
     return m1 + (severity - a) * ((m2 - m1) / (b - a))

--- a/colour/characterisation/aces_it.py
+++ b/colour/characterisation/aces_it.py
@@ -163,8 +163,8 @@ def sd_to_aces_relative_exposure_values(
     **kwargs: Any,
 ) -> NDArrayFloat:
     """
-    Convert given spectral distribution to *ACES2065-1* colourspace relative
-    exposure values.
+    Convert spectral distribution to *ACES2065-1* colourspace relative exposure
+    values.
 
     Parameters
     ----------
@@ -408,8 +408,8 @@ def white_balance_multipliers(
     sensitivities: RGB_CameraSensitivities, illuminant: SpectralDistribution
 ) -> NDArrayFloat:
     """
-    Compute the *RGB* white balance multipliers for given camera *RGB*
-    spectral sensitivities and illuminant.
+    Compute *RGB* white balance multipliers for camera *RGB* spectral
+    sensitivities and illuminant.
 
     Parameters
     ----------
@@ -457,8 +457,8 @@ def best_illuminant(
     illuminants: Mapping,
 ) -> SpectralDistribution:
     """
-    Select the best illuminant for given *RGB* white balance multipliers, and
-    sensitivities in given series of illuminants.
+    Select the best illuminant for *RGB* white balance multipliers and
+    sensitivities in series of illuminants.
 
     Parameters
     ----------
@@ -505,7 +505,7 @@ def normalise_illuminant(
     illuminant: SpectralDistribution, sensitivities: RGB_CameraSensitivities
 ) -> SpectralDistribution:
     """
-    Normalise given illuminant with given camera *RGB* spectral sensitivities.
+    Normalise illuminant with camera *RGB* spectral sensitivities.
 
     The multiplicative inverse scaling factor :math:`k` is computed by
     multiplying the illuminant by the sensitivities channel with the maximum
@@ -555,8 +555,8 @@ def training_data_sds_to_RGB(
     illuminant: SpectralDistribution,
 ) -> Tuple[NDArrayFloat, NDArrayFloat]:
     """
-    Convert given training data to *RGB* tristimulus values using given
-    illuminant and given camera *RGB* spectral sensitivities.
+    Convert training data to *RGB* tristimulus values using illuminant and
+    camera *RGB* spectral sensitivities.
 
     Parameters
     ----------
@@ -625,8 +625,8 @@ def training_data_sds_to_XYZ(
     ) = "CAT02",
 ) -> NDArrayFloat:
     """
-    Convert given training data to *CIE XYZ* tristimulus values using given
-    illuminant and given standard observer colour matching functions.
+    Convert training data to *CIE XYZ* tristimulus values using illuminant
+    and standard observer colour matching functions.
 
     Parameters
     ----------
@@ -702,8 +702,7 @@ def whitepoint_preserving_matrix(
     M: ArrayLike, RGB_w: ArrayLike = (1, 1, 1)
 ) -> NDArrayFloat:
     """
-    Normalise given matrix :math:`M` to preserve given white point
-    :math:`RGB_w`.
+    Normalise matrix :math:`M` to preserve white point :math:`RGB_w`.
 
     Parameters
     ----------
@@ -999,10 +998,10 @@ def matrix_idt(
     | Tuple[NDArrayFloat, NDArrayFloat]
 ):
     """
-    Compute an *Input Device Transform* (IDT) matrix for given camera *RGB*
-    spectral sensitivities, illuminant, training data, standard observer colour
-    matching functions and optimisation settings according to *RAW to ACES* v1
-    and *P-2013-001* procedures.
+    Compute an *Input Device Transform* (IDT) matrix for camera *RGB* spectral
+    sensitivities, illuminant, training data, standard observer colour matching
+    functions and optimisation settings according to *RAW to ACES* v1 and
+    *P-2013-001* procedures.
 
     Parameters
     ----------
@@ -1040,7 +1039,7 @@ def matrix_idt(
     Examples
     --------
     Computing the IDT matrix for a *CANON EOS 5DMark II* and
-    *CIE Illuminant D Series* *D55* using the method given in *RAW to ACES* v1:
+    *CIE Illuminant D Series* *D55* using the method specified in *RAW to ACES* v1:
 
     >>> path = os.path.join(
     ...     ROOT_RESOURCES_RAWTOACES,
@@ -1152,10 +1151,10 @@ def camera_RGB_to_ACES2065_1(
     clip: bool = False,
 ) -> NDArrayFloat:
     """
-    Convert given camera *RGB* colourspace array to *ACES2065-1* colourspace
-    using the *Input Device Transform* (IDT) matrix :math:`B`, the white
-    balance multipliers :math:`b` and the exposure factor :math:`k` according
-    to *P-2013-001* procedure.
+    Convert camera *RGB* colourspace array to *ACES2065-1* colourspace using
+    the *Input Device Transform* (IDT) matrix :math:`B`, the white balance
+    multipliers :math:`b` and the exposure factor :math:`k` according to
+    *P-2013-001* procedure.
 
     Parameters
     ----------

--- a/colour/characterisation/cameras.py
+++ b/colour/characterisation/cameras.py
@@ -5,8 +5,8 @@ Cameras Sensitivities
 Define the spectral distributions classes for the datasets from
 the :mod:`colour.characterisation.datasets.cameras` module:
 
--   :class:`colour.characterisation.RGB_CameraSensitivities`: Implement support
-    for a camera *RGB* sensitivities.
+-   :class:`colour.characterisation.RGB_CameraSensitivities`: Define support
+    for camera *RGB* sensitivities.
 """
 
 from __future__ import annotations
@@ -52,7 +52,7 @@ __all__ = [
 
 class RGB_CameraSensitivities(MultiSpectralDistributions):
     """
-    Implement support for a camera *RGB* sensitivities.
+    Define support for camera *RGB* sensitivities.
 
     Parameters
     ----------

--- a/colour/characterisation/correction.py
+++ b/colour/characterisation/correction.py
@@ -13,7 +13,7 @@ Define various objects for colour correction, like colour matching two images:
     Polynomial expansion using *Vandermonde* method.
 -   :attr:`colour.POLYNOMIAL_EXPANSION_METHODS` : Supported polynomial
     expansion methods.
--   :func:`colour.polynomial_expansion`: Polynomial expansion of given
+-   :func:`colour.polynomial_expansion`: Polynomial expansion of
     :math:`a` array.
 -   :func:`colour.characterisation.matrix_colour_correction_Cheung2004` :
     Colour correction matrix computation using *Cheung et al. (2004)* method.
@@ -25,8 +25,7 @@ Define various objects for colour correction, like colour matching two images:
 -   :attr:`colour.MATRIX_COLOUR_CORRECTION_METHODS` : Supported colour
     correction matrix methods.
 -   :func:`colour.matrix_colour_correction` : Colour correction matrix
-    computation from given :math:`M_T` colour array to :math:`M_R` colour
-    array.
+    computation from :math:`M_T` colour array to :math:`M_R` colour array.
 -   :func:`colour.apply_matrix_colour_correction_Cheung2004` : Apply a colour
     correction matrix computed using *Cheung et al. (2004)* method.
 -   :func:`colour.apply_matrix_colour_correction_Finlayson2015 `: Apply a
@@ -45,9 +44,9 @@ Define various objects for colour correction, like colour matching two images:
     Colour correction using *Vandermonde* method.
 -   :attr:`colour.COLOUR_CORRECTION_METHODS` : Supported colour correction
     methods.
--   :func:`colour.colour_correction` : Colour correction of given *RGB*
-    colourspace array using the colour correction matrix from given
-    :math:`M_T` colour array to :math:`M_R` colour array.
+-   :func:`colour.colour_correction` : Colour correction of *RGB*
+    colourspace array using the colour correction matrix from :math:`M_T`
+    colour array to :math:`M_R` colour array.
 
 References
 ----------
@@ -126,7 +125,7 @@ def matrix_augmented_Cheung2004(
     terms: Literal[3, 4, 5, 7, 8, 10, 11, 14, 16, 17, 19, 20, 22, 35] | int = 3,
 ) -> NDArrayFloat:  # pyright: ignore
     """
-    Perform polynomial expansion of given *RGB* colourspace array using
+    Perform polynomial expansion of *RGB* colourspace array using
     *Cheung et al. (2004)* method.
 
     Parameters
@@ -143,7 +142,7 @@ def matrix_augmented_Cheung2004(
 
     Notes
     -----
-    -   This definition combines the augmented matrices given in
+    -   This definition combines the augmented matrices specified in
         :cite:`Cheung2004` and :cite:`Westland2004`.
 
     References
@@ -431,7 +430,7 @@ def polynomial_expansion_Finlayson2015(
     root_polynomial_expansion: bool = True,
 ) -> NDArrayFloat:  # pyright: ignore
     """
-    Perform polynomial expansion of given *RGB* colourspace array using
+    Perform polynomial expansion of *RGB* colourspace array using
     *Finlayson et al. (2015)* method.
 
     Parameters
@@ -622,7 +621,7 @@ def polynomial_expansion_Finlayson2015(
 
 def polynomial_expansion_Vandermonde(a: ArrayLike, degree: int = 1) -> NDArrayFloat:
     """
-    Perform polynomial expansion of given :math:`a` array using *Vandermonde*
+    Perform polynomial expansion of :math:`a` array using *Vandermonde*
     method.
 
     Parameters
@@ -681,7 +680,7 @@ def polynomial_expansion(
     **kwargs: Any,
 ) -> NDArrayFloat:
     """
-    Perform polynomial expansion of given :math:`a` array.
+    Perform polynomial expansion of :math:`a` array.
 
     Parameters
     ----------
@@ -737,7 +736,7 @@ def matrix_colour_correction_Cheung2004(
     terms: Literal[3, 4, 5, 7, 8, 10, 11, 14, 16, 17, 19, 20, 22, 35] | int = 3,
 ) -> NDArrayFloat:
     """
-    Compute a colour correction matrix from given :math:`M_T` colour array to
+    Compute a colour correction matrix from :math:`M_T` colour array to
     :math:`M_R` colour array using *Cheung et al. (2004)* method.
 
     Parameters
@@ -781,7 +780,7 @@ def matrix_colour_correction_Finlayson2015(
     root_polynomial_expansion: bool = True,
 ) -> NDArrayFloat:
     """
-    Compute a colour correction matrix from given :math:`M_T` colour array to
+    Compute a colour correction matrix from :math:`M_T` colour array to
     :math:`M_R` colour array using *Finlayson et al. (2015)* method.
 
     Parameters
@@ -825,7 +824,7 @@ def matrix_colour_correction_Vandermonde(
     M_T: ArrayLike, M_R: ArrayLike, degree: int = 1
 ) -> NDArrayFloat:
     """
-    Compute a colour correction matrix from given :math:`M_T` colour array to
+    Compute a colour correction matrix from :math:`M_T` colour array to
     :math:`M_R` colour array using *Vandermonde* method.
 
     Parameters
@@ -888,11 +887,11 @@ def matrix_colour_correction(
     **kwargs: Any,
 ) -> NDArrayFloat:
     """
-    Compute a colour correction matrix from given :math:`M_T` colour array to
+    Compute a colour correction matrix from :math:`M_T` colour array to
     :math:`M_R` colour array.
 
     The resulting colour correction matrix is computed using multiple linear or
-    polynomial regression using given method. The purpose of that object
+    polynomial regression using specified method. The purpose of that object
     is for example the matching of two *ColorChecker* colour rendition charts
     together.
 
@@ -1007,8 +1006,8 @@ def apply_matrix_colour_correction_Cheung2004(
     terms: Literal[3, 4, 5, 7, 8, 10, 11, 14, 16, 17, 19, 20, 22, 35] | int = 3,
 ) -> NDArrayFloat:
     """
-    Apply given colour correction matrix :math:`CCM` computed using
-    *Cheung et al. (2004)* method to given *RGB* colourspace array.
+    Apply colour correction matrix :math:`CCM` computed using
+    *Cheung et al. (2004)* method to *RGB* colourspace array.
 
     Parameters
     ----------
@@ -1060,8 +1059,8 @@ def apply_matrix_colour_correction_Finlayson2015(
     root_polynomial_expansion: bool = True,
 ) -> NDArrayFloat:
     """
-    Apply given colour correction matrix :math:`CCM` computed using
-    *Finlayson et al. (2015)* method to given *RGB* colourspace array.
+    Apply colour correction matrix :math:`CCM` computed using
+    *Finlayson et al. (2015)* method to *RGB* colourspace array.
 
     Parameters
     ----------
@@ -1112,8 +1111,8 @@ def apply_matrix_colour_correction_Vandermonde(
     RGB: ArrayLike, CCM: ArrayLike, degree: int = 1
 ) -> NDArrayFloat:
     """
-    Apply given colour correction matrix :math:`CCM` computed using
-    *Vandermonde* method to given *RGB* colourspace array.
+    Apply colour correction matrix :math:`CCM` computed using
+    *Vandermonde* method to *RGB* colourspace array.
 
     Parameters
     ----------
@@ -1184,8 +1183,7 @@ def apply_matrix_colour_correction(
     **kwargs: Any,
 ) -> NDArrayFloat:
     """
-    Apply given colour correction matrix :math:`CCM` to given *RGB* colourspace
-    array.
+    Apply colour correction matrix :math:`CCM` to *RGB* colourspace array.
 
     Parameters
     ----------
@@ -1250,9 +1248,9 @@ def colour_correction_Cheung2004(
     terms: Literal[3, 4, 5, 7, 8, 10, 11, 14, 16, 17, 19, 20, 22, 35] | int = 3,
 ) -> NDArrayFloat:
     """
-    Perform colour correction of given *RGB* colourspace array using the
-    colour correction matrix from given :math:`M_T` colour array to
-    :math:`M_R` colour array using *Cheung et al. (2004)* method.
+    Perform colour correction of *RGB* colourspace array using the colour
+    correction matrix from :math:`M_T` colour array to :math:`M_R` colour
+    array using *Cheung et al. (2004)* method.
 
     Parameters
     ----------
@@ -1297,9 +1295,9 @@ def colour_correction_Finlayson2015(
     root_polynomial_expansion: bool = True,
 ) -> NDArrayFloat:
     """
-    Perform colour correction of given *RGB* colourspace array using the
-    colour correction matrix from given :math:`M_T` colour array to
-    :math:`M_R` colour array using *Finlayson et al. (2015)* method.
+    Perform colour correction of *RGB* colourspace array using the colour
+    correction matrix from :math:`M_T` colour array to :math:`M_R` colour
+    array using *Finlayson et al. (2015)* method.
 
     Parameters
     ----------
@@ -1347,9 +1345,9 @@ def colour_correction_Vandermonde(
     RGB: ArrayLike, M_T: ArrayLike, M_R: ArrayLike, degree: int = 1
 ) -> NDArrayFloat:
     """
-    Perform colour correction of given *RGB* colourspace array using the
-    colour correction matrix from given :math:`M_T` colour array to
-    :math:`M_R` colour array using *Vandermonde* method.
+    Perform colour correction of *RGB* colourspace array using the colour
+    correction matrix from :math:`M_T` colour array to :math:`M_R` colour
+    array using *Vandermonde* method.
 
     Parameters
     ----------
@@ -1413,9 +1411,9 @@ def colour_correction(
     **kwargs: Any,
 ) -> NDArrayFloat:
     """
-    Perform colour correction of given *RGB* colourspace array using the
-    colour correction matrix from given :math:`M_T` colour array to
-    :math:`M_R` colour array.
+    Perform colour correction of *RGB* colourspace array using the colour
+    correction matrix from :math:`M_T` colour array to :math:`M_R` colour
+    array.
 
     Parameters
     ----------

--- a/colour/characterisation/datasets/colour_checkers/chromaticity_coordinates.py
+++ b/colour/characterisation/datasets/colour_checkers/chromaticity_coordinates.py
@@ -379,7 +379,7 @@ Reference *ColorChecker Classic* data from *X-Rite (2016)*.
 Notes
 -----
 -   The rounded *ColorChecker24 - Before November 2014* values should match the
-    *ColorChecker Classic 2005* values. They are given for reference of the
+    *ColorChecker Classic 2005* values. They are specified for reference of the
     original *CIE L\\*a\\*b\\** colourspace values.
 """
 

--- a/colour/characterisation/displays.py
+++ b/colour/characterisation/displays.py
@@ -5,8 +5,8 @@ RGB Display Primaries
 Define the spectral distributions classes for the datasets from
 the :mod:`colour.characterisation.datasets.displays` module:
 
--   :class:`colour.characterisation.RGB_DisplayPrimaries`: Implements support
-    for a *RGB* display (such as a *CRT* or *LCD*) primaries multi-spectral
+-   :class:`colour.characterisation.RGB_DisplayPrimaries`: Define support for
+    *RGB* display (such as *CRT* or *LCD*) primaries multi-spectral
     distributions.
 """
 
@@ -53,8 +53,8 @@ __all__ = [
 
 class RGB_DisplayPrimaries(MultiSpectralDistributions):
     """
-    Implement support for a *RGB* display (such as a *CRT* or *LCD*)
-    primaries multi-spectral distributions.
+    Define support for *RGB* display (such as *CRT* or *LCD*) primaries
+    multi-spectral distributions.
 
     Parameters
     ----------

--- a/colour/colorimetry/blackbody.py
+++ b/colour/colorimetry/blackbody.py
@@ -68,8 +68,8 @@ def planck_law(
     n: float = CONSTANT_N,
 ) -> NDArrayFloat:
     """
-    Return the spectral radiance of a blackbody as a function of wavelength at
-    thermodynamic temperature :math:`T[K]` in a medium having index of
+    Compute the spectral radiance of a blackbody as a function of wavelength at
+    specified thermodynamic temperature :math:`T[K]` in a medium with index of
     refraction :math:`n`.
 
     Parameters
@@ -151,9 +151,9 @@ def sd_blackbody(
     n: float = CONSTANT_N,
 ) -> SpectralDistribution:
     """
-    Return the spectral distribution of the planckian radiator for given
-    temperature :math:`T[K]` with values in
-    *watts per steradian per square metre per nanometer* (:math:`W/sr/m^2/nm`).
+    Generate the spectral distribution of the planckian radiator for specified
+    temperature :math:`T[K]` with values in *watts per steradian per square
+    metre per nanometer* (:math:`W/sr/m^2/nm`).
 
     Parameters
     ----------
@@ -222,9 +222,9 @@ def sd_blackbody(
 
 def rayleigh_jeans_law(wavelength: ArrayLike, temperature: ArrayLike) -> NDArrayFloat:
     """
-    Return the approximation of the spectral radiance of a blackbody as a
-    function of wavelength at thermodynamic temperature :math:`T[K]` according
-    to *Rayleigh-Jeans* law.
+    Approximate the spectral radiance of a blackbody as a function of
+    wavelength at specified thermodynamic temperature :math:`T[K]` according to
+    *Rayleigh-Jeans* law.
 
     Parameters
     ----------
@@ -290,10 +290,10 @@ def sd_rayleigh_jeans(
     shape: SpectralShape = SPECTRAL_SHAPE_DEFAULT,
 ) -> SpectralDistribution:
     """
-    Return the spectral distribution of the planckian radiator for given
-    temperature :math:`T[K]` with values in
-    *watts per steradian per square metre per nanometer* (:math:`W/sr/m^2/nm`)
-    according to *Rayleigh-Jeans* law.
+    Generate the spectral distribution of the planckian radiator for specified
+    temperature :math:`T[K]` with values in *watts per steradian per square
+    metre per nanometer* (:math:`W/sr/m^2/nm`) according to
+    *Rayleigh-Jeans* law.
 
     Parameters
     ----------

--- a/colour/colorimetry/cmfs.py
+++ b/colour/colorimetry/cmfs.py
@@ -5,13 +5,12 @@ Colour Matching Functions
 Define the colour matching functions classes for the datasets from
 the :mod:`colour.colorimetry.datasets.cmfs` module:
 
--   :class:`colour.colorimetry.LMS_ConeFundamentals`: Implements support for
-    the *Stockman and Sharpe* *LMS* cone fundamentals colour matching
-    functions.
--   :class:`colour.colorimetry.RGB_ColourMatchingFunctions`: Implements support
-    for the *CIE RGB* colour matching functions.
--   :class:`colour.colorimetry.XYZ_ColourMatchingFunctions`: Implements support
-    for the *CIE Standard Observers* *XYZ* colour matching functions.
+-   :class:`colour.colorimetry.LMS_ConeFundamentals`: Define support for
+    *Stockman and Sharpe* *LMS* cone fundamentals colour matching functions.
+-   :class:`colour.colorimetry.RGB_ColourMatchingFunctions`: Define support
+    for *CIE RGB* colour matching functions.
+-   :class:`colour.colorimetry.XYZ_ColourMatchingFunctions`: Define support
+    for *CIE Standard Observers* *XYZ* colour matching functions.
 """
 
 from __future__ import annotations
@@ -59,8 +58,8 @@ __all__ = [
 
 class LMS_ConeFundamentals(MultiSpectralDistributions):
     """
-    Implement support for the Stockman and Sharpe *LMS* cone fundamentals
-    colour matching functions.
+    Provide support for *Stockman and Sharpe* *LMS* cone fundamentals colour
+    matching functions.
 
     Parameters
     ----------
@@ -128,7 +127,7 @@ class LMS_ConeFundamentals(MultiSpectralDistributions):
 
 class RGB_ColourMatchingFunctions(MultiSpectralDistributions):
     """
-    Implement support for the *CIE RGB* colour matching functions.
+    Provide support for *CIE RGB* colour matching functions.
 
     Parameters
     ----------
@@ -196,7 +195,7 @@ class RGB_ColourMatchingFunctions(MultiSpectralDistributions):
 
 class XYZ_ColourMatchingFunctions(MultiSpectralDistributions):
     """
-    Implement support for the *CIE* Standard Observers *XYZ* colour matching
+    Provide support for *CIE* Standard Observers *XYZ* colour matching
     functions.
 
     Parameters

--- a/colour/colorimetry/correction.py
+++ b/colour/colorimetry/correction.py
@@ -12,7 +12,7 @@ The following correction methods are available:
 -   :attr:`colour.BANDPASS_CORRECTION_METHODS`: Supported spectral bandpass
     dependence correction methods.
 -   :func:`colour.bandpass_correction`: Spectral bandpass dependence
-    correction using given method.
+    correction using specified method.
 
 References
 ----------
@@ -54,8 +54,8 @@ def bandpass_correction_Stearns1988(
     sd: SpectralDistribution,
 ) -> SpectralDistribution:
     """
-    Implement spectral bandpass dependence correction on given spectral
-    distribution using *Stearns and Stearns (1988)* method.
+    Perform spectral bandpass dependence correction on spectral distribution
+    using *Stearns and Stearns (1988)* method.
 
     Parameters
     ----------
@@ -126,8 +126,8 @@ def bandpass_correction(
     method: Literal["Stearns 1988"] | str = "Stearns 1988",
 ) -> SpectralDistribution:
     """
-    Implement spectral bandpass dependence correction on given spectral
-    distribution using given method.
+    Perform spectral bandpass dependence correction on spectral distribution
+    using specified method.
 
     Parameters
     ----------

--- a/colour/colorimetry/datasets/illuminants/chromaticity_coordinates.py
+++ b/colour/colorimetry/datasets/illuminants/chromaticity_coordinates.py
@@ -416,8 +416,8 @@ computed as follows::
 
 -   *CIE Illuminant D Series D50* illuminant and
     *CIE Standard Illuminant D Series D65* chromaticity coordinates are rounded
-    to 4 decimals as given in the typical RGB colourspaces literature. Their
-    chromaticity coordinates as given in :cite:`CIETC1-482004h` are
+    to 4 decimals as specified in the typical RGB colourspaces literature. Their
+    chromaticity coordinates as specified in :cite:`CIETC1-482004h` are
     (0.34567, 0.35851) and (0.31272, 0.32903) respectively.
 -   *CIE* illuminants with chromaticity coordinates not defined in the
     reference :cite:`Wikipedia2006a` have been calculated using their
@@ -427,7 +427,7 @@ computed as follows::
     :func:`colour.sd_to_XYZ` definitions.
 -   *ICC D50* chromaticity coordinates were computed with
     :func:`colour.XYZ_to_xy` definition from the *CIE XYZ* tristimulus values
-    as given by *ICC*: [96.42, 100.00, 82.49].
+    as specified by *ICC*: [96.42, 100.00, 82.49].
 
 References
 ----------

--- a/colour/colorimetry/datasets/illuminants/hunterlab.py
+++ b/colour/colorimetry/datasets/illuminants/hunterlab.py
@@ -7,7 +7,7 @@ dataset for the *CIE 1931 2 Degree Standard Observer* and
 *CIE 1964 10 Degree Standard Observer*.
 
 The currently implemented data has been extracted from :cite:`HunterLab2008b`,
-however you may want to use different data according to the tables given in
+however you may want to use different data according to the tables specified in
 :cite:`HunterLab2008c`.
 
 References

--- a/colour/colorimetry/datasets/illuminants/sds.py
+++ b/colour/colorimetry/datasets/illuminants/sds.py
@@ -4876,9 +4876,9 @@ Spectral distributions of the *ISO* illuminants.
 Notes
 -----
 -   All the *ISO 7589 Sensitometric* spectral distributions are transmitted by
-    the *ISO Standard Lens* given in :attr:`colour.SDS_LENSES` attribute except
+    the *ISO Standard Lens* specified in :attr:`colour.SDS_LENSES` attribute except
     for the *ISO 7589 Sensitometric Printer* spectral distribution which is
-    modulated by both the *ISO Standard Lens* and the *ISO 7589 Diffuser* given
+    modulated by both the *ISO Standard Lens* and the *ISO 7589 Diffuser* specified
     in :attr:`colour.FILTERS_SDS` attribute:
 
     -   *ISO 7589 Sensitometric Daylight* = \

--- a/colour/colorimetry/datasets/illuminants/tristimulus_values.py
+++ b/colour/colorimetry/datasets/illuminants/tristimulus_values.py
@@ -16,10 +16,10 @@ Notes
 -----
 -   The intent of the data in this module is to provide a practical reference
     if it is required to use the exact *CIE XYZ* tristimulus values of the
-    *CIE* illuminants as given in :cite:`Carter2018`. Indeed different rounding
+    *CIE* illuminants as specified in :cite:`Carter2018`. Indeed different rounding
     practises in the colorimetric conversions yield different values for those
     illuminants, as a related example, *CIE Standard Illuminant D Series D65*
-    chromaticity coordinates are commonly given as (0.31270, 0.32900) but
+    chromaticity coordinates are commonly specified as (0.31270, 0.32900) but
     :cite:`Carter2018` defines them as (0.31271, 0.32903).
 
 References

--- a/colour/colorimetry/dominant.py
+++ b/colour/colorimetry/dominant.py
@@ -58,10 +58,10 @@ def closest_spectral_locus_wavelength(
     xy: ArrayLike, xy_n: ArrayLike, xy_s: ArrayLike, inverse: bool = False
 ) -> Tuple[NDArrayInt, NDArrayFloat]:
     """
-    Return the coordinates and closest spectral locus wavelength index to the
-    point where the line defined by the given achromatic stimulus :math:`xy_n`
-    to colour stimulus :math:`xy_n` *CIE xy* chromaticity coordinates
-    intersects the spectral locus.
+    Compute the coordinates and closest spectral locus wavelength index to the
+    point where the line defined by the achromatic stimulus :math:`xy_n` to
+    colour stimulus :math:`xy_n` *CIE xy* chromaticity coordinates intersects
+    the spectral locus.
 
     Parameters
     ----------
@@ -131,9 +131,9 @@ def dominant_wavelength(
     inverse: bool = False,
 ) -> Tuple[NDArrayFloat, NDArrayFloat, NDArrayFloat]:
     """
-    Return the *dominant wavelength* :math:`\\lambda_d` for given colour
-    stimulus :math:`xy` and the related :math:`xy_wl` first and :math:`xy_{cw}`
-    second intersection coordinates with the spectral locus.
+    Compute the *dominant wavelength* :math:`\\lambda_d` for colour stimulus
+    :math:`xy` and the related :math:`xy_wl` first and :math:`xy_{cw}` second
+    intersection coordinates with the spectral locus.
 
     In the eventuality where the :math:`xy_wl` first intersection coordinates
     are on the line of purples, the *complementary wavelength* will be computed
@@ -225,7 +225,7 @@ def complementary_wavelength(
     cmfs: MultiSpectralDistributions | None = None,
 ) -> Tuple[NDArrayFloat, NDArrayFloat, NDArrayFloat]:
     """
-    Return the *complementary wavelength* :math:`\\lambda_c` for given colour
+    Compute the *complementary wavelength* :math:`\\lambda_c` for colour
     stimulus :math:`xy` and the related :math:`xy_wl` first and :math:`xy_{cw}`
     second intersection coordinates with the spectral locus.
 
@@ -235,7 +235,7 @@ def complementary_wavelength(
 
     The *dominant wavelength* is indicated by a negative sign and the
     :math:`xy_{cw}` second intersection coordinates which are set by default to
-    the same value than :math:`xy_wl` first intersection coordinates will be
+    the same value as :math:`xy_wl` first intersection coordinates will be
     set to the *dominant wavelength* intersection coordinates with the spectral
     locus.
 
@@ -293,8 +293,7 @@ def excitation_purity(
     cmfs: MultiSpectralDistributions | None = None,
 ) -> NDArrayFloat:
     """
-    Return the *excitation purity* :math:`P_e` for given colour stimulus
-    :math:`xy`.
+    Compute the *excitation purity* :math:`P_e` for colour stimulus :math:`xy`.
 
     Parameters
     ----------
@@ -340,7 +339,7 @@ def colorimetric_purity(
     cmfs: MultiSpectralDistributions | None = None,
 ) -> NDArrayFloat:
     """
-    Return the *colorimetric purity* :math:`P_c` for given colour stimulus
+    Compute the *colorimetric purity* :math:`P_c` for colour stimulus
     :math:`xy`.
 
     Parameters

--- a/colour/colorimetry/generation.py
+++ b/colour/colorimetry/generation.py
@@ -94,7 +94,7 @@ def sd_constant(
     k: float, shape: SpectralShape = SPECTRAL_SHAPE_DEFAULT, **kwargs: Any
 ) -> SpectralDistribution:
     """
-    Return a spectral distribution of given spectral shape filled with
+    Generate a spectral distribution of specified spectral shape filled with
     constant :math:`k` values.
 
     Parameters
@@ -117,7 +117,7 @@ def sd_constant(
 
     Notes
     -----
-    -   By default, the spectral distribution will use the shape given by
+    -   By default, the spectral distribution will use the shape specified by
         :attr:`colour.SPECTRAL_SHAPE_DEFAULT` attribute.
     -   The interpolator is set to :class:`colour.LinearInterpolator` class.
 
@@ -142,7 +142,8 @@ def sd_zeros(
     shape: SpectralShape = SPECTRAL_SHAPE_DEFAULT, **kwargs: Any
 ) -> SpectralDistribution:
     """
-    Return a spectral distribution of given spectral shape filled with zeros.
+    Generate a spectral distribution of specified spectral shape filled with
+    zeros.
 
     Parameters
     ----------
@@ -162,7 +163,7 @@ def sd_zeros(
 
     Notes
     -----
-    -   By default, the spectral distribution will use the shape given by
+    -   By default, the spectral distribution will use the shape specified by
         :attr:`colour.SPECTRAL_SHAPE_DEFAULT` attribute.
     -   The interpolator is set to :class:`colour.LinearInterpolator` class.
 
@@ -182,7 +183,8 @@ def sd_ones(
     shape: SpectralShape = SPECTRAL_SHAPE_DEFAULT, **kwargs: Any
 ) -> SpectralDistribution:
     """
-    Return a spectral distribution of given spectral shape filled with ones.
+    Generate a spectral distribution of specified spectral shape filled with
+    ones.
 
     Parameters
     ----------
@@ -202,7 +204,7 @@ def sd_ones(
 
     Notes
     -----
-    -   By default, the spectral distribution will use the shape given by
+    -   By default, the spectral distribution will use the shape specified by
         :attr:`colour.SPECTRAL_SHAPE_DEFAULT` attribute.
     -   The interpolator is set to :class:`colour.LinearInterpolator` class.
 
@@ -225,7 +227,7 @@ def msds_constant(
     **kwargs: Any,
 ) -> MultiSpectralDistributions:
     """
-    Return the multi-spectral distributions with given labels and given
+    Generate multi-spectral distributions with specified labels and specified
     spectral shape filled with constant :math:`k` values.
 
     Parameters
@@ -251,7 +253,7 @@ def msds_constant(
 
     Notes
     -----
-    -   By default, the multi-spectral distributions will use the shape given
+    -   By default, the multi-spectral distributions will use the shape specified
         by :attr:`colour.SPECTRAL_SHAPE_DEFAULT` attribute.
     -   The interpolator is set to :class:`colour.LinearInterpolator` class.
 
@@ -281,7 +283,7 @@ def msds_zeros(
     **kwargs: Any,
 ) -> MultiSpectralDistributions:
     """
-    Return the multi-spectral distributionss with given labels and given
+    Generate multi-spectral distributions with specified labels and specified
     spectral shape filled with zeros.
 
     Parameters
@@ -305,7 +307,7 @@ def msds_zeros(
 
     Notes
     -----
-    -   By default, the multi-spectral distributions will use the shape given
+    -   By default, the multi-spectral distributions will use the shape specified
         by :attr:`colour.SPECTRAL_SHAPE_DEFAULT` attribute.
     -   The interpolator is set to :class:`colour.LinearInterpolator` class.
 
@@ -329,7 +331,7 @@ def msds_ones(
     **kwargs: Any,
 ) -> MultiSpectralDistributions:
     """
-    Return the multi-spectral distributionss with given labels and given
+    Generate multi-spectral distributions with specified labels and specified
     spectral shape filled with ones.
 
     Parameters
@@ -353,7 +355,7 @@ def msds_ones(
 
     Notes
     -----
-    -   By default, the multi-spectral distributions will use the shape given
+    -   By default, the multi-spectral distributions will use the shape specified
         by :attr:`colour.SPECTRAL_SHAPE_DEFAULT` attribute.
     -   The interpolator is set to :class:`colour.LinearInterpolator` class.
 
@@ -378,8 +380,9 @@ def sd_gaussian_normal(
     **kwargs: Any,
 ) -> SpectralDistribution:
     """
-    Return a gaussian spectral distribution of given spectral shape at
-    given mean wavelength :math:`\\mu` and standard deviation :math:`sigma`.
+    Generate a gaussian spectral distribution of specified spectral shape at
+    specified mean wavelength :math:`\\mu` and standard deviation
+    :math:`sigma`.
 
     Parameters
     ----------
@@ -404,7 +407,7 @@ def sd_gaussian_normal(
 
     Notes
     -----
-    -   By default, the spectral distribution will use the shape given by
+    -   By default, the spectral distribution will use the shape specified by
         :attr:`colour.SPECTRAL_SHAPE_DEFAULT` attribute.
 
     Examples
@@ -433,8 +436,8 @@ def sd_gaussian_fwhm(
     **kwargs: Any,
 ) -> SpectralDistribution:
     """
-    Return a gaussian spectral distribution of given spectral shape at given
-    peak wavelength and full width at half maximum.
+    Generate a gaussian spectral distribution of specified spectral shape at
+    specified peak wavelength and full width at half maximum.
 
     Parameters
     ----------
@@ -460,7 +463,7 @@ def sd_gaussian_fwhm(
 
     Notes
     -----
-    -   By default, the spectral distribution will use the shape given by
+    -   By default, the spectral distribution will use the shape specified by
         :attr:`colour.SPECTRAL_SHAPE_DEFAULT` attribute.
 
     Examples
@@ -499,8 +502,8 @@ def sd_gaussian(
     **kwargs: Any,
 ) -> SpectralDistribution:
     """
-    Return a gaussian spectral distribution of given spectral shape using
-    given method.
+    Return a gaussian spectral distribution of specified spectral shape using
+    specified method.
 
     Parameters
     ----------
@@ -531,7 +534,7 @@ def sd_gaussian(
 
     Notes
     -----
-    -   By default, the spectral distribution will use the shape given by
+    -   By default, the spectral distribution will use the shape specified by
         :attr:`colour.SPECTRAL_SHAPE_DEFAULT` attribute.
 
     Examples
@@ -564,8 +567,8 @@ def sd_single_led_Ohno2005(
     **kwargs: Any,
 ) -> SpectralDistribution:
     """
-    Return a single *LED* spectral distribution of given spectral shape at
-    given peak wavelength and half spectral width :math:`\\Delta\\lambda_{0.5}`
+    Return a single *LED* spectral distribution of specified spectral shape at
+    specified peak wavelength and half spectral width :math:`\\Delta\\lambda_{0.5}`
     according to *Ohno (2005)* method.
 
     Parameters
@@ -590,7 +593,7 @@ def sd_single_led_Ohno2005(
 
     Notes
     -----
-    -   By default, the spectral distribution will use the shape given by
+    -   By default, the spectral distribution will use the shape specified by
         :attr:`colour.SPECTRAL_SHAPE_DEFAULT` attribute.
 
     References
@@ -637,8 +640,8 @@ def sd_single_led(
     **kwargs: Any,
 ) -> SpectralDistribution:
     """
-    Return a single *LED* spectral distribution of given spectral shape at
-    given peak wavelength according to given method.
+    Return a single *LED* spectral distribution of specified spectral shape at
+    specified peak wavelength according to specified method.
 
     Parameters
     ----------
@@ -662,7 +665,7 @@ def sd_single_led(
 
     Notes
     -----
-    -   By default, the spectral distribution will use the shape given by
+    -   By default, the spectral distribution will use the shape specified by
         :attr:`colour.SPECTRAL_SHAPE_DEFAULT` attribute.
 
     References
@@ -692,8 +695,8 @@ def sd_multi_leds_Ohno2005(
     **kwargs: Any,
 ) -> SpectralDistribution:
     """
-    Return a multi *LED* spectral distribution of given spectral shape at
-    given peak wavelengths, half spectral widths :math:`\\Delta\\lambda_{0.5}`
+    Return a multi *LED* spectral distribution of specified spectral shape at
+    specified peak wavelengths, half spectral widths :math:`\\Delta\\lambda_{0.5}`
     and peak power ratios according to *Ohno (2005)* method.
 
     The multi *LED* spectral distribution is generated using many single *LED*
@@ -726,7 +729,7 @@ def sd_multi_leds_Ohno2005(
 
     Notes
     -----
-    -   By default, the spectral distribution will use the shape given by
+    -   By default, the spectral distribution will use the shape specified by
         :attr:`colour.SPECTRAL_SHAPE_DEFAULT` attribute.
 
     References
@@ -764,7 +767,7 @@ def sd_multi_leds_Ohno2005(
         )
 
     def _format_array(a: NDArrayFloat) -> str:
-        """Format given array :math:`a`."""
+        """Format specified array :math:`a`."""
 
         return ", ".join([str(e) for e in a])
 
@@ -795,8 +798,8 @@ def sd_multi_leds(
     **kwargs: Any,
 ) -> SpectralDistribution:
     """
-    Return a multi *LED* spectral distribution of given spectral shape at
-    given peak wavelengths.
+    Return a multi *LED* spectral distribution of specified spectral shape at
+    specified peak wavelengths.
 
     Parameters
     ----------
@@ -821,7 +824,7 @@ def sd_multi_leds(
 
     Notes
     -----
-    -   By default, the spectral distribution will use the shape given by
+    -   By default, the spectral distribution will use the shape specified by
         :attr:`colour.SPECTRAL_SHAPE_DEFAULT` attribute.
 
     References

--- a/colour/colorimetry/illuminants.py
+++ b/colour/colorimetry/illuminants.py
@@ -147,8 +147,8 @@ def sd_CIE_illuminant_D_series(
     shape: SpectralShape | None = None,
 ) -> SpectralDistribution:
     """
-    Return the spectral distribution of given *CIE Illuminant D Series* using
-    given *CIE xy* chromaticity coordinates.
+    Return the spectral distribution of specified *CIE Illuminant D Series* using
+    specified *CIE xy* chromaticity coordinates.
 
     Parameters
     ----------
@@ -169,7 +169,7 @@ def sd_CIE_illuminant_D_series(
     Notes
     -----
     -   The nominal *CIE xy* chromaticity coordinates which have been computed
-        with :func:`colour.temperature.CCT_to_xy_CIE_D` must be given according
+        with :func:`colour.temperature.CCT_to_xy_CIE_D` must be specified according
         to *CIE 015:2004* recommendation and thus multiplied by
         1.4388 / 1.4380.
     -   :math:`M1` and :math:`M2` variables are rounded to 3 decimal places

--- a/colour/colorimetry/lefs.py
+++ b/colour/colorimetry/lefs.py
@@ -50,7 +50,7 @@ def mesopic_weighting_function(
     scotopic_lef: SpectralDistribution | None = None,
 ) -> NDArrayFloat:
     """
-    Calculate the mesopic weighting function factor :math:`V_m` at given
+    Calculate the mesopic weighting function factor :math:`V_m` at specified
     wavelength :math:`\\lambda` using the photopic luminance :math:`L_p`.
 
     Parameters
@@ -119,7 +119,7 @@ def sd_mesopic_luminous_efficiency_function(
 ) -> SpectralDistribution:
     """
     Return the mesopic luminous efficiency function :math:`V_m(\\lambda)` for
-    given photopic luminance :math:`L_p`.
+    specified photopic luminance :math:`L_p`.
 
     Parameters
     ----------

--- a/colour/colorimetry/lightness.py
+++ b/colour/colorimetry/lightness.py
@@ -7,26 +7,26 @@ Define the *Lightness* :math:`L` computation objects.
 The following methods are available:
 
 -   :func:`colour.colorimetry.lightness_Glasser1958`: *Lightness* :math:`L`
-    computation of given *luminance* :math:`Y` using
+    computation of specified *luminance* :math:`Y` using
     *Glasser, Mckinney, Reilly and Schnelle (1958)* method.
 -   :func:`colour.colorimetry.lightness_Wyszecki1963`: *Lightness* :math:`W`
-    computation of given *luminance* :math:`Y` using *Wyszecki (1963)* method.
+    computation of specified *luminance* :math:`Y` using *Wyszecki (1963)* method.
 -   :func:`colour.colorimetry.lightness_CIE1976`: *Lightness* :math:`L^*`
-    computation of given *luminance* :math:`Y` as per *CIE 1976*
+    computation of specified *luminance* :math:`Y` as per *CIE 1976*
     recommendation.
 -   :func:`colour.colorimetry.lightness_Fairchild2010`: *Lightness*
-    :math:`L_{hdr}` computation of given *luminance* :math:`Y` using
+    :math:`L_{hdr}` computation of specified *luminance* :math:`Y` using
     *Fairchild and Wyble (2010)* method.
 -   :func:`colour.colorimetry.lightness_Fairchild2011`: *Lightness*
-    :math:`L_{hdr}` computation of given *luminance* :math:`Y` using
+    :math:`L_{hdr}` computation of specified *luminance* :math:`Y` using
     *Fairchild and Chen (2011)* method.
 -   :func:`colour.colorimetry.lightness_Abebe2017`: *Lightness* :math:`L`
-    computation of given *luminance* :math:`Y` using
+    computation of specified *luminance* :math:`Y` using
     *Abebe, Pouli, Larabi and Reinhard (2017)* method.
 -   :attr:`colour.LIGHTNESS_METHODS`: Supported *Lightness* :math:`L`
     computation methods.
--   :func:`colour.lightness`: *Lightness* :math:`L` computation of given
-    *luminance* :math:`Y` using given method.
+-   :func:`colour.lightness`: *Lightness* :math:`L` computation of specified
+    *luminance* :math:`Y` using specified method.
 
 References
 ----------
@@ -110,7 +110,7 @@ __all__ = [
 
 def lightness_Glasser1958(Y: ArrayLike) -> NDArrayFloat:
     """
-    Return the *Lightness* :math:`L` of given *luminance* :math:`Y` using
+    Compute the *Lightness* :math:`L` of specified *luminance* :math:`Y` using
     *Glasser et al. (1958)* method.
 
     Parameters
@@ -156,7 +156,7 @@ def lightness_Glasser1958(Y: ArrayLike) -> NDArrayFloat:
 
 def lightness_Wyszecki1963(Y: ArrayLike) -> NDArrayFloat:
     """
-    Return the *Lightness* :math:`W` of given *luminance* :math:`Y` using
+    Compute the *Lightness* :math:`W` of specified *luminance* :math:`Y` using
     *Wyszecki (1963)* method.
 
 
@@ -211,8 +211,8 @@ def intermediate_lightness_function_CIE1976(
     Y: ArrayLike, Y_n: ArrayLike = 100
 ) -> NDArrayFloat:
     """
-    Return the intermediate value :math:`f(Y/Yn)` in the *Lightness*
-    :math:`L^*` computation for given *luminance* :math:`Y` using given
+    Compute the intermediate value :math:`f(Y/Yn)` in the *Lightness*
+    :math:`L^*` computation for specified *luminance* :math:`Y` using specified
     reference white *luminance* :math:`Y_n` as per *CIE 1976* recommendation.
 
     Parameters
@@ -271,8 +271,8 @@ def intermediate_lightness_function_CIE1976(
 
 def lightness_CIE1976(Y: ArrayLike, Y_n: ArrayLike = 100) -> NDArrayFloat:
     """
-    Return the *Lightness* :math:`L^*` of given *luminance* :math:`Y` using
-    given reference white *luminance* :math:`Y_n` as per *CIE 1976*
+    Compute the *Lightness* :math:`L^*` of specified *luminance* :math:`Y` using
+    specified reference white *luminance* :math:`Y_n` as per *CIE 1976*
     recommendation.
 
     Parameters
@@ -321,7 +321,7 @@ def lightness_CIE1976(Y: ArrayLike, Y_n: ArrayLike = 100) -> NDArrayFloat:
 
 def lightness_Fairchild2010(Y: ArrayLike, epsilon: ArrayLike = 1.836) -> NDArrayFloat:
     """
-    Compute *Lightness* :math:`L_{hdr}` of given *luminance* :math:`Y` using
+    Compute *Lightness* :math:`L_{hdr}` of specified *luminance* :math:`Y` using
     *Fairchild and Wyble (2010)* method according to *Michaelis-Menten*
     kinetics.
 
@@ -381,7 +381,7 @@ def lightness_Fairchild2011(
     method: Literal["hdr-CIELAB", "hdr-IPT"] | str = "hdr-CIELAB",
 ) -> NDArrayFloat:
     """
-    Compute *Lightness* :math:`L_{hdr}` of given *luminance* :math:`Y` using
+    Compute *Lightness* :math:`L_{hdr}` of specified *luminance* :math:`Y` using
     *Fairchild and Chen (2011)* method according to *Michaelis-Menten*
     kinetics.
 
@@ -447,7 +447,7 @@ def lightness_Abebe2017(
     method: Literal["Michaelis-Menten", "Stevens"] | str = "Michaelis-Menten",
 ) -> NDArrayFloat:
     """
-    Compute *Lightness* :math:`L` of given *luminance* :math:`Y` using
+    Compute *Lightness* :math:`L` of specified *luminance* :math:`Y` using
     *Abebe, Pouli, Larabi and Reinhard (2017)* method according to
     *Michaelis-Menten* kinetics or *Stevens's Power Law*.
 
@@ -565,8 +565,8 @@ def lightness(
     **kwargs: Any,
 ) -> NDArrayFloat:
     """
-    Return the *Lightness* :math:`L` of given *luminance* :math:`Y` using
-    given method.
+    Compute the *Lightness* :math:`L` of specified *luminance* :math:`Y` using
+    specified method.
 
     Parameters
     ----------

--- a/colour/colorimetry/luminance.py
+++ b/colour/colorimetry/luminance.py
@@ -7,27 +7,27 @@ Define the *luminance* :math:`Y` computation objects.
 The following methods are available:
 
 -   :func:`colour.colorimetry.luminance_Newhall1943`: *luminance* :math:`Y`
-    computation of given *Munsell* value :math:`V` using
+    computation of specified *Munsell* value :math:`V` using
     *Newhall, Nickerson and Judd (1943)* method.
 -   :func:`colour.colorimetry.luminance_ASTMD1535`: *luminance* :math:`Y`
-    computation of given *Munsell* value :math:`V` using *ASTM D1535-08e1*
+    computation of specified *Munsell* value :math:`V` using *ASTM D1535-08e1*
     method.
 -   :func:`colour.colorimetry.luminance_CIE1976`: *luminance* :math:`Y`
-    computation of given *Lightness* :math:`L^*` as per *CIE 1976*
+    computation of specified *Lightness* :math:`L^*` as per *CIE 1976*
     recommendation.
 -   :func:`colour.colorimetry.luminance_Fairchild2010`: *luminance* :math:`Y`
-    computation of given *Lightness* :math:`L_{hdr}` using
+    computation of specified *Lightness* :math:`L_{hdr}` using
     *Fairchild and Wyble (2010)* method.
 -   :func:`colour.colorimetry.luminance_Fairchild2011`: *luminance* :math:`Y`
-    computation of given *Lightness* :math:`L_{hdr}` using
+    computation of specified *Lightness* :math:`L_{hdr}` using
     *Fairchild and Chen (2011)* method.
 -   :func:`colour.colorimetry.luminance_Abebe2017`: *Luminance* :math:`Y`
-    computation of given *Lightness* :math:`L` using
+    computation of specified *Lightness* :math:`L` using
     *Abebe, Pouli, Larabi and Reinhard (2017)* method.
 -   :attr:`colour.LUMINANCE_METHODS`: Supported *luminance* :math:`Y`
     computation methods.
--   :func:`colour.luminance`: *Luminance* :math:`Y` computation of given
-    *Lightness* :math:`L^*` or given *Munsell* value :math:`V` using given
+-   :func:`colour.luminance`: *Luminance* :math:`Y` computation of specified
+    *Lightness* :math:`L^*` or specified *Munsell* value :math:`V` using specified
     method.
 
 References
@@ -111,7 +111,7 @@ __all__ = [
 
 def luminance_Newhall1943(V: ArrayLike) -> NDArrayFloat:
     """
-    Return the *luminance* :math:`R_Y` of given *Munsell* value :math:`V`
+    Compute the *luminance* :math:`R_Y` of specified *Munsell* value :math:`V`
     using *Newhall et al. (1943)* method.
 
     Parameters
@@ -163,7 +163,7 @@ def luminance_Newhall1943(V: ArrayLike) -> NDArrayFloat:
 
 def luminance_ASTMD1535(V: ArrayLike) -> NDArrayFloat:
     """
-    Return the *luminance* :math:`Y` of given *Munsell* value :math:`V` using
+    Compute the *luminance* :math:`Y` of specified *Munsell* value :math:`V` using
     *ASTM D1535-08e1* method.
 
     Parameters
@@ -217,8 +217,8 @@ def intermediate_luminance_function_CIE1976(
     f_Y_Y_n: ArrayLike, Y_n: ArrayLike = 100
 ) -> NDArrayFloat:
     """
-    Return the *luminance* :math:`Y` in the *luminance* :math:`Y`
-    computation for given intermediate value :math:`f(Y/Yn)` using given
+    Compute the *luminance* :math:`Y` in the *luminance* :math:`Y`
+    computation for specified intermediate value :math:`f(Y/Yn)` using specified
     reference white *luminance* :math:`Y_n` as per *CIE 1976* recommendation.
 
     Parameters
@@ -275,8 +275,8 @@ def intermediate_luminance_function_CIE1976(
 
 def luminance_CIE1976(L_star: ArrayLike, Y_n: ArrayLike = 100) -> NDArrayFloat:
     """
-    Return the *luminance* :math:`Y` of given *Lightness* :math:`L^*` with
-    given reference white *luminance* :math:`Y_n`.
+    Compute the *luminance* :math:`Y` of specified *Lightness* :math:`L^*` with
+    specified reference white *luminance* :math:`Y_n`.
 
     Parameters
     ----------
@@ -330,7 +330,7 @@ def luminance_Fairchild2010(
     L_hdr: ArrayLike, epsilon: ArrayLike = 1.836
 ) -> NDArrayFloat:
     """
-    Compute *luminance* :math:`Y` of given *Lightness* :math:`L_{hdr}` using
+    Compute *luminance* :math:`Y` of specified *Lightness* :math:`L_{hdr}` using
     *Fairchild and Wyble (2010)* method according to *Michaelis-Menten*
     kinetics.
 
@@ -391,7 +391,7 @@ def luminance_Fairchild2011(
     method: Literal["hdr-CIELAB", "hdr-IPT"] | str = "hdr-CIELAB",
 ) -> NDArrayFloat:
     """
-    Compute *luminance* :math:`Y` of given *Lightness* :math:`L_{hdr}` using
+    Compute *luminance* :math:`Y` of specified *Lightness* :math:`L_{hdr}` using
     *Fairchild and Chen (2011)* method according to *Michaelis-Menten*
     kinetics.
 
@@ -585,7 +585,7 @@ def luminance(
     **kwargs: Any,
 ) -> NDArrayFloat:
     """
-    Return the *luminance* :math:`Y` of given *Lightness* :math:`L^*` or given
+    Compute the *luminance* :math:`Y` of specified *Lightness* :math:`L^*` or specified
     *Munsell* value :math:`V`.
 
     Parameters

--- a/colour/colorimetry/photometry.py
+++ b/colour/colorimetry/photometry.py
@@ -41,7 +41,7 @@ def luminous_flux(
     K_m: float = CONSTANT_K_M,
 ) -> float:
     """
-    Return the *luminous flux* for given spectral distribution using given
+    Compute the *luminous flux* for specified spectral distribution using specified
     luminous efficiency function.
 
     Parameters
@@ -89,8 +89,8 @@ def luminous_efficiency(
     sd: SpectralDistribution, lef: SpectralDistribution | None = None
 ) -> float:
     """
-    Return the *luminous efficiency* of given spectral distribution using
-    given luminous efficiency function.
+    Compute the *luminous efficiency* of specified spectral distribution using
+    specified luminous efficiency function.
 
     Parameters
     ----------
@@ -139,8 +139,8 @@ def luminous_efficacy(
     sd: SpectralDistribution, lef: SpectralDistribution | None = None
 ) -> float:
     """
-    Return the *luminous efficacy* in :math:`lm\\cdot W^{-1}` of given
-    spectral distribution using given luminous efficiency function.
+    Compute the *luminous efficacy* in :math:`lm\\cdot W^{-1}` of specified
+    spectral distribution using specified luminous efficiency function.
 
     Parameters
     ----------

--- a/colour/colorimetry/spectrum.py
+++ b/colour/colorimetry/spectrum.py
@@ -366,7 +366,7 @@ class SpectralShape:
 
     def __contains__(self, wavelength: ArrayLike) -> bool:
         """
-        Return if the spectral shape contains given wavelength
+        Return if the spectral shape contains specified wavelength
         :math:`\\lambda`.
 
         Parameters
@@ -430,7 +430,7 @@ class SpectralShape:
 
     def __eq__(self, other: object) -> bool:
         """
-        Return whether the spectral shape is equal to given other object.
+        Return whether the spectral shape is equal to specified other object.
 
         Parameters
         ----------
@@ -440,7 +440,7 @@ class SpectralShape:
         Returns
         -------
         :class:`bool`
-            Whether given object is equal to the spectral shape.
+            Whether specified object is equal to the spectral shape.
 
         Examples
         --------
@@ -457,7 +457,7 @@ class SpectralShape:
 
     def __ne__(self, other: object) -> bool:
         """
-        Return whether the spectral shape is not equal to given other object.
+        Return whether the spectral shape is not equal to specified other object.
 
         Parameters
         ----------
@@ -467,7 +467,7 @@ class SpectralShape:
         Returns
         -------
         :class:`bool`
-            Whether given object is not equal to the spectral shape.
+            Whether specified object is not equal to the spectral shape.
 
         Examples
         --------
@@ -865,10 +865,10 @@ class SpectralDistribution(Signal):
         """
         Interpolate the spectral distribution in-place according to
         *CIE 167:2005* recommendation (if the interpolator has not been changed
-        at instantiation time) or given interpolation arguments.
+        at instantiation time) or specified interpolation arguments.
 
         The logic for choosing the interpolator class when ``interpolator`` is
-        not given is as follows:
+        not specified is as follows:
 
         .. code-block:: python
 
@@ -883,7 +883,7 @@ class SpectralDistribution(Signal):
                 interpolator = CubicSplineInterpolator
 
         The logic for choosing the interpolator keyword arguments when
-        ``interpolator_kwargs`` is not given is as follows:
+        ``interpolator_kwargs`` is not specified is as follows:
 
         .. code-block:: python
 
@@ -1224,7 +1224,7 @@ class SpectralDistribution(Signal):
     ) -> Self:
         """
         Extrapolate the spectral distribution in-place according to
-        *CIE 15:2004* and *CIE 167:2005* recommendations or given extrapolation
+        *CIE 15:2004* and *CIE 167:2005* recommendations or specified extrapolation
         arguments.
 
         Parameters
@@ -1324,15 +1324,15 @@ class SpectralDistribution(Signal):
         extrapolator_kwargs: dict | None = None,
     ) -> Self:
         """
-        Align the spectral distribution in-place to given spectral shape:
-        Interpolates first then extrapolates to fit the given range.
+        Align the spectral distribution in-place to specified spectral shape:
+        Interpolates first then extrapolates to fit the specified range.
 
         Interpolation is performed according to *CIE 167:2005* recommendation
         (if the interpolator has not been changed at instantiation time) or
-        given interpolation arguments.
+        specified interpolation arguments.
 
         The logic for choosing the interpolator class when ``interpolator`` is
-        not given is as follows:
+        not specified is as follows:
 
         .. code-block:: python
 
@@ -1347,7 +1347,7 @@ class SpectralDistribution(Signal):
                 interpolator = CubicSplineInterpolator
 
         The logic for choosing the interpolator keyword arguments when
-        ``interpolator_kwargs`` is not given is as follows:
+        ``interpolator_kwargs`` is not specified is as follows:
 
         .. code-block:: python
 
@@ -1462,7 +1462,7 @@ class SpectralDistribution(Signal):
 
     def trim(self, shape: SpectralShape) -> Self:
         """
-        Trim the spectral distribution wavelengths to given spectral shape.
+        Trim the spectral distribution wavelengths to specified spectral shape.
 
         Parameters
         ----------
@@ -1573,7 +1573,7 @@ class SpectralDistribution(Signal):
 
     def normalise(self, factor: Real = 1) -> Self:
         """
-        Normalise the spectral distribution using given normalization factor.
+        Normalise the spectral distribution using specified normalization factor.
 
         Parameters
         ----------
@@ -2006,10 +2006,10 @@ class MultiSpectralDistributions(MultiSignals):
         """
         Interpolate the multi-spectral distributions in-place according to
         *CIE 167:2005* recommendation (if the interpolator has not been changed
-        at instantiation time) or given interpolation arguments.
+        at instantiation time) or specified interpolation arguments.
 
         The logic for choosing the interpolator class when ``interpolator`` is
-        not given is as follows:
+        not specified is as follows:
 
         .. code-block:: python
 
@@ -2024,7 +2024,7 @@ class MultiSpectralDistributions(MultiSignals):
                 interpolator = CubicSplineInterpolator
 
         The logic for choosing the interpolator keyword arguments when
-        ``interpolator_kwargs`` is not given is as follows:
+        ``interpolator_kwargs`` is not specified is as follows:
 
         .. code-block:: python
 
@@ -2231,7 +2231,7 @@ class MultiSpectralDistributions(MultiSignals):
     ) -> Self:
         """
         Extrapolate the multi-spectral distributions in-place according to
-        *CIE 15:2004* and *CIE 167:2005* recommendations or given extrapolation
+        *CIE 15:2004* and *CIE 167:2005* recommendations or specified extrapolation
         arguments.
 
         Parameters
@@ -2318,15 +2318,15 @@ class MultiSpectralDistributions(MultiSignals):
         extrapolator_kwargs: dict | None = None,
     ) -> Self:
         """
-        Align the multi-spectral distributions in-place to given spectral
-        shape: Interpolates first then extrapolates to fit the given range.
+        Align the multi-spectral distributions in-place to specified spectral
+        shape: Interpolates first then extrapolates to fit the specified range.
 
         Interpolation is performed according to *CIE 167:2005* recommendation
         (if the interpolator has not been changed at instantiation time) or
-        given interpolation arguments.
+        specified interpolation arguments.
 
         The logic for choosing the interpolator class when ``interpolator`` is
-        not given is as follows:
+        not specified is as follows:
 
         .. code-block:: python
 
@@ -2341,7 +2341,7 @@ class MultiSpectralDistributions(MultiSignals):
                 interpolator = CubicSplineInterpolator
 
         The logic for choosing the interpolator keyword arguments when
-        ``interpolator_kwargs`` is not given is as follows:
+        ``interpolator_kwargs`` is not specified is as follows:
 
         .. code-block:: python
 
@@ -2463,7 +2463,7 @@ class MultiSpectralDistributions(MultiSignals):
 
     def trim(self, shape: SpectralShape) -> Self:
         """
-        Trim the multi-spectral distributions wavelengths to given shape.
+        Trim the multi-spectral distributions wavelengths to specified shape.
 
         Parameters
         ----------
@@ -2542,7 +2542,7 @@ class MultiSpectralDistributions(MultiSignals):
 
     def normalise(self, factor: Real = 1) -> Self:
         """
-        Normalise the multi-spectral distributions with given normalization
+        Normalise the multi-spectral distributions with specified normalization
         factor.
 
         Parameters
@@ -2661,7 +2661,7 @@ def reshape_sd(
     **kwargs: Any,
 ) -> TypeSpectralDistribution:
     """
-    Reshape given spectral distribution with given spectral shape.
+    Reshape specified spectral distribution with specified spectral shape.
 
     The reshaped object is cached, thus another call to the definition with the
     same arguments will yield the cached object immediately.
@@ -2735,7 +2735,7 @@ def reshape_msds(
     **kwargs: Any,
 ) -> TypeMultiSpectralDistributions:
     """
-    Reshape given multi-spectral distributions with given spectral shape.
+    Reshape specified multi-spectral distributions with specified spectral shape.
 
     The reshaped object is cached, thus another call to the definition with the
     same arguments will yield the cached object immediately.
@@ -2783,7 +2783,7 @@ def sds_and_msds_to_sds(
     ),
 ) -> List[SpectralDistribution]:
     """
-    Convert given spectral and multi-spectral distributions to a list of
+    Convert specified spectral and multi-spectral distributions to a list of
     spectral distributions.
 
     Parameters
@@ -2849,7 +2849,7 @@ def sds_and_msds_to_msds(
     ),
 ) -> MultiSpectralDistributions:
     """
-    Convert given spectral and multi-spectral distributions to
+    Convert specified spectral and multi-spectral distributions to
     multi-spectral distributions.
 
     The spectral and multi-spectral distributions will be aligned to the

--- a/colour/colorimetry/tests/test_tristimulus_values.py
+++ b/colour/colorimetry/tests/test_tristimulus_values.py
@@ -1553,7 +1553,7 @@ class TestAbsoluteIntegrationToXYZ:
 
     def test_absolute_integration_to_TVS_1nm(self) -> None:
         """
-        Test the absolute, i.e., user given :math:`k` value, integration to
+        Test the absolute, i.e., user specified :math:`k` value, integration to
         tristimulus values for 1nm interval.
         """
 
@@ -1599,7 +1599,7 @@ class TestAbsoluteIntegrationToXYZ:
 
     def test_absolute_integration_to_TVS_5nm(self) -> None:
         """
-        Test the absolute, i.e., user given :math:`k` value, integration to
+        Test the absolute, i.e., user specified :math:`k` value, integration to
         tristimulus values for 5nm interval by ensuring that the *Riemann Sum*
         accounts for the :math:`\\delta w` term.
         """

--- a/colour/colorimetry/tristimulus_values.py
+++ b/colour/colorimetry/tristimulus_values.py
@@ -133,13 +133,13 @@ def handle_spectral_arguments(
     Handle the spectral arguments of various *Colour* definitions performing
     spectral computations.
 
-    -   If ``cmfs`` is not given, one is chosen according to ``cmfs_default``.
-        The returned colour matching functions adopt the spectral shape given
+    -   If ``cmfs`` is not specified, one is chosen according to ``cmfs_default``.
+        The returned colour matching functions adopt the spectral shape specified
         by ``shape_default``.
-    -   If ``illuminant`` is not given, one is chosen according to
+    -   If ``illuminant`` is not specified, one is chosen according to
         ``illuminant_default``. The returned illuminant adopts the spectral
         shape of the returned colour matching functions.
-    -   If ``illuminant`` is given, the returned illuminant spectral shape is
+    -   If ``illuminant`` is specified, the returned illuminant spectral shape is
         aligned to that of the returned colour matching functions.
 
     Parameters
@@ -151,9 +151,9 @@ def handle_spectral_arguments(
         Illuminant spectral distribution, default to
         *CIE Standard Illuminant D65*.
     cmfs_default
-        The default colour matching functions to use if ``cmfs`` is not given.
+        The default colour matching functions to use if ``cmfs`` is not specified.
     illuminant_default
-        The default illuminant to use if ``illuminant`` is not given.
+        The default illuminant to use if ``illuminant`` is not specified.
     shape_default
         The default spectral shape to align the final colour matching functions
         and illuminant.
@@ -205,7 +205,7 @@ def lagrange_coefficients_ASTME2022(
     interval_type: Literal["Boundary", "Inner"] | str = "Inner",
 ) -> NDArrayFloat:
     """
-    Compute the *Lagrange Coefficients* for given interval size using practise
+    Compute the *Lagrange Coefficients* for specified interval size using practise
     *ASTM E2022-11* method.
 
     Parameters
@@ -284,7 +284,7 @@ def tristimulus_weighting_factors_ASTME2022(
     k: Real | None = None,
 ) -> NDArrayFloat:
     """
-    Return a table of tristimulus weighting factors for given colour matching
+    Return a table of tristimulus weighting factors for specified colour matching
     functions and illuminant using practise *ASTM E2022-11* method.
 
     The computed table of tristimulus weighting factors should be used with
@@ -459,7 +459,7 @@ def adjust_tristimulus_weighting_factors_ASTME308(
     W: ArrayLike, shape_r: SpectralShape, shape_t: SpectralShape
 ) -> NDArrayFloat:
     """
-    Adjust given table of tristimulus weighting factors to account for a
+    Adjust specified table of tristimulus weighting factors to account for a
     shorter wavelengths range of the test spectral shape compared to the
     reference spectral shape using practise *ASTM E308-15* method:
     Weights at the wavelengths for which data are not available are added to
@@ -542,8 +542,8 @@ def sd_to_XYZ_integration(
     shape: SpectralShape | None = None,
 ) -> NDArrayFloat:
     """
-    Convert given spectral distribution to *CIE XYZ* tristimulus values
-    using given colour matching functions and illuminant according to classical
+    Convert specified spectral distribution to *CIE XYZ* tristimulus values
+    using specified colour matching functions and illuminant according to classical
     integration method.
 
     The spectral distribution can be either a
@@ -600,7 +600,7 @@ def sd_to_XYZ_integration(
         results different to the code path using a
         :class:`colour.SpectralDistribution` class instance: the former
         favours execution speed by aligning the colour matching functions and
-        illuminant to the given spectral shape while the latter favours
+        illuminant to the specified spectral shape while the latter favours
         precision by aligning the spectral distribution to the colour matching
         functions.
 
@@ -738,8 +738,8 @@ def sd_to_XYZ_tristimulus_weighting_factors_ASTME308(
     k: Real | None = None,
 ) -> NDArrayFloat:
     """
-    Convert given spectral distribution to *CIE XYZ* tristimulus values
-    using given colour matching functions and illuminant using a table of
+    Convert specified spectral distribution to *CIE XYZ* tristimulus values
+    using specified colour matching functions and illuminant using a table of
     tristimulus weighting factors according to practise *ASTM E308-15* method.
 
     Parameters
@@ -884,8 +884,8 @@ def sd_to_XYZ_ASTME308(
     k: Real | None = None,
 ) -> NDArrayFloat:
     """
-    Convert given spectral distribution to *CIE XYZ* tristimulus values using
-    given colour matching functions and illuminant according to practise
+    Convert specified spectral distribution to *CIE XYZ* tristimulus values using
+    specified colour matching functions and illuminant according to practise
     *ASTM E308-15* method.
 
     Parameters
@@ -1109,8 +1109,8 @@ def sd_to_XYZ(
     **kwargs: Any,
 ) -> NDArrayFloat:
     """
-    Convert given spectral distribution to *CIE XYZ* tristimulus values using
-    given colour matching functions, illuminant and method.
+    Convert specified spectral distribution to *CIE XYZ* tristimulus values using
+    specified colour matching functions, illuminant and method.
 
     If ``method`` is *Integration*, the spectral distribution can be either a
     :class:`colour.SpectralDistribution` class instance or an `ArrayLike` in
@@ -1188,7 +1188,7 @@ def sd_to_XYZ(
         results different to the code path using a
         :class:`colour.SpectralDistribution` class instance: the former
         favours execution speed by aligning the colour matching functions and
-        illuminant to the given spectral shape while the latter favours
+        illuminant to the specified spectral shape while the latter favours
         precision by aligning the spectral distribution to the colour matching
         functions.
 
@@ -1296,8 +1296,8 @@ def msds_to_XYZ_integration(
     shape: SpectralShape | None = None,
 ) -> NDArrayFloat:
     """
-    Convert given multi-spectral distributions to *CIE XYZ* tristimulus values
-    using given colour matching functions and illuminant.
+    Convert specified multi-spectral distributions to *CIE XYZ* tristimulus values
+    using specified colour matching functions and illuminant.
 
     The multi-spectral distributions can be either a
     :class:`colour.MultiSpectralDistributions` class instance or an
@@ -1354,7 +1354,7 @@ def msds_to_XYZ_integration(
         produces results different to the code path using a
         :class:`colour.MultiSpectralDistributions` class instance: the former
         favours execution speed by aligning the colour matching functions and
-        illuminant to the given spectral shape while the latter favours
+        illuminant to the specified spectral shape while the latter favours
         precision by aligning the multi-spectral distributions to the colour
         matching functions.
     -   If precision is required, it is possible to interpolate the
@@ -1534,8 +1534,8 @@ def msds_to_XYZ_ASTME308(
     mi_20nm_interpolation_method: bool = True,
 ) -> NDArrayFloat:
     """
-    Convert given multi-spectral distributions to *CIE XYZ* tristimulus values
-    using given colour matching functions and illuminant according to practise
+    Convert specified multi-spectral distributions to *CIE XYZ* tristimulus values
+    using specified colour matching functions and illuminant according to practise
     *ASTM E308-15* method.
 
     Parameters
@@ -1786,8 +1786,8 @@ def msds_to_XYZ(
     **kwargs: Any,
 ) -> NDArrayFloat:
     """
-    Convert given multi-spectral distributions to *CIE XYZ* tristimulus values
-    using given colour matching functions and illuminant. For the *Integration*
+    Convert specified multi-spectral distributions to *CIE XYZ* tristimulus values
+    using specified colour matching functions and illuminant. For the *Integration*
     method, the multi-spectral distributions can be either a
     :class:`colour.MultiSpectralDistributions` class instance or an
     `ArrayLike` in which case the ``shape`` must be passed.
@@ -1864,7 +1864,7 @@ def msds_to_XYZ(
         produces results different to the code path using a
         :class:`colour.MultiSpectralDistributions` class instance: the former
         favours execution speed by aligning the colour matching functions and
-        illuminant to the given spectral shape while the latter favours
+        illuminant to the specified spectral shape while the latter favours
         precision by aligning the multi-spectral distributions to the colour
         matching functions.
     -   If precision is required, it is possible to interpolate the
@@ -2044,8 +2044,8 @@ def wavelength_to_XYZ(
     cmfs: MultiSpectralDistributions | None = None,
 ) -> NDArrayFloat:
     """
-    Convert given wavelength :math:`\\lambda` to *CIE XYZ* tristimulus values
-    using given colour matching functions.
+    Convert specified wavelength :math:`\\lambda` to *CIE XYZ* tristimulus values
+    using specified colour matching functions.
 
     If the wavelength :math:`\\lambda` is not available in the colour matching
     function, its value will be calculated according to *CIE 15:2004*

--- a/colour/colorimetry/uniformity.py
+++ b/colour/colorimetry/uniformity.py
@@ -53,7 +53,7 @@ def spectral_uniformity(
     use_second_order_derivatives: bool = False,
 ) -> NDArrayFloat:
     """
-    Compute the *spectral uniformity* (or *spectral flatness*) of given
+    Compute the *spectral uniformity* (or *spectral flatness*) of specified
     spectral distributions.
 
     Spectral uniformity :math:`(r')^2` is computed as follows:

--- a/colour/colorimetry/whiteness.py
+++ b/colour/colorimetry/whiteness.py
@@ -5,25 +5,25 @@ Whiteness Index :math:`W`
 Define the *whiteness* index :math:`W` computation objects:
 
 -   :func:`colour.colorimetry.whiteness_Berger1959`: *Whiteness* index
-    :math:`WI` computation of given sample *CIE XYZ* tristimulus values using
+    :math:`WI` computation of specified sample *CIE XYZ* tristimulus values using
     *Berger (1959)* method.
 -   :func:`colour.colorimetry.whiteness_Taube1960`: *Whiteness* index
-    :math:`WI` computation of given sample *CIE XYZ* tristimulus values using
+    :math:`WI` computation of specified sample *CIE XYZ* tristimulus values using
     *Taube (1960)* method.
 -   :func:`colour.colorimetry.whiteness_Stensby1968`: *Whiteness* index
-    :math:`WI` computation of given sample *CIE L\\*a\\*b\\** colourspace array
+    :math:`WI` computation of specified sample *CIE L\\*a\\*b\\** colourspace array
     using *Stensby (1968)* method.
 -   :func:`colour.colorimetry.whiteness_ASTME313`: *Whiteness* index :math:`WI`
-    of given sample *CIE XYZ* tristimulus values using *ASTM E313* method.
+    of specified sample *CIE XYZ* tristimulus values using *ASTM E313* method.
 -   :func:`colour.colorimetry.whiteness_Ganz1979`: *Whiteness* index :math:`W`
-    and *tint* :math:`T` computation of given sample *CIE xy* chromaticity
+    and *tint* :math:`T` computation of specified sample *CIE xy* chromaticity
     coordinates using *Ganz and Griesser (1979)* method.
 -   :func:`colour.colorimetry.whiteness_CIE2004`: *Whiteness* :math:`W` or
-    :math:`W_{10}` and *tint* :math:`T` or :math:`T_{10}` computation of given
+    :math:`W_{10}` and *tint* :math:`T` or :math:`T_{10}` computation of specified
     sample *CIE xy* chromaticity coordinates using *CIE 2004* method.
 -   :attr:`colour.WHITENESS_METHODS`: Supported *whiteness* computations
     methods.
--   :func:`colour.whiteness`: *Whiteness* :math:`W` computation using given
+-   :func:`colour.whiteness`: *Whiteness* :math:`W` computation using specified
     method.
 
 References
@@ -83,7 +83,7 @@ __all__ = [
 
 def whiteness_Berger1959(XYZ: ArrayLike, XYZ_0: ArrayLike) -> NDArrayFloat:
     """
-    Return the *whiteness* index :math:`WI` of given sample *CIE XYZ*
+    Return the *whiteness* index :math:`WI` of specified sample *CIE XYZ*
     tristimulus values using *Berger (1959)* method.
 
     Parameters
@@ -140,7 +140,7 @@ def whiteness_Berger1959(XYZ: ArrayLike, XYZ_0: ArrayLike) -> NDArrayFloat:
 
 def whiteness_Taube1960(XYZ: ArrayLike, XYZ_0: ArrayLike) -> NDArrayFloat:
     """
-    Return the *whiteness* index :math:`WI` of given sample *CIE XYZ*
+    Return the *whiteness* index :math:`WI` of specified sample *CIE XYZ*
     tristimulus values using *Taube (1960)* method.
 
     Parameters
@@ -197,7 +197,7 @@ def whiteness_Taube1960(XYZ: ArrayLike, XYZ_0: ArrayLike) -> NDArrayFloat:
 
 def whiteness_Stensby1968(Lab: ArrayLike) -> NDArrayFloat:
     """
-    Return the *whiteness* index :math:`WI` of given sample *CIE L\\*a\\*b\\**
+    Return the *whiteness* index :math:`WI` of specified sample *CIE L\\*a\\*b\\**
     colourspace array using *Stensby (1968)* method.
 
     Parameters
@@ -252,7 +252,7 @@ def whiteness_Stensby1968(Lab: ArrayLike) -> NDArrayFloat:
 
 def whiteness_ASTME313(XYZ: ArrayLike) -> NDArrayFloat:
     """
-    Return the *whiteness* index :math:`WI` of given sample *CIE XYZ*
+    Return the *whiteness* index :math:`WI` of specified sample *CIE XYZ*
     tristimulus values using *ASTM E313* method.
 
     Parameters
@@ -300,7 +300,7 @@ def whiteness_ASTME313(XYZ: ArrayLike) -> NDArrayFloat:
 
 def whiteness_Ganz1979(xy: ArrayLike, Y: ArrayLike) -> NDArrayFloat:
     """
-    Return the *whiteness* index :math:`W` and *tint* :math:`T` of given
+    Return the *whiteness* index :math:`W` and *tint* :math:`T` of specified
     sample *CIE xy* chromaticity coordinates using *Ganz and Griesser (1979)*
     method.
 
@@ -374,7 +374,7 @@ def whiteness_CIE2004(
 ) -> NDArrayFloat:
     """
     Return the *whiteness* :math:`W` or :math:`W_{10}` and *tint* :math:`T`
-    or :math:`T_{10}` of given sample *CIE xy* chromaticity coordinates using
+    or :math:`T_{10}` of specified sample *CIE xy* chromaticity coordinates using
     *CIE 2004* method.
 
     Parameters
@@ -393,7 +393,7 @@ def whiteness_CIE2004(
     -------
     :class:`numpy.ndarray`
         *Whiteness* :math:`W` or :math:`W_{10}` and *tint* :math:`T` or
-        :math:`T_{10}` of given sample.
+        :math:`T_{10}` of specified sample.
 
     Notes
     -----
@@ -487,7 +487,7 @@ def whiteness(
     **kwargs: Any,
 ) -> NDArrayFloat:
     """
-    Return the *whiteness* :math:`W` using given method.
+    Return the *whiteness* :math:`W` using specified method.
 
     Parameters
     ----------

--- a/colour/colorimetry/yellowness.py
+++ b/colour/colorimetry/yellowness.py
@@ -5,17 +5,17 @@ Yellowness Index :math:`Y`
 Define the *yellowness* index :math:`Y` computation objects:
 
 -   :func:`colour.colorimetry.yellowness_ASTMD1925`: *Yellowness* index
-    :math:`YI` computation of given sample *CIE XYZ* tristimulus values using
+    :math:`YI` computation of specified sample *CIE XYZ* tristimulus values using
     *ASTM D1925* method.
 -   :func:`colour.colorimetry.yellowness_ASTME313_alternative`: *Yellowness*
-    index :math:`YI` computation of given sample *CIE XYZ* tristimulus values
+    index :math:`YI` computation of specified sample *CIE XYZ* tristimulus values
     using the alternative *ASTM E313* method.
 -   :func:`colour.colorimetry.yellowness_ASTME313`: *Yellowness*
-    index :math:`YI` computation of given sample *CIE XYZ* tristimulus values
+    index :math:`YI` computation of specified sample *CIE XYZ* tristimulus values
     using the recommended *ASTM E313* method.
 -   :attr:`colour.YELLOWNESS_METHODS`: Supported *yellowness* computations
     methods.
--   :func:`colour.yellownes`: *Yellowness* :math:`YI` computation using given
+-   :func:`colour.yellownes`: *Yellowness* :math:`YI` computation using specified
     method.
 
 References
@@ -69,7 +69,7 @@ __all__ = [
 
 def yellowness_ASTMD1925(XYZ: ArrayLike) -> NDArrayFloat:
     """
-    Return the *yellowness* index :math:`YI` of given sample *CIE XYZ*
+    Return the *yellowness* index :math:`YI` of specified sample *CIE XYZ*
     tristimulus values using *ASTM D1925* method.
 
     ASTM D1925 has been specifically developed for the definition of the
@@ -126,7 +126,7 @@ def yellowness_ASTMD1925(XYZ: ArrayLike) -> NDArrayFloat:
 
 def yellowness_ASTME313_alternative(XYZ: ArrayLike) -> NDArrayFloat:
     """
-    Return the *yellowness* index :math:`YI` of given sample *CIE XYZ*
+    Return the *yellowness* index :math:`YI` of specified sample *CIE XYZ*
     tristimulus values using the alternative *ASTM E313* method.
 
     In the original form of *Test Method E313*, an alternative equation was
@@ -227,7 +227,7 @@ def yellowness_ASTME313(
     ]["D65"],
 ) -> NDArrayFloat:
     """
-    Return the *yellowness* index :math:`YI` of given sample *CIE XYZ*
+    Return the *yellowness* index :math:`YI` of specified sample *CIE XYZ*
     tristimulus values using *ASTM E313* method.
 
     ASTM E313 has successfully been used for a variety of white or near white
@@ -306,7 +306,7 @@ def yellowness(
     **kwargs: Any,
 ) -> NDArrayFloat:
     """
-    Return the *yellowness* :math:`W` using given method.
+    Return the *yellowness* :math:`W` using specified method.
 
     Parameters
     ----------

--- a/colour/constants/cie.py
+++ b/colour/constants/cie.py
@@ -2,7 +2,7 @@
 CIE Constants
 =============
 
-Define the *CIE* constants.
+Define *CIE* constants.
 
 References
 ----------

--- a/colour/constants/common.py
+++ b/colour/constants/common.py
@@ -2,7 +2,7 @@
 Common Constants
 ================
 
-Define the common constants objects that don't belong to any specific
+Define common constants objects that don't belong to any specific
 category.
 """
 
@@ -41,8 +41,8 @@ THRESHOLD_INTEGER: float = 1e-3
 if is_documentation_building():  # pragma: no cover
     THRESHOLD_INTEGER = DocstringFloat(THRESHOLD_INTEGER)
     THRESHOLD_INTEGER.__doc__ = """
-Integer threshold value when checking if a float point number is almost an
-int.
+Integer threshold value when checking if a floating point number is almost an
+integer.
 """
 
 EPSILON: float = cast(float, np.finfo(np.double).eps)

--- a/colour/continuous/abstract.py
+++ b/colour/continuous/abstract.py
@@ -2,7 +2,7 @@
 Abstract Continuous Function
 ============================
 
-Define the abstract class implementing support for abstract continuous
+Define an abstract class implementing support for abstract continuous
 function:
 
 -   :class:`colour.continuous.AbstractContinuousFunction`.
@@ -54,7 +54,7 @@ __all__ = [
 
 class AbstractContinuousFunction(ABC, MixinCallback):
     """
-    Define the base class for abstract continuous function.
+    Define the base class for an abstract continuous function.
 
     This is an :class:`ABCMeta` abstract class that must be inherited by
     sub-classes.
@@ -472,7 +472,7 @@ arithmetical_operation`
     @abstractmethod
     def __contains__(self, x: ArrayLike | slice) -> bool:
         """
-        Return whether the abstract continuous function contains given
+        Return whether the abstract continuous function contains specified
         independent domain variable :math:`x`, must be reimplemented by
         sub-classes.
 
@@ -518,7 +518,7 @@ arithmetical_operation`
     @abstractmethod
     def __eq__(self, other: object) -> bool:
         """
-        Return whether the abstract continuous function is equal to given
+        Return whether the abstract continuous function is equal to specified
         other object, must be reimplemented by sub-classes.
 
         Parameters
@@ -530,7 +530,8 @@ arithmetical_operation`
         Returns
         -------
         :class:`bool`
-            Whether given object is equal to the abstract continuous function.
+            Whether specified object is equal to the abstract continuous
+            function.
         """
 
         ...  # pragma: no cover
@@ -538,8 +539,8 @@ arithmetical_operation`
     @abstractmethod
     def __ne__(self, other: object) -> bool:
         """
-        Return whether the abstract continuous function is not equal to given
-        other object, must be reimplemented by sub-classes.
+        Return whether the abstract continuous function is not equal to
+        specified other object, must be reimplemented by sub-classes.
 
         Parameters
         ----------
@@ -550,7 +551,7 @@ arithmetical_operation`
         Returns
         -------
         :class:`bool`
-            Whether given object is not equal to the abstract continuous
+            Whether specified object is not equal to the abstract continuous
             function.
         """
 
@@ -737,7 +738,7 @@ arithmetical_operation`
         in_place: bool = False,
     ) -> Self:
         """
-        Perform given arithmetical operation with operand :math:`a`, the
+        Perform specified arithmetical operation with operand :math:`a`, the
         operation can be either performed on a copy or in-place, must be
         reimplemented by sub-classes.
 
@@ -766,8 +767,8 @@ arithmetical_operation`
     ) -> Self:
         """
         Fill NaNs in independent domain variable :math:`x` and corresponding
-        range variable :math:`y` using given method, must be reimplemented by
-        sub-classes.
+        range variable :math:`y` using specified method, must be reimplemented
+        by sub-classes.
 
         Parameters
         ----------
@@ -787,7 +788,7 @@ arithmetical_operation`
 
     def domain_distance(self, a: ArrayLike) -> NDArrayFloat:
         """
-        Return the euclidean distance between given array and independent
+        Return the euclidean distance between specified array and independent
         domain :math:`x` closest element.
 
         Parameters
@@ -800,7 +801,7 @@ arithmetical_operation`
         -------
         :class:`numpy.ndarray`
             Euclidean distance between independent domain variable :math:`x`
-            and given variable :math:`a`.
+            and specified variable :math:`a`.
         """
 
         n = closest(self.domain, a)

--- a/colour/continuous/multi_signals.py
+++ b/colour/continuous/multi_signals.py
@@ -2,7 +2,7 @@
 Multi Signals
 =============
 
-Define the class implementing support for multi-continuous signals:
+Define a class implementing support for multi-continuous signals:
 
 -   :class:`colour.continuous.MultiSignals`
 """
@@ -98,7 +98,7 @@ class MultiSignals(AbstractContinuousFunction):
     Other Parameters
     ----------------
     dtype
-        float point data type.
+        Floating point data type.
     extrapolator
         Extrapolator class type to use as extrapolating function for the
         :class:`colour.continuous.Signal` sub-class instances.
@@ -942,8 +942,8 @@ class MultiSignals(AbstractContinuousFunction):
 
     def __contains__(self, x: ArrayLike | slice) -> bool:
         """
-        Return whether the multi-continuous signals contains given independent
-        domain variable :math:`x`.
+        Return whether the multi-continuous signals contains specified
+        independent domain variable :math:`x`.
 
         Parameters
         ----------
@@ -971,8 +971,8 @@ class MultiSignals(AbstractContinuousFunction):
 
     def __eq__(self, other: object) -> bool:
         """
-        Return whether the multi-continuous signals is equal to given other
-        object.
+        Return whether the multi-continuous signals is equal to specified
+        other object.
 
         Parameters
         ----------
@@ -982,7 +982,7 @@ class MultiSignals(AbstractContinuousFunction):
         Returns
         -------
         :class:`bool`
-            Whether given object is equal to the multi-continuous signals.
+            Whether specified object is equal to the multi-continuous signals.
 
         Examples
         --------
@@ -1022,7 +1022,7 @@ class MultiSignals(AbstractContinuousFunction):
 
     def __ne__(self, other: object) -> bool:
         """
-        Return whether the multi-continuous signals is not equal to given
+        Return whether the multi-continuous signals is not equal to specified
         other object.
 
         Parameters
@@ -1034,7 +1034,8 @@ class MultiSignals(AbstractContinuousFunction):
         Returns
         -------
         :class:`bool`
-            Whether given object is not equal to the multi-continuous signals.
+            Whether specified object is not equal to the multi-continuous
+            signals.
 
         Examples
         --------
@@ -1064,7 +1065,7 @@ class MultiSignals(AbstractContinuousFunction):
         in_place: bool = False,
     ) -> MultiSignals:
         """
-        Perform given arithmetical operation with operand :math:`a`, the
+        Perform specified arithmetical operation with operand :math:`a`, the
         operation can be either performed on a copy or in-place.
 
         Parameters
@@ -1228,7 +1229,7 @@ class MultiSignals(AbstractContinuousFunction):
         **kwargs: Any,
     ) -> Dict[str, Signal]:
         """
-        Unpack given data for multi-continuous signals instantiation.
+        Unpack specified data for multi-continuous signals instantiation.
 
         Parameters
         ----------
@@ -1244,7 +1245,7 @@ class MultiSignals(AbstractContinuousFunction):
             Names to use for the :class:`colour.continuous.Signal` sub-class
             instances.
         dtype
-            float point data type.
+            Floating point data type.
         signal_type
             A :class:`colour.continuous.Signal` sub-class type.
 
@@ -1546,7 +1547,7 @@ class MultiSignals(AbstractContinuousFunction):
     ) -> MultiSignals:
         """
         Fill NaNs in independent domain variable :math:`x` and corresponding
-        range variable :math:`y` using given method.
+        range variable :math:`y` using specified method.
 
         Parameters
         ----------

--- a/colour/continuous/signal.py
+++ b/colour/continuous/signal.py
@@ -2,7 +2,7 @@
 Signal
 ======
 
-Define the class implementing support for continuous signal:
+Define a class implementing support for continuous signal:
 
 -   :class:`colour.continuous.Signal`
 """
@@ -74,7 +74,7 @@ __all__ = [
 
 class Signal(AbstractContinuousFunction):
     """
-    Define the base class for continuous signal.
+    Define the base class for a continuous signal.
 
     The class implements the :meth:`Signal.function` method so that evaluating
     the function for any independent domain variable :math:`x \\in\\mathbb{R}`
@@ -98,13 +98,13 @@ class Signal(AbstractContinuousFunction):
     domain
         Values to initialise the :attr:`colour.continuous.Signal.domain`
         attribute with. If both ``data`` and ``domain`` arguments are defined,
-        the latter with be used to initialise the
+        the latter will be used to initialise the
         :attr:`colour.continuous.Signal.domain` property.
 
     Other Parameters
     ----------------
     dtype
-        float point data type.
+        Floating point data type.
     extrapolator
         Extrapolator class type to use as extrapolating function.
     extrapolator_kwargs
@@ -802,8 +802,8 @@ class Signal(AbstractContinuousFunction):
 
     def __contains__(self, x: ArrayLike | slice) -> bool:
         """
-        Return whether the continuous signal contains given independent domain
-        variable :math:`x`.
+        Return whether the continuous signal contains specified independent
+        domain variable :math:`x`.
 
         Parameters
         ----------
@@ -843,7 +843,8 @@ class Signal(AbstractContinuousFunction):
     @ndarray_copy_enable(False)
     def __eq__(self, other: object) -> bool:
         """
-        Return whether the continuous signal is equal to given other object.
+        Return whether the continuous signal is equal to specified other
+        object.
 
         Parameters
         ----------
@@ -853,7 +854,7 @@ class Signal(AbstractContinuousFunction):
         Returns
         -------
         :class:`bool`
-            Whether given object is equal to the continuous signal.
+            Whether specified object is equal to the continuous signal.
 
         Examples
         --------
@@ -892,7 +893,7 @@ class Signal(AbstractContinuousFunction):
 
     def __ne__(self, other: object) -> bool:
         """
-        Return whether the continuous signal is not equal to given other
+        Return whether the continuous signal is not equal to specified other
         object.
 
         Parameters
@@ -903,7 +904,7 @@ class Signal(AbstractContinuousFunction):
         Returns
         -------
         :class:`bool`
-            Whether given object is not equal to the continuous signal.
+            Whether specified object is not equal to the continuous signal.
 
         Examples
         --------
@@ -933,7 +934,8 @@ class Signal(AbstractContinuousFunction):
         default: Real = 0,
     ) -> None:
         """
-        Fill NaNs in independent domain variable :math:`x` using given method.
+        Fill NaNs in independent domain variable :math:`x` using specified
+        method.
 
         Parameters
         ----------
@@ -959,7 +961,8 @@ class Signal(AbstractContinuousFunction):
         default: Real = 0,
     ) -> None:
         """
-        Fill NaNs in corresponding range variable :math:`y` using given method.
+        Fill NaNs in corresponding range variable :math:`y` using specified
+        method.
 
         Parameters
         ----------
@@ -986,7 +989,7 @@ class Signal(AbstractContinuousFunction):
         in_place: bool = False,
     ) -> AbstractContinuousFunction:
         """
-        Perform given arithmetical operation with operand :math:`a`, the
+        Perform specified arithmetical operation with operand :math:`a`, the
         operation can be either performed on a copy or in-place.
 
         Parameters
@@ -1091,7 +1094,7 @@ class Signal(AbstractContinuousFunction):
         dtype: Type[DTypeFloat] | None = None,
     ) -> tuple:
         """
-        Unpack given data for continuous signal instantiation.
+        Unpack specified data for continuous signal instantiation.
 
         Parameters
         ----------
@@ -1218,7 +1221,7 @@ class Signal(AbstractContinuousFunction):
     ) -> Signal:
         """
         Fill NaNs in independent domain variable :math:`x` and corresponding
-        range variable :math:`y` using given method.
+        range variable :math:`y` using specified method.
 
         Parameters
         ----------

--- a/colour/contrast/__init__.py
+++ b/colour/contrast/__init__.py
@@ -69,7 +69,7 @@ def contrast_sensitivity_function(
 ) -> NDArrayFloat:
     """
     Return the contrast sensitivity :math:`S` of the human eye according to
-    the contrast sensitivity function (CSF) described by given method.
+    the contrast sensitivity function (CSF) described by specified method.
 
     Parameters
     ----------

--- a/colour/contrast/barten1999.py
+++ b/colour/contrast/barten1999.py
@@ -98,7 +98,7 @@ def pupil_diameter_Barten1999(
     Y_0: ArrayLike | None = None,
 ) -> NDArrayFloat:
     """
-    Return the pupil diameter for given luminance and object or stimulus
+    Return the pupil diameter for specified luminance and object or stimulus
     angular size using *Barten (1999)* method.
 
     Parameters
@@ -172,11 +172,11 @@ def sigma_Barten1999(
 
     Warnings
     --------
-    This definition expects :math:`\\sigma_{0}` and :math:`C_{ab}` to be given
-    in degrees and :math:`degrees\\div mm` respectively. However, in the
-    literature, the values for :math:`\\sigma_{0}` and
-    :math:`C_{ab}` are usually given in :math:`arc min` and
-    :math:`arc min\\div mm` respectively, thus they need to be divided by 60.
+    This definition expects :math:`\\sigma_{0}` and :math:`C_{ab}` to be
+    specified in degrees and :math:`degrees\\div mm` respectively. However, in
+    the literature, the values for :math:`\\sigma_{0}` and :math:`C_{ab}` are
+    usually specified in :math:`arc min` and :math:`arc min\\div mm`
+    respectively, thus they need to be divided by 60.
 
     References
     ----------
@@ -202,9 +202,9 @@ def retinal_illuminance_Barten1999(
     apply_stiles_crawford_effect_correction: bool = True,
 ) -> NDArrayFloat:
     """
-    Return the retinal illuminance :math:`E` in Trolands for given average
-    luminance :math:`L` and pupil diameter :math:`d` using *Barten (1999)*
-    method.
+    Return the retinal illuminance :math:`E` in Trolands for specified
+    average luminance :math:`L` and pupil diameter :math:`d` using
+    *Barten (1999)* method.
 
     Parameters
     ----------
@@ -386,9 +386,9 @@ def contrast_sensitivity_function_Barten1999(
     Warnings
     --------
     This definition expects :math:`\\sigma_{0}` and :math:`C_{ab}` used in the
-    computation of :math:`\\sigma` to be given in degrees and
+    computation of :math:`\\sigma` to be specified in degrees and
     :math:`degrees\\div mm` respectively. However, in the literature, the
-    values for :math:`\\sigma_{0}` and :math:`C_{ab}` are usually given in
+    values for :math:`\\sigma_{0}` and :math:`C_{ab}` are usually specified in
     :math:`arc min` and :math:`arc min\\div mm` respectively, thus they need to
     be divided by 60.
 

--- a/colour/corresponding/datasets/breneman1987.py
+++ b/colour/corresponding/datasets/breneman1987.py
@@ -1234,7 +1234,7 @@ BRENEMAN_EXPERIMENT_11_RESULTS = (
     ),
 )
 """
-*Breneman (1987)* experiment 1 results.
+*Breneman (1987)* experiment 11 results.
 
 Notes
 -----

--- a/colour/corresponding/prediction.py
+++ b/colour/corresponding/prediction.py
@@ -535,7 +535,7 @@ def corresponding_chromaticities_prediction_VonKries(
 ) -> Tuple[CorrespondingChromaticitiesPrediction, ...]:
     """
     Return the corresponding chromaticities prediction for *Von Kries*
-    chromatic adaptation model using given transform.
+    chromatic adaptation model using specified transform.
 
     Parameters
     ----------
@@ -608,7 +608,7 @@ def corresponding_chromaticities_prediction_Zhai2018(
 ) -> Tuple[CorrespondingChromaticitiesPrediction, ...]:
     """
     Return the corresponding chromaticities prediction for
-    *Zhai and Luo (2018)* chromatic adaptation model using given transform.
+    *Zhai and Luo (2018)* chromatic adaptation model using specified transform.
 
     Parameters
     ----------
@@ -724,7 +724,7 @@ def corresponding_chromaticities_prediction(
     **kwargs: Any,
 ) -> Tuple[CorrespondingChromaticitiesPrediction, ...]:
     """
-    Return the corresponding chromaticities prediction for given chromatic
+    Return the corresponding chromaticities prediction for specified chromatic
     adaptation model.
 
     Parameters

--- a/colour/difference/__init__.py
+++ b/colour/difference/__init__.py
@@ -143,9 +143,9 @@ def delta_E(
     **kwargs: Any,
 ) -> NDArrayFloat:
     """
-    Return the difference :math:`\\Delta E_{ab}` between two given
+    Return the difference :math:`\\Delta E_{ab}` between two specified
     *CIE L\\*a\\*b\\**, :math:`IC_TC_P`, or :math:`J'a'b'` colourspace arrays
-    using given method.
+    using specified method.
 
     Parameters
     ----------
@@ -165,7 +165,7 @@ def delta_E(
         Chroma weighting factor.
     l
         {:func:`colour.difference.delta_E_CIE2000`},
-        Lightness weighting factor.
+        lightness weighting factor.
     textiles
         {:func:`colour.difference.delta_E_CIE1994`,
         :func:`colour.difference.delta_E_CIE2000`,
@@ -175,8 +175,8 @@ def delta_E(
 \\ k_CH=0.5` weights are used instead of
         :math:`k_L=k_C=k_H=1,\\ k_1=0.045,\\ k_2=0.015,\\ k_E=k_CH=1.0`.
 
-    Returns
-    -------
+    Return
+    ------
     :class:`numpy.ndarray`
         Colour difference :math:`\\Delta E_{ab}`.
 

--- a/colour/difference/cam02_ucs.py
+++ b/colour/difference/cam02_ucs.py
@@ -47,7 +47,7 @@ def delta_E_Luo2006(
     Jpapbp_1: ArrayLike, Jpapbp_2: ArrayLike, coefficients: Coefficients_UCS_Luo2006
 ) -> NDArrayFloat:
     """
-    Return the difference :math:`\\Delta E'` between two given
+    Return the difference :math:`\\Delta E'` between two specified
     *Luo et al. (2006)* *CAM02-LCD*, *CAM02-SCD*, or *CAM02-UCS* colourspaces
     :math:`J'a'b'` arrays.
 
@@ -114,7 +114,7 @@ def delta_E_Luo2006(
 
 def delta_E_CAM02LCD(Jpapbp_1: ArrayLike, Jpapbp_2: ArrayLike) -> NDArrayFloat:
     """
-    Return the difference :math:`\\Delta E'` between two given
+    Return the difference :math:`\\Delta E'` between two specified
     *Luo et al. (2006)* *CAM02-LCD* colourspaces :math:`J'a'b'` arrays.
 
     Parameters
@@ -172,7 +172,7 @@ def delta_E_CAM02LCD(Jpapbp_1: ArrayLike, Jpapbp_2: ArrayLike) -> NDArrayFloat:
 
 def delta_E_CAM02SCD(Jpapbp_1: ArrayLike, Jpapbp_2: ArrayLike) -> NDArrayFloat:
     """
-    Return the difference :math:`\\Delta E'` between two given
+    Return the difference :math:`\\Delta E'` between two specified
     *Luo et al. (2006)* *CAM02-SCD* colourspaces :math:`J'a'b'` arrays.
 
     Parameters
@@ -230,7 +230,7 @@ def delta_E_CAM02SCD(Jpapbp_1: ArrayLike, Jpapbp_2: ArrayLike) -> NDArrayFloat:
 
 def delta_E_CAM02UCS(Jpapbp_1: ArrayLike, Jpapbp_2: ArrayLike) -> NDArrayFloat:
     """
-    Return the difference :math:`\\Delta E'` between two given
+    Return the difference :math:`\\Delta E'` between two specified
     *Luo et al. (2006)* *CAM02-UCS* colourspaces :math:`J'a'b'` arrays.
 
     Parameters

--- a/colour/difference/delta_e.py
+++ b/colour/difference/delta_e.py
@@ -111,7 +111,7 @@ References
 
 def delta_E_CIE1976(Lab_1: ArrayLike, Lab_2: ArrayLike) -> NDArrayFloat:
     """
-    Return the difference :math:`\\Delta E_{76}` between two given
+    Return the difference :math:`\\Delta E_{76}` between two specified
     *CIE L\\*a\\*b\\** colourspace arrays using *CIE 1976* recommendation.
 
     Parameters
@@ -163,7 +163,7 @@ def delta_E_CIE1994(
     Lab_1: ArrayLike, Lab_2: ArrayLike, textiles: bool = False
 ) -> NDArrayFloat:
     """
-    Return the difference :math:`\\Delta E_{94}` between two given
+    Return the difference :math:`\\Delta E_{94}` between two specified
     *CIE L\\*a\\*b\\** colourspace arrays using *CIE 1994* recommendation.
 
     Parameters
@@ -261,7 +261,7 @@ class Attributes_Specification_CIE2000(MixinDataclassArithmetic):
     Parameters
     ----------
     J
-        Correlate of *Lightness* :math:`J`.
+        Correlate of *lightness* :math:`J`.
     C
         Correlate of *chroma* :math:`C`.
     h
@@ -292,7 +292,7 @@ def intermediate_attributes_CIE2000(
 ) -> Attributes_Specification_CIE2000:
     """
     Return the intermediate attributes to compute the difference
-    :math:`\\Delta E_{00}` between two given *CIE L\\*a\\*b\\** colourspace
+    :math:`\\Delta E_{00}` between two specified *CIE L\\*a\\*b\\** colourspace
     arrays using *CIE 2000* recommendation.
 
     Parameters
@@ -430,7 +430,7 @@ def delta_E_CIE2000(
     Lab_1: ArrayLike, Lab_2: ArrayLike, textiles: bool = False
 ) -> NDArrayFloat:
     """
-    Return the difference :math:`\\Delta E_{00}` between two given
+    Return the difference :math:`\\Delta E_{00}` between two specified
     *CIE L\\*a\\*b\\** colourspace arrays using *CIE 2000* recommendation.
 
     Parameters
@@ -444,7 +444,7 @@ def delta_E_CIE2000(
         :math:`k_L=2,\\ k_C=k_H=1` weights are used instead of
         :math:`k_L=k_C=k_H=1`.
 
-    Returns
+    Return
     -------
     :class:`numpy.ndarray`
         Colour difference :math:`\\Delta E_{00}`.
@@ -520,11 +520,11 @@ def delta_E_CMC(
     c: float = 1,
 ) -> NDArrayFloat:
     """
-    Return the difference :math:`\\Delta E_{CMC}` between two given
+    Return the difference :math:`\\Delta E_{CMC}` between two specified
     *CIE L\\*a\\*b\\** colourspace arrays using *Colour Measurement Committee*
     recommendation.
 
-    The quasimetric has two parameters: *Lightness* (l) and *chroma* (c),
+    The quasimetric has two parameters: *lightness* (l) and *chroma* (c),
     allowing the users to weight the difference based on the ratio of l:c.
     Commonly used values are 2:1 for acceptability and 1:1 for the threshold of
     imperceptibility.
@@ -611,7 +611,7 @@ def delta_E_CMC(
 
 def delta_E_ITP(ICtCp_1: ArrayLike, ICtCp_2: ArrayLike) -> NDArrayFloat:
     """
-    Return the difference :math:`\\Delta E_{ITP}` between two given
+    Return the difference :math:`\\Delta E_{ITP}` between two specified
     :math:`IC_TC_P` colour encoding arrays using
     *Recommendation ITU-R BT.2124*.
 

--- a/colour/difference/din99.py
+++ b/colour/difference/din99.py
@@ -42,7 +42,7 @@ def delta_E_DIN99(
     Lab_1: ArrayLike, Lab_2: ArrayLike, textiles: bool = False
 ) -> NDArrayFloat:
     """
-    Return the difference :math:`\\Delta E_{DIN99}` between two given
+    Return the difference :math:`\\Delta E_{DIN99}` between two specified
     *CIE L\\*a\\*b\\** colourspace arrays using *DIN99* formula.
 
     Parameters

--- a/colour/difference/huang2015.py
+++ b/colour/difference/huang2015.py
@@ -101,7 +101,7 @@ def power_function_Huang2015(
     ) = "CIE 2000",
 ) -> NDArrayFloat:
     """
-    Improve the performance of the :math:`\\Delta E` value for given
+    Improve the performance of the :math:`\\Delta E` value for specified
     coefficients using
     *Huang, Cui, Melgosa, Sanchez-Maranon, Li, Luo and Liu (2015)*
     power-function: :math:`d_E^{\\prime}=a*d_{E^b}`.

--- a/colour/difference/stress.py
+++ b/colour/difference/stress.py
@@ -7,8 +7,8 @@ index:
 
 -   :func:`colour.index_stress_Garcia2007`: :math:`STRESS` index computation
     according to *García, Huertas, Melgosa and Cui (2007)* method.
--   :func:`colour.index_stress`: *Lightness* :math:`STRESS` index computation
-    according to given method.
+-   :func:`colour.index_stress`: *lightness* :math:`STRESS` index computation
+    according to specified method.
 
 References
 ----------
@@ -108,7 +108,7 @@ def index_stress(
     """
     Compute the
     *Kruskal's Standardized Residual Sum of Squares (:math:`STRESS`)*
-    index according to given method.
+    index according to specified method.
 
     Parameters
     ----------

--- a/colour/examples/adaptation/examples_cie1994.py
+++ b/colour/examples/adaptation/examples_cie1994.py
@@ -1,4 +1,10 @@
-"""Showcase *CIE 1994* chromatic adaptation model computations."""
+"""
+Demonstrate *CIE 1994* chromatic adaptation model computations.
+
+This module provides examples of chromatic adaptation computations using the
+*CIE 1994* chromatic adaptation model, illustrating forward adaptation
+calculations between different illumination conditions.
+"""
 
 import numpy as np
 
@@ -14,7 +20,7 @@ Y_o = 20
 E_o1 = 1000
 E_o2 = 1000
 message_box(
-    f'Computing chromatic adaptation using "CIE 1994" chromatic adaptation '
+    f'Compute chromatic adaptation using "CIE 1994" chromatic adaptation '
     f"model.\n\n"
     f'\t"XYZ_1": {XYZ_1}\n'
     f'\t"xy_o1": {xy_o1}\n'

--- a/colour/examples/adaptation/examples_cmccat2000.py
+++ b/colour/examples/adaptation/examples_cmccat2000.py
@@ -1,4 +1,10 @@
-"""Showcase *CMCCAT2000* chromatic adaptation model computations."""
+"""
+Demonstrate *CMCCAT2000* chromatic adaptation model computations.
+
+This module provides examples of chromatic adaptation computations using the
+*CMCCAT2000* chromatic adaptation model, illustrating both forward and
+inverse adaptation calculations under various luminance adaptation conditions.
+"""
 
 import numpy as np
 
@@ -13,7 +19,7 @@ XYZ_wr = np.array([0.9481, 1.0000, 1.0730])
 L_A1 = 200
 L_A2 = 200
 message_box(
-    f'Computing chromatic adaptation using "CMCCAT200" forward chromatic '
+    f'Compute chromatic adaptation using "CMCCAT200" forward chromatic '
     f"adaptation model.\n\n"
     f'\t"XYZ":\n\t\t{XYZ}\n'
     f'\t"XYZ_w":\n\t\t{XYZ_w}\n'
@@ -37,7 +43,7 @@ print("\n")
 
 XYZ_c = np.array([0.19526983, 0.23068340, 0.24971752])
 message_box(
-    f'Computing chromatic adaptation using "CMCCAT200" inverse chromatic '
+    f'Compute chromatic adaptation using "CMCCAT200" inverse chromatic '
     f"adaptation model.\n\n"
     f'\t"XYZ_c": {XYZ_c}\n'
     f'\t"XYZ_w": {XYZ_w}\n'

--- a/colour/examples/adaptation/examples_fairchild1990.py
+++ b/colour/examples/adaptation/examples_fairchild1990.py
@@ -1,4 +1,10 @@
-"""Showcase *Fairchild (1990)* chromatic adaptation model computations."""
+"""
+Demonstrate *Fairchild (1990)* chromatic adaptation model computations.
+
+This module provides examples of chromatic adaptation computations using the
+*Fairchild (1990)* chromatic adaptation model, illustrating colour
+transformations under different viewing conditions.
+"""
 
 import numpy as np
 
@@ -12,7 +18,7 @@ XYZ_n = np.array([1.1115, 1.0000, 0.3520])
 XYZ_r = np.array([0.9481, 1.0000, 1.0730])
 Y_n = 200
 message_box(
-    f'Computing chromatic adaptation using "Fairchild (1990)" chromatic '
+    f'Compute chromatic adaptation using "Fairchild (1990)" chromatic '
     f"adaptation model.\n\n"
     f'\t"XYZ_1": {XYZ_1}\n'
     f'\t"XYZ_n": {XYZ_n}\n'

--- a/colour/examples/adaptation/examples_vonkries.py
+++ b/colour/examples/adaptation/examples_vonkries.py
@@ -1,4 +1,10 @@
-"""Showcase *Von Kries* chromatic adaptation model computations."""
+"""
+Demonstrate *Von Kries* chromatic adaptation model computations.
+
+This module provides examples of chromatic adaptation computations using the
+*Von Kries* chromatic adaptation model and various chromatic adaptation
+transforms.
+"""
 
 import numpy as np
 
@@ -10,7 +16,7 @@ message_box('"Von Kries" Chromatic Adaptation Model Computations')
 XYZ_w = np.array([0.95045593, 1.00000000, 1.08905775])
 XYZ_wr = np.array([0.96429568, 1.00000000, 0.82510460])
 message_box(
-    f'Computing the chromatic adaptation matrix from two source "CIE XYZ" '
+    f'Compute the chromatic adaptation matrix from two source "CIE XYZ" '
     f'tristimulus values arrays, default CAT is "CAT02".\n\n'
     f'\t"XYZ_w": {XYZ_w}\n'
     f'\t"XYZ_wr": {XYZ_wr}'
@@ -19,7 +25,7 @@ print(colour.adaptation.matrix_chromatic_adaptation_VonKries(XYZ_w, XYZ_wr))
 
 print("\n")
 
-message_box('Using "Bradford" CAT.')
+message_box('Use "Bradford" CAT.')
 print(
     colour.adaptation.matrix_chromatic_adaptation_VonKries(
         XYZ_w, XYZ_wr, transform="Bradford"
@@ -29,7 +35,7 @@ print(
 print("\n")
 
 message_box(
-    "Computing the chromatic adaptation matrix from "
+    "Compute the chromatic adaptation matrix from "
     'the "CIE Standard Illuminant A" to '
     'the "CIE Standard Illuminant D Series D65" using the "Von Kries" CAT.'
 )
@@ -45,7 +51,7 @@ print("\n")
 
 XYZ = np.array([1.14176346, 1.00000000, 0.49815206])
 message_box(
-    f'Adapting given "CIE XYZ" tristimulus values from '
+    f'Adapt given "CIE XYZ" tristimulus values from '
     f'the "CIE Standard Illuminant A" to the '
     f'"CIE Standard Illuminant D Series D65" using the "Sharp" CAT.\n\n'
     f'\t"XYZ": {XYZ}'

--- a/colour/examples/adaptation/examples_zhai2018.py
+++ b/colour/examples/adaptation/examples_zhai2018.py
@@ -1,4 +1,11 @@
-"""Showcase *Zhai and Luo (2018)* chromatic adaptation model computations."""
+"""
+Demonstrate *Zhai and Luo (2018)* chromatic adaptation model computations.
+
+This module provides examples of chromatic adaptation computations using the
+*Zhai and Luo (2018)* chromatic adaptation model, illustrating advanced
+colour transformation techniques under varying degree of adaptation
+conditions.
+"""
 
 import numpy as np
 
@@ -14,7 +21,7 @@ D_b = 0.9407
 D_d = 0.9800
 XYZ_wo = np.array([1, 1, 1])
 message_box(
-    f'Computing chromatic adaptation using "Zhai and Luo (2018)" chromatic '
+    f'Compute chromatic adaptation using "Zhai and Luo (2018)" chromatic '
     f"adaptation model.\n\n"
     f'\t"XYZ_b": {XYZ_b}\n'
     f'\t"XYZ_wb": {XYZ_wb}\n'

--- a/colour/examples/algebra/examples_interpolation.py
+++ b/colour/examples/algebra/examples_interpolation.py
@@ -1,4 +1,11 @@
-"""Showcase interpolation computations."""
+"""
+Demonstrate interpolation computations.
+
+This module provides examples of various interpolation methods and their
+application to spectral data and colour lookup table operations, illustrating
+the differences between interpolation techniques for both uniform and
+non-uniform data distributions.
+"""
 
 import os
 
@@ -13,7 +20,7 @@ from colour.utilities import message_box
 message_box("Interpolation Computations")
 
 message_box(
-    'Comparing the "Sprague (1880)" and "Cubic Spline" recommended '
+    'Compare the "Sprague (1880)" and "Cubic Spline" recommended '
     'interpolation methods to the "Pchip" method.'
 )
 
@@ -156,7 +163,7 @@ print("\n")
 
 V_xyz = np.random.random((6, 3))
 message_box(
-    f'Performing "trilinear" interpolation of given "xyz" values:\n\n'
+    f'Perform "trilinear" interpolation of given "xyz" values:\n\n'
     f"{V_xyz}\n\n"
     f"using given interpolation table."
 )
@@ -178,7 +185,7 @@ print(colour.algebra.table_interpolation_trilinear(V_xyz, table))
 print("\n")
 
 message_box(
-    f'Performing "tetrahedral" interpolation of given "xyz" values:\n\n'
+    f'Perform "tetrahedral" interpolation of given "xyz" values:\n\n'
     f"{V_xyz}\n\n"
     f"using given interpolation table."
 )

--- a/colour/examples/appearance/examples_atd95.py
+++ b/colour/examples/appearance/examples_atd95.py
@@ -1,4 +1,10 @@
-"""Showcase *ATD (1995)* colour appearance model computations."""
+"""
+Demonstrate *ATD (1995)* colour appearance model computations.
+
+This module provides examples of colour appearance model computations using the
+*ATD (1995)* model, illustrating forward transformation from tristimulus values
+to colour appearance correlates and reference specification broadcasting.
+"""
 
 import numpy as np
 
@@ -6,7 +12,7 @@ import colour
 from colour.appearance.atd95 import CAM_ReferenceSpecification_ATD95
 from colour.utilities import message_box
 
-message_box('"ATD (1995)" Colour Appearance Model Computations')
+message_box('Compute "ATD (1995)" Colour Appearance Model Correlates')
 
 XYZ = np.array([19.01, 20.00, 21.78])
 XYZ_0 = np.array([95.05, 100.00, 108.88])
@@ -14,7 +20,7 @@ Y_0 = 318.31
 k_1 = 0.0
 k_2 = 50.0
 message_box(
-    f'Converting to the "ATD (1995)" colour appearance model specification '
+    f'Convert to the "ATD (1995)" colour appearance model specification '
     f"using given parameters:\n\n"
     f"\tXYZ: {XYZ}\n"
     f"\tXYZ_0: {XYZ_0}\n"
@@ -28,7 +34,7 @@ print(specification)
 print("\n")
 
 message_box(
-    'Broadcasting the current output "ATD (1995)" colour appearance '
+    'Broadcast the current output "ATD (1995)" colour appearance '
     "model specification to the reference specification.\n"
     "The intent of this reference specification is to provide names "
     'as closest as possible to the "Mark D. Fairchild" reference.\n'

--- a/colour/examples/appearance/examples_cam16.py
+++ b/colour/examples/appearance/examples_cam16.py
@@ -1,11 +1,17 @@
-"""Showcase *CAM16* colour appearance model computations."""
+"""
+Demonstrate *CAM16* colour appearance model computations.
+
+This module provides examples of colour appearance model computations using the
+*CAM16* model, illustrating both forward and inverse transformations between
+tristimulus values and colour appearance correlates.
+"""
 
 import numpy as np
 
 import colour
 from colour.utilities import message_box
 
-message_box('"CAM16" Colour Appearance Model Computations')
+message_box('Compute "CAM16" Colour Appearance Model Correlates')
 
 XYZ = np.array([19.01, 20.00, 21.78])
 XYZ_w = np.array([95.05, 100.00, 108.88])
@@ -13,7 +19,7 @@ L_A = 318.31
 Y_b = 20.0
 surround = colour.VIEWING_CONDITIONS_CAM16["Average"]
 message_box(
-    f'Converting to the "CAM16" colour appearance model specification '
+    f'Convert to the "CAM16" colour appearance model specification '
     f"using given parameters:\n\n"
     f"\tXYZ: {XYZ}\n"
     f"\tXYZ_w: {XYZ_w}\n"
@@ -31,7 +37,7 @@ C = 0.10335574
 h = 217.06795977
 specification = colour.CAM_Specification_CAM16(J, C, h)
 message_box(
-    f'Converting to "CIE XYZ" tristimulus values using given parameters:\n\n'
+    f'Convert to "CIE XYZ" tristimulus values using given parameters:\n\n'
     f"\tJ: {J}\n"
     f"\tC: {C}\n"
     f"\th: {h}\n"

--- a/colour/examples/appearance/examples_ciecam02.py
+++ b/colour/examples/appearance/examples_ciecam02.py
@@ -1,11 +1,17 @@
-"""Showcase *CIECAM02* colour appearance model computations."""
+"""
+Demonstrate *CIECAM02* colour appearance model computations.
+
+This module provides examples of colour appearance model computations using the
+*CIECAM02* model, illustrating both forward and inverse transformations between
+tristimulus values and colour appearance correlates.
+"""
 
 import numpy as np
 
 import colour
 from colour.utilities import message_box
 
-message_box('"CIECAM02" Colour Appearance Model Computations')
+message_box('Compute "CIECAM02" Colour Appearance Model Correlates')
 
 XYZ = np.array([19.01, 20.00, 21.78])
 XYZ_w = np.array([95.05, 100.00, 108.88])
@@ -13,7 +19,7 @@ L_A = 318.31
 Y_b = 20.0
 surround = colour.VIEWING_CONDITIONS_CIECAM02["Average"]
 message_box(
-    f'Converting to the "CIECAM02" colour appearance model specification '
+    f'Convert to the "CIECAM02" colour appearance model specification '
     f"using given parameters:\n\n"
     f"\tXYZ: {XYZ}\n"
     f"\tXYZ_w: {XYZ_w}\n"
@@ -31,7 +37,7 @@ C = 0.10470776
 h = 219.04843266
 specification = colour.CAM_Specification_CIECAM02(J, C, h)
 message_box(
-    f'Converting to "CIE XYZ" tristimulus values using given parameters:\n\n'
+    f'Convert to "CIE XYZ" tristimulus values using given parameters:\n\n'
     f"\tJ: {J}\n"
     f"\tC: {C}\n"
     f"\th: {h}\n"

--- a/colour/examples/appearance/examples_ciecam16.py
+++ b/colour/examples/appearance/examples_ciecam16.py
@@ -1,11 +1,17 @@
-"""Showcase *CIECAM16* colour appearance model computations."""
+"""
+Demonstrate *CIECAM16* colour appearance model computations.
+
+This module provides examples of colour appearance model computations using the
+*CIECAM16* model, illustrating both forward and inverse transformations between
+tristimulus values and colour appearance correlates.
+"""
 
 import numpy as np
 
 import colour
 from colour.utilities import message_box
 
-message_box('"CIECAM16" Colour Appearance Model Computations')
+message_box('Compute "CIECAM16" Colour Appearance Model Correlates')
 
 XYZ = np.array([19.01, 20.00, 21.78])
 XYZ_w = np.array([95.05, 100.00, 108.88])
@@ -13,7 +19,7 @@ L_A = 318.31
 Y_b = 20.0
 surround = colour.VIEWING_CONDITIONS_CIECAM16["Average"]
 message_box(
-    f'Converting to the "CIECAM16" colour appearance model specification '
+    f'Convert to the "CIECAM16" colour appearance model specification '
     f"using given parameters:\n\n"
     f"\tXYZ: {XYZ}\n"
     f"\tXYZ_w: {XYZ_w}\n"
@@ -31,7 +37,7 @@ C = 0.10335574
 h = 217.06795977
 specification = colour.CAM_Specification_CIECAM16(J, C, h)
 message_box(
-    f'Converting to "CIE XYZ" tristimulus values using given parameters:\n\n'
+    f'Convert to "CIE XYZ" tristimulus values using given parameters:\n\n'
     f"\tJ: {J}\n"
     f"\tC: {C}\n"
     f"\th: {h}\n"

--- a/colour/examples/appearance/examples_hellwig2022.py
+++ b/colour/examples/appearance/examples_hellwig2022.py
@@ -1,11 +1,17 @@
-"""Showcase *Hellwig and Fairchild (2022)* colour appearance model computations."""
+"""
+Demonstrate *Hellwig and Fairchild (2022)* colour appearance model computations.
+
+This module provides examples of colour appearance model computations using the
+*Hellwig and Fairchild (2022)* model, illustrating both forward and inverse
+transformations between tristimulus values and colour appearance correlates.
+"""
 
 import numpy as np
 
 import colour
 from colour.utilities import message_box
 
-message_box('"Hellwig and Fairchild (2022)" Colour Appearance Model Computations')
+message_box('Compute "Hellwig and Fairchild (2022)" Colour Appearance Model Correlates')
 
 XYZ = np.array([19.01, 20.00, 21.78])
 XYZ_w = np.array([95.05, 100.00, 108.88])
@@ -13,7 +19,7 @@ L_A = 318.31
 Y_b = 20.0
 surround = colour.VIEWING_CONDITIONS_HELLWIG2022["Average"]
 message_box(
-    f'Converting to the "Hellwig and Fairchild (2022)" colour appearance '
+    f'Convert to the "Hellwig and Fairchild (2022)" colour appearance '
     f"model specification "
     f"using given parameters:\n\n"
     f"\tXYZ: {XYZ}\n"
@@ -32,7 +38,7 @@ C = 0.02576362
 h = 217.06795977
 specification = colour.CAM_Specification_Hellwig2022(J, C, h)
 message_box(
-    f'Converting to "CIE XYZ" tristimulus values using given parameters:\n\n'
+    f'Convert to "CIE XYZ" tristimulus values using given parameters:\n\n'
     f"\tJ: {J}\n"
     f"\tC: {C}\n"
     f"\th: {h}\n"

--- a/colour/examples/appearance/examples_hke.py
+++ b/colour/examples/appearance/examples_hke.py
@@ -1,4 +1,9 @@
-"""Showcase Helmholtz—Kohlrausch effect estimation computations."""
+"""
+Demonstrate Helmholtz—Kohlrausch effect estimation computations.
+
+This module provides examples of Helmholtz—Kohlrausch effect compensation
+methods.
+"""
 
 import colour
 from colour.plotting import colour_style, plot_multi_colour_swatches
@@ -20,7 +25,7 @@ for patch in swatches:
     in_XYZ = colour.Luv_to_XYZ(colour.uv_to_Luv(patch))
     swatches_XYZ.append(in_XYZ * (average_luminance / in_XYZ[1]))
 
-# Adapting Luminance, 250 cd/m^2 represents a typical modern computer
+# Adapting luminance, 250 cd/m^2 represents a typical modern computer
 # display peak luminance.
 L_a = 250 * average_luminance
 
@@ -50,21 +55,21 @@ for i in range(len(swatches)):
 colour_style()
 
 message_box(
-    "Plotting swatches with the same luminance (Y).\n"
+    "Plot swatches with the same luminance (Y).\n"
     "The Helmholtz—Kohlrausch effect will be very noticeable."
 )
 plot_multi_colour_swatches(swatches_normal, compare_swatches="stacked")
 
 message_box(
-    "Plotting HKE-compensated swatches with VCC method.\n"
-    "The Helmholtz—Kohlrausch effect has been compensated using VCC"
+    "Plot HKE-compensated swatches with VCC method.\n"
+    "The Helmholtz—Kohlrausch effect has been compensated using VCC "
     "(variable chromatic colour) method."
 )
 plot_multi_colour_swatches(swatches_VCC, compare_swatches="stacked")
 
 message_box(
-    "Plotting HKE-compensated swatches with VAC method.\n"
-    "The Helmholtz—Kohlrausch effect has been compensated for using VAC"
+    "Plot HKE-compensated swatches with VAC method.\n"
+    "The Helmholtz—Kohlrausch effect has been compensated for using VAC "
     "(variable achromatic colour) method."
 )
 plot_multi_colour_swatches(swatches_VAC, compare_swatches="stacked")

--- a/colour/examples/appearance/examples_hunt.py
+++ b/colour/examples/appearance/examples_hunt.py
@@ -1,4 +1,10 @@
-"""Showcase *Hunt* colour appearance model computations."""
+"""
+Demonstrate *Hunt* colour appearance model computations.
+
+This module provides examples of colour appearance model computations using the
+*Hunt* model, illustrating forward transformations from tristimulus values to
+colour appearance correlates and reference specification broadcasting.
+"""
 
 import numpy as np
 
@@ -6,7 +12,7 @@ import colour
 from colour.appearance.hunt import CAM_ReferenceSpecification_Hunt
 from colour.utilities import message_box
 
-message_box('"Hunt" Colour Appearance Model Computations')
+message_box('Compute "Hunt" Colour Appearance Model Correlates')
 
 XYZ = np.array([19.01, 20.00, 21.78])
 XYZ_w = np.array([95.05, 100.00, 108.88])
@@ -15,7 +21,7 @@ L_A = 318.31
 surround = colour.VIEWING_CONDITIONS_HUNT["Normal Scenes"]
 CCT_w = 6504.0
 message_box(
-    f'Converting to the "Hunt" colour appearance model specification using '
+    f'Convert to the "Hunt" colour appearance model specification using '
     f"given parameters:\n\n"
     f"\tXYZ: {XYZ}\n"
     f"\tXYZ_w: {XYZ_w}\n"
@@ -31,7 +37,7 @@ print(specification)
 print("\n")
 
 message_box(
-    'Broadcasting the current output "Hunt" colour appearance '
+    'Broadcast the current output "Hunt" colour appearance '
     "model specification to the reference specification.\n"
     "The intent of this reference specification is to provide names "
     'as closest as possible to the "Mark D. Fairchild" reference.\n'

--- a/colour/examples/appearance/examples_kim2009.py
+++ b/colour/examples/appearance/examples_kim2009.py
@@ -1,11 +1,19 @@
-"""Showcase *Kim, Weyrich and Kautz (2009)* colour appearance model computations."""
+"""
+Demonstrate *Kim, Weyrich and Kautz (2009)* colour appearance model computations.
+
+This module provides examples of colour appearance model computations using the
+*Kim, Weyrich and Kautz (2009)* model, illustrating both forward and inverse
+transformations between tristimulus values and colour appearance correlates.
+"""
 
 import numpy as np
 
 import colour
 from colour.utilities import message_box
 
-message_box('"Kim, Weyrich and Kautz (2009)" Colour Appearance Model Computations')
+message_box(
+    'Compute "Kim, Weyrich and Kautz (2009)" Colour Appearance Model Correlates'
+)
 
 XYZ = np.array([19.01, 20.00, 21.78])
 XYZ_w = np.array([95.05, 100.00, 108.88])
@@ -13,7 +21,7 @@ L_A = 318.31
 media = colour.MEDIA_PARAMETERS_KIM2009["CRT Displays"]
 surround = colour.VIEWING_CONDITIONS_KIM2009["Average"]
 message_box(
-    f'Converting to the "Kim, Weyrich and Kautz (2009)" colour appearance '
+    f'Convert to the "Kim, Weyrich and Kautz (2009)" colour appearance '
     f"model specification using given parameters:\n\n"
     f"\tXYZ: {XYZ}\n"
     f"\tXYZ_w: {XYZ_w}\n"
@@ -31,7 +39,7 @@ C = 0.559245592437371
 h = 219.048066776629530
 specification = colour.CAM_Specification_Kim2009(J, C, h)
 message_box(
-    f'Converting to "CIE XYZ" tristimulus values using given parameters:\n\n'
+    f'Convert to "CIE XYZ" tristimulus values using given parameters:\n\n'
     f"\tJ: {J}\n"
     f"\tC: {C}\n"
     f"\th: {h}\n"

--- a/colour/examples/appearance/examples_llab.py
+++ b/colour/examples/appearance/examples_llab.py
@@ -1,4 +1,10 @@
-"""Showcase *LLAB(l:c)* colour appearance model computations."""
+"""
+Demonstrate *LLAB(l:c)* colour appearance model computations.
+
+This module provides examples of colour appearance model computations using the
+*LLAB(l:c)* model, illustrating forward transformations from tristimulus values
+to colour appearance correlates with reference specification broadcasting.
+"""
 
 import numpy as np
 
@@ -6,7 +12,7 @@ import colour
 from colour.appearance.llab import CAM_ReferenceSpecification_LLAB
 from colour.utilities import message_box
 
-message_box('"LLAB(l:c)" Colour Appearance Model Computations')
+message_box('Compute "LLAB(l:c)" Colour Appearance Model Correlates')
 
 XYZ = np.array([19.01, 20.00, 21.78])
 XYZ_0 = np.array([95.05, 100.00, 108.88])
@@ -14,7 +20,7 @@ Y_b = 20.0
 L = 318.31
 surround = colour.VIEWING_CONDITIONS_LLAB["ref_average_4_minus"]
 message_box(
-    f'Converting to the  "LLAB(l:c)" colour appearance model specification '
+    f'Convert to the  "LLAB(l:c)" colour appearance model specification '
     f"using given parameters:\n\n"
     f"\tXYZ: {XYZ}\n"
     f"\tXYZ_0: {XYZ_0}\n"
@@ -28,7 +34,7 @@ print(specification)
 print("\n")
 
 message_box(
-    'Broadcasting the current output "LLAB(l:c)" colour appearance '
+    'Broadcast the current output "LLAB(l:c)" colour appearance '
     "model specification to the reference specification.\n"
     "The intent of this reference specification is to provide names "
     'as closest as possible to the "Mark D. Fairchild" reference.\n'

--- a/colour/examples/appearance/examples_nayatani95.py
+++ b/colour/examples/appearance/examples_nayatani95.py
@@ -1,4 +1,10 @@
-"""Showcase *Nayatani (1995)* colour appearance model computations."""
+"""
+Demonstrate *Nayatani (1995)* colour appearance model computations.
+
+This module provides examples of colour appearance model computations using the
+*Nayatani (1995)* model, illustrating forward transformations from tristimulus
+values to colour appearance correlates with reference specification broadcasting.
+"""
 
 import numpy as np
 
@@ -6,7 +12,7 @@ import colour
 from colour.appearance.nayatani95 import CAM_ReferenceSpecification_Nayatani95
 from colour.utilities import message_box
 
-message_box('"Nayatani (1995)" Colour Appearance Model Computations')
+message_box('Compute "Nayatani (1995)" Colour Appearance Model Correlates')
 
 XYZ = np.array([19.01, 20.00, 21.78])
 XYZ_n = np.array([95.05, 100.00, 108.88])
@@ -14,7 +20,7 @@ Y_o = 20.0
 E_o = 5000.0
 E_or = 1000.0
 message_box(
-    f'Converting to the "Nayatani (1995)" colour appearance model '
+    f'Convert to the "Nayatani (1995)" colour appearance model '
     f"specification using given parameters:\n\n"
     f"\tXYZ: {XYZ}\n"
     f"\tXYZ_n: {XYZ_n}\n"
@@ -28,7 +34,7 @@ print(specification)
 print("\n")
 
 message_box(
-    'Broadcasting the current output "Nayatani (1995)" colour appearance '
+    'Broadcast the current output "Nayatani (1995)" colour appearance '
     "model specification to the reference specification.\n"
     "The intent of this reference specification is to provide names "
     'as closest as possible to the "Mark D. Fairchild" reference.\n'

--- a/colour/examples/appearance/examples_rlab.py
+++ b/colour/examples/appearance/examples_rlab.py
@@ -1,4 +1,10 @@
-"""Showcase *RLAB* colour appearance model computations."""
+"""
+Demonstrate *RLAB* colour appearance model computations.
+
+This module provides examples of colour appearance model computations using the
+*RLAB* model, illustrating forward transformations from tristimulus values to
+colour appearance correlates with reference specification broadcasting.
+"""
 
 import numpy as np
 
@@ -6,7 +12,7 @@ import colour
 from colour.appearance.rlab import CAM_ReferenceSpecification_RLAB
 from colour.utilities import message_box
 
-message_box('"RLAB" Colour Appearance Model Computations')
+message_box('Compute "RLAB" Colour Appearance Model Correlates')
 
 XYZ = np.array([19.01, 20.00, 21.78])
 XYZ_n = np.array([109.85, 100, 35.58])
@@ -14,7 +20,7 @@ Y_n = 31.83
 sigma = colour.VIEWING_CONDITIONS_RLAB["Average"]
 D = colour.appearance.D_FACTOR_RLAB["Hard Copy Images"]
 message_box(
-    f'Converting to the "RLAB" colour appearance model specification using '
+    f'Convert to the "RLAB" colour appearance model specification using '
     f"given parameters:\n\n"
     f"\tXYZ: {XYZ}\n"
     f"\tXYZ_n: {XYZ_n}\n"
@@ -28,7 +34,7 @@ print(specification)
 print("\n")
 
 message_box(
-    'Broadcasting the current output "RLAB" colour appearance '
+    'Broadcast the current output "RLAB" colour appearance '
     "model specification to the reference specification.\n"
     "The intent of this reference specification is to provide names "
     'as closest as possible to the "Mark D. Fairchild" reference.\n'

--- a/colour/examples/appearance/examples_zcam.py
+++ b/colour/examples/appearance/examples_zcam.py
@@ -1,4 +1,11 @@
-"""Showcase *ZCAM* colour appearance model computations."""
+"""
+Demonstrate *ZCAM* colour appearance model computations.
+
+This module provides examples of colour appearance model computations using the
+*ZCAM* model, illustrating both forward and inverse transformations between
+tristimulus values and colour appearance correlates with reference
+specification broadcasting.
+"""
 
 import numpy as np
 
@@ -6,7 +13,7 @@ import colour
 from colour.appearance.zcam import CAM_ReferenceSpecification_ZCAM
 from colour.utilities import message_box
 
-message_box('"ZCAM" Colour Appearance Model Computations')
+message_box('Compute "ZCAM" Colour Appearance Model Correlates')
 
 XYZ = np.array([19.01, 20.00, 21.78])
 XYZ_w = np.array([95.05, 100.00, 108.88])
@@ -14,7 +21,7 @@ L_A = 318.31
 Y_b = 20.0
 surround = colour.VIEWING_CONDITIONS_ZCAM["Average"]
 message_box(
-    f'Converting to the "ZCAM" colour appearance model specification using '
+    f'Convert to the "ZCAM" colour appearance model specification using '
     f"given parameters:\n\n"
     f"\tXYZ: {XYZ}\n"
     f"\tXYZ_w: {XYZ_w}\n"
@@ -28,7 +35,7 @@ print(specification)
 print("\n")
 
 message_box(
-    'Broadcasting the current output "ZCAM" colour appearance model '
+    'Broadcast the current output "ZCAM" colour appearance model '
     "specification to the reference specification."
 )
 
@@ -42,7 +49,7 @@ C = 0.18427174878137914
 h = 219.74741565783773
 specification = colour.CAM_Specification_ZCAM(J, C, h)
 message_box(
-    f'Converting to "CIE XYZ" tristimulus values using given parameters:\n\n'
+    f'Convert to "CIE XYZ" tristimulus values using given parameters:\n\n'
     f"\tJ: {J}\n"
     f"\tC: {C}\n"
     f"\th: {h}\n"

--- a/colour/examples/blindness/examples_machado2009.py
+++ b/colour/examples/blindness/examples_machado2009.py
@@ -1,4 +1,10 @@
-"""Showcase Machado (2009) simulation of colour vision deficiency."""
+"""
+Demonstrate *Machado et al. (2009)* colour vision deficiency simulation.
+
+This module demonstrates the computation and application of colour vision
+deficiency matrices using *Machado et al. (2009)* method for simulating
+protanomaly, deuteranomaly, and tritanomaly conditions.
+"""
 
 import numpy as np
 
@@ -13,7 +19,7 @@ M_a = colour.matrix_anomalous_trichromacy_Machado2009(
     np.array([10, 0, 0]),
 )
 message_box(
-    f'Computing a "Protanomaly" matrix using '
+    f'Compute a "Protanomaly" matrix using '
     f'"Stockman & Sharpe 2 Degree Cone Fundamentals" and '
     f'"Typical CRT Brainard 1997" "RGB" display primaries for a 10nm shift:\n\n{M_a}'
 )
@@ -22,7 +28,7 @@ print("\n")
 
 M_a = colour.matrix_cvd_Machado2009("Protanomaly", 0.5)
 message_box(
-    f'Retrieving a "Protanomaly" pre-computed matrix for a 50% severity:\n\n{M_a}'
+    f'Retrieve a "Protanomaly" pre-computed matrix for a 50% severity:\n\n{M_a}'
 )
 
 print("\n")
@@ -33,7 +39,7 @@ M_a = colour.matrix_anomalous_trichromacy_Machado2009(
     np.array([0, 10, 0]),
 )
 message_box(
-    f'Computing a "Deuteranomaly" matrix using '
+    f'Compute a "Deuteranomaly" matrix using '
     f'"Stockman & Sharpe 2 Degree Cone Fundamentals" and '
     f'"Typical CRT Brainard 1997" "RGB" display primaries for a 10nm shift:\n\n{M_a}'
 )
@@ -42,7 +48,7 @@ print("\n")
 
 M_a = colour.matrix_cvd_Machado2009("Deuteranomaly", 0.5)
 message_box(
-    f'Retrieving a "Deuteranomaly" pre-computed matrix for a 50% severity:\n\n{M_a}'
+    f'Retrieve a "Deuteranomaly" pre-computed matrix for a 50% severity:\n\n{M_a}'
 )
 
 print("\n")
@@ -53,7 +59,7 @@ M_a = colour.matrix_anomalous_trichromacy_Machado2009(
     np.array([0, 0, 27]),
 )
 message_box(
-    f'Computing a "Tritanomaly" matrix using '
+    f'Compute a "Tritanomaly" matrix using '
     f'"Stockman & Sharpe 2 Degree Cone Fundamentals" and '
     f'"Typical CRT Brainard 1997" "RGB" display primaries for a 27nm shift:\n\n{M_a}'
 )
@@ -62,5 +68,5 @@ print("\n")
 
 M_a = colour.matrix_cvd_Machado2009("Tritanomaly", 0.5)
 message_box(
-    f'Retrieving a "Tritanomaly" pre-computed matrix for a 50% severity:\n\n{M_a}'
+    f'Retrieve a "Tritanomaly" pre-computed matrix for a 50% severity:\n\n{M_a}'
 )

--- a/colour/examples/characterisation/examples_aces_it.py
+++ b/colour/examples/characterisation/examples_aces_it.py
@@ -1,6 +1,9 @@
 """
-Showcases *Academy Color Encoding System* *Input Transform* related
-computations.
+Demonstrate *Academy Color Encoding System* *Input Transform* computations.
+
+This module demonstrates the computation of ACES relative exposure values
+from spectral distributions and the creation of input device transforms
+for cameras using various optimisation methods.
 """
 
 import os
@@ -12,7 +15,7 @@ from colour.utilities import message_box
 message_box('"ACES" "Input Transform" Computations')
 
 message_box(
-    'Computing "ACES" relative exposure values for some colour rendition '
+    'Compute "ACES" relative exposure values for some colour rendition '
     "chart spectral distributions:\n\n"
     '\t("dark skin", "blue sky")'
 )
@@ -30,7 +33,7 @@ print(
 print("\n")
 
 message_box(
-    'Computing "ACES" relative exposure values for various ideal '
+    'Compute "ACES" relative exposure values for various ideal '
     "reflectors:\n\n"
     '\t("18%", "100%")'
 )
@@ -48,7 +51,7 @@ print(colour.sd_to_aces_relative_exposure_values(perfect_reflector))
 print("\n")
 
 message_box(
-    'Computing an "ACES" input device transform for a "CANON EOS 5DMark II" '
+    'Compute an "ACES" input device transform for a "CANON EOS 5DMark II" '
     "and and *CIE Illuminant D Series* *D55*:"
 )
 
@@ -69,7 +72,7 @@ print(
 )
 
 message_box(
-    'Optimising in "Oklab" colourspace using "Finlayson et al. (2015)" '
+    'Optimise in "Oklab" colourspace using "Finlayson et al. (2015)" '
     "root-polynomials colour correction:"
 )
 

--- a/colour/examples/characterisation/examples_colour_checkers.py
+++ b/colour/examples/characterisation/examples_colour_checkers.py
@@ -1,4 +1,10 @@
-"""Showcase colour rendition charts computations."""
+"""
+Demonstrate colour rendition chart computations.
+
+This module demonstrates the usage of colour rendition chart datasets,
+including chromaticity coordinates and spectral distributions, and
+their conversion to various colourspaces.
+"""
 
 from pprint import pprint
 
@@ -30,7 +36,7 @@ for name, xyY in data.items():
 print("\n")
 
 message_box(
-    'Converting the "ColorChecker 2005" colour rendition chart "CIE xyY" '
+    'Convert the "ColorChecker 2005" colour rendition chart "CIE xyY" '
     'colourspace values to "sRGB" colourspace "RGB" values:\n\n'
     '\t("Patch Name", ["R", "G", "B"])'
 )

--- a/colour/examples/characterisation/examples_correction.py
+++ b/colour/examples/characterisation/examples_correction.py
@@ -1,4 +1,10 @@
-"""Showcase colour correction computations."""
+"""
+Demonstrate colour correction computations.
+
+This module demonstrates various colour correction methods including
+*Cheung et al. (2004)*, *Finlayson et al. (2015)*, and *Vandermonde* matrix
+approaches for correcting colour rendition chart measurements.
+"""
 
 import numpy as np
 
@@ -66,7 +72,7 @@ M_R = np.array(
 )
 
 message_box(
-    'Computing the colour correction matrix correcting a "M_T" "ColorChecker"'
+    'Compute the colour correction matrix correcting a "M_T" "ColorChecker"'
     'colour rendition chart to a "M_R" one using '
     '"Cheung, Westland, Connah and Ripamonti (2004)" method '
     "with 3 terms polynomial."
@@ -78,7 +84,7 @@ print(colour.matrix_colour_correction(M_T, M_R, method="Cheung 2004"))
 print("\n")
 
 message_box(
-    'Computing the colour correction matrix correcting a "M_T" "ColorChecker"'
+    'Compute the colour correction matrix correcting a "M_T" "ColorChecker"'
     'colour rendition chart to a "M_R" one using '
     '"Cheung, Westland, Connah and Ripamonti (2004)" method '
     "with 7 terms polynomial."
@@ -90,7 +96,7 @@ print(colour.matrix_colour_correction(M_T, M_R, method="Cheung 2004", terms=7))
 print("\n")
 
 message_box(
-    'Computing the colour correction matrix correcting a "M_T" "ColorChecker"'
+    'Compute the colour correction matrix correcting a "M_T" "ColorChecker"'
     'colour rendition chart to a "M_R" one using '
     '"Finlayson, MacKiewicz and Hurlbert (2015)" method '
     "with polynomial of degree 1."
@@ -102,7 +108,7 @@ print(colour.matrix_colour_correction(M_T, M_R, method="Finlayson 2015"))
 print("\n")
 
 message_box(
-    'Computing the colour correction matrix correcting a "M_T" "ColorChecker"'
+    'Compute the colour correction matrix correcting a "M_T" "ColorChecker"'
     'colour rendition chart to a "M_R" one using '
     '"Finlayson, MacKiewicz and Hurlbert (2015)" method '
     "with polynomial of degree 3."
@@ -114,7 +120,7 @@ print(colour.matrix_colour_correction(M_T, M_R, method="Finlayson 2015", degree=
 print("\n")
 
 message_box(
-    'Computing the colour correction matrix correcting a "M_T" "ColorChecker"'
+    'Compute the colour correction matrix correcting a "M_T" "ColorChecker"'
     'colour rendition chart to a "M_R" one using '
     '"Vandermonde" method with polynomial of degree 1.'
 )
@@ -125,7 +131,7 @@ print(colour.matrix_colour_correction(M_T, M_R, method="Vandermonde"))
 print("\n")
 
 message_box(
-    'Computing the colour correction matrix correcting a "M_T" "ColorChecker"'
+    'Compute the colour correction matrix correcting a "M_T" "ColorChecker"'
     'colour rendition chart to a "M_R" one using '
     '"Vandermonde" method with polynomial of degree 3.'
 )

--- a/colour/examples/colorimetry/examples_blackbody.py
+++ b/colour/examples/colorimetry/examples_blackbody.py
@@ -1,4 +1,10 @@
-"""Showcase blackbody / planckian radiator computations."""
+"""
+Demonstrate blackbody / planckian radiator computations.
+
+This module provides examples of blackbody radiator spectral distribution
+computations and related colorimetric calculations, illustrating planckian
+locus operations and correlated colour temperature determinations.
+"""
 
 import colour
 from colour.utilities import message_box

--- a/colour/examples/colorimetry/examples_cmfs.py
+++ b/colour/examples/colorimetry/examples_cmfs.py
@@ -1,4 +1,9 @@
-"""Showcase colour matching functions computations."""
+"""
+Demonstrate colour matching functions computations.
+
+This module provides examples of colour matching functions operations and
+conversions between different standard observers.
+"""
 
 from pprint import pprint
 

--- a/colour/examples/colorimetry/examples_correction.py
+++ b/colour/examples/colorimetry/examples_correction.py
@@ -1,4 +1,9 @@
-"""Showcase colour spectral bandpass dependence correction computations."""
+"""
+Demonstrate colour spectral bandpass dependence correction computations.
+
+This module provides examples of spectral bandpass dependence correction
+using various methods.
+"""
 
 import numpy as np
 

--- a/colour/examples/colorimetry/examples_dominant.py
+++ b/colour/examples/colorimetry/examples_dominant.py
@@ -1,4 +1,9 @@
-"""Showcase dominant wavelength and purity of a colour computations."""
+"""
+Demonstrate dominant wavelength and purity computations.
+
+This module provides examples of dominant wavelength, complementary
+wavelength and purity calculations for colour stimuli.
+"""
 
 import numpy as np
 

--- a/colour/examples/colorimetry/examples_illuminants.py
+++ b/colour/examples/colorimetry/examples_illuminants.py
@@ -1,4 +1,9 @@
-"""Showcase illuminants datasets."""
+"""
+Demonstrate illuminants datasets.
+
+This module provides examples of illuminants spectral distributions
+and chromaticity coordinates datasets.
+"""
 
 from pprint import pprint
 

--- a/colour/examples/colorimetry/examples_lefs.py
+++ b/colour/examples/colorimetry/examples_lefs.py
@@ -1,4 +1,9 @@
-"""Showcase luminous efficiency functions computations."""
+"""
+Demonstrate luminous efficiency functions computations.
+
+This module provides examples of luminous efficiency functions and mesopic
+luminous efficiency function calculations.
+"""
 
 from pprint import pprint
 

--- a/colour/examples/colorimetry/examples_light_sources.py
+++ b/colour/examples/colorimetry/examples_light_sources.py
@@ -1,4 +1,9 @@
-"""Showcase light sources datasets."""
+"""
+Demonstrate light sources datasets.
+
+This module provides examples of light sources spectral distributions
+and chromaticity coordinates datasets.
+"""
 
 from pprint import pprint
 

--- a/colour/examples/colorimetry/examples_lightness.py
+++ b/colour/examples/colorimetry/examples_lightness.py
@@ -1,4 +1,9 @@
-"""Showcase *Lightness* computations."""
+"""
+Demonstrate lightness computations.
+
+This module provides examples of lightness calculations using various
+standard methods.
+"""
 
 import numpy as np
 

--- a/colour/examples/colorimetry/examples_luminance.py
+++ b/colour/examples/colorimetry/examples_luminance.py
@@ -1,4 +1,9 @@
-"""Showcase *Luminance* computations."""
+"""
+Demonstrate luminance computations.
+
+This module provides examples of luminance calculations using various
+standard methods.
+"""
 
 import colour
 from colour.utilities import message_box

--- a/colour/examples/colorimetry/examples_photometry.py
+++ b/colour/examples/colorimetry/examples_photometry.py
@@ -1,4 +1,9 @@
-"""Showcase *Photometry* computations."""
+"""
+Demonstrate photometry computations.
+
+This module provides examples of photometric calculations including luminous
+flux, efficiency and efficacy.
+"""
 
 import colour
 from colour.utilities import message_box

--- a/colour/examples/colorimetry/examples_spectrum.py
+++ b/colour/examples/colorimetry/examples_spectrum.py
@@ -1,4 +1,9 @@
-"""Showcase colour spectrum computations."""
+"""
+Demonstrate colour spectrum computations.
+
+This module provides examples of spectral distribution operations including
+arithmetical operations, interpolation and extrapolation.
+"""
 
 import numpy as np
 

--- a/colour/examples/colorimetry/examples_tristimulus_values.py
+++ b/colour/examples/colorimetry/examples_tristimulus_values.py
@@ -1,4 +1,9 @@
-"""Showcase *CIE XYZ* tristimulus values computations."""
+"""
+Demonstrate CIE XYZ tristimulus values computations.
+
+This module provides examples of tristimulus values calculations for
+spectral distributions and multi-spectral images.
+"""
 
 import numpy as np
 

--- a/colour/examples/colorimetry/examples_uniformity.py
+++ b/colour/examples/colorimetry/examples_uniformity.py
@@ -1,4 +1,9 @@
-"""Showcase spectral uniformity computations."""
+"""
+Demonstrate spectral uniformity computations.
+
+This module provides examples of spectral uniformity (or flatness)
+calculations for test colour samples.
+"""
 
 import colour
 from colour.quality.cfi2017 import load_TCS_CIE2017

--- a/colour/examples/colorimetry/examples_whiteness.py
+++ b/colour/examples/colorimetry/examples_whiteness.py
@@ -1,4 +1,9 @@
-"""Showcase *whiteness* computations."""
+"""
+Demonstrate whiteness computations.
+
+This module provides examples of whiteness calculations using various
+standard methods.
+"""
 
 import numpy as np
 

--- a/colour/examples/colorimetry/examples_yellowness.py
+++ b/colour/examples/colorimetry/examples_yellowness.py
@@ -1,4 +1,9 @@
-"""Showcase *yellowness* computations."""
+"""
+Demonstrate yellowness computations.
+
+This module provides examples of yellowness calculations using various
+standard methods.
+"""
 
 import numpy as np
 

--- a/colour/examples/contrast/examples_contrast.py
+++ b/colour/examples/contrast/examples_contrast.py
@@ -1,4 +1,10 @@
-"""Showcase contrast sensitivity computations."""
+"""
+Demonstrate contrast sensitivity computations.
+
+This module demonstrates contrast sensitivity function computations using
+*Barten (1999)* method, including spatial frequency optimization and minimum
+detectable contrast calculations for various viewing conditions.
+"""
 
 from pprint import pprint
 
@@ -15,7 +21,7 @@ message_box("Contrast Sensitivity Computations")
 colour_style()
 
 message_box(
-    'Computing the contrast sensitivity for a spatial frequency "u" of 4, an '
+    'Compute the contrast sensitivity for a spatial frequency "u" of 4, an '
     'angular size "X_0" of 60 and a retinal illuminance "E" of 65 using '
     '"Barten (1999)" method.'
 )
@@ -25,7 +31,7 @@ pprint(colour.contrast.contrast_sensitivity_function_Barten1999(u=4, X_0=60, E=6
 print("\n")
 
 message_box(
-    "Computing the minimum detectable contrast with the assumed conditions "
+    "Compute the minimum detectable contrast with the assumed conditions "
     'for UHDTV applications as given in the "ITU-R BT.2246-4" "Figure 31" and '
     'using "Barten (1999)" method.'
 )

--- a/colour/examples/corresponding/examples_prediction.py
+++ b/colour/examples/corresponding/examples_prediction.py
@@ -1,4 +1,10 @@
-"""Showcase corresponding chromaticities prediction computations."""
+"""
+Demonstrate corresponding chromaticities prediction computations.
+
+This module demonstrates the prediction of corresponding chromaticities
+using various chromatic adaptation models including *Von Kries*, *CIE 1994*,
+*CMCCAT2000*, and *Fairchild (1990)* methods.
+"""
 
 from pprint import pprint
 
@@ -8,7 +14,7 @@ from colour.utilities import message_box
 message_box("Corresponding Chromaticities Prediction Computations")
 
 message_box(
-    'Computing corresponding chromaticities prediction with "Von Kries" '
+    'Compute corresponding chromaticities prediction with "Von Kries" '
     'chromatic adaptation model for "Breneman (1987)" experiment number "3" '
     'and "Bianco" CAT.'
 )
@@ -26,7 +32,7 @@ pprint(
 print("\n")
 
 message_box(
-    'Computing corresponding chromaticities prediction with "CIE 1994" '
+    'Compute corresponding chromaticities prediction with "CIE 1994" '
     'chromatic adaptation model for "Breneman (1987)" experiment number "1".'
 )
 pprint(colour.corresponding_chromaticities_prediction(3, model="CIE 1994"))
@@ -35,7 +41,7 @@ pprint(colour.corresponding.corresponding_chromaticities_prediction_CIE1994(1))
 print("\n")
 
 message_box(
-    'Computing corresponding chromaticities prediction with "CMCCAT2000" '
+    'Compute corresponding chromaticities prediction with "CMCCAT2000" '
     'chromatic adaptation model for "Breneman (1987)" experiment number "1".'
 )
 pprint(colour.corresponding_chromaticities_prediction(3, model="CMCCAT2000"))
@@ -44,7 +50,7 @@ pprint(colour.corresponding.corresponding_chromaticities_prediction_CMCCAT2000(1
 print("\n")
 
 message_box(
-    'Computing corresponding chromaticities prediction with Fairchild (1990)" '
+    'Compute corresponding chromaticities prediction with Fairchild (1990)" '
     'chromatic adaptation model for "Breneman (1987)" experiment number "1".'
 )
 pprint(colour.corresponding_chromaticities_prediction(3, model="Fairchild 1990"))

--- a/colour/examples/difference/examples_delta_e.py
+++ b/colour/examples/difference/examples_delta_e.py
@@ -1,4 +1,10 @@
-"""Showcase *Delta E* colour difference computations."""
+"""
+Demonstrate *Delta E* colour difference computations.
+
+This module demonstrates various colour difference computations including
+*CIE 1976*, *CIE 1994*, *CIE 2000*, *CAM02-UCS*, *CAM16-UCS*, and other colour
+difference metrics for perceptual colour evaluation.
+"""
 
 import numpy as np
 
@@ -10,7 +16,7 @@ message_box('"Delta E" Computations')
 Lab_1 = np.array([100.00000000, 21.57210357, 272.22819350])
 Lab_2 = np.array([100.00000000, 426.67945353, 72.39590835])
 message_box(
-    f'Computing "Delta E" with "CIE 1976" method from given "CIE L*a*b*" '
+    f'Compute "Delta E" with "CIE 1976" method from given "CIE L*a*b*" '
     f"colourspace matrices:\n\n"
     f"\t{Lab_1}\n"
     f"\t{Lab_2}"

--- a/colour/examples/examples_colour.py
+++ b/colour/examples/examples_colour.py
@@ -1,4 +1,10 @@
-"""Showcase overall *Colour* examples."""
+"""
+Demonstrate overall *Colour* usage examples.
+
+This module provides examples of *Colour's* core functionality, including the
+automatic colour conversion graph system, N-dimensional array support,
+domain-range scale management, and warning filtering mechanisms.
+"""
 
 import warnings
 

--- a/colour/examples/geometry/examples_geometry.py
+++ b/colour/examples/geometry/examples_geometry.py
@@ -1,4 +1,10 @@
-"""Showcase geometry primitives generation examples."""
+"""
+Demonstrate geometry primitives generation.
+
+This module demonstrates the generation of various geometric primitives
+including grids, cubes, quads, and spheres, with support for different
+coordinate systems and rendering frameworks.
+"""
 
 import numpy as np
 
@@ -7,7 +13,7 @@ from colour.utilities import message_box
 
 message_box("Geometry Primitives Generation")
 
-message_box('Generating a "grid":')
+message_box('Generate a "grid":')
 print(
     colour.primitive(
         "Grid",
@@ -26,7 +32,7 @@ print(
 
 print("\n")
 
-message_box('Generating a "cube":')
+message_box('Generate a "cube":')
 print(
     colour.primitive(
         "Cube",
@@ -49,7 +55,7 @@ print(
     )
 )
 
-message_box('Generating the vertices of a "quad" for "Matplotlib":')
+message_box('Generate the vertices of a "quad" for "Matplotlib":')
 print(
     colour.primitive_vertices(
         "Quad MPL",
@@ -72,7 +78,7 @@ print(
 
 print("\n")
 
-message_box('Generating the vertices of a "grid" for "Matplotlib":')
+message_box('Generate the vertices of a "grid" for "Matplotlib":')
 print(
     colour.primitive_vertices(
         "Grid MPL",
@@ -99,7 +105,7 @@ print(
 
 print("\n")
 
-message_box('Generating the vertices of a "cube" for "Matplotlib":')
+message_box('Generate the vertices of a "cube" for "Matplotlib":')
 print(
     colour.primitive_vertices(
         "Cube MPL",
@@ -126,7 +132,7 @@ print(
 
 print("\n")
 
-message_box('Generating the vertices of a "sphere":')
+message_box('Generate the vertices of a "sphere":')
 print(
     colour.primitive_vertices(
         "Sphere",

--- a/colour/examples/graph/examples_graph.py
+++ b/colour/examples/graph/examples_graph.py
@@ -1,4 +1,10 @@
-"""Showcase *Automatic Colour Conversion Graph* computations."""
+"""
+Demonstrate *Automatic Colour Conversion Graph* computations.
+
+This module demonstrates the automatic colour conversion graph functionality,
+showing conversions between spectral distributions, colourspaces, and colour
+appearance models using the unified conversion interface.
+"""
 
 import numpy as np
 
@@ -8,7 +14,7 @@ from colour.utilities import message_box
 message_box("Automatic Colour Conversion Graph")
 
 message_box(
-    'Converting a "ColorChecker" "dark skin" sample spectral distribution to '
+    'Convert a "ColorChecker" "dark skin" sample spectral distribution to '
     '"Output-Referred" "sRGB" colourspace.'
 )
 
@@ -24,7 +30,7 @@ print("\n")
 
 RGB = np.array([0.45675795, 0.30986982, 0.24861924])
 message_box(
-    f'Converting to the "CAM16-UCS" colourspace from given "Output-Referred" '
+    f'Convert to the "CAM16-UCS" colourspace from given "Output-Referred" '
     f'"sRGB" colourspace values:\n\n\t{RGB}'
 )
 print(colour.convert(RGB, "Output-Referred RGB", "CAM16UCS"))
@@ -54,7 +60,7 @@ print("\n")
 
 Jpapbp = np.array([0.39994811, 0.09206558, 0.0812752])
 message_box(
-    f'Converting to the "Output-Referred" "sRGB" colourspace from given '
+    f'Convert to the "Output-Referred" "sRGB" colourspace from given '
     f'"CAM16-UCS" colourspace colourspace values:\n\n\t{RGB}'
 )
 print(

--- a/colour/examples/io/examples_ctl.py
+++ b/colour/examples/io/examples_ctl.py
@@ -1,4 +1,9 @@
-"""Showcase Color Transformation Language (CTL) related examples."""
+"""
+Demonstrate Color Transformation Language (CTL) operations.
+
+This module provides examples of CTL transform operations including
+template generation and image processing.
+"""
 
 import os
 import tempfile

--- a/colour/examples/io/examples_fichet2021.py
+++ b/colour/examples/io/examples_fichet2021.py
@@ -1,6 +1,8 @@
 """
-Showcases *Fichet, Pacanowski and Wilkie (2021)*
-*OpenEXR Layout for Spectral Images* related examples.
+Demonstrate *Fichet, Pacanowski and Wilkie (2021)* OpenEXR Layout for Spectral Images.
+
+This module provides examples of reading and writing spectral images
+using the OpenEXR layout format.
 """
 
 import os

--- a/colour/examples/io/examples_ies_tm2714.py
+++ b/colour/examples/io/examples_ies_tm2714.py
@@ -1,4 +1,9 @@
-"""Showcase *IES TM-27-14* spectral data *XML* files input / output examples."""
+"""
+Demonstrate *IES TM-27-14* spectral data XML file input/output.
+
+This module provides examples of reading and writing spectral data
+from XML files following the *IES TM-27-14* standard.
+"""
 
 import os
 

--- a/colour/examples/io/examples_luts.py
+++ b/colour/examples/io/examples_luts.py
@@ -1,4 +1,9 @@
-"""Showcase Look Up Table (LUT) data related examples."""
+"""
+Demonstrate Look Up Table (LUT) data operations.
+
+This module provides examples of reading and applying various LUT
+formats including *Cinespace*, *Iridas* and *Sony* formats.
+"""
 
 import os
 

--- a/colour/examples/io/examples_tabular.py
+++ b/colour/examples/io/examples_tabular.py
@@ -1,4 +1,9 @@
-"""Showcase input / output *CSV* tabular data related examples."""
+"""
+Demonstrate CSV tabular data input/output operations.
+
+This module provides examples of reading and writing CSV tabular data
+for spectral distributions.
+"""
 
 import os
 from pprint import pprint

--- a/colour/examples/models/examples_cmyk.py
+++ b/colour/examples/models/examples_cmyk.py
@@ -1,4 +1,9 @@
-"""Showcase Cyan-Magenta-Yellow (Black) (CMY(K)) colour transformations."""
+"""
+Demonstrate Cyan-Magenta-Yellow (Black) (CMY(K)) colour transformations.
+
+This module provides examples of colour transformations between RGB,
+CMY and CMYK colour models.
+"""
 
 import numpy as np
 

--- a/colour/examples/models/examples_cylindrical.py
+++ b/colour/examples/models/examples_cylindrical.py
@@ -1,4 +1,9 @@
-"""Showcase cylindrical and spherical colour models computations."""
+"""
+Demonstrate cylindrical and spherical colour models computations.
+
+This module provides examples of colour transformations between RGB
+and cylindrical colour models like HSV, HSL and HCL.
+"""
 
 import numpy as np
 

--- a/colour/examples/models/examples_derivation.py
+++ b/colour/examples/models/examples_derivation.py
@@ -1,4 +1,9 @@
-"""Showcase *RGB* colourspace derivation."""
+"""
+Demonstrate RGB colourspace derivation.
+
+This module provides examples of RGB colourspace derivation including
+primary matrix computations and chromatic adaptation.
+"""
 
 import numpy as np
 

--- a/colour/examples/models/examples_ictcp.py
+++ b/colour/examples/models/examples_ictcp.py
@@ -1,4 +1,9 @@
-"""Showcase *ICtCp* *colour encoding* computations."""
+"""
+Demonstrate *ICtCp* colour encoding computations.
+
+This module provides examples of conversions between RGB colourspaces
+and the *ICtCp* colour encoding.
+"""
 
 import numpy as np
 

--- a/colour/examples/models/examples_models.py
+++ b/colour/examples/models/examples_models.py
@@ -1,4 +1,9 @@
-"""Showcase colour models computations."""
+"""
+Demonstrate colour models computations.
+
+This module provides examples of various colour model transformations
+and conversions between different colourspaces.
+"""
 
 import numpy as np
 

--- a/colour/examples/models/examples_prismatic.py
+++ b/colour/examples/models/examples_prismatic.py
@@ -1,4 +1,9 @@
-"""Showcase *Prismatic* colourspace computations."""
+"""
+Demonstrate Prismatic colourspace computations.
+
+This module provides examples of conversions between RGB and Prismatic
+colourspaces, including desaturation operations.
+"""
 
 import numpy as np
 

--- a/colour/examples/models/examples_rgb.py
+++ b/colour/examples/models/examples_rgb.py
@@ -1,4 +1,9 @@
-"""Showcase *RGB* *colourspaces* computations."""
+"""
+Demonstrate RGB colourspaces computations.
+
+This module provides examples of RGB colourspace transformations
+and conversions between different RGB colourspaces.
+"""
 
 from pprint import pprint
 

--- a/colour/examples/models/examples_transfer_functions.py
+++ b/colour/examples/models/examples_transfer_functions.py
@@ -1,4 +1,9 @@
-"""Showcase colour component transfer functions (CCTF) relates computations."""
+"""
+Demonstrate colour component transfer functions (CCTF) computations.
+
+This module provides examples of colour component transfer functions
+encoding and decoding operations.
+"""
 
 import colour
 from colour.utilities import message_box

--- a/colour/examples/models/examples_ycbcr.py
+++ b/colour/examples/models/examples_ycbcr.py
@@ -1,4 +1,10 @@
-"""Showcase *Y'CbCr* *colour encoding* computations."""
+"""
+Demonstrate *Y'CbCr* colour encoding computations.
+
+This module provides examples of conversions between RGB colourspaces
+and *Y'CbCr
+ 8colour encodings.
+"""
 
 import numpy as np
 

--- a/colour/examples/models/examples_ycocg.py
+++ b/colour/examples/models/examples_ycocg.py
@@ -1,4 +1,9 @@
-"""Showcase *YCoCg* *colour encoding* computations."""
+"""
+Demonstrate *YCoCg* colour encoding computations.
+
+This module provides examples of conversions between RGB colourspaces
+and *YCoCg* colour encoding.
+"""
 
 import numpy as np
 

--- a/colour/examples/notation/examples_hexadecimal.py
+++ b/colour/examples/notation/examples_hexadecimal.py
@@ -1,4 +1,9 @@
-"""Showcase hexadecimal computations."""
+"""
+Demonstrate hexadecimal colour notation computations.
+
+This module demonstrates conversions between RGB colourspace values and
+hexadecimal colour notation representations.
+"""
 
 import numpy as np
 
@@ -9,7 +14,7 @@ message_box("Hexadecimal Computations")
 
 RGB = np.array([0.45620519, 0.03081071, 0.04091952])
 message_box(
-    f'Converting to the "hexadecimal" representation from given "RGB"'
+    f'Convert to the "hexadecimal" representation from given "RGB"'
     f"colourspace values:\n\n\t{RGB}"
 )
 print(colour.notation.hexadecimal.RGB_to_HEX(RGB))
@@ -18,7 +23,7 @@ print("\n")
 
 hex_triplet = "#74070a"
 message_box(
-    f'Converting to the "RGB" colourspace from given "hexadecimal" '
+    f'Convert to the "RGB" colourspace from given "hexadecimal" '
     f"representation:\n\n\t{hex_triplet}"
 )
 print(colour.notation.hexadecimal.HEX_to_RGB(hex_triplet))

--- a/colour/examples/notation/examples_munsell.py
+++ b/colour/examples/notation/examples_munsell.py
@@ -1,4 +1,10 @@
-"""Showcase *Munsell Renotation System* computations."""
+"""
+Demonstrate *Munsell Renotation System* computations.
+
+This module demonstrates *Munsell* colour system computations including
+lightness value calculations using various methods and conversions between
+Munsell colour specifications and *CIE xyY* colourspace values.
+"""
 
 import numpy as np
 
@@ -9,7 +15,7 @@ message_box('"Munsell Renotation System" Computations')
 
 Y = 12.23634268
 message_box(
-    f'Computing "Munsell" value using "Priest, Gibson and MacNicholas (1920)" '
+    f'Compute "Munsell" value using "Priest, Gibson and MacNicholas (1920)" '
     f'method for given "luminance" value:\n\n\t{Y}'
 )
 print(colour.munsell_value(Y, method="Priest 1920"))
@@ -18,7 +24,7 @@ print(colour.notation.munsell_value_Priest1920(Y))
 print("\n")
 
 message_box(
-    f'Computing "Munsell" value using "Munsell, Sloan and Godlove (1933)" '
+    f'Compute "Munsell" value using "Munsell, Sloan and Godlove (1933)" '
     f'method for given "luminance" value:\n\n\t{Y}'
 )
 print(colour.munsell_value(Y, method="Munsell 1933"))
@@ -27,7 +33,7 @@ print(colour.notation.munsell_value_Munsell1933(Y))
 print("\n")
 
 message_box(
-    f'Computing "Munsell" value using "Moon and Spencer (1943)" method for '
+    f'Compute "Munsell" value using "Moon and Spencer (1943)" method for '
     f'given "luminance" value:\n\n\t{Y}'
 )
 print(colour.munsell_value(Y, method="Moon 1943"))
@@ -36,7 +42,7 @@ print(colour.notation.munsell_value_Moon1943(Y))
 print("\n")
 
 message_box(
-    f'Computing "Munsell" value using "Saunderson and Milner (1944)" method '
+    f'Compute "Munsell" value using "Saunderson and Milner (1944)" method '
     f'for given "luminance" value:\n\n\t{Y}'
 )
 print(colour.munsell_value(Y, method="Saunderson 1944"))
@@ -45,7 +51,7 @@ print(colour.notation.munsell_value_Saunderson1944(Y))
 print("\n")
 
 message_box(
-    f'Computing "Munsell" value using "Ladd and Pinney (1955)" method for '
+    f'Compute "Munsell" value using "Ladd and Pinney (1955)" method for '
     f'given "luminance" value:\n\n\t{Y}'
 )
 print(colour.munsell_value(Y, method="Ladd 1955"))
@@ -54,7 +60,7 @@ print(colour.notation.munsell_value_Ladd1955(Y))
 print("\n")
 
 message_box(
-    f'Computing "Munsell" value using "McCamy (1987)" method for given '
+    f'Compute "Munsell" value using "McCamy (1987)" method for given '
     f'"luminance" value:\n\n\t{Y}'
 )
 print(colour.munsell_value(Y, method="McCamy 1987"))
@@ -63,7 +69,7 @@ print(colour.notation.munsell_value_McCamy1987(Y))
 print("\n")
 
 message_box(
-    f'Computing "Munsell" value using "ASTM D1535-08e1" method for given '
+    f'Compute "Munsell" value using "ASTM D1535-08e1" method for given '
     f'"luminance" value:\n\n\t{Y}'
 )
 print(colour.munsell_value(Y, method="ASTM D1535"))
@@ -73,7 +79,7 @@ print("\n")
 
 xyY = np.array([0.38736945, 0.35751656, 0.59362000])
 message_box(
-    f'Converting to the "Munsell" colour from given "CIE xyY" colourspace '
+    f'Convert to the "Munsell" colour from given "CIE xyY" colourspace '
     f"values:\n\n\t{xyY}"
 )
 print(colour.xyY_to_munsell_colour(xyY))
@@ -82,7 +88,7 @@ print("\n")
 
 for munsell_colour in ("4.2YR 8.1/5.3", "N8.9"):
     message_box(
-        f'Converting to the "CIE xyY" colourspace from given "Munsell" '
+        f'Convert to the "CIE xyY" colourspace from given "Munsell" '
         f"colour:\n\n\t{munsell_colour}"
     )
     print(colour.munsell_colour_to_xyY(munsell_colour))

--- a/colour/examples/phenomena/examples_rayleigh.py
+++ b/colour/examples/phenomena/examples_rayleigh.py
@@ -1,4 +1,10 @@
-"""Showcase *Rayleigh Optical Depth* computations examples."""
+"""
+Demonstrate *Rayleigh Optical Depth* computations.
+
+This module demonstrates *Rayleigh* scattering computations including optical
+depth calculations and spectral distribution generation for atmospheric
+scattering phenomena.
+"""
 
 import colour
 from colour.utilities import message_box
@@ -6,7 +12,7 @@ from colour.utilities import message_box
 message_box('"Rayleigh" Optical Depth Computations')
 
 message_box(
-    f'Creating a "Rayleigh" spectral distribution with default spectral '
+    f'Create a "Rayleigh" spectral distribution with default spectral '
     f"shape:\n\n\t{colour.SPECTRAL_SHAPE_DEFAULT}"
 )
 sd_rayleigh = colour.sd_rayleigh_scattering()
@@ -16,7 +22,7 @@ print("\n")
 
 wavelength = 555 * 10e-8
 message_box(
-    f"Computing the scattering cross-section per molecule at given wavelength "
+    f"Compute the scattering cross-section per molecule at given wavelength "
     f"in cm:\n\n\tWavelength: {wavelength}cm"
 )
 print(colour.phenomena.scattering_cross_section(wavelength))
@@ -24,7 +30,7 @@ print(colour.phenomena.scattering_cross_section(wavelength))
 print("\n")
 
 message_box(
-    f'Computing the "Rayleigh" optical depth as function of wavelength in '
+    f'Compute the "Rayleigh" optical depth as function of wavelength in '
     f"cm:\n\n\tWavelength: {wavelength}cm"
 )
 print(colour.phenomena.rayleigh_optical_depth(wavelength))

--- a/colour/examples/plotting/examples_blindness.py
+++ b/colour/examples/plotting/examples_blindness.py
@@ -1,4 +1,9 @@
-"""Showcase corresponding colour blindness plotting examples."""
+"""
+Demonstrate colour blindness plotting.
+
+This module provides examples of colour vision deficiency simulation
+using the *Machado et al. (2009)* model.
+"""
 
 import os
 

--- a/colour/examples/plotting/examples_characterisation_plots.py
+++ b/colour/examples/plotting/examples_characterisation_plots.py
@@ -1,4 +1,9 @@
-"""Showcase characterisation plotting examples."""
+"""
+Demonstrate characterisation plotting.
+
+This module provides examples of plotting colour rendition charts and
+spectral distributions for colour characterisation.
+"""
 
 from pprint import pprint
 

--- a/colour/examples/plotting/examples_colorimetry_plots.py
+++ b/colour/examples/plotting/examples_colorimetry_plots.py
@@ -1,4 +1,9 @@
-"""Showcase colorimetry plotting examples."""
+"""
+Demonstrate colorimetry plotting.
+
+This module provides examples of plotting colorimetric data including
+illuminants, spectral distributions and colour matching functions.
+"""
 
 from pprint import pprint
 

--- a/colour/examples/plotting/examples_common_plots.py
+++ b/colour/examples/plotting/examples_common_plots.py
@@ -1,4 +1,9 @@
-"""Showcase common plotting examples."""
+"""
+Demonstrate common plotting operations.
+
+This module provides examples of basic plotting operations including
+colour swatches and common plot elements.
+"""
 
 from colour.plotting import (
     ColourSwatch,

--- a/colour/examples/plotting/examples_corresponding.py
+++ b/colour/examples/plotting/examples_corresponding.py
@@ -1,4 +1,9 @@
-"""Showcase corresponding chromaticities prediction plotting examples."""
+"""
+Demonstrate corresponding chromaticities prediction plotting.
+
+This module provides examples of plotting corresponding chromaticities
+prediction using various chromatic adaptation models.
+"""
 
 from colour.plotting import colour_style, plot_corresponding_chromaticities_prediction
 from colour.utilities import message_box

--- a/colour/examples/plotting/examples_diagrams_plots.py
+++ b/colour/examples/plotting/examples_diagrams_plots.py
@@ -1,4 +1,9 @@
-"""Showcase *CIE* chromaticity diagrams plotting examples."""
+"""
+Demonstrate CIE chromaticity diagrams plotting.
+
+This module provides examples of plotting various CIE chromaticity
+diagrams and spectral distributions.
+"""
 
 from colour import SDS_ILLUMINANTS
 from colour.plotting import (

--- a/colour/examples/plotting/examples_models_plots.py
+++ b/colour/examples/plotting/examples_models_plots.py
@@ -1,4 +1,9 @@
-"""Showcase colour models plotting examples."""
+"""
+Demonstrate colour models plotting.
+
+This module provides examples of plotting RGB colourspaces and
+colour component transfer functions in chromaticity diagrams.
+"""
 
 from pprint import pprint
 

--- a/colour/examples/plotting/examples_notation_plots.py
+++ b/colour/examples/plotting/examples_notation_plots.py
@@ -1,4 +1,9 @@
-"""Showcase colour notation systems plotting examples."""
+"""
+Demonstrate colour notation systems plotting.
+
+This module provides examples of plotting Munsell value functions
+and other colour notation systems.
+"""
 
 from colour.plotting import (
     colour_style,

--- a/colour/examples/plotting/examples_phenomena_plots.py
+++ b/colour/examples/plotting/examples_phenomena_plots.py
@@ -1,4 +1,9 @@
-"""Showcase optical phenomena plotting examples."""
+"""
+Demonstrate optical phenomena plotting.
+
+This module provides examples of plotting Rayleigh scattering and
+other optical phenomena.
+"""
 
 from colour.phenomena import sd_rayleigh_scattering
 from colour.plotting import (

--- a/colour/examples/plotting/examples_quality_plots.py
+++ b/colour/examples/plotting/examples_quality_plots.py
@@ -1,4 +1,9 @@
-"""Showcase colour quality plotting examples."""
+"""
+Demonstrate colour quality plotting.
+
+This module provides examples of plotting colour rendering indices
+and colour quality scales for various light sources.
+"""
 
 import colour
 from colour.plotting import (

--- a/colour/examples/plotting/examples_section_plots.py
+++ b/colour/examples/plotting/examples_section_plots.py
@@ -1,4 +1,9 @@
-"""Showcase gamut section plotting examples."""
+"""
+Demonstrate gamut section plotting.
+
+This module provides examples of plotting visible spectrum and RGB
+colourspace sections in various colour models.
+"""
 
 import numpy as np
 from matplotlib.lines import Line2D

--- a/colour/examples/plotting/examples_temperature_plots.py
+++ b/colour/examples/plotting/examples_temperature_plots.py
@@ -1,6 +1,8 @@
 """
-Showcases colour temperature and correlated colour temperature plotting
-examples.
+Demonstrate colour temperature and correlated colour temperature plotting.
+
+This module provides examples of plotting planckian locus in various
+chromaticity diagrams.
 """
 
 from colour.plotting import (

--- a/colour/examples/plotting/examples_tm3018.py
+++ b/colour/examples/plotting/examples_tm3018.py
@@ -1,4 +1,9 @@
-"""Showcase *ANSI/IES TM-30-18 Colour Rendition Report* plotting examples."""
+"""
+Demonstrate *ANSI/IES TM-30-18* Colour Rendition Report plotting.
+
+This module provides examples of generating colour rendition reports
+using the *ANSI/IES TM-30-18* standard.
+"""
 
 import colour
 from colour.plotting import colour_style, plot_single_sd_colour_rendition_report

--- a/colour/examples/plotting/examples_volume_plots.py
+++ b/colour/examples/plotting/examples_volume_plots.py
@@ -1,4 +1,9 @@
-"""Showcase colour models volume and gamut plotting examples."""
+"""
+Demonstrate colour models volume and gamut plotting.
+
+This module provides examples of plotting RGB colourspace volumes and
+gamuts in various reference colourspaces.
+"""
 
 import numpy as np
 

--- a/colour/examples/quality/examples_cfi.py
+++ b/colour/examples/quality/examples_cfi.py
@@ -1,4 +1,9 @@
-"""Showcase *Colour Fidelity Index* (CFI) computations."""
+"""
+Demonstrate *Colour Fidelity Index* (CFI) computations.
+
+This module provides examples of colour fidelity index calculations
+using various standard methods.
+"""
 
 from pprint import pprint
 

--- a/colour/examples/quality/examples_cqs.py
+++ b/colour/examples/quality/examples_cqs.py
@@ -1,4 +1,9 @@
-"""Showcase *Colour Quality Scale* (CQS) computations."""
+"""
+Demonstrate *Colour Quality Scale* (CQS) computations.
+
+This module provides examples of colour quality scale calculations for
+various light sources.
+"""
 
 from pprint import pprint
 

--- a/colour/examples/quality/examples_cri.py
+++ b/colour/examples/quality/examples_cri.py
@@ -1,4 +1,9 @@
-"""Showcase *Colour Rendering Index* (CRI) computations."""
+"""
+Demonstrate *Colour Rendering Index* (CRI) computations.
+
+This module provides examples of colour rendering index calculations
+for various light sources.
+"""
 
 from pprint import pprint
 

--- a/colour/examples/quality/examples_ssi.py
+++ b/colour/examples/quality/examples_ssi.py
@@ -1,4 +1,9 @@
-"""Showcase *Academy Spectral Similarity Index* (SSI) computations."""
+"""
+Demonstrate *Academy Spectral Similarity Index* (SSI) computations.
+
+This module provides examples of spectral similarity index calculations
+for comparing light sources.
+"""
 
 import colour
 from colour.utilities import message_box

--- a/colour/examples/recovery/examples_jakob2019.py
+++ b/colour/examples/recovery/examples_jakob2019.py
@@ -1,4 +1,9 @@
-"""Showcase reflectance recovery computations using *Jakob et al. (2019)* method."""
+"""
+Demonstrate reflectance recovery computations using *Jakob et al. (2019)* method.
+
+This module provides examples of reflectance recovery from tristimulus
+values using the *Jakob et al. (2019)* method.
+"""
 
 import numpy as np
 

--- a/colour/examples/recovery/examples_jiang2013.py
+++ b/colour/examples/recovery/examples_jiang2013.py
@@ -1,6 +1,8 @@
 """
-Showcases camera *RGB* sensitivities recovery computations using
-*Jiang et al. (2013)* method.
+Demonstrate camera RGB sensitivities recovery using *Jiang et al. (2013)* method.
+
+This module provides examples of camera RGB sensitivities recovery
+computations using the *Jiang et al. (2013)* method.
 """
 
 import colour

--- a/colour/examples/recovery/examples_mallet2019.py
+++ b/colour/examples/recovery/examples_mallet2019.py
@@ -1,5 +1,8 @@
 """
-Showcases reflectance recovery computations using *Mallett et al. (2019)*
+Demonstrate reflectance recovery computations using *Mallett et al. (2019)* method.
+
+This module provides examples of reflectance recovery from tristimulus
+values and spectral primary decomposition using the *Mallett et al. (2019)*
 method.
 """
 

--- a/colour/examples/recovery/examples_meng2015.py
+++ b/colour/examples/recovery/examples_meng2015.py
@@ -1,4 +1,9 @@
-"""Showcase reflectance recovery computations using *Meng et al. (2015)* method."""
+"""
+Demonstrate reflectance recovery computations using *Meng et al. (2015)* method.
+
+This module provides examples of reflectance recovery from tristimulus
+values using the *Meng et al. (2015)* method.
+"""
 
 import numpy as np
 

--- a/colour/examples/recovery/examples_otsu2018.py
+++ b/colour/examples/recovery/examples_otsu2018.py
@@ -1,4 +1,9 @@
-"""Showcase reflectance recovery computations using *Otsu et al. (2018)* method."""
+"""
+Demonstrate reflectance recovery computations using *Otsu et al. (2018)* method.
+
+This module provides examples of reflectance recovery from tristimulus
+values using the *Otsu et al. (2018)* method.
+"""
 
 import numpy as np
 

--- a/colour/examples/recovery/examples_smits1999.py
+++ b/colour/examples/recovery/examples_smits1999.py
@@ -1,4 +1,9 @@
-"""Showcase reflectance recovery computations using *Smits (1999)* method."""
+"""
+Demonstrate reflectance recovery computations using *Smits (1999)* method.
+
+This module provides examples of reflectance recovery from RGB colourspace
+values using the *Smits (1999)* method.
+"""
 
 import numpy as np
 

--- a/colour/examples/temperature/examples_cct.py
+++ b/colour/examples/temperature/examples_cct.py
@@ -1,4 +1,10 @@
-"""Showcase correlated colour temperature computations."""
+"""
+Demonstrate correlated colour temperature computations.
+
+This module demonstrates conversions between chromaticity coordinates and
+correlated colour temperature using various computational methods including
+*Ohno (2013)*, *Robertson (1968)*, *McCamy (1992)*, and others.
+"""
 
 import colour
 from colour.utilities import message_box
@@ -10,7 +16,7 @@ illuminant = colour.SDS_ILLUMINANTS["D65"]
 xy = colour.XYZ_to_xy(colour.sd_to_XYZ(illuminant, cmfs) / 100)
 uv = colour.UCS_to_uv(colour.XYZ_to_UCS(colour.xy_to_XYZ(xy)))
 message_box(
-    f'Converting to "CCT" and "D_uv" from given "CIE UCS" colourspace "uv" '
+    f'Convert to "CCT" and "D_uv" from given "CIE UCS" colourspace "uv" '
     f'chromaticity coordinates using "Ohno (2013)" method:\n\n\t{uv}'
 )
 print(colour.uv_to_CCT(uv, cmfs=cmfs))
@@ -25,7 +31,7 @@ print(colour.temperature.uv_to_CCT_Ohno2013(uv, cmfs=cmfs, spacing=1.01))
 print("\n")
 
 message_box(
-    f'Converting to "CCT" and "D_uv" from given "CIE UCS" colourspace "uv" '
+    f'Convert to "CCT" and "D_uv" from given "CIE UCS" colourspace "uv" '
     f'chromaticity coordinates using "Robertson (1968)" method:\n\n\t{uv}'
 )
 print(colour.uv_to_CCT(uv, method="Robertson 1968"))
@@ -35,7 +41,7 @@ print("\n")
 
 CCT_D_uv = [6503.49254150, 0.00320598]
 message_box(
-    f'Converting to "CIE UCS" colourspace "uv" chromaticity coordinates from '
+    f'Convert to "CIE UCS" colourspace "uv" chromaticity coordinates from '
     f'given "CCT" and "D_uv" using "Ohno (2013)" method:\n\n\t{CCT_D_uv}'
 )
 print(colour.CCT_to_uv(CCT_D_uv, cmfs=cmfs))
@@ -44,7 +50,7 @@ print(colour.temperature.CCT_to_uv_Ohno2013(CCT_D_uv, cmfs=cmfs))
 print("\n")
 
 message_box(
-    f'Converting to "CIE UCS" colourspace "uv" chromaticity coordinates from '
+    f'Convert to "CIE UCS" colourspace "uv" chromaticity coordinates from '
     f'given "CCT" and "D_uv" using "Robertson (1968)" method:\n\n\t{CCT_D_uv}'
 )
 print(colour.CCT_to_uv(CCT_D_uv, method="Robertson 1968"))
@@ -54,7 +60,7 @@ print("\n")
 
 CCT = 6503.49254150
 message_box(
-    f'Converting to "CIE UCS" colourspace "uv" chromaticity coordinates from '
+    f'Convert to "CIE UCS" colourspace "uv" chromaticity coordinates from '
     f'given "CCT" using "Planck (1900)" method:\n\n\t{CCT_D_uv}'
 )
 print(colour.CCT_to_uv(CCT, method="Planck 1900"))
@@ -63,7 +69,7 @@ print(colour.temperature.CCT_to_uv_Planck1900(CCT))
 print("\n")
 
 message_box(
-    f'Converting to "CIE UCS" colourspace "uv" chromaticity coordinates from '
+    f'Convert to "CIE UCS" colourspace "uv" chromaticity coordinates from '
     f'given "CCT" using "Krystek (1985)" method:\n\n\t({CCT})'
 )
 print(colour.CCT_to_uv(CCT, method="Krystek 1985"))
@@ -73,7 +79,7 @@ print("\n")
 
 xy = colour.CCS_ILLUMINANTS["CIE 1931 2 Degree Standard Observer"]["D65"]
 message_box(
-    f'Converting to "CCT" from given "CIE xy" chromaticity coordinates using '
+    f'Convert to "CCT" from given "CIE xy" chromaticity coordinates using '
     f'"McCamy (1992)" method:\n\n\t{xy}'
 )
 print(colour.xy_to_CCT(xy, method="McCamy 1992"))
@@ -82,7 +88,7 @@ print(colour.temperature.xy_to_CCT_McCamy1992(xy))
 print("\n")
 
 message_box(
-    f'Converting to "CCT" from given "CIE xy" chromaticity coordinates using '
+    f'Convert to "CCT" from given "CIE xy" chromaticity coordinates using '
     f'"Hernandez-Andres, Lee and Romero (1999)" method:\n\n\t{xy}'
 )
 print(colour.xy_to_CCT(xy, method="Hernandez 1999"))
@@ -92,7 +98,7 @@ print("\n")
 
 CCT = 6503.49254150
 message_box(
-    f'Converting to "CIE xy" chromaticity coordinates from given "CCT" using '
+    f'Convert to "CIE xy" chromaticity coordinates from given "CCT" using '
     f'"Kang, Moon, Hong, Lee, Cho and Kim (2002)" method:\n\n\t{CCT}'
 )
 print(colour.CCT_to_xy(CCT, method="Kang 2002"))
@@ -101,7 +107,7 @@ print(colour.temperature.CCT_to_xy_Kang2002(CCT))
 print("\n")
 
 message_box(
-    f'Converting to "CIE xy" chromaticity coordinates from given "CCT" using '
+    f'Convert to "CIE xy" chromaticity coordinates from given "CCT" using '
     f'"CIE Illuminant D Series" method:\n\n\t{CCT}'
 )
 print(colour.CCT_to_xy(CCT, method="CIE Illuminant D Series"))

--- a/colour/examples/volume/examples_rgb.py
+++ b/colour/examples/volume/examples_rgb.py
@@ -1,4 +1,9 @@
-"""Showcase RGB colourspace volume computations."""
+"""
+Demonstrate RGB colourspace volume computations.
+
+This module demonstrates the computation of RGB colourspace limits, volumes,
+and gamut coverage using Monte Carlo methods for colourspace analysis.
+"""
 
 import colour
 from colour.utilities import message_box
@@ -8,7 +13,7 @@ from colour.utilities import message_box
 if __name__ == "__main__":
     message_box("RGB Colourspace Volume Computations")
 
-    message_box('Computing the "ProPhoto RGB" RGB colourspace limits.')
+    message_box('Compute the "ProPhoto RGB" RGB colourspace limits.')
     limits = colour.RGB_colourspace_limits(colour.RGB_COLOURSPACES["ProPhoto RGB"])
     print(limits)
 
@@ -16,7 +21,7 @@ if __name__ == "__main__":
 
     samples = int(10e4)
     message_box(
-        f'Computing the "ProPhoto RGB" RGB colourspace volume using {samples} '
+        f'Compute the "ProPhoto RGB" RGB colourspace volume using {samples} '
         f"samples."
     )
     print(
@@ -30,7 +35,7 @@ if __name__ == "__main__":
     print("\n")
 
     message_box(
-        f'Computing "ProPhoto RGB" RGB colourspace coverage of '
+        f'Compute "ProPhoto RGB" RGB colourspace coverage of '
         f'"Pointer\'s Gamut" using {samples} samples.'
     )
     print(

--- a/colour/geometry/ellipse.py
+++ b/colour/geometry/ellipse.py
@@ -50,8 +50,8 @@ __all__ = [
 
 def ellipse_coefficients_general_form(coefficients: ArrayLike) -> NDArrayFloat:
     """
-    Return the general form ellipse coefficients from given canonical form
-    ellipse coefficients.
+    Generate the general form ellipse coefficients from specified canonical
+    form ellipse coefficients.
 
     The canonical form ellipse coefficients are as follows: the center
     coordinates :math:`x_c` and :math:`y_c`, semi-major axis length
@@ -103,8 +103,8 @@ def ellipse_coefficients_canonical_form(
     coefficients: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Return the canonical form ellipse coefficients from given general form
-    ellipse coefficients.
+    Generate the canonical form ellipse coefficients from specified general
+    form ellipse coefficients.
 
     The general form ellipse coefficients are the coefficients of the implicit
     second-order polynomial/quadratic curve expressed as follows:
@@ -166,8 +166,8 @@ def ellipse_coefficients_canonical_form(
 
 def point_at_angle_on_ellipse(phi: ArrayLike, coefficients: ArrayLike) -> NDArrayFloat:
     """
-    Return the coordinates of the point at angle :math:`\\phi` in degrees on
-    the ellipse with given canonical form coefficients.
+    Generate the coordinates of the point at angle :math:`\\phi` in degrees
+    on the ellipse with specified canonical form coefficients.
 
     Parameters
     ----------
@@ -175,7 +175,7 @@ def point_at_angle_on_ellipse(phi: ArrayLike, coefficients: ArrayLike) -> NDArra
         Point at angle :math:`\\phi` in degrees to retrieve the coordinates
         of.
     coefficients
-        General form ellipse coefficients as follows: the center coordinates
+        Canonical form ellipse coefficients as follows: the center coordinates
         :math:`x_c` and :math:`y_c`, semi-major axis length :math:`a_a`,
         semi-minor axis length :math:`a_b` and rotation angle :math:`\\theta`
         in degrees of its semi-major axis :math:`a_a`.
@@ -209,9 +209,9 @@ def point_at_angle_on_ellipse(phi: ArrayLike, coefficients: ArrayLike) -> NDArra
 
 def ellipse_fitting_Halir1998(a: ArrayLike) -> NDArrayFloat:
     """
-    Return the coefficients of the implicit second-order polynomial/quadratic
-    curve that fits given point array :math:`a` using
-    *Halir and Flusser (1998)* method.
+    Generate the coefficients of the implicit second-order
+    polynomial/quadratic curve that fits specified point array :math:`a`
+    using *Halir and Flusser (1998)* method.
 
     The implicit second-order polynomial is expressed as follows:
 
@@ -230,7 +230,7 @@ def ellipse_fitting_Halir1998(a: ArrayLike) -> NDArrayFloat:
     -------
     :class:`numpy.ndarray`
         Coefficients of the implicit second-order polynomial/quadratic
-        curve that fits given point array :math:`a`.
+        curve that fits specified point array :math:`a`.
 
     References
     ----------
@@ -293,9 +293,9 @@ def ellipse_fitting(
     a: ArrayLike, method: Literal["Halir 1998"] | str = "Halir 1998"
 ) -> NDArrayFloat:
     """
-    Return the coefficients of the implicit second-order polynomial/quadratic
-    curve that fits given point array :math:`a` using
-    given method.
+    Generate the coefficients of the implicit second-order
+    polynomial/quadratic curve that fits specified point array :math:`a`
+    using specified method.
 
     The implicit second-order polynomial is expressed as follows:
 
@@ -316,7 +316,7 @@ def ellipse_fitting(
     -------
     :class:`numpy.ndarray`
         Coefficients of the implicit second-order polynomial/quadratic
-        curve that fits given point array :math:`a`.
+        curve that fits specified point array :math:`a`.
 
     References
     ----------

--- a/colour/geometry/intersection.py
+++ b/colour/geometry/intersection.py
@@ -52,7 +52,7 @@ def extend_line_segment(
 ) -> NDArrayFloat:
     """
     Extend the line segment defined by point arrays :math:`a` and :math:`b` by
-    given distance and return the new end point.
+    specified distance and generate the new end point.
 
     Parameters
     ----------

--- a/colour/geometry/primitives.py
+++ b/colour/geometry/primitives.py
@@ -461,7 +461,7 @@ def primitive(
     method: Literal["Cube", "Grid"] | str = "Cube", **kwargs: Any
 ) -> Tuple[NDArray, NDArray, NDArray]:
     """
-    Return a geometry primitive using given method.
+    Generate a geometry primitive using specified method.
 
     Parameters
     ----------

--- a/colour/geometry/section.py
+++ b/colour/geometry/section.py
@@ -39,7 +39,7 @@ __all__ = [
 
 def edges_to_chord(edges: ArrayLike, index: int = 0) -> NDArrayFloat:
     """
-    Convert given edges to a chord, starting at given index.
+    Convert specified edges to a chord, starting at specified index.
 
     Parameters
     ----------
@@ -139,7 +139,7 @@ def unique_vertices(
     decimals: int = np.finfo(DTYPE_FLOAT_DEFAULT).precision - 1,  # pyright: ignore
 ) -> NDArrayFloat:
     """
-    Return the unique vertices from given vertices.
+    Generate the unique vertices from specified vertices.
 
     Parameters
     ----------
@@ -155,7 +155,7 @@ def unique_vertices(
 
     Notes
     -----
-    -   The vertices are rounded at given ``decimals``.
+    -   The vertices are rounded at specified ``decimals``.
 
     Examples
     --------
@@ -181,7 +181,7 @@ def hull_section(
     normalise: bool = False,
 ) -> NDArrayFloat:
     """
-    Compute the hull section for given axis at given origin.
+    Compute the hull section for specified axis at specified origin.
 
     Parameters
     ----------
@@ -198,6 +198,11 @@ def hull_section(
     -------
     :class:`numpy.ndarray`
         Hull section vertices.
+
+    Raises
+    ------
+    ValueError
+        If no section exists on the specified axis at the given origin.
 
     Examples
     --------

--- a/colour/geometry/vertices.py
+++ b/colour/geometry/vertices.py
@@ -61,7 +61,7 @@ def primitive_vertices_quad_mpl(
     axis: Literal["+z", "+x", "+y", "yz", "xz", "xy"] | str = "+z",
 ) -> NDArrayFloat:
     """
-    Return the vertices of a quad primitive for use with *Matplotlib*
+    Generate the vertices of a quad primitive for use with *Matplotlib*
     :class:`mpl_toolkits.mplot3d.art3d.Poly3DCollection` class.
 
     Parameters
@@ -134,8 +134,8 @@ def primitive_vertices_grid_mpl(
     axis: Literal["+z", "+x", "+y", "yz", "xz", "xy"] | str = "+z",
 ) -> NDArrayFloat:
     """
-    Return the vertices of a grid primitive made of quad primitives for use
-    with *Matplotlib* :class:`mpl_toolkits.mplot3d.art3d.Poly3DCollection`
+    Generate the vertices of a grid primitive made of quad primitives for
+    use with *Matplotlib* :class:`mpl_toolkits.mplot3d.art3d.Poly3DCollection`
     class.
 
     Parameters
@@ -230,8 +230,8 @@ def primitive_vertices_cube_mpl(
     ) = None,
 ) -> NDArrayFloat:
     """
-    Return the vertices of a cube primitive made of grid primitives for use
-    with *Matplotlib* :class:`mpl_toolkits.mplot3d.art3d.Poly3DCollection`
+    Generate the vertices of a cube primitive made of grid primitives for
+    use with *Matplotlib* :class:`mpl_toolkits.mplot3d.art3d.Poly3DCollection`
     class.
 
     Parameters
@@ -347,7 +347,7 @@ def primitive_vertices_sphere(
     axis: Literal["+z", "+x", "+y", "yz", "xz", "xy"] | str = "+z",
 ) -> NDArrayFloat:
     """
-    Return the vertices of a latitude-longitude sphere primitive.
+    Generate the vertices of a latitude-longitude sphere primitive.
 
     Parameters
     ----------
@@ -480,7 +480,7 @@ def primitive_vertices(
     **kwargs: Any,
 ) -> NDArrayFloat:
     """
-    Return the vertices of a geometry primitive using given method.
+    Generate the vertices of a geometry primitive using specified method.
 
     Parameters
     ----------

--- a/colour/graph/conversion.py
+++ b/colour/graph/conversion.py
@@ -348,17 +348,17 @@ def CAM16_to_JMh_CAM16(specification: CAM_Specification_CAM16) -> NDArrayFloat:
 
 def JMh_CAM16_to_CAM16(JMh: ArrayLike) -> CAM_Specification_CAM16:
     """
-    Convert from *CAM6* :math:`JMh` correlates to *CAM6* specification.
+    Convert from *CAM16* :math:`JMh` correlates to *CAM16* specification.
 
     Parameters
     ----------
     JMh
-         *CAM6* :math:`JMh` correlates.
+         *CAM16* :math:`JMh` correlates.
 
     Returns
     -------
-    :class:`colour.CAM6_Specification`
-        *CAM6* colour appearance model specification.
+    :class:`colour.CAM_Specification_CAM16`
+        *CAM16* colour appearance model specification.
 
     Examples
     --------
@@ -402,17 +402,17 @@ def CIECAM16_to_JMh_CIECAM16(specification: CAM_Specification_CIECAM16) -> NDArr
 
 def JMh_CIECAM16_to_CIECAM16(JMh: ArrayLike) -> CAM_Specification_CIECAM16:
     """
-    Convert from *CAM6* :math:`JMh` correlates to *CAM6* specification.
+    Convert from *CIECAM16* :math:`JMh` correlates to *CIECAM16* specification.
 
     Parameters
     ----------
     JMh
-         *CAM6* :math:`JMh` correlates.
+         *CIECAM16* :math:`JMh` correlates.
 
     Returns
     -------
-    :class:`colour.CAM6_Specification`
-        *CAM6* colour appearance model specification.
+    :class:`colour.CAM_Specification_CIECAM16`
+        *CIECAM16* colour appearance model specification.
 
     Examples
     --------
@@ -471,7 +471,7 @@ def JMh_Hellwig2022_to_Hellwig2022(
 
     Returns
     -------
-    :class:`colour.CAM6_Specification`
+    :class:`colour.CAM_Specification_Hellwig2022`
         *Hellwig and Fairchild (2022)* colour appearance model specification.
 
     Examples
@@ -542,7 +542,7 @@ def RGB_luminance_to_RGB(Y: ArrayLike) -> NDArrayFloat:
 
 def CCT_D_uv_to_mired(CCT_D_uv: ArrayLike) -> NDArrayFloat:
     """
-    Convert given correlated colour temperature :math:`T_{cp}` and
+    Convert specified correlated colour temperature :math:`T_{cp}` and
     :math:`\\Delta_{uv}` to micro reciprocal degree (mired).
 
     Parameters
@@ -569,13 +569,13 @@ def CCT_D_uv_to_mired(CCT_D_uv: ArrayLike) -> NDArrayFloat:
 
 def mired_to_CCT_D_uv(mired: ArrayLike) -> NDArrayFloat:
     """
-    Convert given micro reciprocal degree (mired) to correlated colour
+    Convert specified micro reciprocal degree (mired) to correlated colour
     temperature :math:`T_{cp}` and :math:`\\Delta_{uv}`.
 
     Parameters
     ----------
-    Micro reciprocal degree (mired).
-
+    mired
+        Micro reciprocal degree (mired).
 
     Returns
     -------
@@ -981,7 +981,7 @@ the edge in the graph.
 
 
 def _format_node_name(name: str) -> str:
-    """Format given name by applying a series of substitutions."""
+    """Format specified name by applying a series of substitutions."""
 
     for pattern, substitution in [
         ("hdr_", "hdr-"),
@@ -1066,8 +1066,8 @@ CONVERSION_GRAPH: nx.DiGraph | None = None  # pyright: ignore # noqa: F821
 @required("NetworkX")
 def _conversion_path(source: str, target: str) -> List[Callable]:
     """
-    Return the conversion path from the source node to the target node in the
-    automatic colour conversion graph.
+    Generate the conversion path from the source node to the target node in
+    the automatic colour conversion graph.
 
     Parameters
     ----------
@@ -1108,18 +1108,18 @@ def _conversion_path(source: str, target: str) -> List[Callable]:
 
 def _lower_order_function(callable_: Callable) -> Callable:
     """
-    Return the lower order function associated with given callable, i.e.,
-    the function wrapped by a partial object.
+    Generate the lower order function associated with specified callable,
+    i.e., the function wrapped by a partial object.
 
     Parameters
     ----------
     callable_
-        Callable to return the lower order function.
+        Callable to generate the lower order function.
 
     Returns
     -------
     Callable
-        Lower order function or given callable if no lower order function
+        Lower order function or specified callable if no lower order function
         exists.
     """
 
@@ -1163,6 +1163,14 @@ def describe_conversion_path(
     kwargs
         {:func:`colour.convert`},
         See the documentation of the previously listed definition.
+
+    Raises
+    ------
+    ValueError
+        If the mode is not one of the supported values.
+    NetworkXNoPath
+        If no conversion path exists between the source and target colour
+        representations.
 
     Examples
     --------
@@ -1246,8 +1254,8 @@ def describe_conversion_path(
 
 def convert(a: Any, source: str, target: str, **kwargs: Any) -> Any:
     """
-    Convert given object :math:`a` from source colour representation to target
-    colour representation using the automatic colour conversion graph.
+    Convert specified object :math:`a` from source colour representation to
+    target colour representation using the automatic colour conversion graph.
 
     The conversion is performed by finding the shortest path in a
     `NetworkX <https://networkx.github.io>`__ :class:`DiGraph` class instance.
@@ -1353,6 +1361,12 @@ verbose={"mode": "Long"})
     -------
     Any
         Converted object :math:`a`.
+
+    Raises
+    ------
+    NetworkXNoPath
+        If no conversion path exists between the source and target colour
+        representations.
 
     Warnings
     --------

--- a/colour/io/__init__.py
+++ b/colour/io/__init__.py
@@ -117,7 +117,7 @@ class io(ModuleAPI):
     """Define a class acting like the *io* module."""
 
     def __getattr__(self, attribute: str) -> Any:
-        """Return the value from the attribute with given name."""
+        """Return the value from the attribute with specified name."""
 
         return super().__getattr__(attribute)
 

--- a/colour/io/ctl.py
+++ b/colour/io/ctl.py
@@ -73,7 +73,8 @@ def ctl_render(
     **kwargs: Any,
 ) -> subprocess.CompletedProcess:  # pragma: no cover
     """
-    Call *ctlrender* on given input image using given *CTL* transforms.
+    Invoke *ctlrender* on the specified input image using the specified
+    *CTL* transforms.
 
     Parameters
     ----------
@@ -83,8 +84,8 @@ def ctl_render(
         Output image path.
     ctl_transforms
         Sequence of *CTL* transforms to apply on the image, either paths to
-        existing *CTL* transforms, multi-line *CTL* code transforms or a mix of
-        both or dictionary of sequence of *CTL* transforms to apply on the
+        existing *CTL* transforms, multi-line *CTL* code transforms or a mix
+        of both or dictionary of sequence of *CTL* transforms to apply on the
         image and their sequence of parameters.
 
     Other Parameters
@@ -92,18 +93,24 @@ def ctl_render(
     args
         Arguments passed to *ctlrender*, e.g., ``-verbose``, ``-force``.
     kwargs
-        Keywords arguments passed to the sub-process calling *ctlrender*, e.g.,
-        to define the environment variables such as ``CTL_MODULE_PATH``.
-
-    Notes
-    -----
-    -   The multi-line *CTL* code transforms are written to disk in a temporary
-        location so that they can be used by *ctlrender*.
+        Keywords arguments passed to the sub-process calling *ctlrender*,
+        e.g., to define the environment variables such as
+        ``CTL_MODULE_PATH``.
 
     Returns
     -------
     :class:`subprocess.CompletedProcess`
         *ctlrender* process completed output.
+
+    Raises
+    ------
+    FileNotFoundError
+        If a specified *CTL* transform file does not exist.
+
+    Notes
+    -----
+    -   The multi-line *CTL* code transforms are written to disk in a
+        temporary location so that they can be used by *ctlrender*.
 
     Examples
     --------
@@ -206,7 +213,8 @@ def process_image_ctl(
     **kwargs: Any,
 ) -> NDArrayFloat:  # pragma: no cover
     """
-    Process given image data with *ctlrender* using given *CTL* transforms.
+    Process the specified image data with *ctlrender* using the specified
+    *CTL* transforms.
 
     Parameters
     ----------
@@ -214,8 +222,8 @@ def process_image_ctl(
         Image data to process with *ctlrender*.
     ctl_transforms
         Sequence of *CTL* transforms to apply on the image, either paths to
-        existing *CTL* transforms, multi-line *CTL* code transforms or a mix of
-        both or dictionary of sequence of *CTL* transforms to apply on the
+        existing *CTL* transforms, multi-line *CTL* code transforms or a mix
+        of both or dictionary of sequence of *CTL* transforms to apply on the
         image and their sequence of parameters.
 
     Other Parameters
@@ -223,18 +231,24 @@ def process_image_ctl(
     args
         Arguments passed to *ctlrender*, e.g., ``-verbose``, ``-force``.
     kwargs
-        Keywords arguments passed to the sub-process calling *ctlrender*, e.g.,
-        to define the environment variables such as ``CTL_MODULE_PATH``.
-
-    Notes
-    -----
-    -   The multi-line *CTL* code transforms are written to disk in a temporary
-        location so that they can be used by *ctlrender*.
+        Keywords arguments passed to the sub-process calling *ctlrender*,
+        e.g., to define the environment variables such as
+        ``CTL_MODULE_PATH``.
 
     Returns
     -------
-    :class`numpy.ndarray`
+    :class:`numpy.ndarray`
         Processed image data.
+
+    Raises
+    ------
+    RuntimeError
+        If the *ctlrender* process returns a non-zero exit code.
+
+    Notes
+    -----
+    -   The multi-line *CTL* code transforms are written to disk in a
+        temporary location so that they can be used by *ctlrender*.
 
     Examples
     --------
@@ -314,8 +328,8 @@ def template_ctl_transform_float(
     header: str | None = None,
 ) -> str:
     """
-    Generate the code for a *CTL* transform to test a function processing
-    per-float channel.
+    Generate *CTL* transform code for testing a function that processes
+    per-float channels.
 
     Parameters
     ----------
@@ -332,7 +346,8 @@ def template_ctl_transform_float(
     imports
         List of imports to use with the *CTL* transform.
     header
-        Header code that can be used to define various functions and globals.
+        Header code that can be used to define various functions and
+        globals.
 
     Returns
     -------
@@ -467,8 +482,8 @@ def template_ctl_transform_float3(
     header: str | None = None,
 ) -> str:
     """
-    Generate the code for a *CTL* transform to test a function processing
-    RGB channels.
+    Generate *CTL* transform code for testing a function that processes
+    *RGB* channels.
 
     Parameters
     ----------
@@ -481,7 +496,8 @@ def template_ctl_transform_float3(
     imports
         List of imports to use with the *CTL* transform.
     header
-        Header code that can be used to define various functions and globals.
+        Header code that can be used to define various functions and
+        globals.
 
     Returns
     -------

--- a/colour/io/fichet2021.py
+++ b/colour/io/fichet2021.py
@@ -144,7 +144,7 @@ def match_groups_to_nm(
     units: Literal["m", "Hz"] | str,
 ) -> float:
     """
-    Convert match groups of a wavelength (or frequency) to the nanometer value.
+    Convert wavelength or frequency match groups to nanometer values.
 
     Parameters
     ----------
@@ -159,6 +159,11 @@ def match_groups_to_nm(
     -------
     :class:`float`
         Nanometer value.
+
+    Raises
+    ------
+    ValueError
+        If the multiplier or units are not supported.
 
     Examples
     --------
@@ -196,8 +201,8 @@ def sd_to_spectrum_attribute_Fichet2021(
     sd: SpectralDistribution, decimals: int = 7
 ) -> str:
     """
-    Convert a spectral distribution to a spectrum attribute value according to
-    *Fichet et al. (2021)*.
+    Convert the specified spectral distribution to a spectrum attribute value
+    according to *Fichet et al. (2021)*.
 
     Parameters
     ----------
@@ -231,8 +236,8 @@ def spectrum_attribute_to_sd_Fichet2021(
     spectrum_attribute: str,
 ) -> SpectralDistribution:
     """
-    Convert a spectrum attribute value to a spectral distribution according to
-    *Fichet et al. (2021)*.
+    Convert the specified spectrum attribute value to a spectral distribution
+    according to *Fichet et al. (2021)*.
 
     Parameters
     ----------
@@ -320,8 +325,8 @@ class Specification_Fichet2021:
     @required("OpenImageIO")
     def from_spectral_image(path: str | PathLike) -> Specification_Fichet2021:
         """
-        Create a *Fichet et al. (2021)* spectral image specification from given
-        image path.
+        Create a *Fichet et al. (2021)* spectral image specification from the
+        specified image path.
 
         Parameters
         ----------
@@ -459,7 +464,7 @@ def read_spectral_image_Fichet2021(
     additional_data: bool = False,
 ) -> ComponentsFichet2021 | Tuple[ComponentsFichet2021, Specification_Fichet2021]:
     """
-    Read the *Fichet et al. (2021)* spectral image at given path using
+    Read the *Fichet et al. (2021)* spectral image at the specified path using
     *OpenImageIO*.
 
     Parameters
@@ -481,8 +486,8 @@ def read_spectral_image_Fichet2021(
     Notes
     -----
     -   Spectrum attributes are not parsed but can be converted to spectral
-        distribution using the :func:`colour.io.spectrum_attribute_to_sd_Fichet2021`
-        definition.
+        distribution using the
+        :func:`colour.io.spectrum_attribute_to_sd_Fichet2021` definition.
 
     References
     ----------
@@ -550,7 +555,7 @@ def sds_and_msds_to_components_Fichet2021(
     **kwargs: Any,
 ) -> ComponentsFichet2021:
     """
-    Convert given spectral and multi-spectral distributions to
+    Convert the specified spectral and multi-spectral distributions to
     *Fichet et al. (2021)* components.
 
     The spectral and multi-spectral distributions will be aligned to the
@@ -562,16 +567,16 @@ def sds_and_msds_to_components_Fichet2021(
         Spectral and multi-spectral distributions to convert to
         *Fichet et al. (2021)* components.
     specification
-        *Fichet et al. (2021)* spectral image specification, used to generate
-        the proper component type, i.e., emissive or other.
+        *Fichet et al. (2021)* spectral image specification, used to
+        generate the proper component type, i.e., emissive or other.
 
     Other Parameters
     ----------------
     shape
-        Optional shape the *Fichet et al. (2021)* components should take: Used
-        when converting spectral distributions of a colour
-        rendition chart to create a rectangular image rather than a single
-        line of values.
+        Optional shape the *Fichet et al. (2021)* components should take:
+        Used when converting spectral distributions of a colour rendition
+        chart to create a rectangular image rather than a single line of
+        values.
 
     Returns
     -------
@@ -618,7 +623,8 @@ def components_to_sRGB_Fichet2021(
     specification: Specification_Fichet2021 = SPECIFICATION_FICHET2021_DEFAULT,
 ) -> Tuple[NDArrayFloat | None, Sequence[Image_Specification_Attribute]]:
     """
-    Convert given *Fichet et al. (2021)* components to *sRGB* colourspace values.
+    Convert the specified *Fichet et al. (2021)* components to *sRGB*
+    colourspace values.
 
     Parameters
     ----------
@@ -637,13 +643,13 @@ def components_to_sRGB_Fichet2021(
     Warnings
     --------
     -   This definition currently assumes a uniform wavelength interval.
-    -   This definition currently does not support integration of bi-spectral
-        component.
+    -   This definition currently does not support integration of
+        bi-spectral component.
 
     Notes
     -----
-    -   When an emissive component is given, its exposure will be normalised so
-        that its median is 0.18.
+    -   When an emissive component is specified, its exposure will be
+        normalised so that its median is 0.18.
 
     References
     ----------
@@ -763,7 +769,8 @@ def write_spectral_image_Fichet2021(
     **kwargs: Any,
 ) -> bool:
     """
-    Write given *Fichet et al. (2021)* components to given path using *OpenImageIO*.
+    Write the specified *Fichet et al. (2021)* components to the specified
+    path using *OpenImageIO*.
 
     Parameters
     ----------
@@ -772,8 +779,8 @@ def write_spectral_image_Fichet2021(
     path
         Image path.
     bit_depth
-        Bit-depth to write the image at, the bit-depth conversion behaviour is
-        ruled directly by *OpenImageIO*.
+        Bit-depth to write the image at, the bit-depth conversion behaviour
+        is ruled directly by *OpenImageIO*.
     specification
         *Fichet et al. (2021)* spectral image specification.
     components_to_RGB_callable
@@ -782,14 +789,14 @@ def write_spectral_image_Fichet2021(
     Other Parameters
     ----------------
     shape
-        Optional shape the *Fichet et al. (2021)* components should take: Used
-        when converting spectral distributions of a colour
-        rendition chart to create a rectangular image rather than a single
-        line of values.
+        Optional shape the *Fichet et al. (2021)* components should take:
+        Used when converting spectral distributions of a colour rendition
+        chart to create a rectangular image rather than a single line of
+        values.
 
     Returns
     -------
-    :class:`bool`:
+    :class:`bool`
         Definition success.
 
     Examples

--- a/colour/io/image.py
+++ b/colour/io/image.py
@@ -151,7 +151,7 @@ def add_attributes_to_image_specification_OpenImageIO(
     image_specification: ImageSpec, attributes: Sequence
 ) -> ImageSpec:
     """
-    Add given attributes to given *OpenImageIO* image specification.
+    Add the specified attributes to the specified *OpenImageIO* image specification.
 
     Parameters
     ----------
@@ -164,7 +164,7 @@ def add_attributes_to_image_specification_OpenImageIO(
     Returns
     -------
     :class:`ImageSpec`
-        *OpenImageIO*. image specification.
+        *OpenImageIO* image specification.
 
     Examples
     --------
@@ -225,7 +225,7 @@ def image_specification_OpenImageIO(
     Returns
     -------
     :class:`ImageSpec`
-        *OpenImageIO*. image specification.
+        *OpenImageIO* image specification.
 
     Examples
     --------
@@ -260,20 +260,25 @@ def convert_bit_depth(
     ] = "float32",
 ) -> NDArrayReal:
     """
-    Convert given array to given bit-depth, the current bit-depth of the array
-    is used to determine the appropriate conversion path.
+    Convert the specified array to the specified bit-depth, using the current
+    bit-depth of the array to determine the appropriate conversion path.
 
     Parameters
     ----------
     a
-        Array to convert to given bit-depth.
+        Array to convert to specified bit-depth.
     bit_depth
         Bit-depth.
 
     Returns
     -------
-    :class`numpy.ndarray`
+    :class:`numpy.ndarray`
         Converted array.
+
+    Raises
+    ------
+    AssertionError
+        If the bit-depth or image bit-depth is not supported.
 
     Examples
     --------
@@ -374,7 +379,7 @@ def read_image_OpenImageIO(
     **kwargs: Any,
 ) -> NDArrayReal | Tuple[NDArrayReal, Tuple[Image_Specification_Attribute, ...]]:
     """
-    Read the image data at given path using *OpenImageIO*.
+    Read the image data at the specified path using *OpenImageIO*.
 
     Parameters
     ----------
@@ -389,7 +394,7 @@ def read_image_OpenImageIO(
 
     Returns
     -------
-    :class`numpy.ndarray` or :class:`tuple`
+    :class:`numpy.ndarray` or :class:`tuple`
         Image data or tuple of image data and list of
         :class:`colour.io.Image_Specification_Attribute` class instances.
 
@@ -463,7 +468,7 @@ def read_image_Imageio(
     **kwargs: Any,
 ) -> NDArrayReal:
     """
-    Read the image data at given path using *Imageio*.
+    Read the image data at the specified path using *Imageio*.
 
     Parameters
     ----------
@@ -481,7 +486,7 @@ def read_image_Imageio(
 
     Returns
     -------
-    :class`numpy.ndarray`
+    :class:`numpy.ndarray`
         Image data.
 
     Notes
@@ -535,7 +540,7 @@ def read_image(
     **kwargs: Any,
 ) -> NDArrayReal:
     """
-    Read the image data at given path using given method.
+    Read the image data at the specified path using the specified method.
 
     Parameters
     ----------
@@ -558,14 +563,14 @@ def read_image(
 
     Returns
     -------
-    :class`numpy.ndarray`
+    :class:`numpy.ndarray`
         Image data.
 
     Notes
     -----
-    -   If the given method is *OpenImageIO* but the library is not available
+    -   If the specified method is *OpenImageIO* but the library is not available
         writing will be performed by *Imageio*.
-    -   If the given method is *Imageio*, ``kwargs`` is passed directly to the
+    -   If the specified method is *Imageio*, ``kwargs`` is passed directly to the
         wrapped definition.
     -   For convenience, single channel images are squeezed to 2D arrays.
 
@@ -614,7 +619,7 @@ def write_image_OpenImageIO(
     attributes: Sequence | None = None,
 ) -> bool:
     """
-    Write given image data at given path using *OpenImageIO*.
+    Write the specified image data at the specified path using *OpenImageIO*.
 
     Parameters
     ----------
@@ -740,7 +745,7 @@ def write_image_Imageio(
     **kwargs: Any,
 ) -> bytes | None:
     """
-    Write given image data at given path using *Imageio*.
+    Write the specified image data at the specified path using *Imageio*.
 
     Parameters
     ----------
@@ -834,7 +839,7 @@ def write_image(
     **kwargs: Any,
 ) -> bool:
     """
-    Write given image data at given path using given method.
+    Write the specified image data at the specified path using the specified method.
 
     Parameters
     ----------
@@ -863,9 +868,9 @@ def write_image(
 
     Notes
     -----
-    -   If the given method is *OpenImageIO* but the library is not available
+    -   If the specified method is *OpenImageIO* but the library is not available
         writing will be performed by *Imageio*.
-    -   If the given method is *Imageio*, ``kwargs`` is passed directly to the
+    -   If the specified method is *Imageio*, ``kwargs`` is passed directly to the
         wrapped definition.
     -   It is possible to control how the images are saved by the *Freeimage*
         backend by using the ``flags`` keyword argument and passing a desired
@@ -924,17 +929,25 @@ Source/FreeImage.h
 
 def as_3_channels_image(a: ArrayLike) -> NDArrayFloat:
     """
-    Convert given array :math:`a` to a 3-channels image-like representation.
+    Convert the specified array :math:`a` to a 3-channels image-like
+    representation.
 
     Parameters
     ----------
     a
-         Array :math:`a` to convert to a 3-channels image-like representation.
+         Array :math:`a` to convert to a 3-channels image-like
+         representation.
 
     Returns
     -------
-    :class`numpy.ndarray`
+    :class:`numpy.ndarray`
         3-channels image-like representation of array :math:`a`.
+
+    Raises
+    ------
+    ValueError
+        If the array has more than 3 dimensions or more than 1 or 3
+        channels.
 
     Examples
     --------

--- a/colour/io/luts/__init__.py
+++ b/colour/io/luts/__init__.py
@@ -112,23 +112,29 @@ def read_LUT(
     **kwargs: Any,
 ) -> LUT1D | LUT3x1D | LUT3D | LUTSequence | LUTOperatorMatrix:
     """
-    Read given *LUT* file using given method.
+    Read the specified *LUT* file using the specified method.
 
     Parameters
     ----------
     path
         *LUT* path.
     method
-        Reading method, if *None*, the method will be auto-detected according
-        to extension.
+        Reading method, if *None*, the method will be auto-detected
+        according to extension.
 
     Returns
     -------
-    :class:`colour.LUT1D` or :class:`colour.LUT3x1D` or :class:`colour.LUT3D` \
-or :class:`colour.LUTSequence` or :class:`colour.LUTOperatorMatrix`
+    :class:`colour.LUT1D` or :class:`colour.LUT3x1D` or \
+:class:`colour.LUT3D` or :class:`colour.LUTSequence` or \
+:class:`colour.LUTOperatorMatrix`
         :class:`colour.LUT1D` or :class:`colour.LUT3x1D` or
         :class:`colour.LUT3D` or :class:`colour.LUTSequence` or
         :class:`colour.LUTOperatorMatrix` class instance.
+
+    Raises
+    ------
+    ValueError
+        If the *LUT* file format is not supported or if reading fails.
 
     References
     ----------
@@ -262,22 +268,22 @@ def write_LUT(
     **kwargs: Any,
 ) -> bool:
     """
-    Write given *LUT* to given file using given method.
+    Write the specified *LUT* to the specified file using the specified method.
 
     Parameters
     ----------
     LUT
         :class:`colour.LUT1D` or :class:`colour.LUT3x1D` or
         :class:`colour.LUT3D` or :class:`colour.LUTSequence` or
-        :class:`colour.LUTOperatorMatrix` class instance to write at given
+        :class:`colour.LUTOperatorMatrix` class instance to write at specified
         path.
     path
         *LUT* path.
     decimals
         Formatting decimals.
     method
-        Writing method, if *None*, the method will be auto-detected according
-        to extension.
+        Writing method, if *None*, the method will be auto-detected
+        according to extension.
 
     Returns
     -------

--- a/colour/io/luts/cinespace_csp.py
+++ b/colour/io/luts/cinespace_csp.py
@@ -49,7 +49,7 @@ __all__ = [
 
 def read_LUT_Cinespace(path: str | PathLike) -> LUT3x1D | LUT3D | LUTSequence:
     """
-    Read given *Cinespace* *.csp* *LUT* file.
+    Read the specified *Cinespace* *.csp* *LUT* file.
 
     Parameters
     ----------
@@ -110,12 +110,12 @@ def read_LUT_Cinespace(path: str | PathLike) -> LUT3x1D | LUT3D | LUTSequence:
     unity_range = np.array([[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]])
 
     def _parse_metadata_section(metadata: list) -> tuple:
-        """Parse the metadata at given lines."""
+        """Parse the metadata at specified lines."""
 
         return (metadata[0], metadata[1:]) if len(metadata) > 0 else ("", [])
 
     def _parse_domain_section(lines: List[str]) -> NDArrayFloat:
-        """Parse the domain at given lines."""
+        """Parse the domain at specified lines."""
 
         pre_LUT_size = max(int(lines[i]) for i in [0, 3, 6])
         pre_LUT = [as_float_array(lines[i].split()) for i in [1, 2, 4, 5, 7, 8]]
@@ -137,7 +137,7 @@ def read_LUT_Cinespace(path: str | PathLike) -> LUT3x1D | LUT3D | LUTSequence:
         return np.asarray(pre_LUT_padded)
 
     def _parse_table_section(lines: list[str]) -> tuple[NDArrayInt, NDArrayFloat]:
-        """Parse the table at given lines."""
+        """Parse the table at specified lines."""
 
         size = as_int_array(lines[0].split())
         table = as_float_array([line.split() for line in lines[1:]])
@@ -247,13 +247,13 @@ def write_LUT_Cinespace(
     LUT: LUT1D | LUT3x1D | LUT3D | LUTSequence, path: str | PathLike, decimals: int = 7
 ) -> bool:
     """
-    Write given *LUT* to given  *Cinespace* *.csp* *LUT* file.
+    Write the specified *LUT* to the specified *Cinespace* *.csp* *LUT* file.
 
     Parameters
     ----------
     LUT
         :class:`LUT1D`, :class:`LUT3x1D` or :class:`LUT3D` or
-        :class:`LUTSequence` class instance to write at given path.
+        :class:`LUTSequence` class instance to write at specified path.
     path
         *LUT* path.
     decimals
@@ -339,7 +339,7 @@ def write_LUT_Cinespace(
         attest(2 <= LUT[1].size <= 256, "Cube size must be in domain [2, 256]!")
 
     def _ragged_size(table: ArrayLike) -> list:
-        """Return the ragged size of given table."""
+        """Return the ragged size of specified table."""
 
         R, G, B = tsplit(table)
 

--- a/colour/io/luts/common.py
+++ b/colour/io/luts/common.py
@@ -29,7 +29,7 @@ __all__ = [
 
 def path_to_title(path: str | PathLike) -> str:
     """
-    Convert given file path to title.
+    Convert the specified file path to a title.
 
     Parameters
     ----------

--- a/colour/io/luts/iridas_cube.py
+++ b/colour/io/luts/iridas_cube.py
@@ -48,7 +48,7 @@ __all__ = [
 
 def read_LUT_IridasCube(path: str | PathLike) -> LUT3x1D | LUT3D:
     """
-    Read given *Iridas* *.cube* *LUT* file.
+    Read the specified *Iridas* *.cube* *LUT* file.
 
     Parameters
     ----------
@@ -57,7 +57,7 @@ def read_LUT_IridasCube(path: str | PathLike) -> LUT3x1D | LUT3D:
 
     Returns
     -------
-    :class:`LUT3x1D` or :class:`LUT3D`.
+    :class:`LUT3x1D` or :class:`LUT3D`
         :class:`LUT3x1D` or :class:`LUT3D` class instance.
 
     References
@@ -190,13 +190,13 @@ def write_LUT_IridasCube(
     LUT: LUT1D | LUT3x1D | LUT3D | LUTSequence, path: str | PathLike, decimals: int = 7
 ) -> bool:
     """
-    Write given *LUT* to given  *Iridas* *.cube* *LUT* file.
+    Write the specified *LUT* to the specified *Iridas* *.cube* *LUT* file.
 
     Parameters
     ----------
     LUT
         :class:`LUT1D`, :class:`LUT3x1D`, :class:`LUT3D` or :class:`LUTSequence`
-        class instance to write at given path.
+        class instance to write at specified path.
     path
         *LUT* path.
     decimals

--- a/colour/io/luts/lut.py
+++ b/colour/io/luts/lut.py
@@ -353,7 +353,7 @@ class AbstractLUT(ABC):
 
     def __eq__(self, other: object) -> bool:
         """
-        Return whether the *LUT* is equal to given other object.
+        Return whether the *LUT* is equal to specified other object.
 
         Parameters
         ----------
@@ -363,7 +363,7 @@ class AbstractLUT(ABC):
         Returns
         -------
         :class:`bool`
-            Whether given object is equal to the *LUT*.
+            Whether specified object is equal to the *LUT*.
         """
 
         return isinstance(other, AbstractLUT) and all(
@@ -375,7 +375,7 @@ class AbstractLUT(ABC):
 
     def __ne__(self, other: object) -> bool:
         """
-        Return whether the *LUT* is not equal to given other object.
+        Return whether the *LUT* is not equal to specified other object.
 
         Parameters
         ----------
@@ -385,7 +385,7 @@ class AbstractLUT(ABC):
         Returns
         -------
         :class:`bool`
-            Whether given object is not equal to the *LUT*.
+            Whether specified object is not equal to the *LUT*.
         """
 
         return not (self == other)
@@ -570,7 +570,7 @@ class AbstractLUT(ABC):
         in_place: bool = False,
     ) -> Self:
         """
-        Perform given arithmetical operation with :math:`a` operand, the
+        Perform specified arithmetical operation with :math:`a` operand, the
         operation can be either performed on a copy or in-place, must be
         reimplemented by sub-classes.
 
@@ -609,7 +609,7 @@ class AbstractLUT(ABC):
     @abstractmethod
     def _validate_table(self, table: ArrayLike) -> NDArrayFloat:
         """
-        Validate given table according to *LUT* dimensions.
+        Validate specified table according to *LUT* dimensions.
 
         Parameters
         ----------
@@ -625,7 +625,7 @@ class AbstractLUT(ABC):
     @abstractmethod
     def _validate_domain(self, domain: ArrayLike) -> NDArrayFloat:
         """
-        Validate given domain according to *LUT* dimensions.
+        Validate specified domain according to *LUT* dimensions.
 
         Parameters
         ----------
@@ -672,7 +672,7 @@ class AbstractLUT(ABC):
         domain: ArrayLike | None = None,
     ) -> NDArrayFloat:
         """
-        Return a linear table of given size according to *LUT* dimensions.
+        Return a linear table of specified size according to *LUT* dimensions.
 
         Parameters
         ----------
@@ -706,7 +706,7 @@ class AbstractLUT(ABC):
     @abstractmethod
     def invert(self, **kwargs: Any) -> AbstractLUT:
         """
-        Compute and returns an inverse copy of the *LUT*.
+        Compute and return an inverse copy of the *LUT*.
 
         Other Parameters
         ----------------
@@ -722,7 +722,7 @@ class AbstractLUT(ABC):
     @abstractmethod
     def apply(self, RGB: ArrayLike, **kwargs: Any) -> NDArrayFloat:
         """
-        Apply the *LUT* to given *RGB* colourspace array using given method.
+        Apply the *LUT* to specified *RGB* colourspace array using specified method.
 
         Parameters
         ----------
@@ -758,7 +758,7 @@ class AbstractLUT(ABC):
         **kwargs: Any,
     ) -> AbstractLUT:
         """
-        Convert the *LUT* to given ``cls`` class instance.
+        Convert the *LUT* to specified ``cls`` class instance.
 
         Parameters
         ----------
@@ -887,7 +887,7 @@ class LUT1D(AbstractLUT):
 
     def _validate_table(self, table: ArrayLike) -> NDArrayFloat:
         """
-        Validate given table is a 1D array.
+        Validate specified table is a 1D array.
 
         Parameters
         ----------
@@ -908,7 +908,7 @@ class LUT1D(AbstractLUT):
 
     def _validate_domain(self, domain: ArrayLike) -> NDArrayFloat:
         """
-        Validate given domain.
+        Validate specified domain.
 
         Parameters
         ----------
@@ -1001,12 +1001,12 @@ class LUT1D(AbstractLUT):
 
     def invert(self, **kwargs: Any) -> LUT1D:  # noqa: ARG002
         """
-        Compute and returns an inverse copy of the *LUT*.
+        Compute and return an inverse copy of the *LUT*.
 
         Other Parameters
         ----------------
         kwargs
-            Keywords arguments, only given for signature compatibility with
+            Keywords arguments, only specified for signature compatibility with
             the :meth:`AbstractLUT.invert` method.
 
         Returns
@@ -1050,7 +1050,7 @@ class LUT1D(AbstractLUT):
 
     def apply(self, RGB: ArrayLike, **kwargs: Any) -> NDArrayFloat:
         """
-        Apply the *LUT* to given *RGB* colourspace array using given method.
+        Apply the *LUT* to specified *RGB* colourspace array using specified method.
 
         Parameters
         ----------
@@ -1082,7 +1082,7 @@ class LUT1D(AbstractLUT):
         >>> LUT = LUT1D(LUT1D.linear_table() ** (1 / 2.2))
         >>> RGB = np.array([0.18, 0.18, 0.18])
 
-        *LUT* applied to the given *RGB* colourspace in the forward direction:
+        *LUT* applied to the specified *RGB* colourspace in the forward direction:
 
         >>> LUT.apply(RGB)  # doctest: +ELLIPSIS
         array([ 0.4529220...,  0.4529220...,  0.4529220...])
@@ -1210,7 +1210,7 @@ class LUT3x1D(AbstractLUT):
 
     def _validate_table(self, table: ArrayLike) -> NDArrayFloat:
         """
-        Validate given table is a 3x1D array.
+        Validate specified table is a 3x1D array.
 
         Parameters
         ----------
@@ -1231,7 +1231,7 @@ class LUT3x1D(AbstractLUT):
 
     def _validate_domain(self, domain: ArrayLike) -> NDArrayFloat:
         """
-        Validate given domain.
+        Validate specified domain.
 
         Parameters
         ----------
@@ -1388,12 +1388,12 @@ class LUT3x1D(AbstractLUT):
 
     def invert(self, **kwargs: Any) -> LUT3x1D:  # noqa: ARG002
         """
-        Compute and returns an inverse copy of the *LUT*.
+        Compute and return an inverse copy of the *LUT*.
 
         Other Parameters
         ----------------
         kwargs
-            Keywords arguments, only given for signature compatibility with
+            Keywords arguments, only specified for signature compatibility with
             the :meth:`AbstractLUT.invert` method.
 
         Returns
@@ -1462,7 +1462,7 @@ class LUT3x1D(AbstractLUT):
 
     def apply(self, RGB: ArrayLike, **kwargs: Any) -> NDArrayFloat:
         """
-        Apply the *LUT* to given *RGB* colourspace array using given method.
+        Apply the *LUT* to specified *RGB* colourspace array using specified method.
 
         Parameters
         ----------
@@ -1653,7 +1653,7 @@ class LUT3D(AbstractLUT):
 
     def _validate_table(self, table: ArrayLike) -> NDArrayFloat:
         """
-        Validate given table is a 4D array and that its dimensions are equal.
+        Validate specified table is a 4D array and that its dimensions are equal.
 
         Parameters
         ----------
@@ -1674,7 +1674,7 @@ class LUT3D(AbstractLUT):
 
     def _validate_domain(self, domain: ArrayLike) -> NDArrayFloat:
         """
-        Validate given domain.
+        Validate specified domain.
 
         Parameters
         ----------
@@ -1904,7 +1904,7 @@ class LUT3D(AbstractLUT):
 
     def invert(self, **kwargs: Any) -> LUT3D:
         """
-        Compute and returns an inverse copy of the *LUT*.
+        Compute and return an inverse copy of the *LUT*.
 
         Other Parameters
         ----------------
@@ -1919,9 +1919,9 @@ class LUT3D(AbstractLUT):
             Number of points to query in the KDTree, their mean is computed,
             resulting in a smoother result.
         size
-            Size of the inverse *LUT*. With the given implementation, it is
+            Size of the inverse *LUT*. With the specified implementation, it is
             good practise to double the size of the inverse *LUT* to provide a
-            smoother result. If ``size`` is not given,
+            smoother result. If ``size`` is not specified,
             :math:`2^{\\sqrt{size_{LUT}} + 1} + 1` will be used instead.
 
         Returns
@@ -2007,7 +2007,7 @@ class LUT3D(AbstractLUT):
 
     def apply(self, RGB: ArrayLike, **kwargs: Any) -> NDArrayFloat:
         """
-        Apply the *LUT* to given *RGB* colourspace array using given method.
+        Apply the *LUT* to specified *RGB* colourspace array using specified method.
 
         Parameters
         ----------
@@ -2031,9 +2031,9 @@ class LUT3D(AbstractLUT):
             Number of points to query in the KDTree, their mean is computed,
             resulting in a smoother result.
         size
-            Size of the inverse *LUT*. With the given implementation, it is
+            Size of the inverse *LUT*. With the specified implementation, it is
             good practise to double the size of the inverse *LUT* to provide a
-            smoother result. If ``size`` is not given,
+            smoother result. If ``size`` is not specified,
             :math:`2^{\\sqrt{size_{LUT}} + 1} + 1` will be used instead.
 
         Returns
@@ -2109,7 +2109,7 @@ def LUT_to_LUT(
     **kwargs: Any,
 ) -> AbstractLUT:
     """
-    Convert given *LUT* to given ``cls`` class instance.
+    Convert specified *LUT* to specified ``cls`` class instance.
 
     Parameters
     ----------

--- a/colour/io/luts/operator.py
+++ b/colour/io/luts/operator.py
@@ -136,7 +136,7 @@ class AbstractLUTSequenceOperator(ABC):
     @abstractmethod
     def apply(self, RGB: ArrayLike, *args: Any, **kwargs: Any) -> NDArrayFloat:
         """
-        Apply the *LUT* sequence operator to given *RGB* colourspace array.
+        Apply the *LUT* sequence operator to the specified *RGB* colourspace array.
 
         Parameters
         ----------
@@ -346,7 +346,7 @@ class LUTOperatorMatrix(AbstractLUTSequenceOperator):
         """
 
         def _format(a: ArrayLike) -> str:
-            """Format given array string representation."""
+            """Format specified array string representation."""
 
             return str(a).replace(" [", " " * 14 + "[")
 
@@ -410,7 +410,7 @@ class LUTOperatorMatrix(AbstractLUTSequenceOperator):
 
     def __eq__(self, other: object) -> bool:
         """
-        Return whether the *LUT* operator is equal to given other object.
+        Return whether the *LUT* operator is equal to specified other object.
 
         Parameters
         ----------
@@ -420,7 +420,7 @@ class LUTOperatorMatrix(AbstractLUTSequenceOperator):
         Returns
         -------
         :class:`bool`
-            Whether given object equal to the *LUT* operator.
+            Whether specified object equal to the *LUT* operator.
 
         Examples
         --------
@@ -437,7 +437,7 @@ class LUTOperatorMatrix(AbstractLUTSequenceOperator):
 
     def __ne__(self, other: object) -> bool:
         """
-        Return whether the *LUT* operator is not equal to given other object.
+        Return whether the *LUT* operator is not equal to specified other object.
 
         Parameters
         ----------
@@ -447,7 +447,7 @@ class LUTOperatorMatrix(AbstractLUTSequenceOperator):
         Returns
         -------
         :class:`bool`
-            Whether given object is not equal to the *LUT* operator.
+            Whether specified object is not equal to the *LUT* operator.
 
         Examples
         --------
@@ -466,7 +466,7 @@ class LUTOperatorMatrix(AbstractLUTSequenceOperator):
         **kwargs: Any,
     ) -> NDArrayFloat:
         """
-        Apply the *LUT* operator to given *RGB* array.
+        Apply the *LUT* operator to specified *RGB* array.
 
         Parameters
         ----------

--- a/colour/io/luts/resolve_cube.py
+++ b/colour/io/luts/resolve_cube.py
@@ -49,7 +49,7 @@ __all__ = [
 
 def read_LUT_ResolveCube(path: str | PathLike) -> LUT3x1D | LUT3D | LUTSequence:
     """
-    Read given *Resolve* *.cube* *LUT* file.
+    Read the specified *Resolve* *.cube* *LUT* file.
 
     Parameters
     ----------
@@ -245,13 +245,13 @@ def write_LUT_ResolveCube(
     decimals: int = 7,
 ) -> bool:
     """
-    Write given *LUT* to given  *Resolve* *.cube* *LUT* file.
+    Write the specified *LUT* to specified the *Resolve* *.cube* *LUT* file.
 
     Parameters
     ----------
     LUT
         :class:`LUT1D`, :class:`LUT3x1D` or :class:`LUT3D` or
-        :class:`LUTSequence` class instance to write at given path.
+        :class:`LUTSequence` class instance to write at specified path.
     path
         *LUT* path.
     decimals

--- a/colour/io/luts/sequence.py
+++ b/colour/io/luts/sequence.py
@@ -40,12 +40,13 @@ __all__ = [
 
 class LUTSequence(MutableSequence):
     """
-    Define the base class for a *LUT* sequence, i.e., a series of *LUTs*,
-    *LUT* operators or objects implementing the
-    :class:`colour.hints.ProtocolLUTSequenceItem` protocol.
+    Define the base class for a *LUT* sequence.
 
-    The `colour.LUTSequence` class can be used to model series of *LUTs* such
-    as when a shaper *LUT* is combined with a 3D *LUT*.
+    A *LUT* sequence is a series of *LUTs*, *LUT* operators or objects
+    implementing the :class:`colour.hints.ProtocolLUTSequenceItem` protocol.
+
+    The :class:`colour.LUTSequence` class can be used to model series of *LUTs*
+    such as when a shaper *LUT* is combined with a 3D *LUT*.
 
     Other Parameters
     ----------------
@@ -149,7 +150,7 @@ class LUTSequence(MutableSequence):
 
     def __getitem__(self, index: int | slice) -> Any:
         """
-        Return the *LUT* sequence item(s) at given index (or slice).
+        Return the *LUT* sequence item(s) at specified index (or slice).
 
         Parameters
         ----------
@@ -159,14 +160,14 @@ class LUTSequence(MutableSequence):
         Returns
         -------
         ProtocolLUTSequenceItem
-            *LUT* sequence item(s) at given index (or slice).
+            *LUT* sequence item(s) at specified index (or slice).
         """
 
         return self._sequence[index]
 
     def __setitem__(self, index: int | slice, value: Any) -> None:
         """
-        Set the *LUT* sequence at given index (or slice) with given value.
+        Set the *LUT* sequence at specified index (or slice) with specified value.
 
         Parameters
         ----------
@@ -187,7 +188,7 @@ class LUTSequence(MutableSequence):
 
     def __delitem__(self, index: int | slice) -> None:
         """
-        Delete the *LUT* sequence item(s) at given index (or slice).
+        Delete the *LUT* sequence item(s) at specified index (or slice).
 
         Parameters
         ----------
@@ -266,7 +267,7 @@ class LUTSequence(MutableSequence):
 
     def __eq__(self, other: object) -> bool:
         """
-        Return whether the *LUT* sequence is equal to given other object.
+        Return whether the *LUT* sequence is equal to specified other object.
 
         Parameters
         ----------
@@ -276,7 +277,7 @@ class LUTSequence(MutableSequence):
         Returns
         -------
         :class:`bool`
-            Whether given object is equal to the *LUT* sequence.
+            Whether specified object is equal to the *LUT* sequence.
         """
 
         if not isinstance(other, LUTSequence):
@@ -289,7 +290,7 @@ class LUTSequence(MutableSequence):
 
     def __ne__(self, other: object) -> bool:
         """
-        Return whether the *LUT* sequence is not equal to given other object.
+        Return whether the *LUT* sequence is not equal to specified other object.
 
         Parameters
         ----------
@@ -299,14 +300,14 @@ class LUTSequence(MutableSequence):
         Returns
         -------
         :class:`bool`
-            Whether given object is not equal to the *LUT* sequence.
+            Whether specified object is not equal to the *LUT* sequence.
         """
 
         return not (self == other)
 
     def insert(self, index: int, value: ProtocolLUTSequenceItem) -> None:
         """
-        Insert given *LUT* at given index into the *LUT* sequence.
+        Insert specified *LUT* at specified index into the *LUT* sequence.
 
         Parameters
         ----------
@@ -325,24 +326,23 @@ class LUTSequence(MutableSequence):
 
     def apply(self, RGB: ArrayLike, **kwargs: Any) -> NDArrayFloat:
         """
-        Apply the *LUT* sequence sequentially to given *RGB* colourspace
-        array.
+        Apply the *LUT* sequence sequentially to specified *RGB* colourspace array.
 
         Parameters
         ----------
         RGB
-            *RGB* colourspace array to apply the *LUT* sequence sequentially
-            onto.
+            *RGB* colourspace array to apply the *LUT* sequence
+            sequentially onto.
 
         Other Parameters
         ----------------
         kwargs
-            Keywords arguments, the keys must be the class type names for which
-            they are intended to be used with. There is no implemented way to
-            discriminate which class instance the keyword arguments should be
-            used with, thus if many class instances of the same type are
-            members of the sequence, any matching keyword arguments will be
-            used with all the class instances.
+            Keywords arguments. The keys must be the class type names for
+            which they are intended to be used with. There is no implemented
+            way to discriminate which class instance the keyword arguments
+            should be used with, thus if many class instances of the same
+            type are members of the sequence, any matching keyword arguments
+            will be used with all the class instances.
 
         Returns
         -------

--- a/colour/io/luts/sony_spi1d.py
+++ b/colour/io/luts/sony_spi1d.py
@@ -43,7 +43,7 @@ __all__ = [
 
 def read_LUT_SonySPI1D(path: str | PathLike) -> LUT1D | LUT3x1D:
     """
-    Read given *Sony* *.spi1d* *LUT* file.
+    Read the specified *Sony* *.spi1d* *LUT* file.
 
     Parameters
     ----------
@@ -162,13 +162,13 @@ def write_LUT_SonySPI1D(
     LUT: LUT1D | LUT3x1D | LUTSequence, path: str | PathLike, decimals: int = 7
 ) -> bool:
     """
-    Write given *LUT* to given *Sony* *.spi1d* *LUT* file.
+    Write the specified *LUT* to the specified *Sony* *.spi1d* *LUT* file.
 
     Parameters
     ----------
     LUT
         :class:`LUT1D`, :class:`LUT3x1D` or :class:`LUTSequence` class instance
-        to write at given path.
+        to write at specified path.
     path
         *LUT* path.
     decimals

--- a/colour/io/luts/sony_spi3d.py
+++ b/colour/io/luts/sony_spi3d.py
@@ -44,7 +44,7 @@ __all__ = [
 
 def read_LUT_SonySPI3D(path: str | PathLike) -> LUT3D:
     """
-    Read given *Sony* *.spi3d* *LUT* file.
+    Read specified *Sony* *.spi3d* *LUT* file.
 
     Parameters
     ----------
@@ -147,12 +147,12 @@ def write_LUT_SonySPI3D(
     LUT: LUT3D | LUTSequence, path: str | PathLike, decimals: int = 7
 ) -> bool:
     """
-    Write given *LUT* to given *Sony* *.spi3d* *LUT* file.
+    Write specified *LUT* to specified *Sony* *.spi3d* *LUT* file.
 
     Parameters
     ----------
     LUT
-        :class:`LUT3D` or :class:`LUTSequence` class instance to write at given
+        :class:`LUT3D` or :class:`LUTSequence` class instance to write at specified
         path.
     path
         *LUT* path.

--- a/colour/io/luts/sony_spimtx.py
+++ b/colour/io/luts/sony_spimtx.py
@@ -37,7 +37,7 @@ __all__ = [
 
 def read_LUT_SonySPImtx(path: str | PathLike[str]) -> LUTOperatorMatrix:
     """
-    Read given *Sony* *.spimtx* *LUT* file.
+    Read specified *Sony* *.spimtx* *LUT* file.
 
     Parameters
     ----------
@@ -88,12 +88,12 @@ def write_LUT_SonySPImtx(
     decimals: int = 7,
 ) -> bool:
     """
-    Write given *LUT* to given *Sony* *.spimtx* *LUT* file.
+    Write specified *LUT* to specified *Sony* *.spimtx* *LUT* file.
 
     Parameters
     ----------
     LUT
-        :class:`colour.LUTOperatorMatrix` class instance to write at given
+        :class:`colour.LUTOperatorMatrix` class instance to write at specified
         path.
     path
         *LUT* path.

--- a/colour/io/luts/tests/test_sequence.py
+++ b/colour/io/luts/tests/test_sequence.py
@@ -420,7 +420,7 @@ LUTSequence(
                 **kwargs: Any,
             ) -> NDArrayFloat:
                 """
-                Apply the *LUT* sequence operator to given *RGB* colourspace
+                Apply the *LUT* sequence operator to specified *RGB* colourspace
                 array.
 
                 Parameters

--- a/colour/io/ocio.py
+++ b/colour/io/ocio.py
@@ -34,7 +34,7 @@ __all__ = [
 @required("OpenColorIO")
 def process_image_OpenColorIO(a: ArrayLike, *args: Any, **kwargs: Any) -> NDArrayFloat:
     """
-    Process given image data with *OpenColorIO*.
+    Process the specified image data with *OpenColorIO*.
 
     Parameters
     ----------
@@ -48,14 +48,19 @@ def process_image_OpenColorIO(a: ArrayLike, *args: Any, **kwargs: Any) -> NDArra
         *OpenColorIO* set defined by the ``$OCIO`` environment variable is
         used.
     args
-        Arguments for `Config.getProcessor` method.
-        See https://opencolorio.readthedocs.io/en/latest/api/config.html for
+        Arguments for `Config.getProcessor` method. See
+        https://opencolorio.readthedocs.io/en/latest/api/config.html for
         more information.
 
     Returns
     -------
     :class:`numpy.ndarray`
         Processed image data.
+
+    Raises
+    ------
+    RuntimeError
+        If *OpenColorIO* is not available.
 
     Examples
     --------

--- a/colour/io/tabular.py
+++ b/colour/io/tabular.py
@@ -45,7 +45,7 @@ def read_spectral_data_from_csv_file(
     path: str | PathLike, **kwargs: Any
 ) -> Dict[str, NDArrayFloat]:
     """
-    Read the spectral data from given *CSV* file in the following form::
+    Read spectral data from the specified *CSV* file in the following form::
 
         390, 4.15003e-04, 3.68349e-04, 9.54729e-03
         395, 1.05192e-03, 9.58658e-04, 2.38250e-02
@@ -53,7 +53,7 @@ def read_spectral_data_from_csv_file(
         ...
         830, 9.74306e-07, 9.53411e-08, 0.00000
 
-    and returns it as an *dict* as follows::
+    and convert it to a *dict* as follows::
 
         {
             'wavelength': ndarray,
@@ -77,6 +77,11 @@ def read_spectral_data_from_csv_file(
     -------
     :class:`dict`
         *CSV* file content.
+
+    Raises
+    ------
+    IOError
+        If the file cannot be read.
 
     Notes
     -----
@@ -162,7 +167,7 @@ def read_sds_from_csv_file(
     path: str | PathLike, **kwargs: Any
 ) -> Dict[str, SpectralDistribution]:
     """
-    Read the spectral data from given *CSV* file and returns its content as a
+    Read spectral data from the specified *CSV* file and convert its content to a
     *dict* of :class:`colour.SpectralDistribution` class instances.
 
     Parameters
@@ -179,6 +184,11 @@ def read_sds_from_csv_file(
     -------
     :class:`dict`
         *dict* of :class:`colour.SpectralDistribution` class instances.
+
+    Raises
+    ------
+    IOError
+        If the file cannot be read.
 
     Examples
     --------
@@ -303,12 +313,12 @@ def write_sds_to_csv_file(
     sds: Dict[str, SpectralDistribution], path: str | PathLike
 ) -> bool:
     """
-    Write the given spectral distributions to given *CSV* file.
+    Write the specified spectral distributions to the specified *CSV* file.
 
     Parameters
     ----------
     sds
-        Spectral distributions to write to given *CSV* file.
+        Spectral distributions to write to specified *CSV* file.
     path
         *CSV* file path.
 
@@ -320,7 +330,7 @@ def write_sds_to_csv_file(
     Raises
     ------
     ValueError
-        If the given spectral distributions have different shapes.
+        If the specified spectral distributions have different shapes.
     """
 
     path = str(path)

--- a/colour/io/tm2714.py
+++ b/colour/io/tm2714.py
@@ -625,7 +625,7 @@ class Header_IESTM2714:
 
     def __repr__(self) -> str:
         """
-        Return an evaluable string representation of the header.
+        Generate an evaluable string representation of the header.
 
         Returns
         -------
@@ -667,7 +667,7 @@ class Header_IESTM2714:
 
     def __hash__(self) -> int:
         """
-        Return the header hash.
+        Generate the header hash.
 
         Returns
         -------
@@ -693,7 +693,7 @@ class Header_IESTM2714:
 
     def __eq__(self, other: object) -> bool:
         """
-        Return whether the header is equal to given other object.
+        Determine whether the header is equal to specified other object.
 
         Parameters
         ----------
@@ -703,7 +703,7 @@ class Header_IESTM2714:
         Returns
         -------
         :class:`bool`
-            Whether given object is equal to the header.
+            Whether specified object is equal to the header.
 
         Examples
         --------
@@ -734,7 +734,7 @@ class Header_IESTM2714:
 
     def __ne__(self, other: object) -> bool:
         """
-        Return whether the header is not equal to given other object.
+        Determine whether the header is not equal to specified other object.
 
         Parameters
         ----------
@@ -744,7 +744,7 @@ class Header_IESTM2714:
         Returns
         -------
         :class:`bool`
-            Whether given object is not equal to the header.
+            Whether specified object is not equal to the header.
 
         Examples
         --------
@@ -1481,7 +1481,7 @@ class SpectralDistribution_IESTM2714(SpectralDistribution):
 
     def __repr__(self) -> str:
         """
-        Return an evaluable string representation of the *IES TM-27-14*
+        Generate an evaluable string representation of the *IES TM-27-14*
         spectral distribution.
 
         Returns
@@ -1640,7 +1640,7 @@ class SpectralDistribution_IESTM2714(SpectralDistribution):
 
     def read(self) -> SpectralDistribution_IESTM2714:
         """
-        Read and parses the spectral data *XML* file path.
+        Read and parse the spectral data from the *XML* file path.
 
         Returns
         -------
@@ -1732,12 +1732,17 @@ class SpectralDistribution_IESTM2714(SpectralDistribution):
 
     def write(self) -> bool:
         """
-        Write the spectral distribution spectral data to *XML* file path.
+        Write the spectral distribution spectral data to the *XML* file path.
 
         Returns
         -------
         :class:`bool`
             Definition success.
+
+        Raises
+        ------
+        ValueError
+            If the *IES TM-27-14* spectral distribution path is undefined.
 
         Examples
         --------

--- a/colour/io/uprtek_sekonic.py
+++ b/colour/io/uprtek_sekonic.py
@@ -184,7 +184,7 @@ class SpectralDistribution_UPRTek(SpectralDistribution_IESTM2714):
 
     def __str__(self) -> str:
         """
-        Return a formatted string representation of the *UPRTek* spectral
+        Generate formatted string representation of the *UPRTek* spectral
         distribution.
 
         Returns
@@ -285,12 +285,17 @@ class SpectralDistribution_UPRTek(SpectralDistribution_IESTM2714):
 
     def read(self) -> SpectralDistribution_UPRTek:
         """
-        Read and parses the spectral data from a given *UPRTek* *CSV* file.
+        Read and parse the spectral data from a specified *UPRTek* *CSV* file.
 
         Returns
         -------
         :class:`colour.SpectralDistribution_UPRTek`
             *UPRTek* spectral distribution.
+
+        Raises
+        ------
+        IOError
+            If the file cannot be read.
 
         Examples
         --------
@@ -545,7 +550,7 @@ class SpectralDistribution_Sekonic(SpectralDistribution_UPRTek):
 
     def __str__(self) -> str:
         """
-        Return a formatted string representation of the *Sekonic* spectral
+        Generate formatted string representation of the *Sekonic* spectral
         distribution.
 
         Returns
@@ -643,13 +648,18 @@ class SpectralDistribution_Sekonic(SpectralDistribution_UPRTek):
 
     def read(self) -> SpectralDistribution_Sekonic:
         """
-        Read and parses the spectral data from a given *Sekonic* *Pseudo-XLS*
+        Read and parse the spectral data from a specified *Sekonic* *Pseudo-XLS*
         file.
 
         Returns
         -------
         :class:`colour.SpectralDistribution_Sekonic`
             *Sekonic* spectral distribution.
+
+        Raises
+        ------
+        IOError
+            If the file cannot be read.
 
         Examples
         --------

--- a/colour/io/xrite.py
+++ b/colour/io/xrite.py
@@ -37,7 +37,7 @@ def read_sds_from_xrite_file(
     path: str | PathLike,
 ) -> Dict[str, SpectralDistribution]:
     """
-    Read the spectral data from given *X-Rite* file and returns it as a
+    Read spectral data from the specified *X-Rite* file and convert it to a
     *dict* of :class:`colour.SpectralDistribution` class instances.
 
     Parameters
@@ -49,6 +49,11 @@ def read_sds_from_xrite_file(
     -------
     :class:`dict`
         *dict* of :class:`colour.SpectralDistribution` class instances.
+
+    Raises
+    ------
+    IOError
+        If the file cannot be read.
 
     Notes
     -----

--- a/colour/models/cam02_ucs.py
+++ b/colour/models/cam02_ucs.py
@@ -653,7 +653,7 @@ def XYZ_to_UCS_Luo2006(
     Warnings
     --------
     The ``XYZ_w`` parameter for :func:`colour.XYZ_to_CAM16` definition must be
-    given in the same domain-range scale than the ``XYZ`` parameter.
+    specified in the same domain-range scale than the ``XYZ`` parameter.
 
     Notes
     -----
@@ -740,7 +740,7 @@ def UCS_Luo2006_to_XYZ(
     Warnings
     --------
     The ``XYZ_w`` parameter for :func:`colour.XYZ_to_CAM16` definition must be
-    given in the same domain-range scale than the ``XYZ`` parameter.
+    specified in the same domain-range scale than the ``XYZ`` parameter.
 
     Notes
     -----
@@ -822,7 +822,7 @@ def XYZ_to_CAM02LCD(XYZ: ArrayLike, **kwargs: Any) -> NDArrayFloat:
     Warnings
     --------
     The ``XYZ_w`` parameter for :func:`colour.XYZ_to_CAM16` definition must be
-    given in the same domain-range scale than the ``XYZ`` parameter.
+    specified in the same domain-range scale than the ``XYZ`` parameter.
 
     Notes
     -----
@@ -887,7 +887,7 @@ def CAM02LCD_to_XYZ(Jpapbp: ArrayLike, **kwargs: Any) -> NDArrayFloat:
     Warnings
     --------
     The ``XYZ_w`` parameter for :func:`colour.XYZ_to_CAM16` definition must be
-    given in the same domain-range scale than the ``XYZ`` parameter.
+    specified in the same domain-range scale than the ``XYZ`` parameter.
 
     Notes
     -----
@@ -952,7 +952,7 @@ def XYZ_to_CAM02SCD(XYZ: ArrayLike, **kwargs: Any) -> NDArrayFloat:
     Warnings
     --------
     The ``XYZ_w`` parameter for :func:`colour.XYZ_to_CAM16` definition must be
-    given in the same domain-range scale than the ``XYZ`` parameter.
+    specified in the same domain-range scale than the ``XYZ`` parameter.
 
     Notes
     -----
@@ -1017,7 +1017,7 @@ def CAM02SCD_to_XYZ(Jpapbp: ArrayLike, **kwargs: Any) -> NDArrayFloat:
     Warnings
     --------
     The ``XYZ_w`` parameter for :func:`colour.XYZ_to_CAM16` definition must be
-    given in the same domain-range scale than the ``XYZ`` parameter.
+    specified in the same domain-range scale than the ``XYZ`` parameter.
 
     Notes
     -----
@@ -1082,7 +1082,7 @@ def XYZ_to_CAM02UCS(XYZ: ArrayLike, **kwargs: Any) -> NDArrayFloat:
     Warnings
     --------
     The ``XYZ_w`` parameter for :func:`colour.XYZ_to_CAM16` definition must be
-    given in the same domain-range scale than the ``XYZ`` parameter.
+    specified in the same domain-range scale than the ``XYZ`` parameter.
 
     Notes
     -----
@@ -1147,7 +1147,7 @@ def CAM02UCS_to_XYZ(Jpapbp: ArrayLike, **kwargs: Any) -> NDArrayFloat:
     Warnings
     --------
     The ``XYZ_w`` parameter for :func:`colour.XYZ_to_CAM16` definition must be
-    given in the same domain-range scale than the ``XYZ`` parameter.
+    specified in the same domain-range scale than the ``XYZ`` parameter.
 
     Notes
     -----

--- a/colour/models/cam16_ucs.py
+++ b/colour/models/cam16_ucs.py
@@ -91,7 +91,7 @@ __all__ = [
 
 def _UCS_Luo2006_callable_to_UCS_Li2017_docstring(callable_: Callable) -> str:
     """
-    Convert given *Luo et al. (2006)* callable docstring to
+    Convert specified *Luo et al. (2006)* callable docstring to
     *Li et al. (2017)* docstring.
 
     Parameters
@@ -211,7 +211,7 @@ def XYZ_to_UCS_Li2017(
     Warnings
     --------
     The ``XYZ_w`` parameter for :func:`colour.XYZ_to_CAM16` definition must be
-    given in the same domain-range scale than the ``XYZ`` parameter.
+    specified in the same domain-range scale than the ``XYZ`` parameter.
 
     Notes
     -----
@@ -305,7 +305,7 @@ def UCS_Li2017_to_XYZ(
     Warnings
     --------
     The ``XYZ_w`` parameter for :func:`colour.XYZ_to_CAM16` definition must be
-    given in the same domain-range scale than the ``XYZ`` parameter.
+    specified in the same domain-range scale than the ``XYZ`` parameter.
 
     Notes
     -----

--- a/colour/models/cie_luv.py
+++ b/colour/models/cie_luv.py
@@ -233,7 +233,7 @@ def Luv_to_uv(
     ],
 ) -> NDArrayFloat:
     """
-    Return the :math:`uv^p` chromaticity coordinates from given
+    Return the :math:`uv^p` chromaticity coordinates from specified
     *CIE L\\*u\\*v\\** colourspace array.
 
     Parameters
@@ -293,8 +293,8 @@ def uv_to_Luv(
     L: ArrayLike = 100,
 ) -> NDArrayFloat:
     """
-    Return the *CIE L\\*u\\*v\\** colourspace array from given :math:`uv^p`
-    chromaticity coordinates by extending the array last dimension with given
+    Return the *CIE L\\*u\\*v\\** colourspace array from specified :math:`uv^p`
+    chromaticity coordinates by extending the array last dimension with specified
     :math:`L` *Lightness*.
 
     Parameters
@@ -359,7 +359,7 @@ def uv_to_Luv(
 
 def Luv_uv_to_xy(uv: ArrayLike) -> NDArrayFloat:
     """
-    Return the *CIE xy* chromaticity coordinates from given *CIE L\\*u\\*v\\**
+    Return the *CIE xy* chromaticity coordinates from specified *CIE L\\*u\\*v\\**
     colourspace :math:`uv^p` chromaticity coordinates.
 
     Parameters
@@ -395,7 +395,7 @@ def Luv_uv_to_xy(uv: ArrayLike) -> NDArrayFloat:
 def xy_to_Luv_uv(xy: ArrayLike) -> NDArrayFloat:
     """
     Return the *CIE L\\*u\\*v\\** colourspace :math:`uv^p` chromaticity
-    coordinates from given *CIE xy* chromaticity coordinates.
+    coordinates from specified *CIE xy* chromaticity coordinates.
 
     Parameters
     ----------

--- a/colour/models/cie_ucs.py
+++ b/colour/models/cie_ucs.py
@@ -152,7 +152,7 @@ def UCS_to_XYZ(UVW: ArrayLike) -> NDArrayFloat:
 
 def UCS_to_uv(UVW: ArrayLike) -> NDArrayFloat:
     """
-    Return the *uv* chromaticity coordinates from given *CIE 1960 UCS*
+    Return the *uv* chromaticity coordinates from specified *CIE 1960 UCS*
     :math:`UVW` colourspace array.
 
     Parameters
@@ -195,7 +195,7 @@ def UCS_to_uv(UVW: ArrayLike) -> NDArrayFloat:
 
 def uv_to_UCS(uv: ArrayLike, V: ArrayLike = 1) -> NDArrayFloat:
     """
-    Return the *CIE 1960 UCS* :math:`UVW` colourspace array from given *uv*
+    Return the *CIE 1960 UCS* :math:`UVW` colourspace array from specified *uv*
     chromaticity coordinates.
 
     Parameters
@@ -235,7 +235,7 @@ def uv_to_UCS(uv: ArrayLike, V: ArrayLike = 1) -> NDArrayFloat:
 
 def UCS_uv_to_xy(uv: ArrayLike) -> NDArrayFloat:
     """
-    Return the *CIE xy* chromaticity coordinates from given *CIE 1960 UCS*
+    Return the *CIE xy* chromaticity coordinates from specified *CIE 1960 UCS*
     :math:`UVW` colourspace *uv* chromaticity coordinates.
 
     Parameters
@@ -271,7 +271,7 @@ def UCS_uv_to_xy(uv: ArrayLike) -> NDArrayFloat:
 def xy_to_UCS_uv(xy: ArrayLike) -> NDArrayFloat:
     """
     Return the *CIE 1960 UCS* :math:`UVW` colourspace *uv* chromaticity
-    coordinates from given *CIE xy* chromaticity coordinates.
+    coordinates from specified *CIE xy* chromaticity coordinates.
 
     Parameters
     ----------
@@ -310,7 +310,7 @@ def XYZ_to_CIE1960UCS(
     Convert from *CIE XYZ* tristimulus values to :math:`uvV` colourspace.
 
     This colourspace combines the *CIE 1960 UCS* :math:`UVW` colourspace *uv*
-    chromaticity coordinates with the *luminance* :math:`V` from the
+    chromaticity coordinates with the luminance :math:`V` from the
     *CIE 1960 UCS* :math:`UVW` colourspace.
 
     It is a convenient definition for use with the
@@ -366,7 +366,7 @@ def CIE1960UCS_to_XYZ(
     Convert from *CIE XYZ* tristimulus values to :math:`uvV` colourspace.
 
     This colourspace combines the *CIE 1960 UCS* :math:`UVW` colourspace *uv*
-    chromaticity coordinates with the *luminance* :math:`V` from the
+    chromaticity coordinates with the luminance :math:`V` from the
     *CIE 1960 UCS* :math:`UVW` colourspace.
 
     It is a convenient definition for use with the

--- a/colour/models/cie_xyy.py
+++ b/colour/models/cie_xyy.py
@@ -207,7 +207,7 @@ def xyY_to_xy(xyY: ArrayLike) -> NDArrayFloat:
 def xy_to_xyY(xy: ArrayLike, Y: ArrayLike = 1) -> NDArrayFloat:
     """
     Convert from *CIE xy* chromaticity coordinates to *CIE xyY* colourspace by
-    extending the array last dimension with given :math:`Y` *luminance*.
+    extending the array last dimension with specified :math:`Y` *luminance*.
 
     ``xy`` argument with last dimension being equal to 3 will be assumed to be
     a *CIE xyY* colourspace array argument and will be returned directly by the
@@ -241,7 +241,7 @@ def xy_to_xyY(xy: ArrayLike, Y: ArrayLike = 1) -> NDArrayFloat:
     +------------+-----------------------+---------------+
 
     -   This definition is a convenient object provided to implement support of
-        illuminant argument *luminance* value in various :mod:`colour.models`
+        illuminant argument luminance value in various :mod:`colour.models`
         package objects such as :func:`colour.Lab_to_XYZ` or
         :func:`colour.Luv_to_XYZ`.
 
@@ -279,7 +279,7 @@ def xy_to_xyY(xy: ArrayLike, Y: ArrayLike = 1) -> NDArrayFloat:
 
 def XYZ_to_xy(XYZ: ArrayLike) -> NDArrayFloat:
     """
-    Return the *CIE xy* chromaticity coordinates from given *CIE XYZ*
+    Return the *CIE xy* chromaticity coordinates from specified *CIE XYZ*
     tristimulus values.
 
     Parameters
@@ -316,7 +316,7 @@ def XYZ_to_xy(XYZ: ArrayLike) -> NDArrayFloat:
 
 def xy_to_XYZ(xy: ArrayLike) -> NDArrayFloat:
     """
-    Return the *CIE XYZ* tristimulus values from given *CIE xy* chromaticity
+    Return the *CIE XYZ* tristimulus values from specified *CIE xy* chromaticity
     coordinates.
 
     Parameters

--- a/colour/models/common.py
+++ b/colour/models/common.py
@@ -198,9 +198,9 @@ def Jab_to_JCh(Jab: ArrayLike) -> NDArrayFloat:
 
     This definition is used to perform conversion from *CIE L\\*a\\*b\\**
     colourspace to *CIE L\\*C\\*Hab* colourspace and for other similar
-    conversions. It implements a generic transformation from *Lightness*
+    conversions. It implements a generic transformation from *lightness*
     :math:`J`, :math:`a` and :math:`b` opponent colour dimensions to the
-    correlates of *Lightness* :math:`J`, chroma :math:`C` and hue angle
+    correlates of *lightness* :math:`J`, chroma :math:`C` and hue angle
     :math:`h`.
 
     Parameters
@@ -260,8 +260,8 @@ def JCh_to_Jab(JCh: ArrayLike) -> NDArrayFloat:
     This definition is used to perform conversion from *CIE L\\*C\\*Hab*
     colourspace to *CIE L\\*a\\*b\\** colourspace and for other similar
     conversions. It implements a generic transformation from the correlates of
-    *Lightness* :math:`J`, chroma :math:`C` and hue angle :math:`h` to
-    *Lightness* :math:`J`, :math:`a` and :math:`b` opponent colour dimensions.
+    *lightness* :math:`J`, chroma :math:`C` and hue angle :math:`h` to
+    *lightness* :math:`J`, :math:`a` and :math:`b` opponent colour dimensions.
 
     Parameters
     ----------
@@ -326,7 +326,7 @@ def XYZ_to_Iab(
     This definition is used to perform conversion from *CIE XYZ* tristimulus
     values to *IPT* colourspace and for other similar conversions. It
     implements a generic transformation from *CIE XYZ* tristimulus values to
-    *Lightness* :math:`I`, :math:`a` and :math:`b` representing
+    *lightness* :math:`I`, :math:`a` and :math:`b` representing
     red-green dimension, i.e., the dimension lost by protanopes and
     the yellow-blue dimension, i.e., the dimension lost by tritanopes,
     respectively.
@@ -412,7 +412,7 @@ def Iab_to_XYZ(
 
     This definition is used to perform conversion from *IPT* colourspace to
     *CIE XYZ* tristimulus values and for other similar conversions. It
-    implements a generic transformation from *Lightness* :math:`I`, :math:`a`
+    implements a generic transformation from *lightness* :math:`I`, :math:`a`
     and :math:`b` representing red-green dimension, i.e., the dimension lost by
     protanopes and the yellow-blue dimension, i.e., the dimension lost by
     tritanopes, respectively to *CIE XYZ* tristimulus values.

--- a/colour/models/prolab.py
+++ b/colour/models/prolab.py
@@ -58,7 +58,7 @@ MATRIX_INVERSE_Q: NDArrayFloat = np.linalg.inv(MATRIX_Q)
 
 def projective_transformation(a: ArrayLike, Q: ArrayLike) -> NDArrayFloat:
     """
-    Transform given array :math:`a` with the projective transformation matrix
+    Transform specified array :math:`a` with the projective transformation matrix
     :math:`Q`.
 
     Parameters

--- a/colour/models/rgb/cylindrical.py
+++ b/colour/models/rgb/cylindrical.py
@@ -393,7 +393,7 @@ def RGB_to_HCL(RGB: ArrayLike, gamma: float = 3, Y_0: float = 100) -> NDArrayFlo
     | ``HCL``    | [0, 1]                | [0, 1]        |
     +------------+-----------------------+---------------+
 
-    -   This implementation used the equations given in
+    -   This implementation used the equations specified in
         :cite:`Sarifuddin2005a` and the corrections from
         :cite:`Sarifuddin2021`.
 
@@ -485,7 +485,7 @@ def HCL_to_RGB(HCL: ArrayLike, gamma: float = 3, Y_0: float = 100) -> NDArrayFlo
     | ``RGB``    | [0, 1]                | [0, 1]        |
     +------------+-----------------------+---------------+
 
-    -   This implementation used the equations given in
+    -   This implementation used the equations specified in
         :cite:`Sarifuddin2005a` and the corrections from
         :cite:`Sarifuddin2021`.
 
@@ -519,7 +519,7 @@ def HCL_to_RGB(HCL: ArrayLike, gamma: float = 3, Y_0: float = 100) -> NDArrayFlo
     r_n120 = np.radians(-120)
 
     def _1_2_3(a: ArrayLike) -> NDArrayFloat:
-        """Tail-stack given :math:`a` array as a *bool* dtype."""
+        """Tail-stack specified :math:`a` array as a *bool* dtype."""
 
         return tstack(cast(ArrayLike, [a, a, a]), dtype=np.bool_)
 

--- a/colour/models/rgb/datasets/eci_rgb_v2.py
+++ b/colour/models/rgb/datasets/eci_rgb_v2.py
@@ -76,8 +76,8 @@ MATRIX_XYZ_TO_ECI_RGB_V2: NDArrayFloat = np.linalg.inv(MATRIX_ECI_RGB_V2_TO_XYZ)
 
 def _scale_domain_0_100_range_0_1(a: ArrayLike, callable_: Callable) -> NDArrayFloat:
     """
-    Scale the input domain of given *luminance* :math:`Y` or *Lightness*
-    :math:`L^*` array to [0, 100], call the given callable, and
+    Scale the input domain of specified *luminance* :math:`Y` or *Lightness*
+    :math:`L^*` array to [0, 100], call the specified callable, and
     scales the output range to [0, 1].
 
     Parameters

--- a/colour/models/rgb/datasets/itut_h_273.py
+++ b/colour/models/rgb/datasets/itut_h_273.py
@@ -145,7 +145,7 @@ PRIMARIES_H273_22_UNSPECIFIED: NDArrayFloat = np.array(
     ]
 )
 """
-Colourspace primaries for row *22* as given in
+Colourspace primaries for row *22* as specified in
 *Table 2 - Interpretation of colour primaries (ColourPrimaries) value*.
 
 References
@@ -155,7 +155,7 @@ References
 
 WHITEPOINT_NAME_H273_22_UNSPECIFIED: str = "D65"
 """
-Whitepoint name for row *22* as given in
+Whitepoint name for row *22* as specified in
 *Table 2 - Interpretation of colour primaries (ColourPrimaries) value*.
 
 References
@@ -165,7 +165,7 @@ References
 
 CCS_WHITEPOINT_H273_22_UNSPECIFIED: NDArrayFloat = np.array([0.3127, 0.3290])
 """
-Whitepoint chromaticity coordinates for row *22* as given in
+Whitepoint chromaticity coordinates for row *22* as specified in
 *Table 2 - Interpretation of colour primaries (ColourPrimaries) value*.
 
 References
@@ -177,7 +177,7 @@ MATRIX_H273_22_UNSPECIFIED_RGB_TO_XYZ: NDArrayFloat = normalised_primary_matrix(
     PRIMARIES_H273_22_UNSPECIFIED, CCS_WHITEPOINT_H273_22_UNSPECIFIED
 )
 """
-Row *22* colourspace as given in
+Row *22* colourspace as specified in
 *Table 2 - Interpretation of colour primaries (ColourPrimaries) value* to
 *CIE XYZ* tristimulus values matrix.
 
@@ -190,7 +190,7 @@ MATRIX_XYZ_TO_H273_22_UNSPECIFIED_RGB: NDArrayFloat = np.linalg.inv(
     MATRIX_H273_22_UNSPECIFIED_RGB_TO_XYZ
 )
 """
-*CIE XYZ* tristimulus values to row *22* colourspace as given in
+*CIE XYZ* tristimulus values to row *22* colourspace as specified in
 *Table 2 - Interpretation of colour primaries (ColourPrimaries) value* matrix.
 
 References
@@ -209,7 +209,7 @@ RGB_COLOURSPACE_H273_22_UNSPECIFIED: RGB_Colourspace = RGB_Colourspace(
     linear_function,
 )
 RGB_COLOURSPACE_H273_22_UNSPECIFIED.__doc__ = """
-*Recommendation ITU-T H.273* row *22* colourspace as given in
+*Recommendation ITU-T H.273* row *22* colourspace as specified in
 *Table 2 - Interpretation of colour primaries (ColourPrimaries) value*.
 
 References

--- a/colour/models/rgb/datasets/sharp.py
+++ b/colour/models/rgb/datasets/sharp.py
@@ -66,7 +66,7 @@ PRIMARIES_SHARP_RGB: NDArrayFloat = np.array(
 Notes
 -----
 The primaries were originally derived from the :math:`M_{Sharp}` matrix as
-given in *Ward and Eydelberg-Vileshin (2002)*:
+specified in *Ward and Eydelberg-Vileshin (2002)*:
 
     M_Sharp = np.array(
         [[1.2694, -0.0988, -0.1706],

--- a/colour/models/rgb/derivation.py
+++ b/colour/models/rgb/derivation.py
@@ -3,7 +3,7 @@ RGB Colourspace Derivation
 ==========================
 
 Define the objects related to *RGB* colourspace derivation, essentially
-calculating the normalised primary matrix for given *RGB* colourspace primaries
+calculating the normalised primary matrix for specified *RGB* colourspace primaries
 and whitepoint:
 
 -   :func:`colour.normalised_primary_matrix`
@@ -61,7 +61,7 @@ __all__ = [
 
 def xy_to_z(xy: ArrayLike) -> float:
     """
-    Return the *z* coordinate using given :math:`xy` chromaticity coordinates.
+    Return the *z* coordinate using specified :math:`xy` chromaticity coordinates.
 
     Parameters
     ----------
@@ -89,7 +89,7 @@ def normalised_primary_matrix(
 ) -> NDArrayFloat:
     """
     Compute the *Normalised Primary Matrix* (NPM) converting a *RGB*
-    colourspace array to *CIE XYZ* tristimulus values using given *primaries*
+    colourspace array to *CIE XYZ* tristimulus values using specified *primaries*
     and *whitepoint* :math:`xy` chromaticity coordinates.
 
     Parameters
@@ -140,7 +140,7 @@ def chromatically_adapted_primaries(
     ) = "CAT02",
 ) -> NDArrayFloat:
     """
-    Chromatically adapt given *primaries* :math:`xy` chromaticity coordinates
+    Chromatically adapt specified *primaries* :math:`xy` chromaticity coordinates
     from test ``whitepoint_t`` to reference ``whitepoint_r``.
 
     Parameters
@@ -187,7 +187,7 @@ def chromatically_adapted_primaries(
 def primaries_whitepoint(npm: ArrayLike) -> Tuple[NDArrayFloat, NDArrayFloat]:
     """
     Compute the *primaries* and *whitepoint* :math:`xy` chromaticity
-    coordinates using given *Normalised Primary Matrix* (NPM).
+    coordinates using specified *Normalised Primary Matrix* (NPM).
 
     Parameters
     ----------
@@ -233,7 +233,7 @@ def primaries_whitepoint(npm: ArrayLike) -> Tuple[NDArrayFloat, NDArrayFloat]:
 
 def RGB_luminance_equation(primaries: ArrayLike, whitepoint: ArrayLike) -> str:
     """
-    Return the *luminance equation* from given *primaries* and *whitepoint*.
+    Return the *luminance equation* from specified *primaries* and *whitepoint*.
 
     Parameters
     ----------
@@ -264,7 +264,7 @@ def RGB_luminance(
     RGB: ArrayLike, primaries: ArrayLike, whitepoint: ArrayLike
 ) -> NDArrayFloat:
     """
-    Return the *luminance* :math:`Y` of given *RGB* components from given
+    Return the *luminance* :math:`Y` of specified *RGB* components from specified
     *primaries* and *whitepoint*.
 
     Parameters

--- a/colour/models/rgb/ictcp.py
+++ b/colour/models/rgb/ictcp.py
@@ -122,7 +122,7 @@ MATRIX_ICTCP_LMS_P_TO_ICTCP_BT2100_HLG_2: NDArrayFloat = (
 )
 """
 :math:`LMS_p` *SMPTE ST 2084:2014* encoded normalised cone responses to
-:math:`IC_TC_P` colour encoding matrix as given in *ITU-R BT.2100-2*.
+:math:`IC_TC_P` colour encoding matrix as specified in *ITU-R BT.2100-2*.
 """
 
 MATRIX_ICTCP_ICTCP_TO_LMS_P_BT2100_HLG_2: NDArrayFloat = np.linalg.inv(
@@ -130,7 +130,7 @@ MATRIX_ICTCP_ICTCP_TO_LMS_P_BT2100_HLG_2: NDArrayFloat = np.linalg.inv(
 )
 """
 :math:`IC_TC_P` colour encoding to :math:`LMS_p` *SMPTE ST 2084:2014* encoded
-normalised cone responses matrix as given in *ITU-R BT.2100-2*.
+normalised cone responses matrix as specified in *ITU-R BT.2100-2*.
 """
 
 

--- a/colour/models/rgb/itut_h_273.py
+++ b/colour/models/rgb/itut_h_273.py
@@ -192,8 +192,8 @@ def _clipped_domain_function(
     function: Callable, domain: list | tuple = (0, 1)
 ) -> Callable:
     """
-    Wrap given function and produce a new callable clipping the input value to
-    given domain.
+    Wrap specified function and produce a new callable clipping the input value to
+    specified domain.
 
     Parameters
     ----------
@@ -211,7 +211,7 @@ def _clipped_domain_function(
 
     @functools.wraps(function)
     def wrapped(x: ArrayLike, *args: Any, **kwargs: Any) -> Any:
-        """Wrap given function."""
+        """Wrap specified function."""
 
         return function(np.clip(x, *domain), *args, **kwargs)
 
@@ -495,7 +495,7 @@ Notes
 -----
 -   For simplicity, no clipping is implemented for *TransferCharacteristics 13*
     as it is a function of whether the context is *sRGB* or *sYCC*.
--   For TransferCharacteristics equal to 18, the equations given in Table 3 are
+-   For TransferCharacteristics equal to 18, the equations specified in Table 3 are
     normalized for a source input linear optical intensity Lc with a nominal
     real-valued range of 0 to 1. An alternative scaling that is mathematically
     equivalent is used in ARIB STD-B67 (2015) with the source input linear
@@ -896,7 +896,7 @@ def describe_video_signal_colour_primaries(
     code_point: int, print_description: bool = True, **kwargs: Any
 ) -> str:
     """
-    Describe given video signal colour primaries code point.
+    Describe specified video signal colour primaries code point.
 
     Parameters
     ----------
@@ -1052,7 +1052,7 @@ def describe_video_signal_transfer_characteristics(
     code_point: int, print_description: bool = True, **kwargs: Any
 ) -> str:
     """
-    Describe given video signal transfer characteristics code point.
+    Describe specified video signal transfer characteristics code point.
 
     Parameters
     ----------
@@ -1176,7 +1176,7 @@ def describe_video_signal_matrix_coefficients(
     code_point: int, print_description: bool = True, **kwargs: Any
 ) -> str:
     """
-    Describe given video signal matrix coefficients code point.
+    Describe specified video signal matrix coefficients code point.
 
     Parameters
     ----------

--- a/colour/models/rgb/prismatic.py
+++ b/colour/models/rgb/prismatic.py
@@ -78,7 +78,7 @@ def RGB_to_Prismatic(RGB: ArrayLike) -> NDArrayFloat:
     >>> RGB_to_Prismatic(RGB)  # doctest: +ELLIPSIS
     array([ 0.75...   ,  0.1666666...,  0.3333333...,  0.5...   ])
 
-    Adjusting saturation of given *RGB* colourspace array:
+    Adjusting saturation of specified *RGB* colourspace array:
     >>> saturation = 0.5
     >>> Lrgb = RGB_to_Prismatic(RGB)
     >>> Lrgb[..., 1:] = 1 / 3 + saturation * (Lrgb[..., 1:] - 1 / 3)

--- a/colour/models/rgb/rgb_colourspace.py
+++ b/colour/models/rgb/rgb_colourspace.py
@@ -119,7 +119,7 @@ class RGB_Colourspace:
         -   Derived transformation matrices
 
     Upon instantiation, the :class:`colour.RGB_Colourspace` class stores the
-    given ``matrix_RGB_to_XYZ`` and ``matrix_XYZ_to_RGB`` arguments and also
+    specified ``matrix_RGB_to_XYZ`` and ``matrix_XYZ_to_RGB`` arguments and also
     computes their derived counterpart using the ``primaries`` and
     ``whitepoint`` arguments.
 
@@ -1075,7 +1075,7 @@ def RGB_to_XYZ(
     **kwargs: Any,
 ) -> NDArrayFloat:
     """
-    Convert given *RGB* colourspace array to *CIE XYZ* tristimulus values.
+    Convert specified *RGB* colourspace array to *CIE XYZ* tristimulus values.
 
     Parameters
     ----------
@@ -1205,8 +1205,8 @@ def matrix_RGB_to_RGB(
     ) = "CAT02",
 ) -> NDArrayFloat:
     """
-    Compute the matrix :math:`M` converting from given input *RGB*
-    colourspace to output *RGB* colourspace using given *chromatic
+    Compute the matrix :math:`M` converting from specified input *RGB*
+    colourspace to output *RGB* colourspace using specified *chromatic
     adaptation* method.
 
     Parameters
@@ -1286,8 +1286,8 @@ def RGB_to_RGB(
     **kwargs: Any,
 ) -> NDArrayFloat:
     """
-    Convert given *RGB* colourspace array from given input *RGB* colourspace
-    to output *RGB* colourspace using given *chromatic adaptation* method.
+    Convert specified *RGB* colourspace array from specified input *RGB* colourspace
+    to output *RGB* colourspace using specified *chromatic adaptation* method.
 
     Parameters
     ----------

--- a/colour/models/rgb/transfer_functions/__init__.py
+++ b/colour/models/rgb/transfer_functions/__init__.py
@@ -429,7 +429,7 @@ def log_encoding(
 ) -> NDArrayFloat | NDArrayInt:
     """
     Encode *scene-referred* exposure values to :math:`R'G'B'` video component
-    signal value using given *log* encoding function.
+    signal value using specified *log* encoding function.
 
     Parameters
     ----------
@@ -550,7 +550,7 @@ def log_decoding(
 ) -> NDArrayFloat:
     """
     Decode :math:`R'G'B'` video component signal value to *scene-referred*
-    exposure values using given *log* decoding function.
+    exposure values using specified *log* decoding function.
 
     Parameters
     ----------
@@ -661,7 +661,7 @@ def oetf(
 ) -> NDArrayFloat:
     """
     Encode estimated tristimulus values in a scene to :math:`R'G'B'` video
-    component signal value using given opto-electronic transfer function
+    component signal value using specified opto-electronic transfer function
     (OETF).
 
     Parameters
@@ -736,7 +736,7 @@ def oetf_inverse(
 ) -> NDArrayFloat:
     """
     Decode :math:`R'G'B'` video component signal value to tristimulus values
-    at the display using given inverse opto-electronic transfer function
+    at the display using specified inverse opto-electronic transfer function
     (OETF).
 
     Parameters
@@ -811,7 +811,7 @@ def eotf(
 ) -> NDArrayFloat:
     """
     Decode :math:`R'G'B'` video component signal value to tristimulus values
-    at the display using given electro-optical transfer function (EOTF).
+    at the display using specified electro-optical transfer function (EOTF).
 
     Parameters
     ----------
@@ -882,7 +882,7 @@ def eotf_inverse(
 ) -> NDArrayFloat | NDArrayInt:
     """
     Encode estimated tristimulus values in a scene to :math:`R'G'B'` video
-    component signal value using given inverse electro-optical transfer
+    component signal value using specified inverse electro-optical transfer
     function (EOTF).
 
     Parameters
@@ -979,7 +979,7 @@ def cctf_encoding(
 ) -> NDArrayFloat | NDArrayInt:
     """
     Encode linear :math:`RGB` values to non-linear :math:`R'G'B'` values using
-    given encoding colour component transfer function (Encoding CCTF).
+    specified encoding colour component transfer function (Encoding CCTF).
 
     Parameters
     ----------
@@ -1083,7 +1083,7 @@ def cctf_decoding(
 ) -> NDArrayFloat:
     """
     Decode non-linear :math:`R'G'B'` values to linear :math:`RGB` values using
-    given decoding colour component transfer function (Decoding CCTF).
+    specified decoding colour component transfer function (Decoding CCTF).
 
     Parameters
     ----------
@@ -1170,7 +1170,7 @@ def ootf(
     **kwargs: Any,
 ) -> NDArrayFloat:
     """
-    Map relative scene linear light to display linear light using given
+    Map relative scene linear light to display linear light using specified
     opto-optical transfer function (OOTF / OOCF).
 
     Parameters
@@ -1228,7 +1228,7 @@ def ootf_inverse(
     **kwargs: Any,
 ) -> NDArrayFloat:
     """
-    Map relative display linear light to scene linear light using given
+    Map relative display linear light to scene linear light using specified
     inverse opto-optical transfer function (OOTF / OOCF).
 
     Parameters

--- a/colour/models/rgb/transfer_functions/aces.py
+++ b/colour/models/rgb/transfer_functions/aces.py
@@ -129,7 +129,7 @@ def log_encoding_ACESproxy(
         *ACESproxy* bit-depth.
     out_in
         Whether to return value as int code value or float equivalent of a
-        code value at a given bit-depth.
+        code value at a specified bit-depth.
     constants
         *ACESproxy* constants.
 
@@ -153,7 +153,7 @@ def log_encoding_ACESproxy(
     +----------------+-----------------------+---------------+
 
     \\* This definition has an output int switch, thus the domain-range
-    scale information is only given for the floating point mode.
+    scale information is only specified for the floating point mode.
 
     References
     ----------
@@ -179,7 +179,7 @@ def log_encoding_ACESproxy(
     steps_per_stop = constants[bit_depth].steps_per_stop
 
     def float_2_cv(x: float) -> float:
-        """Convert given numeric to code value."""
+        """Convert specified numeric to code value."""
 
         return np.maximum(CV_min, np.minimum(CV_max, np.round(x)))
 
@@ -215,7 +215,7 @@ def log_decoding_ACESproxy(
         *ACESproxy* bit-depth.
     in_int
         Whether to treat the input value as int code value or float
-        equivalent of a code value at a given bit-depth.
+        equivalent of a code value at a specified bit-depth.
     constants
         *ACESproxy* constants.
 
@@ -239,7 +239,7 @@ def log_decoding_ACESproxy(
     +----------------+-----------------------+---------------+
 
     \\* This definition has an input int switch, thus the domain-range
-    scale information is only given for the floating point mode.
+    scale information is only specified for the floating point mode.
 
     References
     ----------

--- a/colour/models/rgb/transfer_functions/common.py
+++ b/colour/models/rgb/transfer_functions/common.py
@@ -34,7 +34,7 @@ def CV_range(
     bit_depth: int = 10, is_legal: bool = False, is_int: bool = False
 ) -> NDArrayReal:
     """
-    Return the code value :math:`CV` range for given bit-depth, range legality
+    Return the code value :math:`CV` range for specified bit-depth, range legality
     and representation.
 
     Parameters
@@ -80,29 +80,29 @@ def legal_to_full(
     out_int: bool = False,
 ) -> NDArrayReal:
     """
-    Convert given code value :math:`CV` or float equivalent of a code value at
-    a given bit-depth from legal range (studio swing) to full range
+    Convert specified code value :math:`CV` or float equivalent of a code value at
+    a specified bit-depth from legal range (studio swing) to full range
     (full swing).
 
     Parameters
     ----------
     CV
         Legal range code value :math:`CV` or float equivalent of a code value
-        at a given bit-depth.
+        at a specified bit-depth.
     bit_depth
         Bit-depth used for conversion.
     in_int
         Whether to treat the input value as int code value or float
-        equivalent of a code value at a given bit-depth.
+        equivalent of a code value at a specified bit-depth.
     out_int
         Whether to return value as int code value or float equivalent of a
-        code value at a given bit-depth.
+        code value at a specified bit-depth.
 
     Returns
     -------
     :class:`numpy.ndarray`
         Full range code value :math:`CV` or float equivalent of a code value
-        at a given bit-depth.
+        at a specified bit-depth.
 
     Examples
     --------
@@ -147,29 +147,29 @@ def full_to_legal(
     out_int: bool = False,
 ) -> NDArrayReal:
     """
-    Convert given code value :math:`CV` or float equivalent of a code value at
-    a given bit-depth from full range (full swing) to legal range
+    Convert specified code value :math:`CV` or float equivalent of a code value at
+    a specified bit-depth from full range (full swing) to legal range
     (studio swing).
 
     Parameters
     ----------
     CV
         Full range code value :math:`CV` or float equivalent of a code value at
-        a given bit-depth.
+        a specified bit-depth.
     bit_depth
         Bit-depth used for conversion.
     in_int
         Whether to treat the input value as int code value or float
-        equivalent of a code value at a given bit-depth.
+        equivalent of a code value at a specified bit-depth.
     out_int
         Whether to return value as int code value or float equivalent of a
-        code value at a given bit-depth.
+        code value at a specified bit-depth.
 
     Returns
     -------
     :class:`numpy.ndarray`
         Legal range code value :math:`CV` or float equivalent of a code value
-        at a given bit-depth.
+        at a specified bit-depth.
 
     Examples
     --------

--- a/colour/models/rgb/transfer_functions/dcdm.py
+++ b/colour/models/rgb/transfer_functions/dcdm.py
@@ -55,7 +55,7 @@ def eotf_inverse_DCDM(XYZ: ArrayLike, out_int: bool = False) -> NDArrayReal:
         *CIE XYZ* tristimulus values.
     out_int
         Whether to return value as int code value or float equivalent of a
-        code value at a given bit-depth.
+        code value at a specified bit-depth.
 
     Returns
     -------
@@ -85,7 +85,7 @@ def eotf_inverse_DCDM(XYZ: ArrayLike, out_int: bool = False) -> NDArrayReal:
     +----------------+-----------------------+---------------+
 
     \\* This definition has an output int switch, thus the domain-range
-    scale information is only given for the floating point mode.
+    scale information is only specified for the floating point mode.
 
     References
     ----------
@@ -122,7 +122,7 @@ def eotf_DCDM(
         Non-linear *CIE XYZ'* tristimulus values.
     in_int
         Whether to treat the input value as int code value or float
-        equivalent of a code value at a given bit-depth.
+        equivalent of a code value at a specified bit-depth.
 
     Returns
     -------
@@ -152,7 +152,7 @@ def eotf_DCDM(
     +----------------+-----------------------+---------------+
 
     \\* This definition has an input int switch, thus the domain-range
-    scale information is only given for the floating point mode.
+    scale information is only specified for the floating point mode.
 
     References
     ----------

--- a/colour/models/rgb/transfer_functions/dicom_gsdf.py
+++ b/colour/models/rgb/transfer_functions/dicom_gsdf.py
@@ -86,7 +86,7 @@ def eotf_inverse_DICOMGSDF(
         *Luminance* :math:`L`.
     out_int
         Whether to return value as int code value or float equivalent of a
-        code value at a given bit-depth.
+        code value at a specified bit-depth.
     constants
         *DICOM - Grayscale Standard Display Function* constants.
 
@@ -168,7 +168,7 @@ def eotf_DICOMGSDF(
         Just-Noticeable Difference (JND) Index, :math:`j`.
     in_int
         Whether to treat the input value as int code value or float
-        equivalent of a code value at a given bit-depth.
+        equivalent of a code value at a specified bit-depth.
     constants
         *DICOM - Grayscale Standard Display Function* constants.
 

--- a/colour/models/rgb/transfer_functions/itur_bt_2100.py
+++ b/colour/models/rgb/transfer_functions/itur_bt_2100.py
@@ -429,7 +429,7 @@ References
 
 def gamma_function_BT2100_HLG(L_W: float = 1000) -> float:
     """
-    Return the *Reference HLG* system gamma value for given display nominal
+    Return the *Reference HLG* system gamma value for specified display nominal
     peak luminance.
 
     Parameters
@@ -563,7 +563,7 @@ def black_level_lift_BT2100_HLG(
     L_B: float = 0, L_W: float = 1000, gamma: float | None = None
 ) -> float:
     """
-    Return the *Reference HLG* black level lift :math:`\\beta` for given
+    Return the *Reference HLG* black level lift :math:`\\beta` for specified
     display luminance for black, nominal peak luminance and system gamma value.
 
     Parameters
@@ -610,7 +610,7 @@ def eotf_BT2100_HLG_1(
 ) -> NDArrayFloat:
     """
     Define *Recommendation ITU-R BT.2100* *Reference HLG* electro-optical
-    transfer function (EOTF) as given in *ITU-R BT.2100-1*.
+    transfer function (EOTF) as specified in *ITU-R BT.2100-1*.
 
     The EOTF maps the non-linear *HLG* signal into display light.
 
@@ -677,7 +677,7 @@ def eotf_BT2100_HLG_2(
 ) -> NDArrayFloat:
     """
     Define *Recommendation ITU-R BT.2100* *Reference HLG* electro-optical
-    transfer function (EOTF) as given in *ITU-R BT.2100-2* with the
+    transfer function (EOTF) as specified in *ITU-R BT.2100-2* with the
     modified black level behaviour.
 
     The EOTF maps the non-linear *HLG* signal into display light.
@@ -843,7 +843,7 @@ def eotf_inverse_BT2100_HLG_1(
 ) -> NDArrayFloat:
     """
     Define *Recommendation ITU-R BT.2100* *Reference HLG* inverse
-    electro-optical transfer function (EOTF) as given in
+    electro-optical transfer function (EOTF) as specified in
     *ITU-R BT.2100-1*.
 
     Parameters
@@ -911,7 +911,7 @@ def eotf_inverse_BT2100_HLG_2(
 ) -> NDArrayFloat:
     """
     Define *Recommendation ITU-R BT.2100* *Reference HLG* inverse
-    electro-optical transfer function (EOTF) as given in
+    electro-optical transfer function (EOTF) as specified in
     *ITU-R BT.2100-2* with the modified black level behaviour.
 
     Parameters
@@ -1072,7 +1072,7 @@ def ootf_BT2100_HLG_1(
 ) -> NDArrayFloat:
     """
     Define *Recommendation ITU-R BT.2100* *Reference HLG* opto-optical
-    transfer function (OOTF / OOCF) as given in *ITU-R BT.2100-1*.
+    transfer function (OOTF / OOCF) as specified in *ITU-R BT.2100-1*.
 
     The OOTF maps relative scene linear light to display linear light.
 
@@ -1132,7 +1132,7 @@ def ootf_BT2100_HLG_1(
         usage_warning(
             '"Recommendation ITU-R BT.2100" "Reference HLG OOTF" uses '
             "RGB Luminance in computations and expects a vector input, thus "
-            "the given input array will be stacked to compose a vector for "
+            "the specified input array will be stacked to compose a vector for "
             "internal computations but a single component will be output."
         )
         R_S = G_S = B_S = E
@@ -1165,7 +1165,7 @@ def ootf_BT2100_HLG_2(
 ) -> NDArrayFloat:
     """
     Define *Recommendation ITU-R BT.2100* *Reference HLG* opto-optical
-    transfer function (OOTF / OOCF) as given in *ITU-R BT.2100-2*.
+    transfer function (OOTF / OOCF) as specified in *ITU-R BT.2100-2*.
 
     The OOTF maps relative scene linear light to display linear light.
 
@@ -1220,7 +1220,7 @@ def ootf_BT2100_HLG_2(
         usage_warning(
             '"Recommendation ITU-R BT.2100" "Reference HLG OOTF" uses '
             "RGB Luminance in computations and expects a vector input, thus "
-            "the given input array will be stacked to compose a vector for "
+            "the specified input array will be stacked to compose a vector for "
             "internal computations but a single component will be output."
         )
         R_S = G_S = B_S = E
@@ -1343,7 +1343,7 @@ def ootf_inverse_BT2100_HLG_1(
 ) -> NDArrayFloat:
     """
     Define *Recommendation ITU-R BT.2100* *Reference HLG* inverse opto-optical
-    transfer function (OOTF / OOCF) as given in *ITU-R BT.2100-1*.
+    transfer function (OOTF / OOCF) as specified in *ITU-R BT.2100-1*.
 
     Parameters
     ----------
@@ -1401,7 +1401,7 @@ def ootf_inverse_BT2100_HLG_1(
         usage_warning(
             '"Recommendation ITU-R BT.2100" "Reference HLG OOTF" uses '
             "RGB Luminance in computations and expects a vector input, thus "
-            "the given input array will be stacked to compose a vector for "
+            "the specified input array will be stacked to compose a vector for "
             "internal computations but a single component will be output."
         )
         R_D = G_D = B_D = F_D
@@ -1448,7 +1448,7 @@ def ootf_inverse_BT2100_HLG_2(
 ) -> NDArrayFloat:
     """
     Define *Recommendation ITU-R BT.2100* *Reference HLG* inverse opto-optical
-    transfer function (OOTF / OOCF) as given in *ITU-R BT.2100-2*.
+    transfer function (OOTF / OOCF) as specified in *ITU-R BT.2100-2*.
 
     Parameters
     ----------
@@ -1501,7 +1501,7 @@ def ootf_inverse_BT2100_HLG_2(
         usage_warning(
             '"Recommendation ITU-R BT.2100" "Reference HLG OOTF" uses '
             "RGB Luminance in computations and expects a vector input, thus "
-            "the given input array will be stacked to compose a vector for "
+            "the specified input array will be stacked to compose a vector for "
             "internal computations but a single component will be output."
         )
         R_D = G_D = B_D = F_D

--- a/colour/models/rgb/transfer_functions/itut_h_273.py
+++ b/colour/models/rgb/transfer_functions/itut_h_273.py
@@ -448,8 +448,8 @@ def eotf_inverse_H273_ST428_1(L_o: ArrayLike) -> NDArrayFloat:
 
     Notes
     -----
-    -   The function given in :cite:`InternationalTelecommunicationUnion2021`
-        multiplies :math:`L_o` by 48 contrary to what is given in
+    -   The function specified in :cite:`InternationalTelecommunicationUnion2021`
+        multiplies :math:`L_o` by 48 contrary to what is specified in
         :cite:`SocietyofMotionPictureandTelevisionEngineers2019` and
         :func:`colour.models.eotf_inverse_DCDM`.
 
@@ -497,8 +497,8 @@ def eotf_H273_ST428_1(V: ArrayLike) -> NDArrayFloat:
 
     Notes
     -----
-    -   The function given in :cite:`InternationalTelecommunicationUnion2021`
-        divides :math:`L_o` by 48 contrary to what is given in
+    -   The function specified in :cite:`InternationalTelecommunicationUnion2021`
+        divides :math:`L_o` by 48 contrary to what is specified in
         :cite:`SocietyofMotionPictureandTelevisionEngineers2019` and
         :func:`colour.models.eotf_DCDM`.
 

--- a/colour/models/rgb/transfer_functions/rimm_romm_rgb.py
+++ b/colour/models/rgb/transfer_functions/rimm_romm_rgb.py
@@ -78,7 +78,7 @@ def cctf_encoding_ROMMRGB(
         Bit-depth used for conversion.
     out_int
         Whether to return value as int code value or float equivalent of a
-        code value at a given bit-depth.
+        code value at a specified bit-depth.
 
     Returns
     -------
@@ -100,7 +100,7 @@ def cctf_encoding_ROMMRGB(
     +----------------+-----------------------+---------------+
 
     \\* This definition has an output int switch, thus the domain-range
-    scale information is only given for the floating point mode.
+    scale information is only specified for the floating point mode.
 
     References
     ----------
@@ -145,7 +145,7 @@ def cctf_decoding_ROMMRGB(
         Bit-depth used for conversion.
     in_int
         Whether to treat the input value as int code value or float
-        equivalent of a code value at a given bit-depth.
+        equivalent of a code value at a specified bit-depth.
 
     Returns
     -------
@@ -167,7 +167,7 @@ def cctf_decoding_ROMMRGB(
     +----------------+-----------------------+---------------+
 
     \\* This definition has an input int switch, thus the domain-range
-    scale information is only given for the floating point mode.
+    scale information is only specified for the floating point mode.
 
     References
     ----------
@@ -238,7 +238,7 @@ def cctf_encoding_RIMMRGB(
         Bit-depth used for conversion.
     out_int
         Whether to return value as int code value or float equivalent of a
-        code value at a given bit-depth.
+        code value at a specified bit-depth.
     E_clip
         Maximum exposure level.
 
@@ -262,7 +262,7 @@ def cctf_encoding_RIMMRGB(
     +----------------+-----------------------+---------------+
 
     \\* This definition has an output int switch, thus the domain-range
-    scale information is only given for the floating point mode.
+    scale information is only specified for the floating point mode.
 
     References
     ----------
@@ -312,7 +312,7 @@ def cctf_decoding_RIMMRGB(
         Bit-depth used for conversion.
     in_int
         Whether to treat the input value as int code value or float
-        equivalent of a code value at a given bit-depth.
+        equivalent of a code value at a specified bit-depth.
     E_clip
         Maximum exposure level.
 
@@ -336,7 +336,7 @@ def cctf_decoding_RIMMRGB(
     +----------------+-----------------------+---------------+
 
     \\* This definition has an input int switch, thus the domain-range
-    scale information is only given for the floating point mode.
+    scale information is only specified for the floating point mode.
 
     References
     ----------
@@ -390,7 +390,7 @@ def log_encoding_ERIMMRGB(
         Bit-depth used for conversion.
     out_int
         Whether to return value as int code value or float equivalent of a
-        code value at a given bit-depth.
+        code value at a specified bit-depth.
     E_min
         Minimum exposure limit.
     E_clip
@@ -416,7 +416,7 @@ def log_encoding_ERIMMRGB(
     +----------------+-----------------------+---------------+
 
     \\* This definition has an output int switch, thus the domain-range
-    scale information is only given for the floating point mode.
+    scale information is only specified for the floating point mode.
 
     References
     ----------
@@ -479,7 +479,7 @@ def log_decoding_ERIMMRGB(
         Bit-depth used for conversion.
     in_int
         Whether to treat the input value as int code value or float
-        equivalent of a code value at a given bit-depth.
+        equivalent of a code value at a specified bit-depth.
     E_min
         Minimum exposure limit.
     E_clip
@@ -505,7 +505,7 @@ def log_decoding_ERIMMRGB(
     +----------------+-----------------------+---------------+
 
     \\* This definition has an input int switch, thus the domain-range
-    scale information is only given for the floating point mode.
+    scale information is only specified for the floating point mode.
 
     References
     ----------

--- a/colour/models/rgb/ycbcr.py
+++ b/colour/models/rgb/ycbcr.py
@@ -119,7 +119,7 @@ References
 
 def round_BT2100(a: ArrayLike) -> NDArrayFloat:
     """
-    Round given array :math:`a` to the nearest int using the method define
+    Round specified array :math:`a` to the nearest int using the method define
     as `Round` in *RecommendationITU-R BT.2100*.
 
     Parameters
@@ -147,7 +147,7 @@ def round_BT2100(a: ArrayLike) -> NDArrayFloat:
 
 def ranges_YCbCr(bits: int, is_legal: bool, is_int: bool) -> NDArrayFloat:
     """
-    Return the *Y'CbCr* colour encoding ranges array for given bit-depth,
+    Return the *Y'CbCr* colour encoding ranges array for specified bit-depth,
     range legality and representation.
 
     Parameters
@@ -206,7 +206,7 @@ def matrix_YCbCr(
     is_int: bool = False,
 ) -> NDArrayFloat:
     """
-    Compute the *Y'CbCr* to *R'G'B'* matrix for given weights, bit-depth,
+    Compute the *Y'CbCr* to *R'G'B'* matrix for specified weights, bit-depth,
     range legality and representation.
 
     The related offset for the *R'G'B'* to *Y'CbCr* matrix can be computed with
@@ -290,7 +290,7 @@ def offset_YCbCr(
     bits: int = 8, is_legal: bool = False, is_int: bool = False
 ) -> NDArrayFloat:
     """
-    Compute the *R'G'B'* to *Y'CbCr* offsets for given bit-depth, range
+    Compute the *R'G'B'* to *Y'CbCr* offsets for specified bit-depth, range
     legality and representation.
 
     The related *R'G'B'* to *Y'CbCr* matrix can be computed with the
@@ -414,7 +414,7 @@ def RGB_to_YCbCr(
     +----------------+-----------------------+---------------+
 
     \\* This definition has input and output int switches, thus the
-    domain-range scale information is only given for the floating point mode.
+    domain-range scale information is only specified for the floating point mode.
 
     -   The default arguments, ``**{'in_bits': 10, 'in_legal': False,
         'in_int': False, 'out_bits': 8, 'out_legal': True, 'out_int': False}``
@@ -605,7 +605,7 @@ def YCbCr_to_RGB(
     +----------------+-----------------------+---------------+
 
     \\* This definition has input and output int switches, thus the
-    domain-range scale information is only given for the floating point mode.
+    domain-range scale information is only specified for the floating point mode.
 
     Warnings
     --------
@@ -718,7 +718,7 @@ def RGB_to_YcCbcCrc(
     +----------------+-----------------------+---------------+
 
     \\* This definition has input and output int switches, thus the
-    domain-range scale information is only given for the floating point mode.
+    domain-range scale information is only specified for the floating point mode.
 
     Warnings
     --------
@@ -830,7 +830,7 @@ def YcCbcCrc_to_RGB(
     +----------------+-----------------------+---------------+
 
     \\* This definition has input and output int switches, thus the
-    domain-range scale information is only given for the floating point mode.
+    domain-range scale information is only specified for the floating point mode.
 
     Warnings
     --------

--- a/colour/notation/css_color_3.py
+++ b/colour/notation/css_color_3.py
@@ -36,7 +36,7 @@ __all__ = [
 
 def keyword_to_RGB_CSSColor3(keyword: str) -> NDArrayFloat:
     """
-    Convert given colour keyword to *RGB* colourspace according to
+    Convert specified colour keyword to *RGB* colourspace according to
     *CSS Color Module Level 3* *W3C Recommendation*.
 
     Parameters

--- a/colour/notation/datasets/css_color_3.py
+++ b/colour/notation/datasets/css_color_3.py
@@ -2,7 +2,7 @@
 CSS Color Module Level 3 - Web Colours
 ======================================
 
-Define the lists of colour keywords as given by *CSS Color Module Level 3*
+Define the lists of colour keywords as specified by *CSS Color Module Level 3*
 *W3C Recommendation*.
 
 -   :attr:`colour.notation.CSS_COLOR_3_BASIC`
@@ -225,7 +225,7 @@ References
 
 CSS_COLOR_3: CanonicalMapping = CanonicalMapping(CSS_COLOR_3_BASIC)
 CSS_COLOR_3.__doc__ = """
-List of colour keywords as given by as given by *CSS Color Module Level 3*
+List of colour keywords as specified by *CSS Color Module Level 3*
 *W3C Recommendation*.
 
 References

--- a/colour/notation/datasets/munsell/all.py
+++ b/colour/notation/datasets/munsell/all.py
@@ -12,9 +12,9 @@ Notes
     values that are scaled by a :math:`1 / 0.975 \\simeq 1.02568` factor. If
     you are performing conversions using *Munsell* *Colorlab* specification,
     e.g., *2.5R 9/2*, according to *ASTM D1535-08e1* method, you should not
-    scale the output :math:`Y` Luminance. However, if you use directly the
+    scale the output :math:`Y` luminance. However, if you use directly the
     *CIE xyY* colourspace values from the Munsell Renotation data, you should
-    scale the :math:`Y` Luminance before conversions by a :math:`0.975` factor.
+    scale the :math:`Y` luminance before conversions by a :math:`0.975` factor.
 
     *ASTM D1535-08e1* states that::
 

--- a/colour/notation/datasets/munsell/experimental.py
+++ b/colour/notation/datasets/munsell/experimental.py
@@ -13,9 +13,9 @@ Notes
     values that are scaled by a :math:`1 / 0.975 \\simeq 1.02568` factor. If
     you are performing conversions using *Munsell* *Colorlab* specification,
     e.g., *2.5R 9/2*, according to *ASTM D1535-08e1* method, you should not
-    scale the output :math:`Y` Luminance. However, if you use directly the
+    scale the output :math:`Y` luminance. However, if you use directly the
     *CIE xyY* colourspace values from the Munsell Renotation data, you should
-    scale the :math:`Y` Luminance before conversions by a :math:`0.975` factor.
+    scale the :math:`Y` luminance before conversions by a :math:`0.975` factor.
 
     *ASTM D1535-08e1* states that::
 

--- a/colour/notation/datasets/munsell/real.py
+++ b/colour/notation/datasets/munsell/real.py
@@ -13,9 +13,9 @@ Notes
     values that are scaled by a :math:`1 / 0.975 \\simeq 1.02568` factor. If
     you are performing conversions using *Munsell* *Colorlab* specification,
     e.g., *2.5R 9/2*, according to *ASTM D1535-08e1* method, you should not
-    scale the output :math:`Y` Luminance. However, if you use directly the
+    scale the output :math:`Y` luminance. However, if you use directly the
     *CIE xyY* colourspace values from the Munsell Renotation data, you should
-    scale the :math:`Y` Luminance before conversions by a :math:`0.975` factor.
+    scale the :math:`Y` luminance before conversions by a :math:`0.975` factor.
 
     *ASTM D1535-08e1* states that::
 

--- a/colour/notation/hexadecimal.py
+++ b/colour/notation/hexadecimal.py
@@ -127,7 +127,7 @@ def HEX_to_RGB(HEX: ArrayLike) -> NDArrayFloat:
     HEX = np.char.lstrip(HEX, "#")  # pyright: ignore
 
     def to_RGB(x: list) -> list:
-        """Convert given hexadecimal representation to *RGB*."""
+        """Convert specified hexadecimal representation to *RGB*."""
 
         l_x = len(x)
 

--- a/colour/notation/munsell.py
+++ b/colour/notation/munsell.py
@@ -5,29 +5,29 @@ Munsell Renotation System
 Define various objects for *Munsell Renotation System* computations:
 
 -   :func:`colour.notation.munsell_value_Priest1920`: *Munsell* value :math:`V`
-    computation of given *luminance* :math:`Y` using
+    computation of specified *luminance* :math:`Y` using
     *Priest, Gibson and MacNicholas (1920)* method.
 -   :func:`colour.notation.munsell_value_Munsell1933`: *Munsell* value
-    :math:`V` computation of given *luminance* :math:`Y` using
+    :math:`V` computation of specified *luminance* :math:`Y` using
     *Munsell, Sloan and Godlove (1933)* method.
 -   :func:`colour.notation.munsell_value_Moon1943`: *Munsell* value :math:`V`
-    computation of given *luminance* :math:`Y` using
+    computation of specified *luminance* :math:`Y` using
     *Moon and Spencer (1943)* method.
 -   :func:`colour.notation.munsell_value_Saunderson1944`: *Munsell* value
-    :math:`V` computation of given *luminance* :math:`Y` using
+    :math:`V` computation of specified *luminance* :math:`Y` using
     *Saunderson and Milner (1944)* method.
 -   :func:`colour.notation.munsell_value_Ladd1955`: *Munsell* value :math:`V`
-    computation of given *luminance* :math:`Y` using *Ladd and Pinney (1955)*
+    computation of specified *luminance* :math:`Y` using *Ladd and Pinney (1955)*
     method.
 -   :func:`colour.notation.munsell_value_McCamy1987`: *Munsell* value :math:`V`
-    computation of given *luminance* :math:`Y` using *McCamy (1987)* method.
+    computation of specified *luminance* :math:`Y` using *McCamy (1987)* method.
 -   :func:`colour.notation.munsell_value_ASTMD1535`: *Munsell* value
-    :math:`V` computation of given *luminance* :math:`Y` using
+    :math:`V` computation of specified *luminance* :math:`Y` using
     *ASTM D1535-08e1* method.
 -   :attr:`colour.MUNSELL_VALUE_METHODS`: Supported *Munsell* value
     computation methods.
 -   :func:`colour.munsell_value`: *Munsell* value :math:`V` computation of
-    given *luminance* :math:`Y` using given method.
+    specified *luminance* :math:`Y` using specified method.
 -   :func:`colour.munsell_colour_to_xyY`
 -   :func:`colour.xyY_to_munsell_colour`
 
@@ -398,13 +398,13 @@ def _munsell_maximum_chromas_from_renotation() -> (
 
 def munsell_value_Priest1920(Y: ArrayLike) -> NDArrayFloat:
     """
-    Return the *Munsell* value :math:`V` of given *luminance* :math:`Y` using
+    Compute the *Munsell* value :math:`V` of specified *luminance* :math:`Y` using
     *Priest et al. (1920)* method.
 
     Parameters
     ----------
     Y
-        *luminance* :math:`Y`.
+        *Luminance* :math:`Y`.
 
     Returns
     -------
@@ -444,13 +444,13 @@ def munsell_value_Priest1920(Y: ArrayLike) -> NDArrayFloat:
 
 def munsell_value_Munsell1933(Y: ArrayLike) -> NDArrayFloat:
     """
-    Return the *Munsell* value :math:`V` of given *luminance* :math:`Y` using
+    Compute the *Munsell* value :math:`V` of specified *luminance* :math:`Y` using
     *Munsell et al. (1933)* method.
 
     Parameters
     ----------
     Y
-        *luminance* :math:`Y`.
+        *Luminance* :math:`Y`.
 
     Returns
     -------
@@ -490,14 +490,14 @@ def munsell_value_Munsell1933(Y: ArrayLike) -> NDArrayFloat:
 
 def munsell_value_Moon1943(Y: ArrayLike) -> NDArrayFloat:
     """
-    Return the *Munsell* value :math:`V` of given *luminance* :math:`Y` using
+    Compute the *Munsell* value :math:`V` of specified *luminance* :math:`Y` using
     *Moon and Spencer (1943)* method.
 
 
     Parameters
     ----------
     Y
-        *luminance* :math:`Y`.
+        *Luminance* :math:`Y`.
 
     Returns
     -------
@@ -537,13 +537,13 @@ def munsell_value_Moon1943(Y: ArrayLike) -> NDArrayFloat:
 
 def munsell_value_Saunderson1944(Y: ArrayLike) -> NDArrayFloat:
     """
-    Return the *Munsell* value :math:`V` of given *luminance* :math:`Y` using
+    Compute the *Munsell* value :math:`V` of specified *luminance* :math:`Y` using
     *Saunderson and Milner (1944)* method.
 
     Parameters
     ----------
     Y
-        *luminance* :math:`Y`.
+        *Luminance* :math:`Y`.
 
     Returns
     -------
@@ -583,13 +583,13 @@ def munsell_value_Saunderson1944(Y: ArrayLike) -> NDArrayFloat:
 
 def munsell_value_Ladd1955(Y: ArrayLike) -> NDArrayFloat:
     """
-    Return the *Munsell* value :math:`V` of given *luminance* :math:`Y` using
+    Compute the *Munsell* value :math:`V` of specified *luminance* :math:`Y` using
     *Ladd and Pinney (1955)* method.
 
     Parameters
     ----------
     Y
-        *luminance* :math:`Y`.
+        *Luminance* :math:`Y`.
 
     Returns
     -------
@@ -629,13 +629,13 @@ def munsell_value_Ladd1955(Y: ArrayLike) -> NDArrayFloat:
 
 def munsell_value_McCamy1987(Y: ArrayLike) -> NDArrayFloat:
     """
-    Return the *Munsell* value :math:`V` of given *luminance* :math:`Y` using
+    Compute the *Munsell* value :math:`V` of specified *luminance* :math:`Y` using
     *McCamy (1987)* method.
 
     Parameters
     ----------
     Y
-        *luminance* :math:`Y`.
+        *Luminance* :math:`Y`.
 
     Returns
     -------
@@ -686,13 +686,13 @@ def munsell_value_McCamy1987(Y: ArrayLike) -> NDArrayFloat:
 
 def munsell_value_ASTMD1535(Y: ArrayLike) -> NDArrayFloat:
     """
-    Return the *Munsell* value :math:`V` of given *luminance* :math:`Y` using
+    Compute the *Munsell* value :math:`V` of specified *luminance* :math:`Y` using
     an inverse lookup table from *ASTM D1535-08e1* method.
 
     Parameters
     ----------
     Y
-        *luminance* :math:`Y`
+        *Luminance* :math:`Y`
 
     Returns
     -------
@@ -774,13 +774,13 @@ def munsell_value(
     ) = "ASTM D1535",
 ) -> NDArrayFloat:
     """
-    Return the *Munsell* value :math:`V` of given *luminance* :math:`Y` using
-    given method.
+    Compute the *Munsell* value :math:`V` of specified *luminance* :math:`Y` using
+    specified method.
 
     Parameters
     ----------
     Y
-        *luminance* :math:`Y`.
+        *Luminance* :math:`Y`.
     method
         Computation method.
 
@@ -846,7 +846,7 @@ def _munsell_scale_factor() -> NDArrayFloat:
 
 def _munsell_specification_to_xyY(specification: ArrayLike) -> NDArrayFloat:
     """
-    Convert given *Munsell* *Colorlab* specification to *CIE xyY* colourspace.
+    Convert specified *Munsell* *Colorlab* specification to *CIE xyY* colourspace.
 
     Parameters
     ----------
@@ -926,7 +926,7 @@ def _munsell_specification_to_xyY(specification: ArrayLike) -> NDArrayFloat:
 
 def munsell_specification_to_xyY(specification: ArrayLike) -> NDArrayFloat:
     """
-    Convert given *Munsell* *Colorlab* specification to *CIE xyY* colourspace.
+    Convert specified *Munsell* *Colorlab* specification to *CIE xyY* colourspace.
 
     Parameters
     ----------
@@ -984,7 +984,7 @@ def munsell_specification_to_xyY(specification: ArrayLike) -> NDArrayFloat:
 
 def munsell_colour_to_xyY(munsell_colour: ArrayLike) -> NDArrayFloat:
     """
-    Convert given *Munsell* colour to *CIE xyY* colourspace.
+    Convert specified *Munsell* colour to *CIE xyY* colourspace.
 
     Parameters
     ----------
@@ -1045,7 +1045,7 @@ def _xyY_to_munsell_specification(xyY: ArrayLike) -> NDArrayFloat:
     Raises
     ------
     ValueError
-        If the given *CIE xyY* colourspace array is not within MacAdam
+        If the specified *CIE xyY* colourspace array is not within MacAdam
         limits.
     RuntimeError
         If the maximum iterations count has been reached without converging to
@@ -1352,7 +1352,7 @@ def xyY_to_munsell_specification(xyY: ArrayLike) -> NDArrayFloat:
     Raises
     ------
     ValueError
-        If the given *CIE xyY* colourspace array is not within MacAdam
+        If the specified *CIE xyY* colourspace array is not within MacAdam
         limits.
     RuntimeError
         If the maximum iterations count has been reached without converging to
@@ -1464,7 +1464,7 @@ def xyY_to_munsell_colour(
 
 def parse_munsell_colour(munsell_colour: str) -> NDArrayFloat:
     """
-    Parse given *Munsell* colour and returns an intermediate *Munsell*
+    Parse specified *Munsell* colour and return an intermediate *Munsell*
     *Colorlab* specification.
 
     Parameters
@@ -1480,7 +1480,7 @@ def parse_munsell_colour(munsell_colour: str) -> NDArrayFloat:
     Raises
     ------
     ValueError
-        If the given specification is not a valid *Munsell Renotation System*
+        If the specified specification is not a valid *Munsell Renotation System*
         colour specification.
 
     Examples
@@ -1523,7 +1523,7 @@ def parse_munsell_colour(munsell_colour: str) -> NDArrayFloat:
 
 def is_grey_munsell_colour(specification: ArrayLike) -> bool:
     """
-    Return if given *Munsell* *Colorlab* specification is a grey colour.
+    Return whether specified *Munsell* *Colorlab* specification is a grey colour.
 
     Parameters
     ----------
@@ -1552,7 +1552,7 @@ def is_grey_munsell_colour(specification: ArrayLike) -> bool:
 
 def normalise_munsell_specification(specification: ArrayLike) -> NDArrayFloat:
     """
-    Normalise given *Munsell* *Colorlab* specification.
+    Normalise specified *Munsell* *Colorlab* specification.
 
     Parameters
     ----------
@@ -1593,7 +1593,7 @@ def munsell_colour_to_munsell_specification(
     munsell_colour: str,
 ) -> NDArrayFloat:
     """
-    Retrieve a normalised *Munsell* *Colorlab* specification from given
+    Retrieve a normalised *Munsell* *Colorlab* specification from specified
     *Munsell* colour.
 
     Parameters
@@ -1624,7 +1624,7 @@ def munsell_specification_to_munsell_colour(
     chroma_decimals: int = 1,
 ) -> str:
     """
-    Convert from *Munsell* *Colorlab* specification to given *Munsell* colour.
+    Convert from *Munsell* *Colorlab* specification to specified *Munsell* colour.
 
     Parameters
     ----------
@@ -1705,7 +1705,7 @@ def xyY_from_renotation(
     relative_tolerance: float = TOLERANCE_RELATIVE_DEFAULT,
 ) -> NDArrayFloat:
     """
-    Return given existing *Munsell* *Colorlab* specification *CIE xyY*
+    Return specified existing *Munsell* *Colorlab* specification *CIE xyY*
     colourspace vector from *Munsell Renotation System* data.
 
     Parameters
@@ -1727,7 +1727,7 @@ def xyY_from_renotation(
     Raises
     ------
     ValueError
-        If the given specification doesn't exist in *Munsell Renotation System*
+        If the specified specification doesn't exist in *Munsell Renotation System*
         data.
 
     Examples
@@ -1764,7 +1764,7 @@ def xyY_from_renotation(
 
 def is_specification_in_renotation(specification: ArrayLike) -> bool:
     """
-    Return whether given *Munsell* *Colorlab* specification is in
+    Return whether specified *Munsell* *Colorlab* specification is in
     *Munsell Renotation System* data.
 
     Parameters
@@ -1795,7 +1795,7 @@ def is_specification_in_renotation(specification: ArrayLike) -> bool:
 
 def bounding_hues_from_renotation(hue_and_code: ArrayLike) -> NDArrayFloat:
     """
-    Return for a given *Munsell* *Colorlab* specification hue and *Munsell*
+    Return for a specified *Munsell* *Colorlab* specification hue and *Munsell*
     *Colorlab* specification code the two bounding hues from
     *Munsell Renotation System* data.
 
@@ -1997,7 +1997,7 @@ def interpolation_method_from_renotation_ovoid(
 ) -> Literal["Linear", "Radial"] | None:
     """
     Return whether to use linear or radial interpolation when drawing ovoids
-    through data points in the *Munsell Renotation System* data from given
+    through data points in the *Munsell Renotation System* data from specified
     specification.
 
     Parameters
@@ -2273,7 +2273,7 @@ def interpolation_method_from_renotation_ovoid(
 
 def xy_from_renotation_ovoid(specification: ArrayLike) -> NDArrayFloat:
     """
-    Convert given *Munsell* *Colorlab* specification to *CIE xy* chromaticity
+    Convert specified *Munsell* *Colorlab* specification to *CIE xy* chromaticity
     coordinates on *Munsell Renotation System* ovoid.
     The *CIE xy* point will be on the ovoid about the achromatic point,
     corresponding to the *Munsell* *Colorlab* specification
@@ -2343,7 +2343,7 @@ def xy_from_renotation_ovoid(specification: ArrayLike) -> NDArrayFloat:
     chroma = 2 * round(chroma / 2)
 
     # Checking if renotation data is available without interpolation using
-    # given threshold.
+    # specified threshold.
     if (
         abs(hue) < THRESHOLD_INTEGER
         or abs(hue - 2.5) < THRESHOLD_INTEGER
@@ -2490,7 +2490,7 @@ def LCHab_to_munsell_specification(LCHab: ArrayLike) -> NDArrayFloat:
 def maximum_chroma_from_renotation(hue_and_value_and_code: ArrayLike) -> float:
     """
     Return the maximum *Munsell* chroma from *Munsell Renotation System* data
-    using given *Munsell* *Colorlab* specification hue, *Munsell* *Colorlab*
+    using specified *Munsell* *Colorlab* specification hue, *Munsell* *Colorlab*
     specification value and *Munsell* *Colorlab* specification code.
 
     Parameters
@@ -2579,7 +2579,7 @@ def maximum_chroma_from_renotation(hue_and_value_and_code: ArrayLike) -> float:
 
 def munsell_specification_to_xy(specification: ArrayLike) -> NDArrayFloat:
     """
-    Convert given *Munsell* *Colorlab* specification to *CIE xy* chromaticity
+    Convert specified *Munsell* *Colorlab* specification to *CIE xy* chromaticity
     coordinates by interpolating over *Munsell Renotation System* data.
 
     Parameters

--- a/colour/phenomena/rayleigh.py
+++ b/colour/phenomena/rayleigh.py
@@ -89,7 +89,7 @@ def air_refraction_index_Penndorf1957(
     wavelength: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Return the air refraction index :math:`n_s` from given wavelength
+    Compute the air refraction index :math:`n_s` from specified wavelength
     :math:`\\lambda` in  micrometers (:math:`\\mu m`) using *Penndorf (1957)*
     method.
 
@@ -122,7 +122,7 @@ def air_refraction_index_Edlen1966(
     wavelength: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Return the air refraction index :math:`n_s` from given wavelength
+    Compute the air refraction index :math:`n_s` from specified wavelength
     :math:`\\lambda` in micrometers (:math:`\\mu m`) using *Edlen (1966)*
     method.
 
@@ -155,7 +155,7 @@ def air_refraction_index_Peck1972(
     wavelength: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Return the air refraction index :math:`n_s` from given wavelength
+    Compute the air refraction index :math:`n_s` from specified wavelength
     :math:`\\lambda` in micrometers (:math:`\\mu m`) using
     *Peck and Reeder (1972)* method.
 
@@ -189,7 +189,7 @@ def air_refraction_index_Bodhaine1999(
     CO2_concentration: ArrayLike = CONSTANT_STANDARD_CO2_CONCENTRATION,
 ) -> NDArrayFloat:
     """
-    Return the air refraction index :math:`n_s` from given wavelength
+    Compute the air refraction index :math:`n_s` from specified wavelength
     :math:`\\lambda` in micrometers (:math:`\\mu m`) using
     *Bodhaine, Wood, Dutton and Slusser (1999)* method.
 
@@ -224,7 +224,7 @@ def air_refraction_index_Bodhaine1999(
 
 def N2_depolarisation(wavelength: ArrayLike) -> NDArrayFloat:
     """
-    Return the depolarisation of nitrogen :math:`N_2` as function of
+    Compute the depolarisation of nitrogen :math:`N_2` as function of
     wavelength :math:`\\lambda` in micrometers (:math:`\\mu m`).
 
     Parameters
@@ -250,7 +250,7 @@ def N2_depolarisation(wavelength: ArrayLike) -> NDArrayFloat:
 
 def O2_depolarisation(wavelength: ArrayLike) -> NDArrayFloat:
     """
-    Return the depolarisation of oxygen :math:`O_2` as function of
+    Compute the depolarisation of oxygen :math:`O_2` as function of
     wavelength :math:`\\lambda` in micrometers (:math:`\\mu m`).
 
     Parameters
@@ -276,7 +276,7 @@ def O2_depolarisation(wavelength: ArrayLike) -> NDArrayFloat:
 
 def F_air_Penndorf1957(wavelength: ArrayLike) -> NDArrayFloat:
     """
-    Return :math:`(6+3_p)/(6-7_p)`, the depolarisation term :math:`F(air)` or
+    Compute :math:`(6+3_p)/(6-7_p)`, the depolarisation term :math:`F(air)` or
     *King Factor* using *Penndorf (1957)* method.
 
     Parameters
@@ -308,7 +308,7 @@ def F_air_Penndorf1957(wavelength: ArrayLike) -> NDArrayFloat:
 
 def F_air_Young1981(wavelength: ArrayLike) -> NDArrayFloat:
     """
-    Return :math:`(6+3_p)/(6-7_p)`, the depolarisation term :math:`F(air)` or
+    Compute :math:`(6+3_p)/(6-7_p)`, the depolarisation term :math:`F(air)` or
     *King Factor* using *Young (1981)* method.
 
     Parameters
@@ -340,7 +340,7 @@ def F_air_Young1981(wavelength: ArrayLike) -> NDArrayFloat:
 
 def F_air_Bates1984(wavelength: ArrayLike) -> NDArrayFloat:
     """
-    Return :math:`(6+3_p)/(6-7_p)`, the depolarisation term :math:`F(air)` or
+    Compute :math:`(6+3_p)/(6-7_p)`, the depolarisation term :math:`F(air)` or
     *King Factor* as function of wavelength :math:`\\lambda` in micrometers
     (:math:`\\mu m`) using *Bates (1984)* method.
 
@@ -373,7 +373,7 @@ def F_air_Bodhaine1999(
     CO2_concentration: ArrayLike = CONSTANT_STANDARD_CO2_CONCENTRATION,
 ) -> NDArrayFloat:
     """
-    Return :math:`(6+3_p)/(6-7_p)`, the depolarisation term :math:`F(air)` or
+    Compute :math:`(6+3_p)/(6-7_p)`, the depolarisation term :math:`F(air)` or
     *King Factor* as function of wavelength :math:`\\lambda` in micrometers
     (:math:`\\mu m`) and :math:`CO_2` concentration in parts per million (ppm)
     using *Bodhaine, Wood, Dutton and Slusser (1999)* method.
@@ -413,7 +413,7 @@ def molecular_density(
     avogadro_constant: ArrayLike = CONSTANT_AVOGADRO,
 ) -> NDArrayFloat:
     """
-    Return the molecular density :math:`N_s` (molecules :math:`cm^{-3}`)
+    Compute the molecular density :math:`N_s` (molecules :math:`cm^{-3}`)
     as function of air temperature :math:`T[K]` in kelvin degrees.
 
     Parameters
@@ -454,7 +454,7 @@ def mean_molecular_weights(
     CO2_concentration: ArrayLike = CONSTANT_STANDARD_CO2_CONCENTRATION,
 ) -> NDArrayFloat:
     """
-    Return the mean molecular weights :math:`m_a` for dry air as function of
+    Compute the mean molecular weights :math:`m_a` for dry air as function of
     :math:`CO_2` concentration in parts per million (ppm).
 
     Parameters
@@ -485,9 +485,9 @@ def gravity_List1968(
     altitude: ArrayLike = CONSTANT_DEFAULT_ALTITUDE,
 ) -> NDArrayFloat:
     """
-    Return the gravity :math:`g` in :math:`cm/s_2` (gal) representative of the
-    mass-weighted column of air molecules above the site of given latitude and
-    altitude using *list (1968)* method.
+    Compute the gravity :math:`g` in :math:`cm/s_2` (gal) representative of the
+    mass-weighted column of air molecules above the site of specified latitude
+    and altitude using *list (1968)* method.
 
     Parameters
     ----------
@@ -539,10 +539,11 @@ def scattering_cross_section(
     F_air_function: Callable = F_air_Bodhaine1999,
 ) -> NDArrayFloat:
     """
-    Return the scattering cross-section per molecule :math:`\\sigma` of dry
+    Compute the scattering cross-section per molecule :math:`\\sigma` of dry
     air as function of wavelength :math:`\\lambda` in centimeters (cm) using
-    given :math:`CO_2` concentration in parts per million (ppm) and temperature
-    :math:`T[K]` in kelvin degrees following *Van de Hulst (1957)* method.
+    specified :math:`CO_2` concentration in parts per million (ppm) and
+    temperature :math:`T[K]` in kelvin degrees following *Van de Hulst (1957)*
+    method.
 
     Parameters
     ----------
@@ -615,7 +616,7 @@ def rayleigh_optical_depth(
     F_air_function: Callable = F_air_Bodhaine1999,
 ) -> NDArrayFloat:
     """
-    Return the *Rayleigh* optical depth :math:`T_r(\\lambda)` as function of
+    Compute the *Rayleigh* optical depth :math:`T_r(\\lambda)` as function of
     wavelength :math:`\\lambda` in centimeters (cm).
 
     Parameters
@@ -702,7 +703,7 @@ def sd_rayleigh_scattering(
     F_air_function: Callable = F_air_Bodhaine1999,
 ) -> SpectralDistribution:
     """
-    Return the *Rayleigh* spectral distribution for given spectral shape.
+    Compute the *Rayleigh* spectral distribution for specified spectral shape.
 
     Parameters
     ----------

--- a/colour/plotting/blindness.py
+++ b/colour/plotting/blindness.py
@@ -53,7 +53,7 @@ def plot_cvd_simulation_Machado2009(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Perform colour vision deficiency simulation on given *RGB* colourspace
+    Perform colour vision deficiency simulation on specified *RGB* colourspace
     array using *Machado et al. (2009)* model.
 
     Parameters

--- a/colour/plotting/characterisation.py
+++ b/colour/plotting/characterisation.py
@@ -62,7 +62,7 @@ def plot_single_colour_checker(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot given colour checker.
+    Plot specified colour checker.
 
     Parameters
     ----------
@@ -111,7 +111,7 @@ def plot_multi_colour_checkers(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot and compares given colour checkers.
+    Plot and compares specified colour checkers.
 
     Parameters
     ----------

--- a/colour/plotting/colorimetry.py
+++ b/colour/plotting/colorimetry.py
@@ -125,7 +125,7 @@ def plot_single_sd(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot given spectral distribution.
+    Plot specified spectral distribution.
 
     Parameters
     ----------
@@ -279,7 +279,7 @@ def plot_multi_sds(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot given spectral distributions.
+    Plot specified spectral distributions.
 
     Parameters
     ----------
@@ -443,7 +443,7 @@ def plot_single_cmfs(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot given colour matching functions.
+    Plot specified colour matching functions.
 
     Parameters
     ----------
@@ -493,7 +493,7 @@ def plot_multi_cmfs(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot given colour matching functions.
+    Plot specified colour matching functions.
 
     Parameters
     ----------
@@ -590,7 +590,7 @@ def plot_single_illuminant_sd(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot given single illuminant spectral distribution.
+    Plot specified single illuminant spectral distribution.
 
     Parameters
     ----------
@@ -650,7 +650,7 @@ def plot_multi_illuminant_sds(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot given illuminants spectral distributions.
+    Plot specified illuminants spectral distributions.
 
     Parameters
     ----------
@@ -722,7 +722,7 @@ def plot_visible_spectrum(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot the visible colours spectrum using given standard observer *CIE XYZ*
+    Plot the visible colours spectrum using specified standard observer *CIE XYZ*
     colour matching functions.
 
     Parameters
@@ -797,7 +797,7 @@ def plot_single_lightness_function(
     function: Callable | str, **kwargs: Any
 ) -> Tuple[Figure, Axes]:
     """
-    Plot given *Lightness* function.
+    Plot specified *Lightness* function.
 
     Parameters
     ----------
@@ -840,7 +840,7 @@ def plot_multi_lightness_functions(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot given *Lightness* functions.
+    Plot specified *Lightness* functions.
 
     Parameters
     ----------
@@ -893,7 +893,7 @@ def plot_single_luminance_function(
     function: Callable | str, **kwargs: Any
 ) -> Tuple[Figure, Axes]:
     """
-    Plot given *Luminance* function.
+    Plot specified *Luminance* function.
 
     Parameters
     ----------
@@ -935,7 +935,7 @@ def plot_multi_luminance_functions(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot given *Luminance* functions.
+    Plot specified *Luminance* functions.
 
     Parameters
     ----------
@@ -993,7 +993,7 @@ def plot_blackbody_spectral_radiance(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot given blackbody spectral radiance.
+    Plot specified blackbody spectral radiance.
 
     Parameters
     ----------

--- a/colour/plotting/common.py
+++ b/colour/plotting/common.py
@@ -241,7 +241,7 @@ CONSTANTS_ARROW_STYLE: Structure = Structure(
 
 def colour_style(use_style: bool = True) -> dict:
     """
-    Return *Colour* plotting style.
+    Get *Colour* plotting style.
 
     Parameters
     ----------
@@ -347,11 +347,11 @@ def override_style(**kwargs: Any) -> Callable:
     keywords = dict(kwargs)
 
     def wrapper(function: Callable) -> Callable:
-        """Wrap given function wrapper."""
+        """Wrap specified function wrapper."""
 
         @functools.wraps(function)
         def wrapped(*args: Any, **kwargs: Any) -> Any:
-            """Wrap given function."""
+            """Wrap specified function."""
 
             keywords.update(kwargs)
 
@@ -466,7 +466,7 @@ class ColourSwatch:
 
 def colour_cycle(**kwargs: Any) -> itertools.cycle:
     """
-    Return a colour cycle iterator using given colour map.
+    Create a colour cycle iterator using specified colour map.
 
     Other Parameters
     ----------------
@@ -515,7 +515,7 @@ class KwargsArtist(TypedDict):
 
 def artist(**kwargs: KwargsArtist | Any) -> Tuple[Figure, Axes]:
     """
-    Return the current figure and its axes or creates a new one.
+    Get the current figure and its axes or create a new one.
 
     Other Parameters
     ----------------
@@ -616,7 +616,7 @@ class KwargsRender(TypedDict):
     axes
         Axes to apply the render elements onto.
     filename
-        Figure will be saved using given ``filename`` argument.
+        Figure will be saved using specified ``filename`` argument.
     show
         Whether to show the figure and call :func:`matplotlib.pyplot.show`
         definition.
@@ -773,7 +773,7 @@ def label_rectangles(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Add labels above given rectangles.
+    Add labels above specified rectangles.
 
     Parameters
     ----------
@@ -838,7 +838,7 @@ def label_rectangles(
 
 def uniform_axes3d(**kwargs: Any) -> Tuple[Figure, Axes3D]:
     """
-    Set equal aspect ratio to given 3d axes.
+    Set equal aspect ratio to specified 3d axes.
 
     Other Parameters
     ----------------
@@ -878,7 +878,7 @@ def filter_passthrough(
     allow_non_siblings: bool = True,
 ) -> dict:
     """
-    Return mapping objects matching given filterers while passing through
+    Filter mapping objects matching specified filterers while passing through
     class instances whose type is one of the mapping element types.
 
     This definition allows passing custom but compatible objects to the various
@@ -1001,7 +1001,7 @@ def filter_RGB_colourspaces(
     allow_non_siblings: bool = True,
 ) -> Dict[str, RGB_Colourspace]:
     """
-    Return the *RGB* colourspaces matching given filterers.
+    Filter the *RGB* colourspaces matching specified filterers.
 
     Parameters
     ----------
@@ -1030,7 +1030,7 @@ def filter_cmfs(
     allow_non_siblings: bool = True,
 ) -> Dict[str, MultiSpectralDistributions]:
     """
-    Return the colour matching functions matching given filterers.
+    Filter the colour matching functions matching specified filterers.
 
     Parameters
     ----------
@@ -1059,7 +1059,7 @@ def filter_illuminants(
     allow_non_siblings: bool = True,
 ) -> Dict[str, SpectralDistribution]:
     """
-    Return the illuminants matching given filterers.
+    Filter the illuminants matching specified filterers.
 
     Parameters
     ----------
@@ -1096,7 +1096,7 @@ def filter_colour_checkers(
     allow_non_siblings: bool = True,
 ) -> Dict[str, ColourChecker]:
     """
-    Return the colour checkers matching given filterers.
+    Filter the colour checkers matching specified filterers.
 
     Parameters
     ----------
@@ -1124,8 +1124,8 @@ def update_settings_collection(
     expected_count: int,
 ) -> None:
     """
-    Update given settings collection, *in-place*, with given keyword arguments
-    and expected count of settings collection elements.
+    Update specified settings collection, *in-place*, with specified keyword
+    arguments and expected count of settings collection elements.
 
     Parameters
     ----------
@@ -1177,7 +1177,7 @@ def plot_single_colour_swatch(
     colour_swatch: ArrayLike | ColourSwatch, **kwargs: Any
 ) -> Tuple[Figure, Axes]:
     """
-    Plot given colour swatch.
+    Plot specified colour swatch.
 
     Parameters
     ----------
@@ -1234,7 +1234,7 @@ def plot_multi_colour_swatches(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot given colours swatches.
+    Plot specified colours swatches.
 
     Parameters
     ----------
@@ -1442,7 +1442,7 @@ def plot_single_function(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot given function.
+    Plot specified function.
 
     Parameters
     ----------
@@ -1511,7 +1511,7 @@ def plot_multi_functions(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot given functions.
+    Plot specified functions.
 
     Parameters
     ----------
@@ -1624,7 +1624,7 @@ def plot_image(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot given image.
+    Plot specified image.
 
     Parameters
     ----------

--- a/colour/plotting/corresponding.py
+++ b/colour/plotting/corresponding.py
@@ -62,7 +62,7 @@ def plot_corresponding_chromaticities_prediction(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot given chromatic adaptation model corresponding chromaticities
+    Plot specified chromatic adaptation model corresponding chromaticities
     prediction.
 
     Parameters

--- a/colour/plotting/diagrams.py
+++ b/colour/plotting/diagrams.py
@@ -229,7 +229,7 @@ def lines_spectral_locus(
 ) -> Tuple[NDArray, NDArray]:
     """
     Return the *Spectral Locus* line vertices, i.e., positions, normals and
-    colours, according to given method.
+    colours, according to specified method.
 
     Parameters
     ----------
@@ -380,7 +380,7 @@ def plot_spectral_locus(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot the *Spectral Locus* according to given method.
+    Plot the *Spectral Locus* according to specified method.
 
     Parameters
     ----------
@@ -512,7 +512,7 @@ def plot_chromaticity_diagram_colours(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot the *Chromaticity Diagram* colours according to given method.
+    Plot the *Chromaticity Diagram* colours according to specified method.
 
     Parameters
     ----------
@@ -632,7 +632,7 @@ def plot_chromaticity_diagram(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot the *Chromaticity Diagram* according to given method.
+    Plot the *Chromaticity Diagram* according to specified method.
 
     Parameters
     ----------
@@ -905,8 +905,8 @@ def plot_sds_in_chromaticity_diagram(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot given spectral distribution chromaticity coordinates into the
-    *Chromaticity Diagram* using given method.
+    Plot specified spectral distribution chromaticity coordinates into the
+    *Chromaticity Diagram* using specified method.
 
     Parameters
     ----------
@@ -1131,7 +1131,7 @@ def plot_sds_in_chromaticity_diagram_CIE1931(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot given spectral distribution chromaticity coordinates into the
+    Plot specified spectral distribution chromaticity coordinates into the
     *CIE 1931 Chromaticity Diagram*.
 
     Parameters
@@ -1243,7 +1243,7 @@ def plot_sds_in_chromaticity_diagram_CIE1960UCS(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot given spectral distribution chromaticity coordinates into the
+    Plot specified spectral distribution chromaticity coordinates into the
     *CIE 1960 UCS Chromaticity Diagram*.
 
     Parameters
@@ -1356,7 +1356,7 @@ def plot_sds_in_chromaticity_diagram_CIE1976UCS(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot given spectral distribution chromaticity coordinates into the
+    Plot specified spectral distribution chromaticity coordinates into the
     *CIE 1976 UCS Chromaticity Diagram*.
 
     Parameters

--- a/colour/plotting/models.py
+++ b/colour/plotting/models.py
@@ -211,7 +211,7 @@ def colourspace_model_axis_reorder(
     direction: Literal["Forward", "Inverse"] | str = "Forward",
 ) -> NDArrayFloat:
     """
-    Reorder the axes of given colourspace model :math:`a` array according to
+    Reorder the axes of specified colourspace model :math:`a` array according to
     the most common volume plotting axes order.
 
     Parameters
@@ -272,7 +272,7 @@ def lines_pointer_gamut(
 ) -> tuple[NDArray, NDArray]:
     """
     Return the *Pointer's Gamut* line vertices, i.e., positions, normals and
-    colours, according to given method.
+    colours, according to specified method.
 
     Parameters
     ----------
@@ -363,7 +363,7 @@ def plot_pointer_gamut(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot *Pointer's Gamut* according to given method.
+    Plot *Pointer's Gamut* according to specified method.
 
     Parameters
     ----------
@@ -467,8 +467,8 @@ def plot_RGB_colourspaces_in_chromaticity_diagram(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot given *RGB* colourspaces in the *Chromaticity Diagram* according
-    to given method.
+    Plot specified *RGB* colourspaces in the *Chromaticity Diagram* according
+    to specified method.
 
     Parameters
     ----------
@@ -489,7 +489,7 @@ def plot_RGB_colourspaces_in_chromaticity_diagram(
     show_pointer_gamut
         Whether to display the *Pointer's Gamut*.
     chromatically_adapt
-        Whether to chromatically adapt the *RGB* colourspaces given in
+        Whether to chromatically adapt the *RGB* colourspaces specified in
         ``colourspaces`` to the whitepoint of the default plotting colourspace.
     plot_kwargs
         Keyword arguments for the :func:`matplotlib.pyplot.plot` definition,
@@ -677,7 +677,7 @@ def plot_RGB_colourspaces_in_chromaticity_diagram_CIE1931(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot given *RGB* colourspaces in the *CIE 1931 Chromaticity Diagram*.
+    Plot specified *RGB* colourspaces in the *CIE 1931 Chromaticity Diagram*.
 
     Parameters
     ----------
@@ -696,7 +696,7 @@ def plot_RGB_colourspaces_in_chromaticity_diagram_CIE1931(
     show_pointer_gamut
         Whether to display the *Pointer's Gamut*.
     chromatically_adapt
-        Whether to chromatically adapt the *RGB* colourspaces given in
+        Whether to chromatically adapt the *RGB* colourspaces specified in
         ``colourspaces`` to the whitepoint of the default plotting colourspace.
     plot_kwargs
         Keyword arguments for the :func:`matplotlib.pyplot.plot` definition,
@@ -772,7 +772,7 @@ def plot_RGB_colourspaces_in_chromaticity_diagram_CIE1960UCS(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot given *RGB* colourspaces in the *CIE 1960 UCS Chromaticity Diagram*.
+    Plot specified *RGB* colourspaces in the *CIE 1960 UCS Chromaticity Diagram*.
 
     Parameters
     ----------
@@ -792,7 +792,7 @@ def plot_RGB_colourspaces_in_chromaticity_diagram_CIE1960UCS(
     show_pointer_gamut
         Whether to display the *Pointer's Gamut*.
     chromatically_adapt
-        Whether to chromatically adapt the *RGB* colourspaces given in
+        Whether to chromatically adapt the *RGB* colourspaces specified in
         ``colourspaces`` to the whitepoint of the default plotting colourspace.
     plot_kwargs
         Keyword arguments for the :func:`matplotlib.pyplot.plot` definition,
@@ -868,7 +868,7 @@ def plot_RGB_colourspaces_in_chromaticity_diagram_CIE1976UCS(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot given *RGB* colourspaces in the *CIE 1976 UCS Chromaticity Diagram*.
+    Plot specified *RGB* colourspaces in the *CIE 1976 UCS Chromaticity Diagram*.
 
     Parameters
     ----------
@@ -888,7 +888,7 @@ def plot_RGB_colourspaces_in_chromaticity_diagram_CIE1976UCS(
     show_pointer_gamut
         Whether to display the *Pointer's Gamut*.
     chromatically_adapt
-        Whether to chromatically adapt the *RGB* colourspaces given in
+        Whether to chromatically adapt the *RGB* colourspaces specified in
         ``colourspaces`` to the whitepoint of the default plotting colourspace.
     plot_kwargs
         Keyword arguments for the :func:`matplotlib.pyplot.plot` definition,
@@ -957,8 +957,8 @@ def plot_RGB_chromaticities_in_chromaticity_diagram(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot given *RGB* colourspace array in the *Chromaticity Diagram* according
-    to given method.
+    Plot specified *RGB* colourspace array in the *Chromaticity Diagram* according
+    to specified method.
 
     Parameters
     ----------
@@ -977,7 +977,7 @@ def plot_RGB_chromaticities_in_chromaticity_diagram(
         The following special keyword arguments can also be used:
 
         -   ``c`` : If ``c`` is set to *RGB*, the scatter will use the colours
-            as given by the ``RGB`` argument.
+            as specified by the ``RGB`` argument.
         -   ``apply_cctf_encoding`` : If ``apply_cctf_encoding`` is set to
             *False*, the encoding colour component transfer function /
             opto-electronic transfer function is not applied when encoding the
@@ -1087,7 +1087,7 @@ def plot_RGB_chromaticities_in_chromaticity_diagram_CIE1931(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot given *RGB* colourspace array in the *CIE 1931 Chromaticity Diagram*.
+    Plot specified *RGB* colourspace array in the *CIE 1931 Chromaticity Diagram*.
 
     Parameters
     ----------
@@ -1104,7 +1104,7 @@ def plot_RGB_chromaticities_in_chromaticity_diagram_CIE1931(
         The following special keyword arguments can also be used:
 
         -   ``c`` : If ``c`` is set to *RGB*, the scatter will use the colours
-            as given by the ``RGB`` argument.
+            as specified by the ``RGB`` argument.
         -   ``apply_cctf_encoding`` : If ``apply_cctf_encoding`` is set to
             *False*, the encoding colour component transfer function /
             opto-electronic transfer function is not applied when encoding the
@@ -1165,7 +1165,7 @@ def plot_RGB_chromaticities_in_chromaticity_diagram_CIE1960UCS(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot given *RGB* colourspace array in the
+    Plot specified *RGB* colourspace array in the
     *CIE 1960 UCS Chromaticity Diagram*.
 
     Parameters
@@ -1184,7 +1184,7 @@ def plot_RGB_chromaticities_in_chromaticity_diagram_CIE1960UCS(
         The following special keyword arguments can also be used:
 
         -   ``c`` : If ``c`` is set to *RGB*, the scatter will use the colours
-            as given by the ``RGB`` argument.
+            as specified by the ``RGB`` argument.
         -   ``apply_cctf_encoding`` : If ``apply_cctf_encoding`` is set to
             *False*, the encoding colour component transfer function /
             opto-electronic transfer function is not applied when encoding the
@@ -1245,7 +1245,7 @@ def plot_RGB_chromaticities_in_chromaticity_diagram_CIE1976UCS(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot given *RGB* colourspace array in the
+    Plot specified *RGB* colourspace array in the
     *CIE 1976 UCS Chromaticity Diagram*.
 
     Parameters
@@ -1264,7 +1264,7 @@ def plot_RGB_chromaticities_in_chromaticity_diagram_CIE1976UCS(
         The following special keyword arguments can also be used:
 
         -   ``c`` : If ``c`` is set to *RGB*, the scatter will use the colours
-            as given by the ``RGB`` argument.
+            as specified by the ``RGB`` argument.
         -   ``apply_cctf_encoding`` : If ``apply_cctf_encoding`` is set to
             *False*, the encoding colour component transfer function /
             opto-electronic transfer function is not applied when encoding the
@@ -1317,7 +1317,7 @@ def ellipses_MacAdam1942(
 ) -> List[NDArrayFloat]:
     """
     Return *MacAdam (1942) Ellipses (Observer PGN)* coefficients according to
-    given method.
+    specified method.
 
     Parameters
     ----------
@@ -1366,7 +1366,7 @@ def plot_ellipses_MacAdam1942_in_chromaticity_diagram(
 ) -> Tuple[Figure, Axes]:
     """
     Plot *MacAdam (1942) Ellipses (Observer PGN)* in the
-    *Chromaticity Diagram* according to given method.
+    *Chromaticity Diagram* according to specified method.
 
     Parameters
     ----------
@@ -1677,7 +1677,7 @@ def plot_single_cctf(
     cctf: Callable | str, cctf_decoding: bool = False, **kwargs: Any
 ) -> Tuple[Figure, Axes]:
     """
-    Plot given colourspace colour component transfer function.
+    Plot specified colourspace colour component transfer function.
 
     Parameters
     ----------
@@ -1726,7 +1726,7 @@ def plot_multi_cctfs(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot given colour component transfer functions.
+    Plot specified colour component transfer functions.
 
     Parameters
     ----------
@@ -1789,7 +1789,7 @@ def plot_constant_hue_loci(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot given constant hue loci colour matches data such as that from
+    Plot specified constant hue loci colour matches data such as that from
     :cite:`Hung1995` or :cite:`Ebner1998` that are easily loaded with
     `Colour - Datasets <https://github.com/colour-science/colour-datasets>`__.
 
@@ -1823,7 +1823,7 @@ def plot_constant_hue_loci(
         The following special keyword arguments can also be used:
 
         -   ``c`` : If ``c`` is set to *RGB*, the scatter will use the colours
-            as given by the ``RGB`` argument.
+            as specified by the ``RGB`` argument.
     convert_kwargs
         Keyword arguments for the :func:`colour.convert` definition.
 

--- a/colour/plotting/notation.py
+++ b/colour/plotting/notation.py
@@ -42,7 +42,7 @@ def plot_single_munsell_value_function(
     function: Callable | str, **kwargs: Any
 ) -> Tuple[Figure, Axes]:
     """
-    Plot given *Lightness* function.
+    Plot specified *Lightness* function.
 
     Parameters
     ----------
@@ -86,7 +86,7 @@ def plot_multi_munsell_value_functions(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot given *Munsell* value functions.
+    Plot specified *Munsell* value functions.
 
     Parameters
     ----------

--- a/colour/plotting/quality.py
+++ b/colour/plotting/quality.py
@@ -85,7 +85,7 @@ def plot_colour_quality_bars(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot the colour quality data of given illuminants or light sources colour
+    Plot the colour quality data of specified illuminants or light sources colour
     quality specifications.
 
     Parameters
@@ -251,7 +251,7 @@ def plot_single_sd_colour_rendering_index_bars(
     sd: SpectralDistribution, **kwargs: Any
 ) -> Tuple[Figure, Axes]:
     """
-    Plot the *Colour Rendering Index* (CRI) of given illuminant or light
+    Plot the *Colour Rendering Index* (CRI) of specified illuminant or light
     source spectral distribution.
 
     Parameters
@@ -301,7 +301,7 @@ def plot_multi_sds_colour_rendering_indexes_bars(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot the *Colour Rendering Index* (CRI) of given illuminants or light
+    Plot the *Colour Rendering Index* (CRI) of specified illuminants or light
     sources spectral distributions.
 
     Parameters
@@ -381,7 +381,7 @@ def plot_single_sd_colour_quality_scale_bars(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot the *Colour Quality Scale* (CQS) of given illuminant or light source
+    Plot the *Colour Quality Scale* (CQS) of specified illuminant or light source
     spectral distribution.
 
     Parameters
@@ -436,7 +436,7 @@ def plot_multi_sds_colour_quality_scales_bars(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot the *Colour Quality Scale* (CQS) of given illuminants or light
+    Plot the *Colour Quality Scale* (CQS) of specified illuminants or light
     sources spectral distributions.
 
     Parameters

--- a/colour/plotting/section.py
+++ b/colour/plotting/section.py
@@ -115,7 +115,7 @@ def plot_hull_section_colours(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot the section colours of given *trimesh* hull along given axis and
+    Plot the section colours of specified *trimesh* hull along specified axis and
     origin.
 
     Parameters
@@ -285,7 +285,7 @@ def plot_hull_section_contour(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot the section contour of given *trimesh* hull along given axis and
+    Plot the section contour of specified *trimesh* hull along specified axis and
     origin.
 
     Parameters
@@ -420,7 +420,7 @@ def plot_visible_spectrum_section(
 ) -> Tuple[Figure, Axes]:
     """
     Plot the visible spectrum volume, i.e., *Rösch-MacAdam* colour solid,
-    section colours along given axis and origin.
+    section colours along specified axis and origin.
 
     Parameters
     ----------
@@ -566,7 +566,7 @@ def plot_RGB_colourspace_section(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot given *RGB* colourspace section colours along given axis and origin.
+    Plot specified *RGB* colourspace section colours along specified axis and origin.
 
     Parameters
     ----------

--- a/colour/plotting/temperature.py
+++ b/colour/plotting/temperature.py
@@ -103,7 +103,7 @@ def lines_daylight_locus(
 ) -> Tuple[NDArray]:
     """
     Return the *Daylight Locus* line vertices, i.e., positions, normals and
-    colours, according to given method.
+    colours, according to specified method.
 
     Parameters
     ----------
@@ -133,7 +133,7 @@ def lines_daylight_locus(
 
     def CCT_to_plotting_colourspace(CCT: ArrayLike) -> NDArrayFloat:
         """
-        Convert given correlated colour temperature :math:`T_{cp}` to the
+        Convert specified correlated colour temperature :math:`T_{cp}` to the
         default plotting colourspace.
         """
 
@@ -174,7 +174,7 @@ def plot_daylight_locus(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot the *Daylight Locus* according to given method.
+    Plot the *Daylight Locus* according to specified method.
 
     Parameters
     ----------
@@ -266,7 +266,7 @@ def lines_planckian_locus(
 ) -> Tuple[NDArray, NDArray]:
     """
     Return the *Planckian Locus* line vertices, i.e., positions, normals and
-    colours, according to given method.
+    colours, according to specified method.
 
     Parameters
     ----------
@@ -315,7 +315,7 @@ def lines_planckian_locus(
 
     def CCT_D_uv_to_plotting_colourspace(CCT_D_uv: ArrayLike) -> NDArrayFloat:
         """
-        Convert given correlated colour temperature :math:`T_{cp}` and
+        Convert specified correlated colour temperature :math:`T_{cp}` and
         :math:`\\Delta_{uv}` to the default plotting colourspace.
         """
 
@@ -397,7 +397,7 @@ def plot_planckian_locus(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot the *Planckian Locus* according to given method.
+    Plot the *Planckian Locus* according to specified method.
 
     Parameters
     ----------
@@ -536,8 +536,8 @@ def plot_planckian_locus_in_chromaticity_diagram(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot the *Planckian Locus* and given illuminants in the
-    *Chromaticity Diagram* according to given method.
+    Plot the *Planckian Locus* and specified illuminants in the
+    *Chromaticity Diagram* according to specified method.
 
     Parameters
     ----------
@@ -730,7 +730,7 @@ def plot_planckian_locus_in_chromaticity_diagram_CIE1931(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot the *Planckian Locus* and given illuminants in
+    Plot the *Planckian Locus* and specified illuminants in
     *CIE 1931 Chromaticity Diagram*.
 
     Parameters
@@ -809,7 +809,7 @@ def plot_planckian_locus_in_chromaticity_diagram_CIE1960UCS(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot the *Planckian Locus* and given illuminants in
+    Plot the *Planckian Locus* and specified illuminants in
     *CIE 1960 UCS Chromaticity Diagram*.
 
     Parameters
@@ -890,7 +890,7 @@ def plot_planckian_locus_in_chromaticity_diagram_CIE1976UCS(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot the *Planckian Locus* and given illuminants in
+    Plot the *Planckian Locus* and specified illuminants in
     *CIE 1976 UCS Chromaticity Diagram*.
 
     Parameters

--- a/colour/plotting/tm3018/components.py
+++ b/colour/plotting/tm3018/components.py
@@ -437,7 +437,7 @@ def plot_colour_vector_graphic(
     )
 
     def corner_label_and_text(label: str, text: str, ha: str, va: str) -> None:
-        """Draw a label and text in given corner."""
+        """Draw a label and text in specified corner."""
 
         x = -1.45 if ha == "left" else 1.45
         y = 1.45 if va == "top" else -1.45
@@ -484,7 +484,7 @@ def plot_16_bin_bars(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot the 16 bin bars for given values according to
+    Plot the 16 bin bars for specified values according to
     *ANSI/IES TM-30-18 Colour Rendition Report*.
 
     Parameters

--- a/colour/plotting/tm3018/report.py
+++ b/colour/plotting/tm3018/report.py
@@ -161,7 +161,7 @@ _VALUE_NOT_APPLICABLE: str = "N/A"
 
 def _plot_report_header(axes: Axes) -> Axes:
     """
-    Plot the report header, i.e., the title, on given axes.
+    Plot the report header, i.e., the title, on specified axes.
 
     Parameters
     ----------
@@ -191,7 +191,7 @@ def _plot_report_header(axes: Axes) -> Axes:
 
 def _plot_report_footer(axes: Axes) -> Axes:
     """
-    Plot the report footer on given axes.
+    Plot the report footer on specified axes.
 
     Parameters
     ----------
@@ -240,7 +240,7 @@ def plot_single_sd_colour_rendition_report_full(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Generate the full *ANSI/IES TM-30-18 Colour Rendition Report* for given
+    Generate the full *ANSI/IES TM-30-18 Colour Rendition Report* for specified
     spectral distribution.
 
     Parameters
@@ -544,7 +544,7 @@ def plot_single_sd_colour_rendition_report_intermediate(
 ) -> Tuple[Figure, Axes]:
     """
     Generate the intermediate *ANSI/IES TM-30-18 Colour Rendition Report* for
-    given spectral distribution.
+    specified spectral distribution.
 
     Parameters
     ----------
@@ -637,7 +637,7 @@ def plot_single_sd_colour_rendition_report_simple(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Generate the simple *ANSI/IES TM-30-18 Colour Rendition Report* for given
+    Generate the simple *ANSI/IES TM-30-18 Colour Rendition Report* for specified
     spectral distribution.
 
     Parameters
@@ -719,8 +719,8 @@ def plot_single_sd_colour_rendition_report(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Generate the *ANSI/IES TM-30-18 Colour Rendition Report* for given
-    spectral distribution according to given method.
+    Generate the *ANSI/IES TM-30-18 Colour Rendition Report* for specified
+    spectral distribution according to specified method.
 
     Parameters
     ----------

--- a/colour/plotting/volume.py
+++ b/colour/plotting/volume.py
@@ -83,7 +83,7 @@ def nadir_grid(
     """
     Return a grid on *CIE xy* plane made of quad geometric elements and its
     associated faces and edges colours. Ticks and labels are added to the
-    given axes according to the extended grid settings.
+    specified axes according to the extended grid settings.
 
     Parameters
     ----------
@@ -433,7 +433,7 @@ def plot_RGB_colourspaces_gamuts(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes3D]:
     """
-    Plot given *RGB* colourspaces gamuts in given reference colourspace.
+    Plot specified *RGB* colourspaces gamuts in specified reference colourspace.
 
     Parameters
     ----------
@@ -459,7 +459,7 @@ def plot_RGB_colourspaces_gamuts(
         spectral locus boundaries. ``cmfs`` can be of any type or form
         supported by the :func:`colour.plotting.common.filter_cmfs` definition.
     chromatically_adapt
-        Whether to chromatically adapt the *RGB* colourspaces given in
+        Whether to chromatically adapt the *RGB* colourspaces specified in
         ``colourspaces`` to the whitepoint of the default plotting colourspace.
     convert_kwargs
         Keyword arguments for the :func:`colour.convert` definition.
@@ -675,7 +675,7 @@ def plot_RGB_scatter(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes3D]:
     """
-    Plot given *RGB* colourspace array in a scatter plot.
+    Plot specified *RGB* colourspace array in a scatter plot.
 
     Parameters
     ----------
@@ -709,7 +709,7 @@ def plot_RGB_scatter(
         spectral locus boundaries. ``cmfs`` can be of any type or form
         supported by the :func:`colour.plotting.common.filter_cmfs` definition.
     chromatically_adapt
-        Whether to chromatically adapt the *RGB* colourspaces given in
+        Whether to chromatically adapt the *RGB* colourspaces specified in
         ``colourspaces`` to the whitepoint of the default plotting colourspace.
     convert_kwargs
         Keyword arguments for the :func:`colour.convert` definition.

--- a/colour/quality/__init__.py
+++ b/colour/quality/__init__.py
@@ -80,8 +80,8 @@ def colour_fidelity_index(
     | ColourQuality_Specification_ANSIIESTM3018
 ):
     """
-    Return the *Colour Fidelity Index* (CFI) :math:`R_f` of given spectral
-    distribution using given method.
+    Compute the *Colour Fidelity Index* (CFI) :math:`R_f` of specified
+    spectral distribution using specified method.
 
     Parameters
     ----------

--- a/colour/quality/cfi2017.py
+++ b/colour/quality/cfi2017.py
@@ -161,7 +161,7 @@ def colour_fidelity_index_CIE2017(
     sd_test: SpectralDistribution, additional_data: bool = False
 ) -> float | ColourRendering_Specification_CIE2017:
     """
-    Return the *CIE 2017 Colour Fidelity Index* (CFI) :math:`R_f` of given
+    Compute the *CIE 2017 Colour Fidelity Index* (CFI) :math:`R_f` of specified
     spectral distribution.
 
     Parameters
@@ -266,7 +266,7 @@ def colour_fidelity_index_CIE2017(
 
 def load_TCS_CIE2017(shape: SpectralShape) -> MultiSpectralDistributions:
     """
-    Load the *CIE 2017 Test Colour Samples* dataset appropriate for the given
+    Load the *CIE 2017 Test Colour Samples* dataset appropriate for the specified
     spectral shape.
 
     The datasets are cached and won't be loaded again on subsequent calls to
@@ -318,7 +318,7 @@ def load_TCS_CIE2017(shape: SpectralShape) -> MultiSpectralDistributions:
 def CCT_reference_illuminant(sd: SpectralDistribution) -> NDArrayFloat:
     """
     Compute the reference illuminant correlated colour temperature
-    :math:`T_{cp}` and :math:`\\Delta_{uv}` for given test spectral
+    :math:`T_{cp}` and :math:`\\Delta_{uv}` for specified test spectral
     distribution using *Ohno (2013)* method.
 
     Parameters
@@ -348,7 +348,7 @@ def CCT_reference_illuminant(sd: SpectralDistribution) -> NDArrayFloat:
 
 def sd_reference_illuminant(CCT: float, shape: SpectralShape) -> SpectralDistribution:
     """
-    Compute the reference illuminant for a given correlated colour temperature
+    Compute the reference illuminant for a specified correlated colour temperature
     :math:`T_{cp}` for use in *CIE 2017 Colour Fidelity Index* (CFI)
     computation.
 
@@ -439,7 +439,7 @@ def tcs_colorimetry_data(
     cmfs: MultiSpectralDistributions,
 ) -> Tuple[DataColorimetry_TCS_CIE2017, ...]:
     """
-    Return the *test colour samples* colorimetry data under given test light
+    Compute the *test colour samples* colorimetry data under specified test light
     source or reference illuminant spectral distribution for the
     *CIE 2017 Colour Fidelity Index* (CFI) computations.
 
@@ -456,7 +456,7 @@ def tcs_colorimetry_data(
     Returns
     -------
     :class:`tuple`
-        *Test colour samples* colorimetry data under the given test light
+        *Test colour samples* colorimetry data under the specified test light
         source or reference illuminant spectral distribution.
 
     Examples

--- a/colour/quality/cqs.py
+++ b/colour/quality/cqs.py
@@ -205,8 +205,8 @@ def colour_quality_scale(
     method: Literal["NIST CQS 7.4", "NIST CQS 9.0"] | str = "NIST CQS 9.0",
 ) -> float | ColourRendering_Specification_CQS:
     """
-    Return the *Colour Quality Scale* (CQS) of given spectral distribution
-    using given method.
+    Compute the *Colour Quality Scale* (CQS) of specified spectral distribution
+    using specified method.
 
     Parameters
     ----------
@@ -328,7 +328,7 @@ def colour_quality_scale(
 
 def gamut_area(Lab: ArrayLike) -> float:
     """
-    Return the gamut area :math:`G` covered by given *CIE L\\*a\\*b\\**
+    Compute the gamut area :math:`G` covered by specified *CIE L\\*a\\*b\\**
     matrices.
 
     Parameters
@@ -387,7 +387,7 @@ def vs_colorimetry_data(
     chromatic_adaptation: bool = False,
 ) -> Tuple[DataColorimetry_VS, ...]:
     """
-    Return the *VS test colour samples* colorimetry data.
+    Compute the *VS test colour samples* colorimetry data.
 
     Parameters
     ----------
@@ -444,7 +444,7 @@ def CCT_factor(
     reference_data: Tuple[DataColorimetry_VS, ...], XYZ_r: ArrayLike
 ) -> float:
     """
-    Return the correlated colour temperature factor penalizing lamps with
+    Compute the correlated colour temperature factor penalizing lamps with
     extremely low correlated colour temperatures.
 
     Parameters
@@ -480,8 +480,8 @@ def CCT_factor(
 
 def scale_conversion(D_E_ab: float, CCT_f: float, scaling_f: float) -> float:
     """
-    Return the *Colour Quality Scale* (CQS) for given :math:`\\Delta E_{ab}`
-    value and given correlated colour temperature penalizing factor.
+    Compute the *Colour Quality Scale* (CQS) for specified :math:`\\Delta E_{ab}`
+    value and specified correlated colour temperature penalizing factor.
 
     Parameters
     ----------
@@ -505,7 +505,7 @@ def delta_E_RMS(
     CQS_data: Dict[int, DataColourQualityScale_VS], attribute: str
 ) -> float:
     """
-    Compute the root-mean-square average for given *Colour Quality Scale*
+    Compute the root-mean-square average for specified *Colour Quality Scale*
     (CQS) data.
 
     Parameters
@@ -538,7 +538,7 @@ def colour_quality_scales(
     CCT_f: float,
 ) -> Dict[int, DataColourQualityScale_VS]:
     """
-    Return the *VS test colour samples* rendering scales.
+    Compute the *VS test colour samples* rendering scales.
 
     Parameters
     ----------

--- a/colour/quality/cri.py
+++ b/colour/quality/cri.py
@@ -155,7 +155,7 @@ def colour_rendering_index(
     method: Literal["CIE 1995", "CIE 2024"] | str = "CIE 1995",
 ) -> float | ColourRendering_Specification_CRI:
     """
-    Return the *Colour Rendering Index* (CRI) :math:`Q_a` of given spectral
+    Compute the *Colour Rendering Index* (CRI) :math:`Q_a` of specified spectral
     distribution.
 
     Parameters
@@ -248,7 +248,7 @@ def tcs_colorimetry_data(
     method: Literal["CIE 1995", "CIE 2024"] | str = "CIE 1995",
 ) -> Tuple[DataColorimetry_TCS, ...]:
     """
-    Return the *test colour samples* colorimetry data.
+    Compute the *test colour samples* colorimetry data.
 
     Parameters
     ----------
@@ -335,7 +335,7 @@ def colour_rendering_indexes(
     reference_data: Tuple[DataColorimetry_TCS, ...],
 ) -> Dict[int, DataColourQualityScale_TCS]:
     """
-    Return the *test colour samples* rendering indexes :math:`Q_a`.
+    Compute the *test colour samples* rendering indexes :math:`Q_a`.
 
     Parameters
     ----------

--- a/colour/quality/ssi.py
+++ b/colour/quality/ssi.py
@@ -55,8 +55,8 @@ def spectral_similarity_index(
     round_result: bool = True,
 ) -> NDArrayFloat:
     """
-    Return the *Academy Spectral Similarity Index* (SSI) of given test
-    spectral distribution with given reference spectral distribution.
+    Compute the *Academy Spectral Similarity Index* (SSI) of specified test
+    spectral distribution with specified reference spectral distribution.
 
     Parameters
     ----------

--- a/colour/quality/tm3018.py
+++ b/colour/quality/tm3018.py
@@ -120,8 +120,8 @@ def colour_fidelity_index_ANSIIESTM3018(
     sd_test: SpectralDistribution, additional_data: bool = False
 ) -> float | ColourQuality_Specification_ANSIIESTM3018:
     """
-    Return the *ANSI/IES TM-30-18 Colour Fidelity Index* (CFI) :math:`R_f`
-    of given spectral distribution.
+    Compute the *ANSI/IES TM-30-18 Colour Fidelity Index* (CFI) :math:`R_f`
+    of specified spectral distribution.
 
     Parameters
     ----------

--- a/colour/recovery/__init__.py
+++ b/colour/recovery/__init__.py
@@ -119,8 +119,8 @@ def XYZ_to_sd(
     **kwargs: Any,
 ) -> SpectralDistribution:
     """
-    Recover the spectral distribution of given *CIE XYZ* tristimulus
-    values using given method.
+    Recover the spectral distribution of specified *CIE XYZ* tristimulus
+    values using specified method.
 
     Parameters
     ----------
@@ -186,7 +186,7 @@ def XYZ_to_sd(
     | ``XYZ``    | [0, 1]                | [0, 1]        |
     +------------+-----------------------+---------------+
 
-    -   *Smits (1999)* method will internally convert given *CIE XYZ*
+    -   *Smits (1999)* method will internally convert specified *CIE XYZ*
         tristimulus values to *sRGB* colourspace array assuming equal energy
         illuminant *E*.
 

--- a/colour/recovery/datasets/otsu2018.py
+++ b/colour/recovery/datasets/otsu2018.py
@@ -1320,6 +1320,6 @@ SELECTOR_ARRAY_OTSU2018: NDArrayFloat = np.array(
     ]
 )
 """
-Array describing how to select the appropriate cluster for given *CIE xy*
+Array describing how to select the appropriate cluster for specified *CIE xy*
 chromaticity coordinates.
 """

--- a/colour/recovery/jakob2019.py
+++ b/colour/recovery/jakob2019.py
@@ -142,7 +142,7 @@ def sd_Jakob2019(
     coefficients: ArrayLike, shape: SpectralShape = SPECTRAL_SHAPE_JAKOB2019
 ) -> SpectralDistribution:
     """
-    Return a spectral distribution following the spectral model given by
+    Generate a spectral distribution following the spectral model specified by
     *Jakob and Hanika (2019)*.
 
     Parameters
@@ -241,7 +241,7 @@ def error_function(
 ):
     """
     Compute :math:`\\Delta E_{76}` between the target colour and the colour
-    defined by given spectral model, along with its gradient.
+    defined by specified spectral model, along with its gradient.
 
     Parameters
     ----------
@@ -340,7 +340,7 @@ def dimensionalise_coefficients(
     coefficients: ArrayLike, shape: SpectralShape
 ) -> NDArrayFloat:
     """
-    Rescale the dimensionless coefficients to given spectral shape.
+    Rescale the dimensionless coefficients to specified spectral shape.
 
     A dimensionless form of the reflectance spectral model is used in the
     optimisation process. Instead of the usual spectral shape, specified in
@@ -437,7 +437,7 @@ def find_coefficients_Jakob2019(
     Returns
     -------
     :class:`tuple`
-        Tuple of computed coefficients that best fit the given colour and
+        Tuple of computed coefficients that best fit the specified colour and
         :math:`\\Delta E_{76}` between the target colour and the colour
         corresponding to the computed coefficients.
 
@@ -555,8 +555,8 @@ def XYZ_to_sd_Jakob2019(
     additional_data: bool = False,
 ) -> Tuple[SpectralDistribution, float] | SpectralDistribution:
     """
-    Recover the spectral distribution of given *CIE XYZ* tristimulus values
-    using *Jakob and Hanika (2019)* method.
+    Recover the spectral distribution of specified *CIE XYZ* tristimulus
+    values using *Jakob and Hanika (2019)* method.
 
     Parameters
     ----------
@@ -873,8 +873,8 @@ class LUT3D_Jakob2019:
         print_callable: Callable = print,
     ) -> None:
         """
-        Generate the lookup table data for given *RGB* colourspace, colour
-        matching functions, illuminant and given size.
+        Generate the lookup table data for specified *RGB* colourspace, colour
+        matching functions, illuminant and specified size.
 
         Parameters
         ----------
@@ -1023,7 +1023,7 @@ class LUT3D_Jakob2019:
 
     def RGB_to_coefficients(self, RGB: ArrayLike) -> NDArrayFloat:
         """
-        Look up a given *RGB* colourspace array and return corresponding
+        Look up a specified *RGB* colourspace array and return corresponding
         coefficients. Interpolation is used for colours not on the table grid.
 
         Parameters
@@ -1083,7 +1083,7 @@ class LUT3D_Jakob2019:
         self, RGB: ArrayLike, shape: SpectralShape = SPECTRAL_SHAPE_JAKOB2019
     ) -> SpectralDistribution:
         """
-        Look up a given *RGB* colourspace array and return the corresponding
+        Look up a specified *RGB* colourspace array and return the corresponding
         spectral distribution.
 
         Parameters

--- a/colour/recovery/jiang2013.py
+++ b/colour/recovery/jiang2013.py
@@ -100,7 +100,7 @@ def PCA_Jiang2013(
     | Tuple[NDArrayFloat, NDArrayFloat, NDArrayFloat]
 ):
     """
-    Perform the *Principal Component Analysis* (PCA) on given camera *RGB*
+    Perform the *Principal Component Analysis* (PCA) on specified camera *RGB*
     sensitivities.
 
     Parameters
@@ -138,7 +138,7 @@ def PCA_Jiang2013(
     def normalised_sensitivity(
         msds: MultiSpectralDistributions, channel: str
     ) -> NDArrayFloat:
-        """Return a normalised camera *RGB* sensitivity."""
+        """Generate a normalised camera *RGB* sensitivity."""
 
         sensitivity = cast(SpectralDistribution, msds.signals[channel].copy())
 
@@ -176,7 +176,7 @@ def RGB_to_sd_camera_sensitivity_Jiang2013(
     shape: SpectralShape | None = None,
 ) -> SpectralDistribution:
     """
-    Recover a single camera *RGB* sensitivity for given camera *RGB* values
+    Recover a single camera *RGB* sensitivity for specified camera *RGB* values
     using *Jiang et al. (2013)* method.
 
     Parameters
@@ -308,8 +308,8 @@ def RGB_to_msds_camera_sensitivities_Jiang2013(
     shape: SpectralShape | None = None,
 ) -> MultiSpectralDistributions:
     """
-    Recover the camera *RGB* sensitivities for given camera *RGB* values using
-    *Jiang et al. (2013)* method.
+    Recover the camera *RGB* sensitivities for specified camera *RGB* values
+    using *Jiang et al. (2013)* method.
 
     Parameters
     ----------

--- a/colour/recovery/mallett2019.py
+++ b/colour/recovery/mallett2019.py
@@ -59,7 +59,7 @@ def spectral_primary_decomposition_Mallett2019(
 ) -> MultiSpectralDistributions:
     """
     Perform the spectral primary decomposition as described in *Mallett and
-    Yuksel (2019)* for given *RGB* colourspace.
+    Yuksel (2019)* for specified *RGB* colourspace.
 
     Parameters
     ----------
@@ -86,7 +86,7 @@ def spectral_primary_decomposition_Mallett2019(
     Returns
     -------
     :class:`colour.MultiSpectralDistributions`
-        Basis functions for given *RGB* colourspace.
+        Basis functions for specified *RGB* colourspace.
 
     References
     ----------
@@ -222,7 +222,7 @@ def RGB_to_sd_Mallett2019(
     basis_functions: MultiSpectralDistributions = MSDS_BASIS_FUNCTIONS_sRGB_MALLETT2019,
 ) -> SpectralDistribution:
     """
-    Recover the spectral distribution of given *RGB* colourspace array using
+    Recover the spectral distribution of specified *RGB* colourspace array using
     *Mallett and Yuksel (2019)* method.
 
     Parameters

--- a/colour/recovery/meng2015.py
+++ b/colour/recovery/meng2015.py
@@ -61,7 +61,7 @@ def XYZ_to_sd_Meng2015(
     optimisation_kwargs: dict | None = None,
 ) -> SpectralDistribution:
     """
-    Recover the spectral distribution of given *CIE XYZ* tristimulus values
+    Recover the spectral distribution of specified *CIE XYZ* tristimulus values
     using *Meng et al. (2015)* method.
 
     Parameters
@@ -84,6 +84,11 @@ def XYZ_to_sd_Meng2015(
     -------
     :class:`colour.SpectralDistribution`
         Recovered spectral distribution.
+
+    Raises
+    ------
+    RuntimeError
+        If the optimisation failed.
 
     Notes
     -----

--- a/colour/recovery/otsu2018.py
+++ b/colour/recovery/otsu2018.py
@@ -251,7 +251,7 @@ class Dataset_Otsu2018:
 
     def select(self, xy: ArrayLike) -> int:
         """
-        Return the cluster index appropriate for the given *CIE xy*
+        Determine the cluster index appropriate for the specified *CIE xy*
         coordinates.
 
         Parameters
@@ -294,7 +294,7 @@ class Dataset_Otsu2018:
 
     def cluster(self, xy: ArrayLike) -> Tuple[NDArrayFloat, NDArrayFloat]:
         """
-        Return the basis functions and dataset mean for the given *CIE xy*
+        Retrieve the basis functions and dataset mean for the specified *CIE xy*
         coordinates.
 
         Parameters
@@ -367,7 +367,7 @@ class Dataset_Otsu2018:
 
     def write(self, path: str | PathLike) -> None:
         """
-        Write the dataset to an *.npz* file at given path.
+        Write the dataset to an *.npz* file at specified path.
 
         Parameters
         ----------
@@ -444,7 +444,7 @@ def XYZ_to_sd_Otsu2018(
     clip: bool = True,
 ) -> SpectralDistribution:
     """
-    Recover the spectral distribution of given *CIE XYZ* tristimulus values
+    Recover the spectral distribution of specified *CIE XYZ* tristimulus values
     using *Otsu et al. (2018)* method.
 
     Parameters
@@ -786,7 +786,7 @@ class Data_Otsu2018:
 
     def __len__(self) -> int:
         """
-        Return the number of colours in the data.
+        Determine the number of colours in the data.
 
         Returns
         -------
@@ -798,8 +798,8 @@ class Data_Otsu2018:
 
     def origin(self, i: int, direction: int) -> float:
         """
-        Return the origin *CIE x* or *CIE y* chromaticity coordinate for given
-        index and direction.
+        Retrieve the origin *CIE x* or *CIE y* chromaticity coordinate for
+        specified index and direction.
 
         Parameters
         ----------
@@ -828,7 +828,7 @@ class Data_Otsu2018:
 
     def partition(self, axis: PartitionAxis) -> Tuple[Data_Otsu2018, Data_Otsu2018]:
         """
-        Partition the data using given partition axis.
+        Partition the data using specified partition axis.
 
         Parameters
         ----------
@@ -904,7 +904,7 @@ class Data_Otsu2018:
 
     def reconstruct(self, XYZ: ArrayLike) -> SpectralDistribution:
         """
-        Reconstruct the reflectance for the given *CIE XYZ* tristimulus
+        Reconstruct the reflectance for the specified *CIE XYZ* tristimulus
         values.
 
         Parameters
@@ -947,7 +947,7 @@ class Data_Otsu2018:
 
     def reconstruction_error(self) -> float:
         """
-        Return the reconstruction error of the data. The error is computed by
+        Compute the reconstruction error of the data. The error is computed by
         reconstructing the reflectances for the reference *CIE XYZ* tristimulus
         values using PCA and, comparing the reconstructed reflectances against
         the reference reflectances.
@@ -1076,7 +1076,7 @@ class Node_Otsu2018(TreeNode):
 
     def split(self, children: Sequence[Self], axis: PartitionAxis) -> None:
         """
-        Convert the leaf node into an inner node using given children and
+        Convert the leaf node into an inner node using specified children and
         partition axis.
 
         Parameters
@@ -1110,7 +1110,7 @@ class Node_Otsu2018(TreeNode):
         Returns
         -------
         :class:`tuple`
-            Tuple of tuple of nodes created by splitting a node with a given
+            Tuple of tuple of nodes created by splitting a node with a specified
             partition, partition axis, i.e., the horizontal or vertical line,
             partitioning the 2D space in two half-planes and partition error.
         """
@@ -1172,7 +1172,7 @@ class Node_Otsu2018(TreeNode):
 
     def leaf_reconstruction_error(self) -> float:
         """
-        Return the reconstruction error of the node data. The error is
+        Compute the reconstruction error of the node data. The error is
         computed by reconstructing the reflectances for the data reference
         *CIE XYZ* tristimulus values using PCA and, comparing the reconstructed
         reflectances against the data reference reflectances.
@@ -1584,7 +1584,7 @@ the initial error.
         else:
 
             def add_rows(node: Node_Otsu2018, data: dict | None = None) -> dict | None:
-                """Add rows for given node and its children."""
+                """Add rows for specified node and its children."""
 
                 data = optional(data, {"rows": [], "node_to_leaf_id": {}, "leaf_id": 0})
 

--- a/colour/recovery/smits1999.py
+++ b/colour/recovery/smits1999.py
@@ -94,7 +94,7 @@ def XYZ_to_RGB_Smits1999(XYZ: ArrayLike) -> NDArrayFloat:
 
 def RGB_to_sd_Smits1999(RGB: ArrayLike) -> SpectralDistribution:
     """
-    Recover the spectral distribution of given *RGB* colourspace array using
+    Recover the spectral distribution of specified *RGB* colourspace array using
     *Smits (1999)* method.
 
     Parameters

--- a/colour/temperature/__init__.py
+++ b/colour/temperature/__init__.py
@@ -144,9 +144,9 @@ def uv_to_CCT(
     **kwargs: Any,
 ) -> NDArrayFloat:
     """
-    Return the correlated colour temperature :math:`T_{cp}` and
-    :math:`\\Delta_{uv}` from given *CIE UCS* colourspace *uv* chromaticity
-    coordinates using given method.
+    Compute the correlated colour temperature :math:`T_{cp}` and
+    :math:`\\Delta_{uv}` from specified *CIE UCS* colourspace *uv* chromaticity
+    coordinates using specified method.
 
     Parameters
     ----------
@@ -237,8 +237,8 @@ def CCT_to_uv(
     **kwargs: Any,
 ) -> NDArrayFloat:
     """
-    Return the *CIE UCS* colourspace *uv* chromaticity coordinates from given
-    correlated colour temperature :math:`T_{cp}` using given method.
+    Compute the *CIE UCS* colourspace *uv* chromaticity coordinates from specified
+    correlated colour temperature :math:`T_{cp}` using specified method.
 
     Parameters
     ----------
@@ -332,8 +332,8 @@ def xy_to_CCT(
     ) = "CIE Illuminant D Series",
 ) -> NDArrayFloat:
     """
-    Return the correlated colour temperature :math:`T_{cp}` from given
-    *CIE xy* chromaticity coordinates using given method.
+    Compute the correlated colour temperature :math:`T_{cp}` from specified
+    *CIE xy* chromaticity coordinates using specified method.
 
     Parameters
     ----------
@@ -417,8 +417,8 @@ def CCT_to_xy(
     ) = "CIE Illuminant D Series",
 ) -> NDArrayFloat:
     """
-    Return the *CIE xy* chromaticity coordinates from given correlated colour
-    temperature :math:`T_{cp}` using given method.
+    Compute the *CIE xy* chromaticity coordinates from specified correlated colour
+    temperature :math:`T_{cp}` using specified method.
 
     Parameters
     ----------

--- a/colour/temperature/cie_d.py
+++ b/colour/temperature/cie_d.py
@@ -51,7 +51,7 @@ def xy_to_CCT_CIE_D(
     xy: ArrayLike, optimisation_kwargs: dict | None = None
 ) -> NDArrayFloat:
     """
-    Return the correlated colour temperature :math:`T_{cp}` of a
+    Compute the correlated colour temperature :math:`T_{cp}` of a
     *CIE Illuminant D Series* from its *CIE xy* chromaticity coordinates.
 
     Parameters
@@ -122,7 +122,7 @@ def xy_to_CCT_CIE_D(
 
 def CCT_to_xy_CIE_D(CCT: ArrayLike) -> NDArrayFloat:
     """
-    Return the *CIE xy* chromaticity coordinates of a
+    Compute the *CIE xy* chromaticity coordinates of a
     *CIE Illuminant D Series* from its correlated colour temperature
     :math:`T_{cp}`.
 

--- a/colour/temperature/hernandez1999.py
+++ b/colour/temperature/hernandez1999.py
@@ -6,10 +6,10 @@ Define the *Hernandez-Andres et al. (1999)* correlated colour temperature
 :math:`T_{cp}` computations objects:
 
 -   :func:`colour.temperature.xy_to_CCT_Hernandez1999`: Correlated colour
-    temperature :math:`T_{cp}` computation of given *CIE xy* chromaticity
+    temperature :math:`T_{cp}` computation of specified *CIE xy* chromaticity
     coordinates using *Hernandez-Andres, Lee and Romero (1999)* method.
 -   :func:`colour.temperature.CCT_to_xy_Hernandez1999`: *CIE xy* chromaticity
-    coordinates computation of given correlated colour temperature
+    coordinates computation of specified correlated colour temperature
     :math:`T_{cp}` using *Hernandez-Andres, Lee and Romero (1999)* method.
 
 References
@@ -50,7 +50,7 @@ __all__ = [
 
 def xy_to_CCT_Hernandez1999(xy: ArrayLike) -> NDArrayFloat:
     """
-    Return the correlated colour temperature :math:`T_{cp}` from given
+    Compute the correlated colour temperature :math:`T_{cp}` from specified
     *CIE xy* chromaticity coordinates using *Hernandez-Andres et al. (1999)*
     method.
 
@@ -104,7 +104,7 @@ def CCT_to_xy_Hernandez1999(
     CCT: ArrayLike, optimisation_kwargs: dict | None = None
 ) -> NDArrayFloat:
     """
-    Return the *CIE xy* chromaticity coordinates from given correlated colour
+    Compute the *CIE xy* chromaticity coordinates from specified correlated colour
     temperature :math:`T_{cp}` using *Hernandez-Andres et al. (1999)* method.
 
     Parameters

--- a/colour/temperature/kang2002.py
+++ b/colour/temperature/kang2002.py
@@ -48,7 +48,7 @@ def xy_to_CCT_Kang2002(
     xy: ArrayLike, optimisation_kwargs: dict | None = None
 ) -> NDArrayFloat:
     """
-    Return the correlated colour temperature :math:`T_{cp}` from given
+    Compute the correlated colour temperature :math:`T_{cp}` from specified
     *CIE xy* chromaticity coordinates using *Kang et al. (2002)* method.
 
     Parameters
@@ -119,7 +119,7 @@ def xy_to_CCT_Kang2002(
 
 def CCT_to_xy_Kang2002(CCT: ArrayLike) -> NDArrayFloat:
     """
-    Return the *CIE xy* chromaticity coordinates from given correlated colour
+    Compute the *CIE xy* chromaticity coordinates from specified correlated colour
     temperature :math:`T_{cp}` using *Kang et al. (2002)* method.
 
     Parameters

--- a/colour/temperature/krystek1985.py
+++ b/colour/temperature/krystek1985.py
@@ -48,7 +48,7 @@ def uv_to_CCT_Krystek1985(
     uv: ArrayLike, optimisation_kwargs: dict | None = None
 ) -> NDArrayFloat:
     """
-    Return the correlated colour temperature :math:`T_{cp}` from given
+    Compute the correlated colour temperature :math:`T_{cp}` from specified
     *CIE UCS* colourspace *uv* chromaticity coordinates using *Krystek (1985)*
     method.
 
@@ -125,7 +125,7 @@ def uv_to_CCT_Krystek1985(
 
 def CCT_to_uv_Krystek1985(CCT: ArrayLike) -> NDArrayFloat:
     """
-    Return the *CIE UCS* colourspace *uv* chromaticity coordinates from given
+    Compute the *CIE UCS* colourspace *uv* chromaticity coordinates from specified
     correlated colour temperature :math:`T_{cp}` using *Krystek (1985)* method.
 
     Parameters

--- a/colour/temperature/mccamy1992.py
+++ b/colour/temperature/mccamy1992.py
@@ -48,7 +48,7 @@ __all__ = [
 
 def xy_to_CCT_McCamy1992(xy: ArrayLike) -> NDArrayFloat:
     """
-    Return the correlated colour temperature :math:`T_{cp}` from given
+    Compute the correlated colour temperature :math:`T_{cp}` from specified
     *CIE xy* chromaticity coordinates using *McCamy (1992)* method.
 
     Parameters
@@ -87,7 +87,7 @@ def CCT_to_xy_McCamy1992(
     CCT: ArrayLike, optimisation_kwargs: dict | None = None
 ) -> NDArrayFloat:
     """
-    Return the *CIE xy* chromaticity coordinates from given correlated colour
+    Compute the *CIE xy* chromaticity coordinates from specified correlated colour
     temperature :math:`T_{cp}` using *McCamy (1992)* method.
 
     Parameters

--- a/colour/temperature/ohno2013.py
+++ b/colour/temperature/ohno2013.py
@@ -78,7 +78,7 @@ def planckian_table(
     spacing: float,
 ) -> NDArrayFloat:
     """
-    Return a planckian table from given *CIE UCS* colourspace *uv*
+    Generate a planckian table from specified *CIE UCS* colourspace *uv*
     chromaticity coordinates, colour matching functions and temperature range
     using *Ohno (2013)* method.
 
@@ -153,8 +153,8 @@ def uv_to_CCT_Ohno2013(
     spacing: float | None = None,
 ) -> NDArrayFloat:
     """
-    Return the correlated colour temperature :math:`T_{cp}` and
-    :math:`\\Delta_{uv}` from given *CIE UCS* colourspace *uv* chromaticity
+    Compute the correlated colour temperature :math:`T_{cp}` and
+    :math:`\\Delta_{uv}` from specified *CIE UCS* colourspace *uv* chromaticity
     coordinates, colour matching functions and temperature range using
     *Ohno (2013)* method.
 
@@ -279,7 +279,7 @@ def CCT_to_uv_Ohno2013(
     CCT_D_uv: ArrayLike, cmfs: MultiSpectralDistributions | None = None
 ) -> NDArrayFloat:
     """
-    Return the *CIE UCS* colourspace *uv* chromaticity coordinates from given
+    Compute the *CIE UCS* colourspace *uv* chromaticity coordinates from specified
     correlated colour temperature :math:`T_{cp}`, :math:`\\Delta_{uv}` and
     colour matching functions using *Ohno (2013)* method.
 
@@ -345,8 +345,8 @@ def XYZ_to_CCT_Ohno2013(
     spacing: float | None = None,
 ) -> NDArrayFloat:
     """
-    Return the correlated colour temperature :math:`T_{cp}` and
-    :math:`\\Delta_{uv}` from given *CIE XYZ* tristimulus values, colour
+    Compute the correlated colour temperature :math:`T_{cp}` and
+    :math:`\\Delta_{uv}` from specified *CIE XYZ* tristimulus values, colour
     matching functions and temperature range using *Ohno (2013)* method.
 
     Parameters
@@ -396,7 +396,7 @@ def CCT_to_XYZ_Ohno2013(
     CCT_D_uv: ArrayLike, cmfs: MultiSpectralDistributions | None = None
 ) -> NDArrayFloat:
     """
-    Return the *CIE XYZ* tristimulus values from given correlated colour
+    Compute the *CIE XYZ* tristimulus values from specified correlated colour
     temperature :math:`T_{cp}`, :math:`\\Delta_{uv}` and colour matching
     functions using *Ohno (2013)* method.
 

--- a/colour/temperature/planck1900.py
+++ b/colour/temperature/planck1900.py
@@ -54,8 +54,8 @@ def uv_to_CCT_Planck1900(
     optimisation_kwargs: dict | None = None,
 ) -> NDArrayFloat:
     """
-    Return the correlated colour temperature :math:`T_{cp}` of a blackbody from
-    given *CIE UCS* colourspace *uv* chromaticity coordinates and colour
+    Compute the correlated colour temperature :math:`T_{cp}` of a blackbody from
+    specified *CIE UCS* colourspace *uv* chromaticity coordinates and colour
     matching functions.
 
     Parameters
@@ -131,9 +131,9 @@ def CCT_to_uv_Planck1900(
     CCT: ArrayLike, cmfs: MultiSpectralDistributions | None = None
 ) -> NDArrayFloat:
     """
-    Return the *CIE UCS* colourspace *uv* chromaticity coordinates from given
+    Compute the *CIE UCS* colourspace *uv* chromaticity coordinates from specified
     correlated colour temperature :math:`T_{cp}` and colour matching functions
-    using the spectral radiance of a blackbody at the given thermodynamic
+    using the spectral radiance of a blackbody at the specified thermodynamic
     temperature.
 
     Parameters

--- a/colour/temperature/robertson1968.py
+++ b/colour/temperature/robertson1968.py
@@ -154,7 +154,7 @@ ISOTEMPERATURE_LINES_ROBERTSON1968: list = [
 
 def mired_to_CCT(mired: ArrayLike) -> NDArrayFloat:
     """
-    Convert given micro reciprocal degree to correlated colour temperature
+    Convert specified micro reciprocal degree to correlated colour temperature
     :math:`T_{cp}`.
 
     Parameters
@@ -181,7 +181,7 @@ def mired_to_CCT(mired: ArrayLike) -> NDArrayFloat:
 
 def CCT_to_mired(CCT: ArrayLike) -> NDArrayFloat:
     """
-    Convert given correlated colour temperature :math:`T_{cp}` to micro
+    Convert specified correlated colour temperature :math:`T_{cp}` to micro
     reciprocal degree (mired).
 
     Parameters
@@ -208,8 +208,8 @@ def CCT_to_mired(CCT: ArrayLike) -> NDArrayFloat:
 
 def _uv_to_CCT_Robertson1968(uv: ArrayLike) -> NDArrayFloat:
     """
-    Return the correlated colour temperature :math:`T_{cp}` and
-    :math:`\\Delta_{uv}` from given *CIE UCS* colourspace *uv* chromaticity
+    Compute the correlated colour temperature :math:`T_{cp}` and
+    :math:`\\Delta_{uv}` from specified *CIE UCS* colourspace *uv* chromaticity
     coordinates using *Roberston (1968)* method.
 
     Parameters
@@ -276,8 +276,8 @@ def _uv_to_CCT_Robertson1968(uv: ArrayLike) -> NDArrayFloat:
 
 def uv_to_CCT_Robertson1968(uv: ArrayLike) -> NDArrayFloat:
     """
-    Return the correlated colour temperature :math:`T_{cp}` and
-    :math:`\\Delta_{uv}` from given *CIE UCS* colourspace *uv* chromaticity
+    Compute the correlated colour temperature :math:`T_{cp}` and
+    :math:`\\Delta_{uv}` from specified *CIE UCS* colourspace *uv* chromaticity
     coordinates using *Roberston (1968)* method.
 
     Parameters
@@ -310,7 +310,7 @@ def uv_to_CCT_Robertson1968(uv: ArrayLike) -> NDArrayFloat:
 
 def _CCT_to_uv_Robertson1968(CCT_D_uv: ArrayLike) -> NDArrayFloat:
     """
-    Return the *CIE UCS* colourspace *uv* chromaticity coordinates from given
+    Compute the *CIE UCS* colourspace *uv* chromaticity coordinates from specified
     correlated colour temperature :math:`T_{cp}` and :math:`\\Delta_{uv}` using
     *Roberston (1968)* method.
 
@@ -370,7 +370,7 @@ def _CCT_to_uv_Robertson1968(CCT_D_uv: ArrayLike) -> NDArrayFloat:
 
 def CCT_to_uv_Robertson1968(CCT_D_uv: ArrayLike) -> NDArrayFloat:
     """
-    Return the *CIE UCS* colourspace *uv* chromaticity coordinates from given
+    Compute the *CIE UCS* colourspace *uv* chromaticity coordinates from specified
     correlated colour temperature :math:`T_{cp}` and :math:`\\Delta_{uv}` using
     *Roberston (1968)* method.
 

--- a/colour/utilities/__init__.py
+++ b/colour/utilities/__init__.py
@@ -302,10 +302,10 @@ __all__ += [
 # ---                API Changes and Deprecation Management                ---#
 # ----------------------------------------------------------------------------#
 class utilities(ModuleAPI):
-    """Define a class acting like the *utilities* module."""
+    """Class acting like the *utilities* module."""
 
     def __getattr__(self, attribute: str) -> Any:
-        """Return the value from the attribute with given name."""
+        """Retrieve the value from the specified attribute."""
 
         return super().__getattr__(attribute)
 

--- a/colour/utilities/array.py
+++ b/colour/utilities/array.py
@@ -2,7 +2,7 @@
 Array Utilities
 ===============
 
-Define array utilities objects.
+Array utilities objects.
 
 References
 ----------
@@ -197,7 +197,7 @@ class MixinDataclassIterable(MixinDataclassFields):
     @property
     def items(self) -> tuple:
         """
-        Getter property for  the :class:`dataclass`-like class items, i.e., the
+        Getter property for the :class:`dataclass`-like class items, i.e., the
         field names and values.
 
         Returns
@@ -490,7 +490,7 @@ class MixinDataclassArithmetic(MixinDataclassArray):
         self, a: Any, operation: str, in_place: bool = False
     ) -> Dataclass:
         """
-        Perform given arithmetical operation with :math:`a` operand on the
+        Perform specified arithmetical operation with :math:`a` operand on the
         :class:`dataclass`-like class.
 
         Parameters
@@ -550,8 +550,8 @@ def as_array(
     dtype: Type[DType] | None = None,
 ) -> NDArray:
     """
-    Convert given variable :math:`a` to :class:`numpy.ndarray` using given
-    :class:`numpy.dtype`.
+    Convert specified variable :math:`a` to :class:`numpy.ndarray` using
+    specified :class:`numpy.dtype`.
 
     Parameters
     ----------
@@ -595,8 +595,8 @@ def as_int(
 ) -> DTypeInt | NDArrayInt: ...
 def as_int(a: ArrayLike, dtype: Type[DTypeInt] | None = None) -> DTypeInt | NDArrayInt:
     """
-    Attempt to convert given variable :math:`a` to :class:`numpy.integer`
-    using given :class:`numpy.dtype`. If variable :math:`a` is not a scalar or
+    Attempt to convert specified variable :math:`a` to :class:`numpy.integer`
+    using specified :class:`numpy.dtype`. If variable :math:`a` is not a scalar or
     0-dimensional, it is converted to :class:`numpy.ndarray`.
 
     Parameters
@@ -649,8 +649,8 @@ def as_float(
     a: ArrayLike, dtype: Type[DTypeFloat] | None = None
 ) -> DTypeFloat | NDArrayFloat:
     """
-    Attempt to convert given variable :math:`a` to :class:`numpy.floating`
-    using given :class:`numpy.dtype`. If variable :math:`a` is not a scalar or
+    Attempt to convert specified variable :math:`a` to :class:`numpy.floating`
+    using specified :class:`numpy.dtype`. If variable :math:`a` is not a scalar or
     0-dimensional, it is converted to :class:`numpy.ndarray`.
 
     Parameters
@@ -698,8 +698,8 @@ def as_float(
 
 def as_int_array(a: ArrayLike, dtype: Type[DTypeInt] | None = None) -> NDArrayInt:
     """
-    Convert given variable :math:`a` to :class:`numpy.ndarray` using given
-    :class:`numpy.dtype`.
+    Convert specified variable :math:`a` to :class:`numpy.ndarray` using
+    specified :class:`numpy.dtype`.
 
     Parameters
     ----------
@@ -733,8 +733,8 @@ def as_int_array(a: ArrayLike, dtype: Type[DTypeInt] | None = None) -> NDArrayIn
 
 def as_float_array(a: ArrayLike, dtype: Type[DTypeFloat] | None = None) -> NDArrayFloat:
     """
-    Convert given variable :math:`a` to :class:`numpy.ndarray` using given
-    :class:`numpy.dtype`.
+    Convert specified variable :math:`a` to :class:`numpy.ndarray` using
+    specified :class:`numpy.dtype`.
 
     Parameters
     ----------
@@ -768,7 +768,8 @@ def as_float_array(a: ArrayLike, dtype: Type[DTypeFloat] | None = None) -> NDArr
 
 def as_int_scalar(a: ArrayLike, dtype: Type[DTypeInt] | None = None) -> int:
     """
-    Convert given :math:`a` variable to :class:`numpy.integer` using given
+    Convert specified :math:`a` variable to :class:`numpy.integer` using
+    specified
     :class:`numpy.dtype`.
 
     Parameters
@@ -806,7 +807,8 @@ def as_int_scalar(a: ArrayLike, dtype: Type[DTypeInt] | None = None) -> int:
 
 def as_float_scalar(a: ArrayLike, dtype: Type[DTypeFloat] | None = None) -> float:
     """
-    Convert given :math:`a` variable to :class:`numpy.floating` using given
+    Convert specified :math:`a` variable to :class:`numpy.floating` using
+    specified
     :class:`numpy.dtype`.
 
     Parameters
@@ -847,7 +849,7 @@ def set_default_int_dtype(
 ) -> None:
     """
     Set *Colour* default :class:`numpy.integer` precision by setting
-    :attr:`colour.constant.DTYPE_INT_DEFAULT` attribute with given
+    :attr:`colour.constant.DTYPE_INT_DEFAULT` attribute with specified
     :class:`numpy.dtype` wherever the attribute is imported.
 
     Parameters
@@ -897,7 +899,7 @@ def set_default_float_dtype(
 ) -> None:
     """
     Set *Colour* default :class:`numpy.floating` precision by setting
-    :attr:`colour.constant.DTYPE_FLOAT_DEFAULT` attribute with given
+    :attr:`colour.constant.DTYPE_FLOAT_DEFAULT` attribute with specified
     :class:`numpy.dtype` wherever the attribute is imported.
 
     Parameters
@@ -918,7 +920,7 @@ def set_default_float_dtype(
         setting the *COLOUR_SCIENCE__DEFAULT_FLOAT_DTYPE* environment variable,
         for example `set COLOUR_SCIENCE__DEFAULT_FLOAT_DTYPE=float32`.
     -   Some definition returning a single-scalar ndarray might not honour the
-        given *float* precision: https://github.com/numpy/numpy/issues/16353
+        specified *float* precision: https://github.com/numpy/numpy/issues/16353
 
     Examples
     --------
@@ -1109,7 +1111,7 @@ def to_domain_1(
     dtype: Type[DTypeFloat] | None = None,
 ) -> NDArray:
     """
-    Scale given array :math:`a` to domain **'1'**. The behaviour is as
+    Scale specified array :math:`a` to domain **'1'**. The behaviour is as
     follows:
 
     -   If *Colour* domain-range scale is **'Reference'** or **'1'**, the
@@ -1171,7 +1173,7 @@ def to_domain_10(
     dtype: Type[DTypeFloat] | None = None,
 ) -> NDArray:
     """
-    Scale given array :math:`a` to domain **'10'**, used by
+    Scale specified array :math:`a` to domain **'10'**, used by
     *Munsell Renotation System*. The behaviour is as follows:
 
     -   If *Colour* domain-range scale is **'Reference'**, the
@@ -1238,7 +1240,7 @@ def to_domain_100(
     dtype: Type[DTypeFloat] | None = None,
 ) -> NDArray:
     """
-    Scale given array :math:`a` to domain **'100'**. The behaviour is as
+    Scale specified array :math:`a` to domain **'100'**. The behaviour is as
     follows:
 
     -   If *Colour* domain-range scale is **'Reference'** or **'100'**
@@ -1300,7 +1302,7 @@ def to_domain_degrees(
     dtype: Type[DTypeFloat] | None = None,
 ) -> NDArray:
     """
-    Scale given array :math:`a` to degrees domain. The behaviour is as
+    Scale specified array :math:`a` to degrees domain. The behaviour is as
     follows:
 
     -   If *Colour* domain-range scale is **'Reference'**, the
@@ -1367,7 +1369,7 @@ def to_domain_int(
     dtype: Type[DTypeFloat] | None = None,
 ) -> NDArray:
     """
-    Scale given array :math:`a` to int domain. The behaviour is as follows:
+    Scale specified array :math:`a` to int domain. The behaviour is as follows:
 
     -   If *Colour* domain-range scale is **'Reference'**, the
         definition is almost entirely by-passed and will conveniently convert
@@ -1439,7 +1441,7 @@ def from_range_1(
     dtype: Type[DTypeFloat] | None = None,
 ) -> NDArray:
     """
-    Scale given array :math:`a` from range **'1'**. The behaviour is as
+    Scale specified array :math:`a` from range **'1'**. The behaviour is as
     follows:
 
     -   If *Colour* domain-range scale is **'Reference'** or **'1'**, the
@@ -1505,7 +1507,7 @@ def from_range_10(
     dtype: Type[DTypeFloat] | None = None,
 ) -> NDArray:
     """
-    Scale given array :math:`a` from range **'10'**, used by
+    Scale specified array :math:`a` from range **'10'**, used by
     *Munsell Renotation System*. The behaviour is as follows:
 
     -   If *Colour* domain-range scale is **'Reference'**, the
@@ -1576,7 +1578,7 @@ def from_range_100(
     dtype: Type[DTypeFloat] | None = None,
 ) -> NDArray:
     """
-    Scale given array :math:`a` from range **'100'**. The behaviour is as
+    Scale specified array :math:`a` from range **'100'**. The behaviour is as
     follows:
 
     -   If *Colour* domain-range scale is **'Reference'** or **'100'**
@@ -1642,7 +1644,7 @@ def from_range_degrees(
     dtype: Type[DTypeFloat] | None = None,
 ) -> NDArray:
     """
-    Scale given array :math:`a` from degrees range. The behaviour is as
+    Scale specified array :math:`a` from degrees range. The behaviour is as
     follows:
 
     -   If *Colour* domain-range scale is **'Reference'**, the
@@ -1713,7 +1715,7 @@ def from_range_int(
     dtype: Type[DTypeFloat] | None = None,
 ) -> NDArray:
     """
-    Scale given array :math:`a` from int range. The behaviour is as follows:
+    Scale specified array :math:`a` from int range. The behaviour is as follows:
 
     -   If *Colour* domain-range scale is **'Reference'**, the
         definition is entirely by-passed.
@@ -2002,7 +2004,7 @@ _CACHE_DISTRIBUTION_INTERVAL: dict = CACHE_REGISTRY.register_cache(
 
 def interval(distribution: ArrayLike, unique: bool = True) -> NDArray:
     """
-    Return the interval size of given distribution.
+    Return the interval size of specified distribution.
 
     Parameters
     ----------
@@ -2064,7 +2066,7 @@ def interval(distribution: ArrayLike, unique: bool = True) -> NDArray:
 
 def is_uniform(distribution: ArrayLike) -> bool:
     """
-    Return whether given distribution is uniform.
+    Return whether specified distribution is uniform.
 
     Parameters
     ----------
@@ -2097,7 +2099,7 @@ def is_uniform(distribution: ArrayLike) -> bool:
 def in_array(a: ArrayLike, b: ArrayLike, tolerance: Real = EPSILON) -> NDArray:
     """
     Return whether each element of the array :math:`a` is also present in the
-    array :math:`b` within given tolerance.
+    array :math:`b` within specified tolerance.
 
     Parameters
     ----------
@@ -2113,7 +2115,7 @@ def in_array(a: ArrayLike, b: ArrayLike, tolerance: Real = EPSILON) -> NDArray:
     -------
     :class:`numpy.ndarray`
         A bool array with array :math:`a` shape describing whether an
-        element of array :math:`a` is present in array :math:`b` within given
+        element of array :math:`a` is present in array :math:`b` within specified
         tolerance.
 
     References
@@ -2143,7 +2145,7 @@ def tstack(
     dtype: Type[DTypeBoolean] | Type[DTypeReal] | None = None,
 ) -> NDArray:
     """
-    Stack given array of arrays :math:`a` along the last axis (tail) to
+    Stack specified array of arrays :math:`a` along the last axis (tail) to
     produce a stacked array.
 
     It is used to stack an array of arrays produced by the
@@ -2206,7 +2208,7 @@ def tsplit(
     dtype: Type[DTypeBoolean] | Type[DTypeReal] | None = None,
 ) -> NDArray:
     """
-    Split given stacked array :math:`a` along the last axis (tail) to produce
+    Split specified stacked array :math:`a` along the last axis (tail) to produce
     an array of arrays.
 
     It is used to split a stacked array produced by the
@@ -2265,7 +2267,7 @@ def tsplit(
 
 def row_as_diagonal(a: ArrayLike) -> NDArray:
     """
-    Return the rows of given array :math:`a` as diagonal matrices.
+    Return the rows of specified array :math:`a` as diagonal matrices.
 
     Parameters
     ----------
@@ -2328,7 +2330,7 @@ def orient(
     ) = "Ignore",
 ) -> NDArray:
     """
-    Orient given array :math:`a` according to given orientation.
+    Orient specified array :math:`a` according to specified orientation.
 
     Parameters
     ----------
@@ -2389,7 +2391,7 @@ def orient(
 
 def centroid(a: ArrayLike) -> NDArrayInt:
     """
-    Return the centroid indexes of given array :math:`a`.
+    Return the centroid indexes of specified array :math:`a`.
 
     Parameters
     ----------
@@ -2436,7 +2438,7 @@ def fill_nan(
     default: Real = 0,
 ) -> NDArray:
     """
-    Fill given array :math:`a` NaN values according to given method.
+    Fill specified array :math:`a` NaN values according to specified method.
 
     Parameters
     ----------
@@ -2477,7 +2479,7 @@ def fill_nan(
 
 def has_only_nan(a: ArrayLike) -> bool:
     """
-    Return whether given array :math:`a` contains only NaN values.
+    Return whether specified array :math:`a` contains only NaN values.
 
     Parameters
     ----------
@@ -2509,7 +2511,7 @@ def has_only_nan(a: ArrayLike) -> bool:
 @contextmanager
 def ndarray_write(a: ArrayLike) -> Generator:
     """
-    Define a context manager setting given array :math:`a` writeable to
+    Define a context manager setting specified array :math:`a` writeable to
     operate one and then read-only.
 
     Parameters
@@ -2569,7 +2571,7 @@ def zeros(
     Returns
     -------
     :class:`numpy.ndarray`
-        Array of given shape and :class:`numpy.dtype`, filled with zeros.
+        Array of specified shape and :class:`numpy.dtype`, filled with zeros.
 
     Examples
     --------
@@ -2607,7 +2609,7 @@ def ones(
     Returns
     -------
     :class:`numpy.ndarray`
-        Array of given shape and type, filled with ones.
+        Array of specified shape and type, filled with ones.
 
     Examples
     --------
@@ -2647,7 +2649,7 @@ def full(
     Returns
     -------
     :class:`numpy.ndarray`
-        Array of given shape and :class:`numpy.dtype`, filled with given value.
+        Array of specified shape and :class:`numpy.dtype`, filled with specified value.
 
     Examples
     --------
@@ -2731,7 +2733,7 @@ def index_along_last_axis(a: ArrayLike, indexes: ArrayLike) -> NDArray:
     >>> np.array_equal(index_along_last_axis(a, indexes), np.min(a, axis=-1))
     True
 
-    In particular, this can be used to manipulate the indexes given by
+    In particular, this can be used to manipulate the indexes specified by
     functions like :func:`np.min` before indexing the array. For example, to
     get elements directly following the smallest elements:
 
@@ -2757,7 +2759,7 @@ def index_along_last_axis(a: ArrayLike, indexes: ArrayLike) -> NDArray:
 
 def format_array_as_row(a: ArrayLike, decimals: int = 7, separator: str = " ") -> str:
     """
-    Format given array :math:`a` as a row.
+    Format specified array :math:`a` as a row.
 
     Parameters
     ----------

--- a/colour/utilities/callback.py
+++ b/colour/utilities/callback.py
@@ -2,7 +2,7 @@
 Callback Management
 ===================
 
-Define the callback management objects.
+Callback management objects.
 """
 
 from __future__ import annotations
@@ -95,7 +95,7 @@ class MixinCallback:
 
     def __setattr__(self, name: str, value: Any) -> None:
         """
-        Set given value to the attribute with given name.
+        Set specified value to the attribute with specified name.
 
         Parameters
         ----------
@@ -113,7 +113,7 @@ class MixinCallback:
 
     def register_callback(self, attribute: str, name: str, function: Callable) -> None:
         """
-        Register the callback with given name for given attribute.
+        Register the callback with specified name for specified attribute.
 
         Parameters
         ----------
@@ -144,7 +144,7 @@ class MixinCallback:
 
     def unregister_callback(self, attribute: str, name: str) -> None:
         """
-        Unregister the callback with given name for given attribute.
+        Unregister the callback with specified name for specified attribute.
 
         Parameters
         ----------

--- a/colour/utilities/common.py
+++ b/colour/utilities/common.py
@@ -2,7 +2,7 @@
 Common Utilities
 ================
 
-Define the common utilities objects that don't fall in any specific category.
+Common utilities objects that don't fall in any specific category.
 
 References
 ----------
@@ -255,7 +255,7 @@ class CacheRegistry:
 
     def register_cache(self, name: str) -> dict:
         """
-        Register a new cache with given name in the registry.
+        Register a new cache with specified name in the registry.
 
         Parameters
         ----------
@@ -285,7 +285,7 @@ class CacheRegistry:
 
     def unregister_cache(self, name: str) -> None:
         """
-        Unregister cache with given name in the registry.
+        Unregister cache with specified name in the registry.
 
         Parameters
         ----------
@@ -319,7 +319,7 @@ class CacheRegistry:
 
     def clear_cache(self, name: str) -> None:
         """
-        Clear the cache with given name.
+        Clear the cache with specified name.
 
         Parameters
         ----------
@@ -399,11 +399,11 @@ def handle_numpy_errors(**kwargs: Any) -> Callable:
     keyword_arguments = kwargs
 
     def wrapper(function: Callable) -> Callable:
-        """Wrap given function wrapper."""
+        """Wrap specified function wrapper."""
 
         @functools.wraps(function)
         def wrapped(*args: Any, **kwargs: Any) -> Any:
-            """Wrap given function."""
+            """Wrap specified function."""
 
             with np.errstate(**keyword_arguments):
                 return function(*args, **kwargs)
@@ -442,7 +442,7 @@ def ignore_python_warnings(function: Callable) -> Callable:
 
     @functools.wraps(function)
     def wrapper(*args: Any, **kwargs: Any) -> Any:
-        """Wrap given function."""
+        """Wrap specified function."""
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
@@ -471,7 +471,7 @@ def attest(condition: bool | DTypeBoolean, message: str = "") -> None:
 
 def batch(sequence: Sequence, k: int | Literal[3] = 3) -> Generator:
     """
-    Return a batch generator from given sequence.
+    Generate batches from specified sequence.
 
     Parameters
     ----------
@@ -532,7 +532,7 @@ class disable_multiprocessing:
 
         @functools.wraps(function)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
-            """Wrap given function."""
+            """Wrap specified function."""
 
             with self:
                 return function(*args, **kwargs)
@@ -624,7 +624,7 @@ def multiprocessing_pool(*args: Any, **kwargs: Any) -> Generator:
             iterable: Sequence,
             chunksize: int | None = None,  # noqa: ARG002
         ) -> list[Any]:
-            """Apply given function to each element of given iterable."""
+            """Apply specified function to each element of specified iterable."""
 
             return [func(a) for a in iterable]
 
@@ -658,7 +658,7 @@ def multiprocessing_pool(*args: Any, **kwargs: Any) -> Generator:
 
 def is_iterable(a: Any) -> bool:
     """
-    Return whether given variable :math:`a` is iterable.
+    Determine whether specified variable :math:`a` is iterable.
 
     Parameters
     ----------
@@ -683,7 +683,7 @@ def is_iterable(a: Any) -> bool:
 
 def is_numeric(a: Any) -> bool:
     """
-    Return whether given variable :math:`a` is a :class:`Real`-like
+    Determine whether specified variable :math:`a` is a :class:`Real`-like
     variable.
 
     Parameters
@@ -732,8 +732,8 @@ def is_numeric(a: Any) -> bool:
 
 def is_integer(a: Any) -> bool:
     """
-    Return whether given variable :math:`a` is an :class:`numpy.integer`-like
-    variable under given threshold.
+    Return whether specified variable :math:`a` is an :class:`numpy.integer`-like
+    variable under specified threshold.
 
     Parameters
     ----------
@@ -763,7 +763,7 @@ def is_integer(a: Any) -> bool:
 
 def is_sibling(element: Any, mapping: Mapping) -> bool:
     """
-    Return whether given element type is present in given mapping types.
+    Return whether specified element type is present in specified mapping types.
 
     Parameters
     ----------
@@ -775,7 +775,7 @@ def is_sibling(element: Any, mapping: Mapping) -> bool:
     Returns
     -------
     :class:`bool`
-        Whether given element type is present in given mapping types.
+        Whether specified element type is present in specified mapping types.
     """
 
     return isinstance(element, tuple({type(element) for element in mapping.values()}))
@@ -783,7 +783,7 @@ def is_sibling(element: Any, mapping: Mapping) -> bool:
 
 def filter_kwargs(function: Callable, **kwargs: Any) -> dict:
     """
-    Filter keyword arguments incompatible with the given function signature.
+    Filter keyword arguments incompatible with the specified function signature.
 
     Parameters
     ----------
@@ -831,14 +831,14 @@ def filter_kwargs(function: Callable, **kwargs: Any) -> dict:
 
 def filter_mapping(mapping: Mapping, names: str | Sequence[str]) -> dict:
     """
-    Filter given mapping with given names.
+    Filter specified mapping with specified names.
 
     Parameters
     ----------
     mapping
         Mapping to filter.
     names
-        Name for given mapping elements or a list of names.
+        Name for specified mapping elements or a list of names.
 
     Returns
     -------
@@ -869,14 +869,14 @@ def filter_mapping(mapping: Mapping, names: str | Sequence[str]) -> dict:
 
     def filter_mapping_with_name(mapping: Mapping, name: str) -> dict:
         """
-        Filter given mapping with given name.
+        Filter specified mapping with specified name.
 
         Parameters
         ----------
         mapping
             Mapping to filter.
         name
-            Name for given mapping elements.
+            Name for specified mapping elements.
 
         Returns
         -------
@@ -909,7 +909,7 @@ def filter_mapping(mapping: Mapping, names: str | Sequence[str]) -> dict:
 
 def first_item(a: Iterable) -> Any:
     """
-    Return the first item of given iterable.
+    Return the first item of specified iterable.
 
     Parameters
     ----------
@@ -973,7 +973,7 @@ def validate_method(
     as_lowercase: bool = True,
 ) -> str:
     """
-    Validate whether given method exists in the given valid methods and
+    Validate whether specified method exists in the specified valid methods and
     optionally returns the method lower cased.
 
     Parameters
@@ -985,7 +985,7 @@ def validate_method(
     message
         Message for the exception.
     as_lowercase
-        Whether to convert the given method to lower case or not.
+        Whether to convert the specified method to lower case or not.
 
     Returns
     -------
@@ -1049,7 +1049,7 @@ def optional(value: T | None, default: T) -> T:
 
 def slugify(object_: Any, allow_unicode: bool = False) -> str:
     """
-    Generate a *SEO* friendly and human-readable slug from given object.
+    Generate a *SEO* friendly and human-readable slug from specified object.
 
     Convert to ASCII if ``allow_unicode`` is *False*. Convert spaces or
     repeated dashes to single dashes. Remove characters that aren't
@@ -1112,7 +1112,7 @@ if is_xxhash_installed():
             seed: int = 0,  # noqa: ARG001
         ) -> int:
             """
-            Generate an integer digest for given argument using *xxhash* if
+            Generate an integer digest for specified argument using *xxhash* if
             available or falling back to :func:`hash` if not.
 
             Parameters

--- a/colour/utilities/deprecation.py
+++ b/colour/utilities/deprecation.py
@@ -2,7 +2,7 @@
 Deprecation Utilities
 =====================
 
-Define various deprecation management related objects.
+Various deprecation management related objects.
 """
 
 from __future__ import annotations
@@ -366,7 +366,7 @@ class ModuleAPI:
 
     def __getattr__(self, attribute: str) -> Any:
         """
-        Return given attribute value while handling deprecation.
+        Return specified attribute value while handling deprecation.
 
         Parameters
         ----------
@@ -420,7 +420,7 @@ class ModuleAPI:
 
 def get_attribute(attribute: str) -> Any:
     """
-    Return given attribute value.
+    Return specified attribute value.
 
     Parameters
     ----------

--- a/colour/utilities/documentation.py
+++ b/colour/utilities/documentation.py
@@ -2,7 +2,7 @@
 Documentation
 =============
 
-Define the documentation related objects.
+Documentation related objects.
 """
 
 from __future__ import annotations

--- a/colour/utilities/metrics.py
+++ b/colour/utilities/metrics.py
@@ -54,7 +54,7 @@ def metric_mse(
 ) -> NDArrayFloat:
     """
     Compute the mean squared error (MSE) or mean squared deviation (MSD)
-    between given variables :math:`a` and :math:`b`.
+    between specified variables :math:`a` and :math:`b`.
 
     Parameters
     ----------
@@ -95,7 +95,7 @@ def metric_psnr(
     axis: int | Tuple[int] | None = None,
 ) -> NDArrayFloat:
     """
-    Compute the peak signal-to-noise ratio (PSNR) between given variables
+    Compute the peak signal-to-noise ratio (PSNR) between specified variables
     :math:`a` and :math:`b`.
 
     Parameters

--- a/colour/utilities/network.py
+++ b/colour/utilities/network.py
@@ -2,7 +2,7 @@
 Network
 =======
 
-Define various node-graph / network related classes:
+Various node-graph / network related classes:
 
 -   :class:`colour.utilities.TreeNode`: A basic node object supporting creation
     of basic node trees.
@@ -75,7 +75,7 @@ __all__ = [
 
 class TreeNode:
     """
-    Represent a basic node supporting the creation of basic node trees.
+    Basic node supporting the creation of basic node trees.
 
     Parameters
     ----------
@@ -539,7 +539,7 @@ class TreeNode:
 
 class Port(MixinLogging):
     """
-    Define an object that can be added either as an input or output port,
+    Object that can be added either as an input or output port,
     i.e., a pin, to a :class:`colour.utilities.PortNode` class and connected to
     another input or output port.
 
@@ -668,7 +668,7 @@ class Port(MixinLogging):
             self._node.dirty = True
 
         # NOTE: Setting the port value implies that all the connected ports
-        # should be also set to the same given value.
+        # should be also set to the same specified value.
         for direct_connection in self._connections:
             self.log(f'Setting "{direct_connection.node}" value to {value}.', "debug")
             direct_connection._value = value  # noqa: SLF001
@@ -840,7 +840,7 @@ class Port(MixinLogging):
 
     def connect(self, port: Port) -> None:
         """
-        Connect the port to the other given port.
+        Connect the port to the other specified port.
 
         Parameters
         ----------
@@ -877,7 +877,7 @@ class Port(MixinLogging):
 
     def disconnect(self, port: Port) -> None:
         """
-        Disconnect the port from the other given port.
+        Disconnect the port from the other specified port.
 
         Parameters
         ----------
@@ -928,7 +928,7 @@ class Port(MixinLogging):
 
 class PortNode(TreeNode, MixinLogging):
     """
-    Define a node with support for input and output ports.
+    Node with support for input and output ports.
 
     Other Parameters
     ----------------
@@ -1119,7 +1119,7 @@ class PortNode(TreeNode, MixinLogging):
         port_type: Type[Port] = Port,
     ) -> Port:
         """
-        Add an input port with given name and value to the node.
+        Add an input port with specified name and value to the node.
 
         Parameters
         ----------
@@ -1153,7 +1153,7 @@ class PortNode(TreeNode, MixinLogging):
         name: str,
     ) -> Port:
         """
-        Remove the input port with given name from the node.
+        Remove the input port with specified name from the node.
 
         Parameters
         ----------
@@ -1193,7 +1193,7 @@ class PortNode(TreeNode, MixinLogging):
         port_type: Type[Port] = Port,
     ) -> Port:
         """
-        Add an output port with given name and value to the node.
+        Add an output port with specified name and value to the node.
 
         Parameters
         ----------
@@ -1227,7 +1227,7 @@ class PortNode(TreeNode, MixinLogging):
         name: str,
     ) -> Port:
         """
-        Remove the output port with given name from the node.
+        Remove the output port with specified name from the node.
 
         Parameters
         ----------
@@ -1261,7 +1261,7 @@ class PortNode(TreeNode, MixinLogging):
 
     def get_input(self, name: str) -> Any:
         """
-        Return the value of the input port with given name.
+        Return the value of the input port with specified name.
 
         Parameters
         ----------
@@ -1295,7 +1295,7 @@ class PortNode(TreeNode, MixinLogging):
 
     def set_input(self, name: str, value: Any) -> None:
         """
-        Set the value of the input port with given name.
+        Set the value of the input port with specified name.
 
         Parameters
         ----------
@@ -1328,7 +1328,7 @@ class PortNode(TreeNode, MixinLogging):
 
     def get_output(self, name: str) -> Any:
         """
-        Return the value of the output port with given name.
+        Return the value of the output port with specified name.
 
         Parameters
         ----------
@@ -1362,7 +1362,7 @@ class PortNode(TreeNode, MixinLogging):
 
     def set_output(self, name: str, value: Any) -> None:
         """
-        Set the value of the output port with given name.
+        Set the value of the output port with specified name.
 
         Parameters
         ----------
@@ -1400,7 +1400,7 @@ class PortNode(TreeNode, MixinLogging):
         target_port: str,
     ) -> None:
         """
-        Connect the given source port to given node target port.
+        Connect the specified source port to specified node target port.
 
         The source port can be an input port but the target port must be
         an output port and conversely, if the source port is an output port, the
@@ -1442,7 +1442,7 @@ class PortNode(TreeNode, MixinLogging):
         target_port: str,
     ) -> None:
         """
-        Disconnect the given source port from given node target port.
+        Disconnect the specified source port from specified node target port.
 
         The source port can be an input port but the target port must be
         an output port and conversely, if the source port is an output port, the
@@ -1553,7 +1553,7 @@ class PortNode(TreeNode, MixinLogging):
 
 class PortGraph(PortNode):
     """
-    Define a node-graph for :class:`colour.utilities.PortNode` class instances.
+    Node-graph for :class:`colour.utilities.PortNode` class instances.
 
     Parameters
     ----------
@@ -1650,7 +1650,7 @@ class PortGraph(PortNode):
 
     def add_node(self, node: PortNode) -> None:
         """
-        Add given node to the node-graph.
+        Add specified node to the node-graph.
 
         Parameters
         ----------
@@ -1691,7 +1691,7 @@ class PortGraph(PortNode):
 
     def remove_node(self, node: PortNode) -> None:
         """
-        Remove given node from the node-graph.
+        Remove specified node from the node-graph.
 
         The node input and output ports will be disconnected from all their
         connections.
@@ -1960,7 +1960,7 @@ class PortGraph(PortNode):
         graphs = [node for node in self.walk_ports() if isinstance(node, PortGraph)]
 
         def is_graph_member(node: PortNode) -> bool:
-            """Return whether the given node is member of a graph."""
+            """Return whether the specified node is member of a graph."""
 
             return any(node in graph.nodes.values() for graph in graphs)
 
@@ -1995,7 +1995,7 @@ class PortGraph(PortNode):
 
 class ExecutionPort(Port):
     """
-    Define a special port for nodes supporting execution input and output
+    Special port for nodes supporting execution input and output
     ports.
     """
 
@@ -2022,7 +2022,7 @@ class ExecutionPort(Port):
 
 class ExecutionNode(PortNode):
     """
-    Define a special node with execution input and output ports.
+    Special node with execution input and output ports.
     """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -2037,7 +2037,7 @@ class ExecutionNode(PortNode):
 
 
 class ControlFlowNode(ExecutionNode):
-    """Define a class inherited by control flow nodes."""
+    """Class inherited by control flow nodes."""
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
@@ -2045,7 +2045,7 @@ class ControlFlowNode(ExecutionNode):
 
 class For(ControlFlowNode):
     """
-    Define a ``for`` loop node.
+    ``for`` loop node.
 
     The node loops over the input port ``array``, sets the ``index`` and
     ``element`` output ports at each iteration and call the
@@ -2119,7 +2119,7 @@ _THREADING_LOCK = threading.Lock()
 def _task_thread(args: Sequence) -> tuple[int, Any]:
     """
     Define the default task for the
-    :class:`colour.utilities.ParallelForThread` loop node
+    :class:`colour.utilities.ParallelForThread` loop node.
 
     Parameters
     ----------
@@ -2142,7 +2142,7 @@ def _task_thread(args: Sequence) -> tuple[int, Any]:
 
 class ThreadPoolExecutorManager:
     """
-    Define a singleton class managing our
+    Singleton class managing our
     :class:`concurrent.futures.ThreadPoolExecutor` class instance.
 
     Attributes
@@ -2201,7 +2201,7 @@ class ThreadPoolExecutorManager:
 
 class ParallelForThread(ControlFlowNode):
     """
-    Define an advanced ``for`` loop node distributing the work across multiple
+    Advanced ``for`` loop node distributing the work across multiple
     threads.
 
     Each generated task receives one ``index`` and ``element`` output ports
@@ -2294,7 +2294,7 @@ class ParallelForThread(ControlFlowNode):
 def _task_multiprocess(args: Sequence) -> tuple[int, Any]:
     """
     Define the default task for the
-    :class:`colour.utilities.ParallelForMultiprocess` loop node
+    :class:`colour.utilities.ParallelForMultiprocess` loop node.
 
     Parameters
     ----------
@@ -2316,7 +2316,7 @@ def _task_multiprocess(args: Sequence) -> tuple[int, Any]:
 
 class ProcessPoolExecutorManager:
     """
-    Define a singleton class managing our
+    Singleton class managing our
     :class:`concurrent.futures.ProcessPoolExecutor` class instance.
 
     Attributes
@@ -2378,7 +2378,7 @@ class ProcessPoolExecutorManager:
 
 class ParallelForMultiprocess(ControlFlowNode):
     """
-    Define an advanced ``for`` loop node distributing the work across multiple
+    Advanced ``for`` loop node distributing the work across multiple
     processes.
 
     Each generated task receives one ``index`` and ``element`` output ports

--- a/colour/utilities/requirements.py
+++ b/colour/utilities/requirements.py
@@ -2,7 +2,7 @@
 Requirements Utilities
 ======================
 
-Define the requirements utilities objects.
+Requirements utilities objects.
 """
 
 from __future__ import annotations
@@ -523,11 +523,11 @@ def required(
     """
 
     def wrapper(function: Callable) -> Callable:
-        """Wrap given function wrapper."""
+        """Wrap specified function wrapper."""
 
         @functools.wraps(function)
         def wrapped(*args: Any, **kwargs: Any) -> Any:
-            """Wrap given function."""
+            """Wrap specified function."""
 
             for requirement in requirements:
                 REQUIREMENTS_TO_CALLABLE[requirement](raise_exception=True)

--- a/colour/utilities/structures.py
+++ b/colour/utilities/structures.py
@@ -2,7 +2,7 @@
 Data Structures
 ===============
 
-Define various data structures classes:
+Various data structures classes:
 
 -   :class:`colour.utilities.Structure`: An object similar to C/C++ structured
     type.
@@ -58,7 +58,7 @@ __all__ = [
 
 class Structure(dict):
     """
-    Define a :class:`dict`-like object allowing to access key values using dot
+    :class:`dict`-like object allowing to access key values using dot
     syntax.
 
     Other Parameters
@@ -97,7 +97,7 @@ class Structure(dict):
 
     def __setattr__(self, name: str, value: Any) -> None:
         """
-        Assign given value to the attribute with given name.
+        Assign specified value to the attribute with specified name.
 
         Parameters
         ----------
@@ -111,7 +111,7 @@ class Structure(dict):
 
     def __delattr__(self, name: str) -> None:
         """
-        Delete the attribute with given name.
+        Delete the attribute with specified name.
 
         Parameters
         ----------
@@ -135,7 +135,7 @@ class Structure(dict):
 
     def __getattr__(self, name: str) -> Any:
         """
-        Return the value from the attribute with given name.
+        Return the value from the attribute with specified name.
 
         Parameters
         ----------
@@ -188,7 +188,7 @@ class Lookup(dict):
 
     def keys_from_value(self, value: Any) -> list:
         """
-        Get the keys associated with given value.
+        Get the keys associated with specified value.
 
         Parameters
         ----------
@@ -198,7 +198,7 @@ class Lookup(dict):
         Returns
         -------
         :class:`list`
-            Keys associated with given value.
+            Keys associated with specified value.
         """
 
         keys = []
@@ -217,7 +217,7 @@ class Lookup(dict):
 
     def first_key_from_value(self, value: Any) -> Any:
         """
-        Get the first key associated with given value.
+        Get the first key associated with specified value.
 
         Parameters
         ----------
@@ -227,7 +227,7 @@ class Lookup(dict):
         Returns
         -------
         :class:`object`
-            First key associated with given value.
+            First key associated with specified value.
         """
 
         return self.keys_from_value(value)[0]
@@ -240,7 +240,7 @@ class CanonicalMapping(MutableMapping):
     keys but also canonical keys, i.e., slugified keys without delimiters.
 
     The item keys are expected to be :class:`str`-like objects thus supporting
-    the :meth:`str.lower` method. Setting items is done by using the given
+    the :meth:`str.lower` method. Setting items is done by using the specified
     keys. Retrieving or deleting an item and testing whether an item exist is
     done by transforming the item's key in a sequence as follows:
 
@@ -345,7 +345,7 @@ class CanonicalMapping(MutableMapping):
 
     def __setitem__(self, item: str | Any, value: Any) -> None:
         """
-        Set given item with given value in the delimiter and case-insensitive
+        Set specified item with specified value in the delimiter and case-insensitive
         :class:`dict`-like object.
 
         Parameters
@@ -362,7 +362,7 @@ class CanonicalMapping(MutableMapping):
 
     def __getitem__(self, item: str | Any) -> Any:
         """
-        Return the value of given item from the delimiter and case-insensitive
+        Return the value of specified item from the delimiter and case-insensitive
         :class:`dict`-like object.
 
         Parameters
@@ -407,7 +407,7 @@ class CanonicalMapping(MutableMapping):
 
     def __delitem__(self, item: str | Any) -> None:
         """
-        Delete given item from the delimiter and case-insensitive
+        Delete specified item from the delimiter and case-insensitive
         :class:`dict`-like object.
 
         Parameters
@@ -452,7 +452,7 @@ class CanonicalMapping(MutableMapping):
     def __contains__(self, item: str | Any) -> bool:
         """
         Return whether the delimiter and case-insensitive :class:`dict`-like
-        object contains given item.
+        object contains specified item.
 
         Parameters
         ----------
@@ -463,7 +463,7 @@ class CanonicalMapping(MutableMapping):
         Returns
         -------
         :class:`bool`
-            Whether given item is in the delimiter and case-insensitive
+            Whether specified item is in the delimiter and case-insensitive
             :class:`dict`-like object.
 
         Notes
@@ -515,7 +515,7 @@ class CanonicalMapping(MutableMapping):
     def __eq__(self, other: object) -> bool:
         """
         Return whether the delimiter and case-insensitive :class:`dict`-like
-        object is equal to given other object.
+        object is equal to specified other object.
 
         Parameters
         ----------
@@ -526,7 +526,7 @@ class CanonicalMapping(MutableMapping):
         Returns
         -------
         :class:`bool`
-            Whether given object is equal to the delimiter and case-insensitive
+            Whether specified object is equal to the delimiter and case-insensitive
             :class:`dict`-like object.
         """
 
@@ -545,7 +545,7 @@ class CanonicalMapping(MutableMapping):
     def __ne__(self, other: object) -> bool:
         """
         Return whether the delimiter and case-insensitive :class:`dict`-like
-        object is not equal to given other object.
+        object is not equal to specified other object.
 
         Parameters
         ----------
@@ -556,7 +556,7 @@ class CanonicalMapping(MutableMapping):
         Returns
         -------
         :class:`bool`
-            Whether given object is not equal to the delimiter and
+            Whether specified object is not equal to the delimiter and
             case-insensitive :class:`dict`-like object.
         """
 
@@ -565,7 +565,7 @@ class CanonicalMapping(MutableMapping):
     @staticmethod
     def _collision_warning(keys: list) -> None:
         """
-        Issue a runtime warning when given keys are colliding.
+        Issue a runtime warning when specified keys are colliding.
 
         Parameters
         ----------
@@ -729,7 +729,7 @@ class LazyCanonicalMapping(CanonicalMapping):
 
     def __getitem__(self, item: str | Any) -> Any:
         """
-        Return the value of given item from the lazy delimiter and
+        Return the value of specified item from the lazy delimiter and
         case-insensitive :class:`dict`-like object.
 
         Parameters

--- a/colour/utilities/tests/test_deprecated.py
+++ b/colour/utilities/tests/test_deprecated.py
@@ -16,7 +16,7 @@ class deprecated(ModuleAPI):
     """Define a class acting like the *deprecated* module."""
 
     def __getattr__(self, attribute: str) -> Any:
-        """Return the value from the attribute with given name."""
+        """Return the value from the attribute with specified name."""
 
         return super().__getattr__(attribute)
 

--- a/colour/utilities/verbose.py
+++ b/colour/utilities/verbose.py
@@ -2,7 +2,7 @@
 Verbose
 =======
 
-Define the verbose related objects.
+Verbose related objects.
 """
 
 from __future__ import annotations
@@ -107,7 +107,7 @@ class MixinLogging:
         ] = "info",
     ) -> None:
         """
-        Log given message using given verbosity level.
+        Log specified message using specified verbosity level.
 
         Parameters
         ----------
@@ -126,7 +126,7 @@ class MixinLogging:
 
 class ColourWarning(Warning):
     """
-    Define the base class of *Colour* warnings.
+    Base class of *Colour* warnings.
 
     It is a subclass of the :class:`Warning` class.
     """
@@ -134,7 +134,7 @@ class ColourWarning(Warning):
 
 class ColourUsageWarning(Warning):
     """
-    Define the base class of *Colour* usage warnings.
+    Base class of *Colour* usage warnings.
 
     It is a subclass of the :class:`colour.utilities.ColourWarning` class.
     """
@@ -142,7 +142,7 @@ class ColourUsageWarning(Warning):
 
 class ColourRuntimeWarning(Warning):
     """
-    Define the base class of *Colour* runtime warnings.
+    Base class of *Colour* runtime warnings.
 
     It is a subclass of the :class:`colour.utilities.ColourWarning` class.
     """
@@ -453,7 +453,7 @@ def filter_warnings(
 
 def as_bool(a: str) -> bool:
     """
-    Convert given string to bool.
+    Convert specified string to bool.
 
     The following string values evaluate to *True*: "1", "On", and "True".
 
@@ -465,7 +465,7 @@ def as_bool(a: str) -> bool:
     Returns
     -------
     :class:`bool`
-        Whether the given string is *True*.
+        Whether the specified string is *True*.
 
     Examples
     --------
@@ -529,7 +529,7 @@ def suppress_warnings(
     python_warnings: bool | LiteralWarning | None = None,
 ) -> Generator:
     """
-    Define a context manager filtering *Colour* and also optionally overall
+    Context manager filtering *Colour* and also optionally overall
     Python warnings.
 
     The possible values for all the actions, i.e., each argument, are as
@@ -579,7 +579,7 @@ def suppress_warnings(
 
 class suppress_stdout:
     """
-    Define a context manager and decorator temporarily suppressing standard
+    Context manager and decorator temporarily suppressing standard
     output.
 
     Examples
@@ -618,7 +618,7 @@ class suppress_stdout:
 @contextmanager
 def numpy_print_options(*args: Any, **kwargs: Any) -> Generator:
     """
-    Define a context manager implementing context changes to *Numpy* print
+    Context manager implementing context changes to *Numpy* print
     behaviour.
 
     Other Parameters
@@ -842,7 +842,7 @@ def describe_environment(
         environment["Runtime"].update(ANCILLARY_RUNTIME_PACKAGES)
 
     def _get_package_version(package: str, mapping: Mapping) -> str:
-        """Return given package version."""
+        """Return specified package version."""
 
         namespace = __import__(package)
 
@@ -943,7 +943,7 @@ def multiline_str(
     separator: str = " : ",
 ) -> str:
     """
-    Return a formatted string representation of the given object.
+    Return a formatted string representation of the specified object.
 
     Parameters
     ----------
@@ -1088,7 +1088,7 @@ def multiline_repr(
     reduce_array_representation: bool = True,
 ) -> str:
     """
-    Return an (almost) evaluable string representation of the given object.
+    Return an (almost) evaluable string representation of the specified object.
 
     Parameters
     ----------
@@ -1137,7 +1137,7 @@ def multiline_repr(
     justify = len(f"{object_.__class__.__name__}") + 1
 
     def _format(attribute: dict) -> str:
-        """Format given attribute and its value."""
+        """Format specified attribute and its value."""
 
         if attribute["name"] is not None:
             value = attribute["formatter"](getattr(object_, attribute["name"]))

--- a/colour/volume/datasets/optimal_colour_stimuli.py
+++ b/colour/volume/datasets/optimal_colour_stimuli.py
@@ -2,7 +2,7 @@
 Optimal Colour Stimuli
 ======================
 
-Define the *MacAdam Optimal Colour Stimuli* for various illuminants in
+*MacAdam Optimal Colour Stimuli* for various illuminants in
 *CIE xyY* colourspace.
 
 The *Optimal Colour Stimuli* data is in the form of a *dict* of

--- a/colour/volume/macadam_limits.py
+++ b/colour/volume/macadam_limits.py
@@ -2,7 +2,7 @@
 Optimal Colour Stimuli - MacAdam Limits
 =======================================
 
-Define the objects related to *Optimal Colour Stimuli* computations.
+Objects related to *Optimal Colour Stimuli* computations.
 """
 
 from __future__ import annotations
@@ -45,7 +45,7 @@ def _XYZ_optimal_colour_stimuli(
     illuminant: Literal["A", "C", "D65"] | str = "D65",
 ) -> NDArrayFloat:
     """
-    Return given illuminant *Optimal Colour Stimuli* in *CIE XYZ* tristimulus
+    Return specified illuminant *Optimal Colour Stimuli* in *CIE XYZ* tristimulus
     values and caches it if not existing.
 
     Parameters
@@ -85,8 +85,8 @@ def is_within_macadam_limits(
     tolerance: float = 100 * EPSILON,
 ) -> NDArrayFloat:
     """
-    Return whether given *CIE xyY* colourspace array is within MacAdam limits
-    of given illuminant.
+    Return whether specified *CIE xyY* colourspace array is within MacAdam limits
+    of specified illuminant.
 
     Parameters
     ----------
@@ -100,7 +100,7 @@ def is_within_macadam_limits(
     Returns
     -------
     :class:`numpy.ndarray`
-        Whether given *CIE xyY* colourspace array is within MacAdam limits.
+        Whether specified *CIE xyY* colourspace array is within MacAdam limits.
 
     Notes
     -----

--- a/colour/volume/mesh.py
+++ b/colour/volume/mesh.py
@@ -2,7 +2,7 @@
 Mesh Volume Computation Helpers
 ===============================
 
-Define the helpers objects related to volume computations.
+Helper objects related to volume computations.
 """
 
 from __future__ import annotations
@@ -34,7 +34,7 @@ def is_within_mesh_volume(
     points: ArrayLike, mesh: ArrayLike, tolerance: float = 100 * EPSILON
 ) -> NDArrayFloat:
     """
-    Return whether given points are within given mesh volume using Delaunay
+    Return whether specified points are within specified mesh volume using Delaunay
     triangulation.
 
     Parameters
@@ -49,7 +49,7 @@ def is_within_mesh_volume(
     Returns
     -------
     :class:`numpy.ndarray`
-        Whether given points are within given mesh volume.
+        Whether specified points are within specified mesh volume.
 
     Examples
     --------

--- a/colour/volume/pointer_gamut.py
+++ b/colour/volume/pointer_gamut.py
@@ -2,7 +2,7 @@
 Pointer's Gamut Volume Computations
 ===================================
 
-Define the objects related to *Pointer's Gamut* volume computations.
+Objects related to *Pointer's Gamut* volume computations.
 """
 
 from __future__ import annotations
@@ -38,7 +38,7 @@ def is_within_pointer_gamut(
     XYZ: ArrayLike, tolerance: float = 100 * EPSILON
 ) -> NDArrayFloat:
     """
-    Return whether given *CIE XYZ* tristimulus values are within Pointer's
+    Return whether specified *CIE XYZ* tristimulus values are within Pointer's
     Gamut volume.
 
     Parameters
@@ -51,7 +51,7 @@ def is_within_pointer_gamut(
     Returns
     -------
     :class:`numpy.ndarray`
-        Whether given *CIE XYZ* tristimulus values are within Pointer's Gamut
+        Whether specified *CIE XYZ* tristimulus values are within Pointer's Gamut
         volume.
 
     Notes

--- a/colour/volume/rgb.py
+++ b/colour/volume/rgb.py
@@ -2,7 +2,7 @@
 RGB Colourspace Volume Computation
 ==================================
 
-Define various RGB colourspace volume computation objects:
+Various RGB colourspace volume computation objects:
 
 -   :func:`colour.RGB_colourspace_limits`
 -   :func:`colour.RGB_colourspace_volume_MonteCarlo`
@@ -91,7 +91,7 @@ def sample_RGB_colourspace_volume_MonteCarlo(
 ) -> int:
     """
     Randomly sample the *CIE L\\*a\\*b\\** colourspace volume and returns the
-    ratio of samples within the given *RGB* colourspace volume.
+    ratio of samples within the specified *RGB* colourspace volume.
 
     Parameters
     ----------
@@ -152,7 +152,7 @@ reproducibility-of-python-pseudo-random-numbers-across-systems-and-versions
 
 def RGB_colourspace_limits(colourspace: RGB_Colourspace) -> NDArrayFloat:
     """
-    Compute given *RGB* colourspace volume limits in *CIE L\\*a\\*b\\**
+    Compute specified *RGB* colourspace volume limits in *CIE L\\*a\\*b\\**
     colourspace.
 
     Parameters
@@ -167,7 +167,7 @@ def RGB_colourspace_limits(colourspace: RGB_Colourspace) -> NDArrayFloat:
 
     Notes
     -----
-    The limits are computed for the given *RGB* colourspace illuminant. This is
+    The limits are computed for the specified *RGB* colourspace illuminant. This is
     important to account for, if the intent is to compare various *RGB*
     colourspaces together. In this instance, they must be chromatically adapted
     to the same illuminant before-hand.
@@ -212,7 +212,7 @@ def RGB_colourspace_volume_MonteCarlo(
     random_state: np.random.RandomState | None = None,
 ) -> float:
     """
-    Perform given *RGB* colourspace volume computation using *Monte Carlo*
+    Perform specified *RGB* colourspace volume computation using *Monte Carlo*
     method and multiprocessing.
 
     Parameters
@@ -296,7 +296,7 @@ def RGB_colourspace_volume_coverage_MonteCarlo(
     random_state: np.random.RandomState | None = None,
 ) -> float:
     """
-    Return given *RGB* colourspace percentage coverage of an arbitrary volume.
+    Return specified *RGB* colourspace percentage coverage of an arbitrary volume.
 
     Parameters
     ----------
@@ -347,7 +347,7 @@ def RGB_colourspace_pointer_gamut_coverage_MonteCarlo(
     random_state: np.random.RandomState | None = None,
 ) -> float:
     """
-    Return given *RGB* colourspace percentage coverage of Pointer's Gamut
+    Return specified *RGB* colourspace percentage coverage of Pointer's Gamut
     volume using *Monte Carlo* method.
 
     Parameters
@@ -393,7 +393,7 @@ def RGB_colourspace_visible_spectrum_coverage_MonteCarlo(
     random_state: np.random.RandomState | None = None,
 ) -> float:
     """
-    Return given *RGB* colourspace percentage coverage of visible spectrum
+    Return specified *RGB* colourspace percentage coverage of visible spectrum
     volume using *Monte Carlo* method.
 
     Parameters

--- a/colour/volume/spectrum.py
+++ b/colour/volume/spectrum.py
@@ -2,7 +2,7 @@
 Rösch-MacAdam colour solid - Visible Spectrum Volume Computations
 =================================================================
 
-Define the objects related to *Rösch-MacAdam* colour solid, visible spectrum
+Objects related to *Rösch-MacAdam* colour solid, visible spectrum
 volume computations.
 
 References
@@ -82,7 +82,7 @@ def generate_pulse_waves(
     filter_jagged_pulses: bool = False,
 ) -> NDArrayFloat:
     """
-    Generate the pulse waves of given number of bins necessary to totally
+    Generate the pulse waves of specified number of bins necessary to totally
     stimulate the colour matching functions and produce the *Rösch-MacAdam*
     colour solid.
 
@@ -252,7 +252,7 @@ def XYZ_outer_surface(
 ) -> NDArrayFloat:
     """
     Generate the *Rösch-MacAdam* colour solid, i.e., *CIE XYZ* colourspace
-    outer surface, for given colour matching functions using multi-spectral
+    outer surface, for specified colour matching functions using multi-spectral
     conversion of pulse waves to *CIE XYZ* tristimulus values.
 
     Parameters
@@ -391,8 +391,8 @@ def is_within_visible_spectrum(
     **kwargs: Any,
 ) -> NDArrayFloat:
     """
-    Return whether given *CIE XYZ* tristimulus values are within the visible
-    spectrum volume, i.e., *Rösch-MacAdam* colour solid, for given colour
+    Return whether specified *CIE XYZ* tristimulus values are within the visible
+    spectrum volume, i.e., *Rösch-MacAdam* colour solid, for specified colour
     matching functions and illuminant.
 
     Parameters


### PR DESCRIPTION
<!--
Thank you for taking the time to create this pull request. If it is the first
time you are contributing to a colour-science repository, a contributing guide
is available to guide the process: https://www.colour-science.org/contributing/.
-->

# Summary

This PR improves the docstrings by using Claude 4 via [Claude Code](https://www.anthropic.com/claude-code).

A few observations:

- This was expensive, more than anticipated: USD$265
   - Retrospectively, it would have been cheaper to get [Claude Max](https://www.anthropic.com/news/max-plan) for a month!
   - Cost was mostly driven by the fact I did a first test, which ( reverted because I did change our return value syntax, I deemed this undesirable .
   - The same prompt had to be executed multiple times because there are many instances where the guidelines were not fully respected
- Guidelines respect as is typically the case with a LLM is often miss or hit
- As I processed the docstrings sub-package by sub-package, the LLM took a slightly different approach every single time.

Was it worth it? I think so! Many small errors were fixed and the quality of the documentation has improved. However, for that particular task, I think it would be better to write a dedicated script that extracts the docstrings using the Python AST and process them by giving the object code and surrounding module code rather than having Claude Code doing the work itself. I was actually looking at whether we could implement a plugin on top of Ruff to do this or twist Pydocstyle's arm a bit!

The prompt I used is as follows:

---
**Task**: Update docstrings in all Python modules within the current sub-package recursively to improve wording and clarity.

**Processing Approach**:
- Think deeply
- Use external tools only for listing Python modules, not for docstring processing
- Process docstrings manually to ensure precision and compliance

**Mandatory Requirements**:

**Content Standards**:
- Apply technical writing style conforming to scientific research standards
- Use imperative mood (e.g., "Generate" not "Generates")
- Replace "given" with "specified" where contextually appropriate
- Make "luminance" and "lightness" lowercase unless sentence-initial or after colon
- Preserve all existing docstring examples without modification
- Add "Raises" section when exceptions are raised by the function
- For docstrings beginning with "Return", consider contextually appropriate alternatives
- Focus on clarity and precision in scientific context
- Preserve all Sphinx markers (:math:, :param:, etc.) without modification
- Maintain all reStructuredText emphasis markers around words, e.g., * in *luminance*, `` in ``RGB``, etc...
- Preserve reStructuredText section headers exactly as written
- Keep empty line between docstring and code

**Restrictions**:
- Do NOT add parameter types (already documented via signature types)
- Do NOT modify any object code outside docstrings
- Do NOT edit module headers unless they contain clear errors
- Do NOT process unit test modules
- Do NOT change "colour" to "color" or "colourspace" to "colorspace"/"color space"
- Do NOT change any reStructuredText section headers, i.e., all the headers underlined with - or = must be kept as is

**Formatting**:
- Wrap all lines at exactly 79 characters

**Verification Checklist**:
Before completing each docstring update, verify:
- [ ] All Sphinx markers preserved
- [ ] Emphasis markers preserved
- [ ] Section headers preserved
- [ ] Imperative mood used consistently
- [ ] "Raises" section added if exceptions present
- [ ] No code modifications outside docstrings
- [ ] British spelling preserved
- [ ] 79-character line wrapping maintained
---

# Preflight

<!-- Please mark any checkboxes that do not apply to this pull request as [N/A]. -->

**Code Style and Quality**

- [x] Unit tests have been implemented and passed.
- [x] Pyright static checking has been run and passed.
- [x] Pre-commit hooks have been run and passed.
- [N/A] New transformations have been added to the _Automatic Colour Conversion Graph_.
- [N/A] New transformations have been exported to the relevant namespaces, e.g. `colour`, `colour.models`.

<!-- The unit tests can be invoked with `uv run invoke tests` -->
<!-- Pyright can be started with `uv run pyright --threads --skipunannotated` -->

**Documentation**

- [N/A] New features are documented along with examples if relevant.
- [N/A] The documentation is [Sphinx](https://www.sphinx-doc.org/en/master/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant.

<!--
Thank you again!
-->
