### PR TITLE
PR: Prefer `complex64` and `complex128` over `csingle` and `cdouble`.

### DIFF
--- a/colour/hints/__init__.py
+++ b/colour/hints/__init__.py
@@ -128,7 +128,7 @@ DTypeInt = (
 )
 DTypeFloat = np.float16 | np.float32 | np.float64
 DTypeReal = DTypeInt | DTypeFloat
-DTypeComplex = np.csingle | np.cdouble
+DTypeComplex = np.complex64 | np.complex128
 DTypeBoolean = np.bool_
 DType = DTypeBoolean | DTypeReal | DTypeComplex
 


### PR DESCRIPTION
Since `numpy>=2.1`, the `float64` and `complex128` scalar types differ from `double` and `cdouble` (see https://github.com/numpy/numpy/issues/29151 for details and https://github.com/numpy/numpy/pull/29155 for the fix). The sized types are (almost always) preferred. And usually, that's already done here. But this case what a bit of an exception, so I corrected it.