### PR TITLE
PR: Improve Docstrings Redux

### DIFF
--- a/colour/adaptation/__init__.py
+++ b/colour/adaptation/__init__.py
@@ -1,4 +1,7 @@
 """
+Provide chromatic adaptation models that predict how colours appear under
+different illumination conditions.
+
 References
 ----------
 -   :cite:`CIETC1-321994b` : CIE TC 1-32. (1994). CIE 109-1994 A Method of
@@ -19,7 +22,7 @@ References
 -   :cite:`Li2002a` : Li, C., Luo, M. R., Rigg, B., & Hunt, R. W. G. (2002).
     CMC 2000 chromatic adaptation transform: CMCCAT2000. Color Research &
     Application, 27(1), 49-58. doi:10.1002/col.10005
--   :cite:`Li2025` :Li, M. (2025). One Step CAT16 Chromatic Adaptation
+-   :cite:`Li2025` : Li, M. (2025). One Step CAT16 Chromatic Adaptation
     Transform. https://github.com/colour-science/colour/pull/1349\
 #issuecomment-3058339414
 -   :cite:`Westland2012k` : Westland, S., Ripamonti, C., & Cheung, V. (2012).
@@ -147,8 +150,8 @@ Supported chromatic adaptation methods.
 References
 ----------
 :cite:`CIETC1-321994b`, :cite:`Fairchild1991a`, :cite:`Fairchild2013s`,
-:cite:`Fairchild2013t`, :cite:`Fairchild2020`, :cite:`Li2002a`, :cite:`Li2025`,
-:cite:`Westland2012k`, :cite:`Zhai2018`
+:cite:`Fairchild2013t`, :cite:`Fairchild2020`, :cite:`Li2002a`,
+:cite:`Li2025`, :cite:`Westland2012k`, :cite:`Zhai2018`
 """
 
 
@@ -171,15 +174,17 @@ def chromatic_adaptation(
     **kwargs: Any,
 ) -> NDArrayFloat:
     """
-    Adapt the specified stimulus from test viewing conditions to reference viewing
-    conditions.
+    Adapt the specified stimulus *CIE XYZ* tristimulus values from test
+    viewing conditions to reference viewing conditions using the specified
+    chromatic adaptation method.
 
     Parameters
     ----------
     XYZ
         *CIE XYZ* tristimulus values of stimulus to adapt.
     XYZ_w
-        Test viewing condition *CIE XYZ* tristimulus values of the whitepoint.
+        Test viewing condition *CIE XYZ* tristimulus values of the
+        whitepoint.
     XYZ_wr
         Reference viewing condition *CIE XYZ* tristimulus values of the
         whitepoint.
@@ -190,10 +195,10 @@ def chromatic_adaptation(
     ----------------
     E_o1
         {:func:`colour.adaptation.chromatic_adaptation_CIE1994`},
-        Test illuminance :math:`E_{o1}` in :math:`cd/m^2`.
+        Test illuminance :math:`E_{o1}` in :math:`lux`.
     E_o2
         {:func:`colour.adaptation.chromatic_adaptation_CIE1994`},
-        Reference illuminance :math:`E_{o2}` in :math:`cd/m^2`.
+        Reference illuminance :math:`E_{o2}` in :math:`lux`.
     n
         {:func:`colour.adaptation.chromatic_adaptation_CIE1994`},
         Noise component in fundamental primary system.
@@ -206,7 +211,8 @@ def chromatic_adaptation(
         Chromatic adaptation direction.
     L_A1
         {:func:`colour.adaptation.chromatic_adaptation_CMCCAT2000`},
-        Luminance of test adapting field :math:`L_{A1}` in :math:`cd/m^2`.
+        Luminance of test adapting field :math:`L_{A1}` in
+        :math:`cd/m^2`.
     L_A2
         {:func:`colour.adaptation.chromatic_adaptation_CMCCAT2000`},
         Luminance of reference adapting field :math:`L_{A2}` in
@@ -219,13 +225,15 @@ def chromatic_adaptation(
         Truth value indicating if the illuminant should be discounted.
     Y_n
         {:func:`colour.adaptation.chromatic_adaptation_Fairchild1990`},
-        Luminance :math:`Y_n` of test adapting stimulus in :math:`cd/m^2`.
+        Luminance :math:`Y_n` of test adapting stimulus in
+        :math:`cd/m^2`.
     L_A
         {:func:`colour.adaptation.chromatic_adaptation_Li2025`},
         Adapting field *luminance* :math:`L_A` in :math:`cd/m^2`.
     F_surround
         {:func:`colour.adaptation.chromatic_adaptation_Li2025`},
-        Maximum degree of adaptation :math:`F` from surround viewing conditions.
+        Maximum degree of adaptation :math:`F` from surround viewing
+        conditions.
     discount_illuminant
         {:func:`colour.adaptation.chromatic_adaptation_Li2025`},
         Truth value indicating if the illuminant should be discounted.
@@ -256,7 +264,7 @@ def chromatic_adaptation(
     Returns
     -------
     :class:`numpy.ndarray`
-        *CIE XYZ_c* tristimulus values of the stimulus corresponding colour.
+        *CIE XYZ* tristimulus values of the stimulus corresponding colour.
 
     Notes
     -----
@@ -282,8 +290,9 @@ def chromatic_adaptation(
 
     References
     ----------
-    :cite:`CIETC1-321994b`, :cite:`Fairchild1991a`, :cite:`Fairchild2013s`,
-    :cite:`Fairchild2013t`, :cite:`Li2002a`,:cite:`Li2025`, :cite:`Westland2012k`
+    :cite:`CIETC1-321994b`, :cite:`Fairchild1991a`,
+    :cite:`Fairchild2013s`, :cite:`Fairchild2013t`, :cite:`Li2002a`,
+    :cite:`Li2025`, :cite:`Westland2012k`
 
     Examples
     --------
@@ -341,9 +350,13 @@ def chromatic_adaptation(
     *Li (2025)* chromatic adaptation:
 
     >>> XYZ = np.array([0.1953, 0.2307, 0.2497])
-    >>> chromatic_adaptation(XYZ, XYZ_w, XYZ_wr, method="Fairchild 1990", Y_n=Y_n)
+    >>> L_A = 64
+    >>> F_surround = 1.0
+    >>> chromatic_adaptation(
+    ...     XYZ, XYZ_w, XYZ_wr, method="Li 2025", L_A=L_A, F_surround=F_surround
+    ... )
     ... # doctest: +ELLIPSIS
-    array([ 0.2332526...,  0.2332455...,  0.7611593...])
+    array([ 0.2039701...,  0.2304747...,  0.6783065...])
 
     *Zhai and Luo (2018)* chromatic adaptation:
 

--- a/colour/adaptation/cie1994.py
+++ b/colour/adaptation/cie1994.py
@@ -2,7 +2,8 @@
 CIE 1994 Chromatic Adaptation Model
 ===================================
 
-Define the *CIE 1994* chromatic adaptation model objects:
+Define the *CIE 1994* chromatic adaptation model for predicting corresponding
+colours under different viewing conditions.
 
 -   :func:`colour.adaptation.chromatic_adaptation_CIE1994`
 
@@ -80,9 +81,9 @@ def chromatic_adaptation_CIE1994(
     n: ArrayLike = 1,
 ) -> NDArrayFloat:
     """
-    Adapt the specified stimulus *CIE XYZ_1* tristimulus values from test viewing
-    conditions to reference viewing conditions using *CIE 1994* chromatic
-    adaptation model.
+    Adapt the specified stimulus *CIE XYZ* tristimulus values from test
+    viewing conditions to reference viewing conditions using the
+    *CIE 1994* chromatic adaptation model.
 
     Parameters
     ----------
@@ -92,8 +93,8 @@ def chromatic_adaptation_CIE1994(
         Chromaticity coordinates :math:`x_{o1}` and :math:`y_{o1}` of test
         illuminant and background.
     xy_o2
-        Chromaticity coordinates :math:`x_{o2}` and :math:`y_{o2}` of reference
-        illuminant and background.
+        Chromaticity coordinates :math:`x_{o2}` and :math:`y_{o2}` of
+        reference illuminant and background.
     Y_o
         Luminance factor :math:`Y_o` of achromatic background as percentage
         normalised to domain [18, 100] in **'Reference'** domain-range scale.
@@ -107,7 +108,7 @@ def chromatic_adaptation_CIE1994(
     Returns
     -------
     :class:`numpy.ndarray`
-        Adapted *CIE XYZ_2* tristimulus values of test stimulus.
+        *CIE XYZ* tristimulus values of the stimulus corresponding colour.
 
     Notes
     -----
@@ -174,7 +175,8 @@ def chromatic_adaptation_CIE1994(
 
 def XYZ_to_RGB_CIE1994(XYZ: ArrayLike) -> NDArrayFloat:
     """
-    Convert *CIE XYZ* tristimulus values to cone responses.
+    Convert from *CIE XYZ* tristimulus values to cone responses using the
+    *CIE 1994* colour appearance model transformation.
 
     Parameters
     ----------
@@ -198,7 +200,8 @@ def XYZ_to_RGB_CIE1994(XYZ: ArrayLike) -> NDArrayFloat:
 
 def RGB_to_XYZ_CIE1994(RGB: ArrayLike) -> NDArrayFloat:
     """
-    Convert cone responses to *CIE XYZ* tristimulus values.
+    Convert from cone responses to *CIE XYZ* tristimulus values using the
+    *CIE 1994* colour appearance model inverse transformation.
 
     Parameters
     ----------
@@ -222,18 +225,20 @@ def RGB_to_XYZ_CIE1994(RGB: ArrayLike) -> NDArrayFloat:
 
 def intermediate_values(xy_o: ArrayLike) -> NDArrayFloat:
     """
-    Compute the intermediate values :math:`\\xi`, :math:`\\eta`,
+    Compute the intermediate values :math:`\\xi`, :math:`\\eta`, and
     :math:`\\zeta`.
 
     Parameters
     ----------
     xy_o
-        Chromaticity coordinates :math:`x_o` and :math:`y_o` of whitepoint.
+        Chromaticity coordinates :math:`x_o` and :math:`y_o` of the
+        whitepoint.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Intermediate values :math:`\\xi`, :math:`\\eta`, :math:`\\zeta`.
+        Intermediate values :math:`\\xi`, :math:`\\eta`, and
+        :math:`\\zeta`.
 
     Examples
     --------
@@ -267,7 +272,7 @@ def effective_adapting_responses(
         Luminance factor :math:`Y_o` of achromatic background as percentage
         normalised to domain [18, 100] in **'Reference'** domain-range scale.
     E_o
-        Test or reference illuminance :math:`E_{o}` in lux.
+        Test or reference illuminance :math:`E_o` in lux.
 
     Returns
     -------
@@ -356,14 +361,14 @@ def beta_2(x: ArrayLike) -> DTypeFloat | NDArrayFloat:
 
 def exponential_factors(RGB_o: ArrayLike) -> NDArrayFloat:
     """
-    Compute the chromatic adaptation exponential factors :math:`\\beta_1(R_o)`,
-    :math:`\\beta_1(G_o)` and :math:`\\beta_2(B_o)` of the specified cone
-    responses.
+    Compute the chromatic adaptation exponential factors
+    :math:`\\beta_1(R_o)`, :math:`\\beta_1(G_o)` and :math:`\\beta_2(B_o)` of
+    the specified cone responses.
 
     Parameters
     ----------
     RGB_o
-         Cone responses.
+        Cone responses.
 
     Returns
     -------
@@ -397,7 +402,7 @@ def K_coefficient(
 ) -> NDArrayFloat:
     """
     Compute the coefficient :math:`K` for correcting the difference between
-    the test and references illuminances.
+    the test and reference illuminances.
 
     Parameters
     ----------
@@ -465,8 +470,8 @@ def corresponding_colour(
     n: ArrayLike = 1,
 ) -> NDArrayFloat:
     """
-    Compute the corresponding colour cone responses of the specified test sample
-    cone responses :math:`RGB_1`.
+    Compute corresponding colour cone responses of the specified test sample cone
+    responses :math:`RGB_1` under chromatic adaptation.
 
     Parameters
     ----------
@@ -474,20 +479,22 @@ def corresponding_colour(
         Test sample cone responses :math:`RGB_1`.
     xez_1
         Intermediate values :math:`\\xi_1`, :math:`\\eta_1`, :math:`\\zeta_1`
-        for the test illuminant and background.
+        for test illuminant and background.
     xez_2
         Intermediate values :math:`\\xi_2`, :math:`\\eta_2`, :math:`\\zeta_2`
-        for the reference illuminant and background.
+        for reference illuminant and background.
     bRGB_o1
         Chromatic adaptation exponential factors :math:`\\beta_1(R_{o1})`,
-        :math:`\\beta_1(G_{o1})` and :math:`\\beta_2(B_{o1})` of test sample.
+        :math:`\\beta_1(G_{o1})` and :math:`\\beta_2(B_{o1})` of test
+        sample.
     bRGB_o2
         Chromatic adaptation exponential factors :math:`\\beta_1(R_{o2})`,
         :math:`\\beta_1(G_{o2})` and :math:`\\beta_2(B_{o2})` of reference
         sample.
     Y_o
         Luminance factor :math:`Y_o` of achromatic background as percentage
-        normalised to domain [18, 100] in **'Reference'** domain-range scale.
+        normalised to domain [18, 100] in **'Reference'** domain-range
+        scale.
     K
         Coefficient :math:`K`.
     n
@@ -496,7 +503,7 @@ def corresponding_colour(
     Returns
     -------
     :class:`numpy.ndarray`
-        Corresponding colour cone responses of specified test sample cone
+        Corresponding colour cone responses of the specified test sample cone
         responses.
 
     Examples

--- a/colour/adaptation/cmccat2000.py
+++ b/colour/adaptation/cmccat2000.py
@@ -2,7 +2,8 @@
 CMCCAT2000 Chromatic Adaptation Model
 =====================================
 
-Define the *CMCCAT2000* chromatic adaptation model objects:
+Define the *CMCCAT2000* chromatic adaptation model for predicting
+corresponding colours under different viewing conditions.
 
 -   :class:`colour.adaptation.InductionFactors_CMCCAT2000`
 -   :class:`colour.VIEWING_CONDITIONS_CMCCAT2000`
@@ -69,12 +70,13 @@ CAT_INVERSE_CMCCAT2000
 @dataclass(frozen=True)
 class InductionFactors_CMCCAT2000(MixinDataclassIterable):
     """
-    *CMCCAT2000* chromatic adaptation model induction factors.
+    Define the *CMCCAT2000* chromatic adaptation model induction factors.
 
     Parameters
     ----------
     F
-        :math:`F` surround condition.
+        :math:`F` surround condition factor that modulates the degree of
+        adaptation based on the viewing environment.
 
     References
     ----------
@@ -92,7 +94,18 @@ VIEWING_CONDITIONS_CMCCAT2000: CanonicalMapping = CanonicalMapping(
     }
 )
 VIEWING_CONDITIONS_CMCCAT2000.__doc__ = """
-Reference *CMCCAT2000* chromatic adaptation model viewing conditions.
+Define the reference *CMCCAT2000* chromatic adaptation model viewing
+conditions.
+
+The viewing conditions include three standard surround conditions with
+their corresponding induction factors:
+
+- *Average*: Induction factor of 1.0
+- *Dim*: Induction factor of 0.8
+- *Dark*: Induction factor of 0.8
+
+These values represent the standard viewing conditions used in the
+*CMCCAT2000* chromatic adaptation transform.
 
 References
 ----------
@@ -109,30 +122,33 @@ def chromatic_adaptation_forward_CMCCAT2000(
     surround: InductionFactors_CMCCAT2000 = VIEWING_CONDITIONS_CMCCAT2000["Average"],
 ) -> NDArrayFloat:
     """
-    Adapt the specified stimulus *CIE XYZ* tristimulus values from test viewing
-    conditions to reference viewing conditions using *CMCCAT2000* forward
-    chromatic adaptation model.
+    Adapt the specified stimulus *CIE XYZ* tristimulus values from test
+    viewing conditions to reference viewing conditions using the
+    *CMCCAT2000* forward chromatic adaptation model.
 
     Parameters
     ----------
     XYZ
         *CIE XYZ* tristimulus values of the stimulus to adapt.
     XYZ_w
-        Test viewing condition *CIE XYZ* tristimulus values of the whitepoint.
+        Test viewing condition *CIE XYZ* tristimulus values of the
+        whitepoint.
     XYZ_wr
         Reference viewing condition *CIE XYZ* tristimulus values of the
         whitepoint.
     L_A1
-        Luminance of test adapting field :math:`L_{A1}` in :math:`cd/m^2`.
+        Luminance of test adapting field :math:`L_{A1}` in
+        :math:`cd/m^2`.
     L_A2
-        Luminance of reference adapting field :math:`L_{A2}` in :math:`cd/m^2`.
+        Luminance of reference adapting field :math:`L_{A2}` in
+        :math:`cd/m^2`.
     surround
         Surround viewing conditions induction factors.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        *CIE XYZ_c* tristimulus values of the stimulus corresponding colour.
+        *CIE XYZ* tristimulus values of the stimulus corresponding colour.
 
     Notes
     -----
@@ -202,14 +218,15 @@ def chromatic_adaptation_inverse_CMCCAT2000(
     surround: InductionFactors_CMCCAT2000 = VIEWING_CONDITIONS_CMCCAT2000["Average"],
 ) -> NDArrayFloat:
     """
-    Adapt the specified stimulus corresponding colour *CIE XYZ* tristimulus
-    values from reference viewing conditions to test viewing conditions using
-    *CMCCAT2000* inverse chromatic adaptation model.
+    Adapt the specified *CIE XYZ* tristimulus values from reference viewing
+    conditions to test viewing conditions using the inverse *CMCCAT2000*
+    chromatic adaptation model.
 
     Parameters
     ----------
     XYZ_c
-        *CIE XYZ* tristimulus values of the stimulus to adapt.
+        *CIE XYZ* tristimulus values of the adapted stimulus in the reference
+        viewing conditions.
     XYZ_w
         Test viewing condition *CIE XYZ* tristimulus values of the whitepoint.
     XYZ_wr
@@ -225,7 +242,8 @@ def chromatic_adaptation_inverse_CMCCAT2000(
     Returns
     -------
     :class:`numpy.ndarray`
-        *CIE XYZ_c* tristimulus values of the adapted stimulus.
+        *CIE XYZ* tristimulus values of the stimulus adapted to the test
+        viewing conditions.
 
     Notes
     -----
@@ -296,10 +314,11 @@ def chromatic_adaptation_CMCCAT2000(
     direction: Literal["Forward", "Inverse"] | str = "Forward",
 ) -> NDArrayFloat:
     """
-    Adapt the specified stimulus *CIE XYZ* tristimulus values using the specified
-    viewing conditions.
+    Adapt the specified stimulus *CIE XYZ* tristimulus values from test
+    viewing conditions to reference viewing conditions using the
+    *CMCCAT2000* chromatic adaptation model.
 
-    This definition is a convenient wrapper around
+    This definition provides a convenient wrapper around
     :func:`colour.adaptation.chromatic_adaptation_forward_CMCCAT2000` and
     :func:`colour.adaptation.chromatic_adaptation_inverse_CMCCAT2000`.
 
@@ -316,7 +335,8 @@ def chromatic_adaptation_CMCCAT2000(
     L_A1
         Luminance of test adapting field :math:`L_{A1}` in :math:`cd/m^2`.
     L_A2
-        Luminance of reference adapting field :math:`L_{A2}` in :math:`cd/m^2`.
+        Luminance of reference adapting field :math:`L_{A2}` in
+        :math:`cd/m^2`.
     surround
         Surround viewing conditions induction factors.
     direction
@@ -325,7 +345,7 @@ def chromatic_adaptation_CMCCAT2000(
     Returns
     -------
     :class:`numpy.ndarray`
-        Adapted stimulus *CIE XYZ* tristimulus values.
+        *CIE XYZ* tristimulus values of the stimulus corresponding colour.
 
     Notes
     -----

--- a/colour/adaptation/datasets/cat.py
+++ b/colour/adaptation/datasets/cat.py
@@ -10,18 +10,18 @@ Define various chromatic adaptation transforms (CAT):
     transform.
 -   :attr:`colour.adaptation.CAT_CAT02`: *CAT02* chromatic adaptation
     transform.
--   :attr:`colour.adaptation.CAT_CAT02_BRILL2008`: *Brill and Susstrunk (2008)*
-    corrected CAT02 chromatic adaptation transform.
+-   :attr:`colour.adaptation.CAT_CAT02_BRILL2008`: *Brill and Susstrunk
+    (2008)* corrected CAT02 chromatic adaptation transform.
 -   :attr:`colour.adaptation.CAT_CAT16`: *CAT16* chromatic adaptation
     transform.
--   :attr:`colour.adaptation.CAT_CMCCAT2000`: *CMCCAT2000* chromatic adaptation
-    transform.
+-   :attr:`colour.adaptation.CAT_CMCCAT2000`: *CMCCAT2000* chromatic
+    adaptation transform.
 -   :attr:`colour.adaptation.CAT_CMCCAT97`: *CMCCAT97* chromatic adaptation
     transform.
 -   :attr:`colour.adaptation.CAT_FAIRCHILD`: *Fairchild* chromatic adaptation
     transform.
--   :attr:`colour.adaptation.CAT_PC_BIANCO2010`:
-    *Bianco and Schettini PC (2010)* chromatic adaptation transform.
+-   :attr:`colour.adaptation.CAT_PC_BIANCO2010`: *Bianco and Schettini PC
+    (2010)* chromatic adaptation transform.
 -   :attr:`colour.adaptation.CAT_SHARP`: *Sharp* chromatic adaptation
     transform.
 -   :attr:`colour.adaptation.CAT_VON_KRIES`: *Von Kries* chromatic adaptation
@@ -31,12 +31,13 @@ Define various chromatic adaptation transforms (CAT):
 
 References
 ----------
--   :cite:`Bianco2010a` : Bianco, S., & Schettini, R. (2010). Two new von Kries
-    based chromatic adaptation transforms found by numerical optimization.
-    Color Research & Application, 35(3), 184-192. doi:10.1002/col.20573
--   :cite:`Brill2008a` : Brill, M. H., & Susstrunk, S. (2008). Repairing gamut
-    problems in CIECAM02: A progress report. Color Research & Application,
-    33(5), 424-426. doi:10.1002/col.20432
+-   :cite:`Bianco2010a` : Bianco, S., & Schettini, R. (2010). Two new von
+    Kries based chromatic adaptation transforms found by numerical
+    optimization. Color Research & Application, 35(3), 184-192.
+    doi:10.1002/col.20573
+-   :cite:`Brill2008a` : Brill, M. H., & Susstrunk, S. (2008). Repairing
+    gamut problems in CIECAM02: A progress report. Color Research &
+    Application, 33(5), 424-426. doi:10.1002/col.20432
 -   :cite:`CIETC1-321994b` : CIE TC 1-32. (1994). CIE 109-1994 A Method of
     Predicting Corresponding Colours under Different Chromatic and Illuminance
     Adaptations. Commission Internationale de l'Eclairage.
@@ -48,8 +49,7 @@ References
     http://rit-mcsl.org/fairchild//files/FairchildYSh.zip
 -   :cite:`Li2007e` : Li, C., Perales, E., Luo, M. R., & Martinez-verdu, F.
     (2007). The Problem with CAT02 and Its Correction.
-    https://pdfs.semanticscholar.org/b5a9/\
-0215ad9a1fb6b01f310b3d64305f7c9feb3a.pdf
+    https://pdfs.semanticscholar.org/b5a9/0215ad9a1fb6b01f310b3d64305f7c9feb3a.pdf
 -   :cite:`Li2017` : Li, C., Li, Z., Wang, Z., Xu, Y., Luo, M. R., Cui, G.,
     Melgosa, M., Brill, M. H., & Pointer, M. (2017). Comprehensive color
     solutions: CAM16, CAT16, and CAM16-UCS. Color Research & Application,
@@ -61,12 +61,12 @@ References
     (1995). Lightness dependency of chroma scales of a nonlinear
     color-appearance model and its latest formulation. Color Research &
     Application, 20(3), 156-167. doi:10.1002/col.5080200305
--   :cite:`Westland2012g` : Westland, S., Ripamonti, C., & Cheung, V. (2012).
-    CMCCAT97. In Computational Colour Science Using MATLAB (2nd ed., p. 80).
-    ISBN:978-0-470-66569-5
--   :cite:`Westland2012k` : Westland, S., Ripamonti, C., & Cheung, V. (2012).
-    CMCCAT2000. In Computational Colour Science Using MATLAB (2nd ed., pp.
-    83-86). ISBN:978-0-470-66569-5
+-   :cite:`Westland2012g` : Westland, S., Ripamonti, C., & Cheung, V.
+    (2012). CMCCAT97. In Computational Colour Science Using MATLAB (2nd ed.,
+    p. 80). ISBN:978-0-470-66569-5
+-   :cite:`Westland2012k` : Westland, S., Ripamonti, C., & Cheung, V.
+    (2012). CMCCAT2000. In Computational Colour Science Using MATLAB (2nd
+    ed., pp. 83-86). ISBN:978-0-470-66569-5
 -   :cite:`Wikipedia2007` : Wikipedia. (2007). CAT02. Retrieved February 24,
     2014, from http://en.wikipedia.org/wiki/CIECAM02#CAT02
 """
@@ -302,11 +302,11 @@ CHROMATIC_ADAPTATION_TRANSFORMS: CanonicalMapping = CanonicalMapping(
     }
 )
 CHROMATIC_ADAPTATION_TRANSFORMS.__doc__ = """
-Chromatic adaptation transforms.
+Supported chromatic adaptation transforms.
 
 References
 ----------
-:cite:`Bianco2010a`, :cite:`Brill2008a`, :cite:`Fairchildb`, :cite:`Li2007e`,
-:cite:`Li2017`, :cite:`Lindbloom2009g`, :cite:`Westland2012g`,
-:cite:`Westland2012k`, :cite:`Wikipedia2007`
+:cite:`Bianco2010a`, :cite:`Brill2008a`, :cite:`Fairchildb`,
+:cite:`Li2007e`, :cite:`Li2017`, :cite:`Lindbloom2009g`,
+:cite:`Westland2012g`, :cite:`Westland2012k`, :cite:`Wikipedia2007`
 """

--- a/colour/adaptation/fairchild1990.py
+++ b/colour/adaptation/fairchild1990.py
@@ -2,7 +2,8 @@
 Fairchild (1990) Chromatic Adaptation Model
 ===========================================
 
-Define the *Fairchild (1990)* chromatic adaptation model objects:
+Define the *Fairchild (1990)* chromatic adaptation model for predicting
+corresponding colours under different viewing conditions.
 
 -   :func:`colour.adaptation.chromatic_adaptation_Fairchild1990`
 
@@ -73,9 +74,9 @@ def chromatic_adaptation_Fairchild1990(
     discount_illuminant: bool = False,
 ) -> NDArrayFloat:
     """
-    Adapt the specified stimulus *CIE XYZ_1* tristimulus values from test viewing
-    conditions to reference viewing conditions using *Fairchild (1990)*
-    chromatic adaptation model.
+    Adapt the specified stimulus *CIE XYZ* tristimulus values from test
+    viewing conditions to reference viewing conditions using the
+    *Fairchild (1990)* chromatic adaptation model.
 
     Parameters
     ----------
@@ -88,14 +89,14 @@ def chromatic_adaptation_Fairchild1990(
         Reference viewing condition *CIE XYZ_r* tristimulus values of the
         whitepoint.
     Y_n
-        luminance :math:`Y_n` of test adapting stimulus in :math:`cd/m^2`.
+        Luminance :math:`Y_n` of test adapting stimulus in :math:`cd/m^2`.
     discount_illuminant
         Truth value indicating if the illuminant should be discounted.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Adapted *CIE XYZ_2* tristimulus values of the stimulus.
+        *CIE XYZ* tristimulus values of the stimulus corresponding colour.
 
     Notes
     -----
@@ -163,7 +164,8 @@ def chromatic_adaptation_Fairchild1990(
 
 def XYZ_to_RGB_Fairchild1990(XYZ: ArrayLike) -> NDArrayFloat:
     """
-    Convert *CIE XYZ* tristimulus values to cone responses.
+    Convert from *CIE XYZ* tristimulus values to cone responses using the
+    *Fairchild (1990)* chromatic adaptation model.
 
     Parameters
     ----------
@@ -224,7 +226,7 @@ def degrees_of_adaptation(
     LMS
         Cone responses.
     Y_n
-        luminance :math:`Y_n` of test adapting stimulus in :math:`cd/m^2`.
+        Luminance :math:`Y_n` of test adapting stimulus in :math:`cd/m^2`.
     v
         Exponent :math:`v`.
     discount_illuminant

--- a/colour/adaptation/fairchild2020.py
+++ b/colour/adaptation/fairchild2020.py
@@ -2,7 +2,8 @@
 Von Kries 2020 (vK20) Chromatic Adaptation Model
 ================================================
 
-Define the *Von Kries 2020* (*vK20*) chromatic adaptation model objects:
+Define the *Von Kries 2020* (*vK20*) chromatic adaptation model for predicting
+corresponding colours under different viewing conditions.
 
 -   :attr:`colour.adaptation.CONDITIONS_DEGREE_OF_ADAPTATION_VK20`
 -   :func:`colour.adaptation.matrix_chromatic_adaptation_vk20`
@@ -10,9 +11,9 @@ Define the *Von Kries 2020* (*vK20*) chromatic adaptation model objects:
 
 References
 ----------
--   :cite:`Fairchild2020` : Fairchild, M. D. (2020). Von Kries 2020: Evolution
-    of degree of chromatic adaptation. Color and Imaging Conference, 28(1),
-    252-257. doi:10.2352/issn.2169-2629.2020.28.40
+-   :cite:`Fairchild2020` : Fairchild, M. D. (2020). Von Kries 2020:
+    Evolution of degree of chromatic adaptation. Color and Imaging
+    Conference, 28(1), 252-257. doi:10.2352/issn.2169-2629.2020.28.40
 """
 
 from __future__ import annotations
@@ -57,7 +58,8 @@ __all__ = [
 @dataclass(frozen=True)
 class Coefficients_DegreeOfAdaptation_vK20(MixinDataclassIterable):
     """
-    *Von Kries 2020* (*vK20*) degree of adaptation coefficients.
+    Define the degree of adaptation coefficients for the *Von Kries 2020*
+    (*vK20*) chromatic adaptation model.
 
     Parameters
     ----------
@@ -94,7 +96,8 @@ CONDITIONS_DEGREE_OF_ADAPTATION_VK20: CanonicalMapping = CanonicalMapping(
     }
 )
 CONDITIONS_DEGREE_OF_ADAPTATION_VK20.__doc__ = """
-Conditions for the *Von Kries 2020* (*vK20*) degree of adaptation coefficients.
+Define the degree of adaptation coefficient conditions for the *Von Kries 2020*
+(*vK20*) chromatic adaptation model.
 
 References
 ----------
@@ -137,19 +140,20 @@ def matrix_chromatic_adaptation_vk20(
 ) -> NDArrayFloat:
     """
     Compute the chromatic adaptation matrix from previous viewing conditions
-    to adapting viewing conditions using *Von Kries 2020* (*vK20*) method.
+    to adapting viewing conditions using the *Von Kries 2020* (*vK20*)
+    method.
 
     Parameters
     ----------
     XYZ_p
-        Previous viewing conditions *CIE XYZ* tristimulus values of the
-        whitepoint.
+        *CIE XYZ* tristimulus values of the whitepoint under previous viewing
+        conditions.
     XYZ_n
-        Adapting viewing conditions *CIE XYZ* tristimulus values of the
-        whitepoint.
+        *CIE XYZ* tristimulus values of the whitepoint under adapting viewing
+        conditions.
     XYZ_r
-        Reference viewing conditions *CIE XYZ* tristimulus values of the
-        whitepoint.
+        *CIE XYZ* tristimulus values of the whitepoint under reference viewing
+        conditions.
     transform
         Chromatic adaptation transform.
     coefficients
@@ -249,8 +253,9 @@ def chromatic_adaptation_vK20(
     ),
 ) -> NDArrayFloat:
     """
-    Adapt the specified stimulus from previous viewing conditions to adapting
-    viewing conditions using *Von Kries 2020* (*vK20*) method.
+    Adapt the specified stimulus *CIE XYZ* tristimulus values from test
+    viewing conditions to reference viewing conditions using the
+    *Von Kries 2020* (*vK20*) chromatic adaptation model.
 
     Parameters
     ----------
@@ -273,7 +278,7 @@ def chromatic_adaptation_vK20(
     Returns
     -------
     :class:`numpy.ndarray`
-        *CIE XYZ_c* tristimulus values of the stimulus corresponding colour.
+        *CIE XYZ* tristimulus values of the stimulus corresponding colour.
 
     Notes
     -----

--- a/colour/adaptation/li2025.py
+++ b/colour/adaptation/li2025.py
@@ -2,13 +2,14 @@
 Li (2025) Chromatic Adaptation Model
 ====================================
 
-Define the *Li (2025)* chromatic adaptation model object:
+Define the *Li (2025)* chromatic adaptation model  for predicting corresponding
+colours under different viewing conditions.
 
 -   :func:`colour.adaptation.chromatic_adaptation_Li2025`
 
 References
 ----------
--   :cite:`Li2025` :Li, M. (2025). One Step CAT16 Chromatic Adaptation
+-   :cite:`Li2025` : Li, M. (2025). One Step CAT16 Chromatic Adaptation
     Transform. https://github.com/colour-science/colour/pull/1349\
 #issuecomment-3058339414
 """
@@ -55,13 +56,13 @@ def chromatic_adaptation_Li2025(
     discount_illuminant: bool = False,
 ) -> NDArrayFloat:
     """
-    Adapt the specified stimulus :math:`XYZ_{s}` tristimulus values from source
-    viewing conditions to destination viewing conditions using *Li (2025)*
-    one-step CAT16 chromatic adaptation model.
+    Adapt the specified stimulus *CIE XYZ* tristimulus values from test
+    viewing conditions to reference viewing conditions using the
+    *Li (2025)* chromatic adaptation model.
 
     This one-step chromatic adaptation transform is based on *CAT16* and
     includes the degree of adaptation calculation from the viewing conditions
-    as given by *CIECAM02* colour appearance model.
+    as specified by *CIECAM02* colour appearance model.
 
     Parameters
     ----------
@@ -74,15 +75,15 @@ def chromatic_adaptation_Li2025(
     L_A
         Adapting field *luminance* :math:`L_A` in :math:`cd/m^2`.
     F_surround
-        Maximum degree of adaptation :math:`F` from surround viewing conditions.
+        Maximum degree of adaptation :math:`F` from surround viewing
+        conditions.
     discount_illuminant
         Truth value indicating if the illuminant should be discounted.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Chromatically adapted *CIE XYZ* tristimulus values under destination
-        illuminant.
+        *CIE XYZ* tristimulus values of the stimulus corresponding colour.
 
     Notes
     -----

--- a/colour/adaptation/vonkries.py
+++ b/colour/adaptation/vonkries.py
@@ -2,7 +2,8 @@
 Von Kries Chromatic Adaptation Model
 ====================================
 
-Define the *Von Kries* chromatic adaptation model objects:
+Define the *Von Kries* chromatic adaptation model for predicting corresponding
+colours under different viewing conditions.
 
 -   :func:`colour.adaptation.matrix_chromatic_adaptation_VonKries`
 -   :func:`colour.adaptation.chromatic_adaptation_VonKries`
@@ -57,8 +58,8 @@ def matrix_chromatic_adaptation_VonKries(
     transform: LiteralChromaticAdaptationTransform | str = "CAT02",
 ) -> NDArrayFloat:
     """
-    Compute the chromatic adaptation matrix from test viewing conditions to
-    reference viewing conditions.
+    Compute the chromatic adaptation matrix from test viewing conditions
+    to reference viewing conditions.
 
     Parameters
     ----------
@@ -143,8 +144,9 @@ def chromatic_adaptation_VonKries(
     transform: LiteralChromaticAdaptationTransform | str = "CAT02",
 ) -> NDArrayFloat:
     """
-    Adapt the specified stimulus from test viewing conditions to reference
-    viewing conditions.
+    Adapt the specified stimulus *CIE XYZ* tristimulus values from test
+    viewing conditions to reference viewing conditions using the *Von Kries*
+    chromatic adaptation model.
 
     Parameters
     ----------
@@ -162,7 +164,7 @@ def chromatic_adaptation_VonKries(
     Returns
     -------
     :class:`numpy.ndarray`
-        *CIE XYZ_c* tristimulus values of the stimulus corresponding colour.
+        *CIE XYZ* tristimulus values of the stimulus corresponding colour.
 
     Notes
     -----

--- a/colour/adaptation/zhai2018.py
+++ b/colour/adaptation/zhai2018.py
@@ -2,7 +2,8 @@
 Zhai and Luo (2018) Chromatic Adaptation Model
 ==============================================
 
-Define the *Zhai and Luo (2018)* chromatic adaptation model object:
+Define the *Zhai and Luo (2018)* two-step chromatic adaptation for predicting
+corresponding colours under different viewing conditions.
 
 -   :func:`colour.adaptation.chromatic_adaptation_Zhai2018`
 
@@ -54,37 +55,36 @@ def chromatic_adaptation_Zhai2018(
     transform: Literal["CAT02", "CAT16"] | str = "CAT02",
 ) -> NDArrayFloat:
     """
-    Adapt the specified sample colour :math:`XYZ_{\\beta}` tristimulus values
-    from input viewing conditions under :math:`\\beta` illuminant to output
-    viewing conditions under :math:`\\delta` illuminant using
+    Adapt the specified stimulus *CIE XYZ* tristimulus values from test
+    viewing conditions to reference viewing conditions using the
     *Zhai and Luo (2018)* chromatic adaptation model.
 
-    According to the definition of :math:`D`, a one-step CAT such as CAT02 can
-    only be used to transform colours from an incomplete adapted field into a
-    complete adapted field. When CAT02 are used to transform an incomplete to
-    incomplete case, :math:`D` has no baseline level to refer to.
-    *Smet et al. (2017)* proposed a new concept of two-step CAT to replace the
-    present CATs such as CAT02 with only one-step transform in order to define
-    :math:`D` more clearly. A two-step CAT involves an illuminant representing
-    the baseline states between the test and reference illuminants for the
-    calculation. In the first step, the test colour is transformed from test
-    illuminant to the baseline illuminant (:math:`BI`), and it is then
-    transformed to the reference illuminant. Degrees of adaptation under the
-    other illuminants should be calculated relative to the adaptation under the
-    :math:`BI`. When :math:`D` becomes lower towards zero, the adaptation point
-    of the observer moves towards the :math:`BI`. Therefore, the chromaticity
-    of the :math:`BI` should be an intrinsic property of the human vision
-    system.
+    According to the definition of :math:`D`, a one-step chromatic adaptation
+    transform (CAT) such as CAT02 can only transform colours from an
+    incomplete adapted field into a complete adapted field. When CAT02 is
+    used to transform from incomplete to incomplete adaptation, :math:`D` has
+    no baseline level to refer to. *Smet et al. (2017)* proposed a two-step
+    CAT concept to replace existing one-step transforms such as CAT02,
+    providing a clearer definition of :math:`D`. A two-step CAT involves a
+    baseline illuminant (BI) representing the baseline state between the test
+    and reference illuminants. In the first step, the test colour is
+    transformed from the test illuminant to the baseline illuminant
+    (:math:`BI`), then subsequently transformed to the reference illuminant.
+    Degrees of adaptation under other illuminants are calculated relative to
+    the adaptation under the :math:`BI`. As :math:`D` approaches zero, the
+    observer's adaptation point moves towards the :math:`BI`. Therefore, the
+    chromaticity of the :math:`BI` is an intrinsic property of the human
+    visual system.
 
     Parameters
     ----------
     XYZ_b
-        Sample colour :math:`XYZ_{\\beta}` under input illuminant
-        :math:`\\beta`.
+        Sample colour :math:`XYZ_{\\beta}` tristimulus values under input
+        illuminant :math:`\\beta`.
     XYZ_wb
-        Input illuminant :math:`\\beta`.
+        Input illuminant :math:`\\beta` tristimulus values.
     XYZ_wd
-        Output illuminant :math:`\\delta`.
+        Output illuminant :math:`\\delta` tristimulus values.
     D_b
         Degree of adaptation :math:`D_{\\beta}` of input illuminant
         :math:`\\beta`.
@@ -92,15 +92,14 @@ def chromatic_adaptation_Zhai2018(
         Degree of adaptation :math:`D_{\\delta}` of output illuminant
         :math:`\\delta`.
     XYZ_wo
-        Baseline illuminant (:math:`BI`) :math:`o`.
+        Baseline illuminant (:math:`BI`) :math:`o` tristimulus values.
     transform
-        Chromatic adaptation transform.
+        Chromatic adaptation transform matrix.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Sample corresponding colour :math:`XYZ_{\\delta}` tristimulus values
-        under output illuminant :math:`\\delta`.
+        *CIE XYZ* tristimulus values of the stimulus corresponding colour.
 
     Notes
     -----

--- a/colour/algebra/__init__.py
+++ b/colour/algebra/__init__.py
@@ -136,7 +136,7 @@ API_CHANGES: dict = {
 """*colour.algebra* sub-package API changes."""
 
 
-API_CHANGES["ObjectRemoved"] = [  # pyright: ignore
+API_CHANGES["ObjectRemoved"] = [
     "colour.algebra.matrix_dot",
 ]
 

--- a/colour/algebra/__init__.py
+++ b/colour/algebra/__init__.py
@@ -116,10 +116,10 @@ __all__ += [
 # ---                API Changes and Deprecation Management                ---#
 # ----------------------------------------------------------------------------#
 class algebra(ModuleAPI):
-    """A class acting like the *algebra* module."""
+    """Define a class acting like the *algebra* module."""
 
     def __getattr__(self, attribute: str) -> Any:
-        """Return the value from the attribute with specified name."""
+        """Return the value from the attribute with given name."""
 
         return super().__getattr__(attribute)
 

--- a/colour/algebra/common.py
+++ b/colour/algebra/common.py
@@ -2,8 +2,11 @@
 Common Utilities
 ================
 
-Common algebra utilities objects that don't fall in any specific
+Define common algebra utility objects that do not fall within any specific
 category.
+
+The *Common* sub-package provides general-purpose mathematical and
+computational utilities used throughout the colour science library.
 """
 
 from __future__ import annotations
@@ -96,13 +99,14 @@ def get_sdiv_mode() -> Literal[
     "Warning Replace With Epsilon",
 ]:
     """
-    Return *Colour* safe division mode.
+    Return the current *Colour* safe division mode.
 
     Returns
     -------
     :class:`str`
-        *Colour* safe division mode, see :func:`colour.algebra.sdiv` definition
-        for an explanation about the possible modes.
+        Current *Colour* safe division mode. See
+        :func:`colour.algebra.sdiv` definition for an explanation of
+        the possible modes.
 
     Examples
     --------
@@ -135,13 +139,13 @@ def set_sdiv_mode(
     ),
 ) -> None:
     """
-    Set *Colour* safe division function mode.
+    Set the *Colour* safe division function mode.
 
     Parameters
     ----------
     mode
-        *Colour* safe division mode, see :func:`colour.algebra.sdiv` definition
-        for an explanation about the possible modes.
+        *Colour* safe division mode. See :func:`colour.algebra.sdiv`
+        definition for an explanation of the possible modes.
 
     Examples
     --------
@@ -180,14 +184,20 @@ def set_sdiv_mode(
 
 class sdiv_mode:
     """
-    A context manager and decorator temporarily setting *Colour* safe
+    Context manager and decorator for temporarily modifying *Colour* safe
     division function mode.
+
+    This utility enables temporary modification of the safe division behavior
+    in *Colour* computations, allowing control over how division operations
+    handle edge cases such as division by zero or near-zero values. The
+    context manager ensures automatic restoration of the original mode upon
+    exit.
 
     Parameters
     ----------
     mode
-       *Colour* safe division function mode, see :func:`colour.algebra.sdiv`
-       definition for an explanation about the possible modes.
+        *Colour* safe division function mode, see :func:`colour.algebra.sdiv`
+        definition for an explanation about the possible modes.
     """
 
     def __init__(
@@ -213,8 +223,8 @@ class sdiv_mode:
 
     def __enter__(self) -> Self:
         """
-        Set the *Colour* safe division function mode upon entering the context
-        manager.
+        Set the *Colour* safe/symmetrical power function state to the
+        specified value upon entering the context manager.
         """
 
         set_sdiv_mode(self._mode)
@@ -223,14 +233,19 @@ class sdiv_mode:
 
     def __exit__(self, *args: Any) -> None:
         """
-        Set the *Colour* safe division function mode upon exiting the context
-        manager.
+        Restore the *Colour* safe / symmetrical power function enabled state
+        upon exiting the context manager.
         """
 
         set_sdiv_mode(self._previous_mode)
 
     def __call__(self, function: Callable) -> Callable:
-        """Call the wrapped definition."""
+        """
+        Call the wrapped definition.
+
+        The decorator applies the specified spectral power distribution
+        state to the wrapped function during its execution.
+        """
 
         @functools.wraps(function)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
@@ -242,37 +257,37 @@ class sdiv_mode:
 
 def sdiv(a: ArrayLike, b: ArrayLike) -> NDArrayFloat:
     """
-    Divide specified array :math:`b` with array :math:`b` while handling
-    zero-division.
+    Perform safe division of array :math:`a` by array :math:`b` while
+    handling zero-division cases.
 
-    This definition avoids NaNs and +/- infs generation when array :math:`b`
-    is equal to zero. This behaviour can be controlled with the
-    :func:`colour.algebra.set_sdiv_mode` definition or with the
+    Avoid NaN and +/- inf generation when array :math:`b` contains zero
+    values. The zero-division handling behaviour is controlled by the
+    :func:`colour.algebra.set_sdiv_mode` definition or the
     :func:`sdiv_mode` context manager. The following modes are available:
 
     -   ``Numpy``: The current *Numpy* zero-division handling occurs.
     -   ``Ignore``: Zero-division occurs silently.
     -   ``Warning``: Zero-division occurs with a warning.
-    -   ``Ignore Zero Conversion``: Zero-division occurs silently and NaNs or
-        +/- infs values are converted to zeros. See :func:`numpy.nan_to_num`
-        definition for more details.
-    -   ``Warning Zero Conversion``: Zero-division occurs with a warning and
-        NaNs or +/- infs values are converted to zeros. See
+    -   ``Ignore Zero Conversion``: Zero-division occurs silently and NaNs
+        or +/- infs values are converted to zeros. See
+        :func:`numpy.nan_to_num` definition for more details.
+    -   ``Warning Zero Conversion``: Zero-division occurs with a warning
+        and NaNs or +/- infs values are converted to zeros. See
         :func:`numpy.nan_to_num` definition for more details.
     -   ``Ignore Limit Conversion``: Zero-division occurs silently and
         NaNs or +/- infs values are converted to zeros or the largest +/-
         finite floating point values representable by the division result
-        :class:`numpy.dtype`. See :func:`numpy.nan_to_num` definition for more
-        details.
-    -   ``Warning Limit Conversion``: Zero-division occurs with a warning and
-        NaNs or +/- infs values are converted to zeros or the largest +/-
-        finite floating point values representable by the division result
-        :class:`numpy.dtype`.
-    -   ``Replace With Epsilon``: Zero-division is avoided by replacing zero
-        denominators with the machine epsilon value from
-        :attr:`colour.constants.EPSILON`.
-    -   ``Warning Replace With Epsilon``: Zero-division is avoided by replacing
+        :class:`numpy.dtype`. See :func:`numpy.nan_to_num` definition for
+        more details.
+    -   ``Warning Limit Conversion``: Zero-division occurs with a warning
+        and NaNs or +/- infs values are converted to zeros or the largest
+        +/- finite floating point values representable by the division
+        result :class:`numpy.dtype`.
+    -   ``Replace With Epsilon``: Zero-division is avoided by replacing
         zero denominators with the machine epsilon value from
+        :attr:`colour.constants.EPSILON`.
+    -   ``Warning Replace With Epsilon``: Zero-division is avoided by
+        replacing zero denominators with the machine epsilon value from
         :attr:`colour.constants.EPSILON` with a warning.
 
     Parameters
@@ -285,7 +300,7 @@ def sdiv(a: ArrayLike, b: ArrayLike) -> NDArrayFloat:
     Returns
     -------
     :class:`np.float` or :class:`numpy.ndarray`
-        Array :math:`b` safely divided by :math:`a`.
+        Array :math:`a` safely divided by :math:`b`.
 
     Examples
     --------
@@ -404,12 +419,12 @@ def is_spow_enabled() -> bool:
 
 def set_spow_enable(enable: bool) -> None:
     """
-    Set *Colour* safe / symmetrical power function enabled state.
+    Set the *Colour* safe/symmetrical power function enabled state.
 
     Parameters
     ----------
     enable
-        Whether to enable *Colour* safe / symmetrical power function.
+        Whether to enable the *Colour* safe/symmetrical power function.
 
     Examples
     --------
@@ -428,14 +443,20 @@ def set_spow_enable(enable: bool) -> None:
 
 class spow_enable:
     """
-    A context manager and decorator temporarily setting *Colour* safe /
-    symmetrical power function enabled state.
+    Context manager and decorator for temporarily setting the state of *Colour*
+    safe/symmetrical power function.
+
+    This utility provides both context manager and decorator functionality to
+    temporarily enable or disable the safe/symmetrical power function used
+    throughout the *Colour* library. When enabled, power operations use a
+    symmetrical implementation that handles negative values appropriately for
+    colour science computations.
 
     Parameters
     ----------
     enable
-        Whether to enable or disable *Colour* safe / symmetrical power
-        function.
+        Whether to enable or disable the *Colour* safe/symmetrical power
+        function for the duration of the context or decorated function.
     """
 
     def __init__(self, enable: bool) -> None:
@@ -482,12 +503,12 @@ def spow(a: ArrayLike, p: ArrayLike) -> DTypeFloat | NDArrayFloat: ...
 def spow(a: ArrayLike, p: ArrayLike) -> DTypeFloat | NDArrayFloat:
     """
     Raise specified array :math:`a` to the power :math:`p` as follows:
-    :math:`sign(a) * |a|^p`.
+    :math:`\\text{sign}(a) \\cdot |a|^p`.
 
-    This definition avoids NaNs generation when array :math:`a` is negative and
-    the power :math:`p` is fractional. This behaviour can be enabled or
-    disabled with the :func:`colour.algebra.set_spow_enable` definition or with
-    the :func:`spow_enable` context manager.
+    This definition avoids NaN generation when array :math:`a` is negative
+    and power :math:`p` is fractional. This behaviour can be enabled or
+    disabled with the :func:`colour.algebra.set_spow_enable` definition or
+    with the :func:`spow_enable` context manager.
 
     Parameters
     ----------
@@ -524,7 +545,10 @@ def spow(a: ArrayLike, p: ArrayLike) -> DTypeFloat | NDArrayFloat:
 
 def normalise_vector(a: ArrayLike) -> NDArrayFloat:
     """
-    Normalise specified vector :math:`a`.
+    Normalise the specified vector :math:`a`.
+
+    The normalisation process scales the vector to have unit length, ensuring
+    that the magnitude of the resulting vector equals 1.
 
     Parameters
     ----------
@@ -534,7 +558,7 @@ def normalise_vector(a: ArrayLike) -> NDArrayFloat:
     Returns
     -------
     :class:`numpy.ndarray`
-        Normalised vector :math:`a`.
+        Normalised vector :math:`a` with unit length.
 
     Examples
     --------
@@ -556,8 +580,8 @@ def normalise_maximum(
     clip: bool = True,
 ) -> NDArrayFloat:
     """
-    Normalise specified array :math:`a` values by :math:`a` maximum value and
-    optionally clip them between.
+    Normalise specified array :math:`a` values by :math:`a` maximum value
+    and optionally clip them between [0, factor].
 
     Parameters
     ----------
@@ -594,13 +618,14 @@ def normalise_maximum(
 
 def vecmul(m: ArrayLike, v: ArrayLike) -> NDArrayFloat:
     """
-    Perform the batched multiplication between the matrix array :math:`m` and
+    Perform batched multiplication between the matrix array :math:`m` and
     vector array :math:`v`.
 
-    It is in intent equivalent to :func:`np.matmul` but with the specific intent
-    of vector multiplication by a matrix. With that intent, vector dimensionality
-    will be increased to enable broadcasting. This definition can be expressed
-    with :func:`np.einsum` using the following subscripts: *'...ij,...j->...i'*.
+    This function is equivalent to :func:`numpy.matmul` but specifically
+    designed for vector multiplication by a matrix. Vector dimensionality is
+    automatically increased to enable broadcasting. The operation can be
+    expressed using :func:`numpy.einsum` with subscripts
+    *'...ij,...j->...i'*.
 
     Parameters
     ----------
@@ -640,8 +665,8 @@ def vecmul(m: ArrayLike, v: ArrayLike) -> NDArrayFloat:
 
 def euclidean_distance(a: ArrayLike, b: ArrayLike) -> NDArrayFloat:
     """
-    Return the *Euclidean* distance between point array :math:`a` and point
-    array :math:`b`.
+    Calculate the *Euclidean* distance between the specified point arrays
+    :math:`a` and :math:`b`.
 
     For a two-dimensional space, the metric is as follows:
 
@@ -656,8 +681,8 @@ def euclidean_distance(a: ArrayLike, b: ArrayLike) -> NDArrayFloat:
 
     Returns
     -------
-    :class:`np.float` or :class:`numpy.ndarray`
-        *Euclidean* distance.
+    :class:`numpy.float64` or :class:`numpy.ndarray`
+        *Euclidean* distance between the two point arrays.
 
     Examples
     --------
@@ -672,10 +697,10 @@ def euclidean_distance(a: ArrayLike, b: ArrayLike) -> NDArrayFloat:
 
 def manhattan_distance(a: ArrayLike, b: ArrayLike) -> NDArrayFloat:
     """
-    Return the *Manhattan* (or *City-Block*) distance between point array
+    Compute the *Manhattan* (or *City-Block*) distance between point array
     :math:`a` and point array :math:`b`.
 
-    For a two-dimensional space, the metric is as follows:
+    For a two-dimensional space, the metric is defined as:
 
     :math:`M_D = |x_a - x_b| + |y_a - y_b|`
 
@@ -706,7 +731,7 @@ def linear_conversion(
     a: ArrayLike, old_range: ArrayLike, new_range: ArrayLike
 ) -> NDArrayFloat:
     """
-    Perform a simple linear conversion of specified array :math:`a` between the
+    Perform simple linear conversion of the specified array :math:`a` between the
     old and new ranges.
 
     Parameters
@@ -745,20 +770,20 @@ def linstep_function(
     clip: bool = False,
 ) -> NDArrayFloat:
     """
-    Perform a simple linear interpolation between specified array :math:`a` and
-    array :math:`b` using :math:`x` array.
+    Perform linear interpolation between specified arrays :math:`a` and
+    :math:`b` using array :math:`x`.
 
     Parameters
     ----------
     x
-        Array :math:`x` value to use to interpolate between array :math:`a` and
-        array :math:`b`.
+        Array :math:`x` containing values to use for interpolation between
+        array :math:`a` and array :math:`b`.
     a
-        Array :math:`a`, the start of the range in which to interpolate.
+        Array :math:`a`, the start of the interpolation range.
     b
-        Array :math:`b`, the end of the range in which to interpolate.
+        Array :math:`b`, the end of the interpolation range.
     clip
-        Whether to clip the output values to range [``a``, ``b``].
+        Whether to clip the output values to range [:math:`a`, :math:`b`].
 
     Returns
     -------
@@ -792,23 +817,30 @@ def smoothstep_function(
     clip: bool = False,
 ) -> NDArrayFloat:
     """
-    Evaluate the *smoothstep* sigmoid-like function on array :math:`x`.
+    Apply the *smoothstep* cubic Hermite interpolation function to
+    array :math:`x`.
+
+    The *smoothstep* function creates a smooth S-shaped curve between
+    specified edge values, commonly used for smooth transitions in
+    colour interpolation and rendering operations.
 
     Parameters
     ----------
     x
-        Array :math:`x`.
+        Input array :math:`x` containing values to be transformed.
     a
-        Low input domain limit, i.e., the left edge.
+        Lower edge value for the interpolation domain.
     b
-        High input domain limit, i.e., the right edge.
+        Upper edge value for the interpolation domain.
     clip
-        Whether to scale, bias and clip input values to domain [``a``, ``b``].
+        Whether to normalize and constrain input values to the domain
+        [:math:`a`, :math:`b`] before applying the *smoothstep* function.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Array :math:`x` after *smoothstep* sigmoid-like function evaluation.
+        Transformed array with values smoothly interpolated using the
+        cubic Hermite polynomial :math:`3x^2 - 2x^3`.
 
     Examples
     --------
@@ -831,17 +863,21 @@ smooth = smoothstep_function
 
 def is_identity(a: ArrayLike) -> bool:
     """
-    Return whether :math:`a` array is an identity matrix.
+    Determine whether the specified array :math:`a` is an identity matrix.
+
+    An identity matrix is a square matrix with ones on the main diagonal
+    and zeros elsewhere, satisfying :math:`I \\cdot A = A \\cdot I = A`
+    for any compatible matrix :math:`A`.
 
     Parameters
     ----------
     a
-        Array :math:`a` to test.
+        Array :math:`a` to test for identity matrix properties.
 
     Returns
     -------
     :class:`bool`
-        Whether :math:`a` array is an identity matrix.
+        Whether the specified array :math:`a` is an identity matrix.
 
     Examples
     --------
@@ -861,31 +897,31 @@ def eigen_decomposition(
     covariance_matrix: bool = False,
 ) -> Tuple[NDArrayFloat, NDArrayFloat]:
     """
-    Return the eigen-values :math:`w` and eigen-vectors :math:`v` of specified
-    array :math:`a` in specified order.
+    Compute the eigenvalues :math:`w` and eigenvectors :math:`v` of the
+    specified array :math:`a` in the specified order.
 
     Parameters
     ----------
     a
-        Array to return the eigen-values :math:`w` and eigen-vectors :math:`v`
-        for
+        Array to compute the eigenvalues :math:`w` and eigenvectors :math:`v`
+        for.
     eigen_w_v_count
-        Eigen-values :math:`w` and eigen-vectors :math:`v` count.
+        Number of eigenvalues :math:`w` and eigenvectors :math:`v` to return.
     descending_order
-        Whether to return the eigen-values :math:`w` and eigen-vectors :math:`v`
+        Whether to return the eigenvalues :math:`w` and eigenvectors :math:`v`
         in descending order.
     covariance_matrix
-        Whether to compute the eigen-values :math:`w` and eigen-vectors
+        Whether to compute the eigenvalues :math:`w` and eigenvectors
         :math:`v` of the array :math:`a` covariance matrix
-        :math:`A =a^T\\cdot a`.
+        :math:`A = a^T \\cdot a`.
 
     Returns
     -------
     :class:`tuple`
-        Tuple of eigen-values :math:`w` and eigen-vectors :math:`v`. The
-        eigenv-alues are in specified order, each repeated according to
-        its multiplicity. The column ``v[:, i]`` is the normalized eigen-vector
-        corresponding to the eige-nvalue ``w[i]``.
+        Tuple of eigenvalues :math:`w` and eigenvectors :math:`v`. The
+        eigenvalues are in the specified order, each repeated according to
+        its multiplicity. The column ``v[:, i]`` is the normalized eigenvector
+        corresponding to the eigenvalue ``w[i]``.
 
     Examples
     --------

--- a/colour/algebra/coordinates/transformations.py
+++ b/colour/algebra/coordinates/transformations.py
@@ -2,22 +2,28 @@
 Coordinates System Transformations
 ==================================
 
-Objects to apply transformations on coordinates systems.
+Provide transformations between different coordinate systems.
+
+This module implements transformations between Cartesian coordinates and
+various other coordinate systems commonly used in colour science and
+computer graphics applications. The transformations preserve the spatial
+relationships while expressing positions in different mathematical
+representations.
 
 The following transformations are available:
 
--   :func:`colour.algebra.cartesian_to_spherical`: Cartesian to spherical
-    transformation.
--   :func:`colour.algebra.spherical_to_cartesian`: Spherical to cartesian
-    transformation.
--   :func:`colour.algebra.cartesian_to_polar`: Cartesian to polar
-    transformation.
--   :func:`colour.algebra.polar_to_cartesian`: Polar to cartesian
-    transformation.
--   :func:`colour.algebra.cartesian_to_cylindrical`: Cartesian to cylindrical
-    transformation.
--   :func:`colour.algebra.cylindrical_to_cartesian`: Cylindrical to cartesian
-    transformation.
+-   :func:`colour.algebra.cartesian_to_spherical`: Transform from Cartesian
+    to spherical coordinate system.
+-   :func:`colour.algebra.spherical_to_cartesian`: Transform from spherical
+    to Cartesian coordinate system.
+-   :func:`colour.algebra.cartesian_to_polar`: Transform from Cartesian to
+    polar coordinate system.
+-   :func:`colour.algebra.polar_to_cartesian`: Transform from polar to
+    Cartesian coordinate system.
+-   :func:`colour.algebra.cartesian_to_cylindrical`: Transform from
+    Cartesian to cylindrical coordinate system.
+-   :func:`colour.algebra.cylindrical_to_cartesian`: Transform from
+    cylindrical to Cartesian coordinate system.
 
 References
 ----------
@@ -72,10 +78,10 @@ def cartesian_to_spherical(a: ArrayLike) -> NDArrayFloat:
     Returns
     -------
     :class:`numpy.ndarray`
-        Spherical coordinates array :math:`\\rho\\theta\\phi`, :math:`\\rho` is
-        in range [0, +inf], :math:`\\theta` is in range [0, pi] radians, i.e.,
-        [0, 180] degrees, and :math:`\\phi` is in range [-pi, pi] radians, i.e.,
-        [-180, 180] degrees.
+        Spherical coordinates array :math:`\\rho\\theta\\phi`, :math:`\\rho`
+        is in range [0, +inf], :math:`\\theta` is in range [0, pi] radians,
+        i.e., [0, 180] degrees, and :math:`\\phi` is in range [-pi, pi]
+        radians, i.e., [-180, 180] degrees.
 
     References
     ----------
@@ -109,8 +115,8 @@ def spherical_to_cartesian(a: ArrayLike) -> NDArrayFloat:
     a
         Spherical coordinates array :math:`\\rho\\theta\\phi` to transform,
         :math:`\\rho` is in range [0, +inf], :math:`\\theta` is in range
-        [0, pi] radians, i.e., [0, 180] degrees, and :math:`\\phi` is in range
-        [-pi, pi] radians, i.e., [-180, 180] degrees.
+        [0, pi] radians, i.e., [0, 180] degrees, and :math:`\\phi` is in
+        range [-pi, pi] radians, i.e., [-180, 180] degrees.
 
     Returns
     -------
@@ -151,9 +157,9 @@ def cartesian_to_polar(a: ArrayLike) -> NDArrayFloat:
     Returns
     -------
     :class:`numpy.ndarray`
-        Polar coordinates array :math:`\\rho\\phi`, :math:`\\rho` is
-        in range [0, +inf], :math:`\\phi` is in range [-pi, pi] radians, i.e.,
-        [-180, 180] degrees.
+        Polar coordinates array :math:`\\rho\\phi`, :math:`\\rho` is in range
+        [0, +inf], :math:`\\phi` is in range [-pi, pi] radians, i.e., [-180,
+        180] degrees.
 
     References
     ----------
@@ -177,14 +183,15 @@ def cartesian_to_polar(a: ArrayLike) -> NDArrayFloat:
 def polar_to_cartesian(a: ArrayLike) -> NDArrayFloat:
     """
     Transform specified polar coordinates array :math:`\\rho\\phi` (radial
-    coordinate, angular coordinate) to cartesian coordinates array :math:`xy`.
+    coordinate, angular coordinate) to Cartesian coordinates array :math:`xy`.
 
     Parameters
     ----------
     a
-        Polar coordinates array :math:`\\rho\\phi` to transform, :math:`\\rho`
-        is in range [0, +inf], :math:`\\phi` is in range [-pi, pi] radians
-        i.e., [-180, 180] degrees.
+        Polar coordinates array :math:`\\rho\\phi` to transform where
+        :math:`\\rho` is the radial coordinate in range [0, +inf] and
+        :math:`\\phi` is the angular coordinate in range [-pi, pi] radians
+        (i.e., [-180, 180] degrees).
 
     Returns
     -------
@@ -224,9 +231,9 @@ def cartesian_to_cylindrical(a: ArrayLike) -> NDArrayFloat:
     Returns
     -------
     :class:`numpy.ndarray`
-        Cylindrical coordinates array :math:`\\rho\\phi z`, :math:`\\rho` is in
-        range [0, +inf], :math:`\\phi` is in range [-pi, pi] radians i.e.,
-        [-180, 180] degrees, :math:`z` is in range [0, +inf].
+        Cylindrical coordinates array :math:`\\rho\\phi z`, :math:`\\rho` is
+        in range [0, +inf], :math:`\\phi` is in range [-pi, pi] radians
+        i.e., [-180, 180] degrees, :math:`z` is in range [0, +inf].
 
     References
     ----------
@@ -256,9 +263,9 @@ def cylindrical_to_cartesian(a: ArrayLike) -> NDArrayFloat:
     ----------
     a
         Cylindrical coordinates array :math:`\\rho\\phi z` to transform,
-        :math:`\\rho` is in range [0, +inf], :math:`\\phi` is in range
-        [-pi, pi] radians i.e., [-180, 180] degrees, :math:`z` is in range
-        [0, +inf].
+        where :math:`\\rho` is in range [0, +inf], :math:`\\phi` is in
+        range [-pi, pi] radians i.e., [-180, 180] degrees, and :math:`z`
+        is in range [0, +inf].
 
     Returns
     -------

--- a/colour/algebra/extrapolation.py
+++ b/colour/algebra/extrapolation.py
@@ -2,9 +2,11 @@
 Extrapolation
 =============
 
-Classes for extrapolating variables:
+Define classes for extrapolating one-dimensional functions beyond their
+original domain.
 
--   :class:`colour.Extrapolator`: 1-D function extrapolation.
+-   :class:`colour.Extrapolator`: Extrapolate 1-D functions using various
+    methods to extend function values beyond the original interpolation range.
 
 References
 ----------
@@ -60,21 +62,23 @@ __all__ = [
 
 class Extrapolator:
     """
-    Extrapolate the 1-D function of specified interpolator.
+    Extrapolate 1-D function values beyond the specified interpolator's
+    domain boundaries.
 
-    The :class:`colour.Extrapolator` class acts as a wrapper around a given
-    *Colour* or *scipy* interpolator class instance with compatible signature.
-    Two extrapolation methods are available:
+    The :class:`colour.Extrapolator` class wraps a specified *Colour* or
+    *scipy* interpolator instance with compatible signature to provide
+    controlled extrapolation behaviour. Two extrapolation methods are
+    supported:
 
-    -   *Linear*: Linearly extrapolates specified points using the slope defined
-        by the interpolator boundaries (xi[0], xi[1]) if x < xi[0] and
-        (xi[-1], xi[-2]) if x > xi[-1].
-    -   *Constant*: Extrapolates specified points by assigning the interpolator
-        boundaries values xi[0] if x < xi[0] and xi[-1] if x > xi[-1].
+    -   *Linear*: Extrapolate values linearly using the slope defined by
+        boundary points (xi[0], xi[1]) for x < xi[0] and (xi[-1], xi[-2])
+        for x > xi[-1].
+    -   *Constant*: Assign boundary values xi[0] for x < xi[0] and xi[-1]
+        for x > xi[-1].
 
-    Specifying the *left* and *right* arguments takes precedence on the chosen
-    extrapolation method and will assign the respective *left* and *right*
-    values to the specified points.
+    Specifying *left* and *right* arguments overrides the chosen
+    extrapolation method, assigning these values to points outside the
+    interpolator's domain.
 
     Parameters
     ----------
@@ -166,19 +170,23 @@ class Extrapolator:
     @property
     def interpolator(self) -> ProtocolInterpolator:
         """
-        Getter and setter property for the *Colour* or *scipy* interpolator
-        class instance.
+        Getter and setter for the interpolator.
+
+        The interpolator must implement the interpolator protocol with an
+        `x` attribute containing the independent variable data.
 
         Parameters
         ----------
         value
-            Value to set the *Colour* or *scipy* interpolator class instance
+            Value to set the interpolator instance implementing the required
+            protocol with an `x` attribute for wavelength or frequency values
             with.
 
         Returns
         -------
         ProtocolInterpolator
-            *Colour* or *scipy* interpolator class instance.
+            Interpolator instance implementing the required protocol with
+            an `x` attribute for wavelength or frequency values.
         """
 
         return self._interpolator
@@ -202,17 +210,23 @@ class Extrapolator:
     @property
     def method(self) -> Literal["Linear", "Constant"] | str:
         """
-        Getter and setter property for the extrapolation method.
+        Getter and setter for the extrapolation method for the interpolator.
+
+        This property controls the behaviour of the interpolator when
+        extrapolating values outside the interpolation domain. The method
+        determines how values are computed beyond the specified boundaries.
 
         Parameters
         ----------
         value
-            Value to set the extrapolation method. with.
+            Value to set the extrapolation method to use, either ``'Linear'``
+            for linear extrapolation or ``'Constant'`` for constant value
+            extrapolation at the boundaries.
 
         Returns
         -------
         :class:`str`
-            Extrapolation method.
+            Extrapolation method to use.
         """
 
         return self._method
@@ -233,17 +247,22 @@ class Extrapolator:
     @property
     def left(self) -> Real | None:
         """
-        Getter and setter property for left value to return for x < xi[0].
+        Getter and setter for the left boundary value.
+
+        Specifies the value to return when evaluating the interpolant at
+        points beyond the leftmost data point ( x < xi[0]).
 
         Parameters
         ----------
         value
-            Left value to return for x < xi[0].
+            Value to return for x < xi[0] for extrapolation beyond the
+            leftmost data point.
 
         Returns
         -------
         Real or :py:data:`None`
-            Left value to return for x < xi[0].
+            Value to return for x < xi[0] for extrapolation beyond the
+            leftmost data point.
         """
 
         return self._left
@@ -263,17 +282,22 @@ class Extrapolator:
     @property
     def right(self) -> Real | None:
         """
-        Getter and setter property for right value to return for x > xi[-1].
+        Getter and setter for the right boundary value.
+
+        Specifies the value to return when evaluating the interpolant at
+        points beyond the rightmost data point (x > xi[-1]).
 
         Parameters
         ----------
         value
-            Right value to return for x > xi[-1].
+            Value to return for x > xi[-1] for extrapolation beyond the
+            rightmost data point.
 
         Returns
         -------
-        Real or :py:data:`None`
-            Right value to return for x > xi[-1].
+        :class:`numbers.Real` or :py:data:`None`
+            Value to return for x > xi[-1] for extrapolation beyond the
+            rightmost data point.
         """
 
         return self._right
@@ -292,17 +316,17 @@ class Extrapolator:
 
     def __call__(self, x: ArrayLike) -> NDArrayFloat:
         """
-        Evaluate the Extrapolator at specified point(s).
+        Evaluate the extrapolator at specified point(s).
 
         Parameters
         ----------
         x
-            Point(s) to evaluate the Extrapolator at.
+            Point(s) to evaluate the extrapolator at.
 
         Returns
         -------
         :class:`numpy.ndarray`
-            Extrapolated points value(s).
+            Extrapolated point value(s).
         """
 
         x = as_float_array(x)
@@ -318,12 +342,12 @@ class Extrapolator:
         Parameters
         ----------
         x
-            Points to evaluate the Extrapolator at.
+            Points to evaluate the extrapolator at.
 
         Returns
         -------
         :class:`numpy.ndarray`
-            Extrapolated points values.
+            Extrapolated point values.
         """
 
         xi = self._interpolator.x

--- a/colour/algebra/interpolation.py
+++ b/colour/algebra/interpolation.py
@@ -2,10 +2,16 @@
 Interpolation
 =============
 
-Classes and definitions for interpolating variables.
+Provide classes and functions for interpolating variables in colour science
+computations.
 
--   :class:`colour.KernelInterpolator`: 1-D function generic interpolation with
-    arbitrary kernel.
+This module implements various interpolation methods for one-dimensional
+functions and multi-dimensional table-based interpolation. These methods
+support spectral data processing, colour transformations, and general
+numerical interpolation tasks in colour science applications.
+
+-   :class:`colour.KernelInterpolator`: 1-D function generic interpolation
+    with arbitrary kernel.
 -   :class:`colour.NearestNeighbourInterpolator`: 1-D function
     nearest-neighbour interpolation.
 -   :class:`colour.LinearInterpolator`: 1-D function linear interpolation.
@@ -16,15 +22,14 @@ Classes and definitions for interpolating variables.
 -   :class:`colour.PchipInterpolator`: 1-D function piecewise cube Hermite
     interpolation.
 -   :class:`colour.NullInterpolator`: 1-D function null interpolation.
--   :func:`colour.lagrange_coefficients`: Computation of
-    *Lagrange Coefficients*.
--   :func:`colour.algebra.table_interpolation_trilinear`: Trilinear
+-   :func:`colour.lagrange_coefficients`: Compute *Lagrange Coefficients*.
+-   :func:`colour.algebra.table_interpolation_trilinear`: Perform trilinear
     interpolation with table.
--   :func:`colour.algebra.table_interpolation_tetrahedral`: Tetrahedral
-    interpolation with table.
+-   :func:`colour.algebra.table_interpolation_tetrahedral`: Perform
+    tetrahedral interpolation with table.
 -   :attr:`colour.TABLE_INTERPOLATION_METHODS`: Supported table interpolation
     methods.
--   :func:`colour.table_interpolation`: Interpolation with table using
+-   :func:`colour.table_interpolation`: Perform interpolation with table using
     specified method.
 
 References
@@ -61,7 +66,6 @@ from __future__ import annotations
 
 import itertools
 import typing
-from collections.abc import Mapping
 from functools import reduce
 
 import numpy as np
@@ -136,6 +140,11 @@ def kernel_nearest_neighbour(x: ArrayLike) -> NDArrayFloat:
     """
     Return the *nearest-neighbour* kernel evaluated at specified samples.
 
+    The *nearest-neighbour* kernel is a discontinuous kernel function that
+    equals 1 for samples within the range [-0.5, 0.5) and 0 elsewhere. This
+    kernel represents the simplest interpolation method where each output
+    value is determined by the closest input sample.
+
     Parameters
     ----------
     x
@@ -161,7 +170,11 @@ def kernel_nearest_neighbour(x: ArrayLike) -> NDArrayFloat:
 
 def kernel_linear(x: ArrayLike) -> NDArrayFloat:
     """
-    Return the *linear* kernel evaluated at specified samples.
+    Evaluate the *linear* kernel at specified samples.
+
+    The *linear* kernel is a triangular function that returns 1 when
+    :math:`|x| < 0.5` and 0 otherwise, providing a simple binary response
+    based on the absolute value of the input.
 
     Parameters
     ----------
@@ -171,7 +184,8 @@ def kernel_linear(x: ArrayLike) -> NDArrayFloat:
     Returns
     -------
     :class:`numpy.ndarray`
-        The *linear* kernel evaluated at specified samples.
+        The *linear* kernel evaluated at specified samples, with values of 1
+        for :math:`|x| < 0.5` and 0 otherwise.
 
     References
     ----------
@@ -191,19 +205,28 @@ def kernel_linear(x: ArrayLike) -> NDArrayFloat:
 
 def kernel_sinc(x: ArrayLike, a: float = 3) -> NDArrayFloat:
     """
-    Return the *sinc* kernel evaluated at specified samples.
+    Evaluate the *sinc* kernel at specified sample positions.
+
+    Compute the *sinc* kernel function, commonly used in signal processing
+    and interpolation applications, for the specified sample positions.
 
     Parameters
     ----------
     x
-        Samples at which to evaluate the *sinc* kernel.
+        Sample positions at which to evaluate the *sinc* kernel.
     a
-        Size of the *sinc* kernel.
+        Size parameter of the *sinc* kernel, controlling the function's
+        support width.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        The *sinc* kernel evaluated at specified samples.
+        *Sinc* kernel values evaluated at the specified sample positions.
+
+    Raises
+    ------
+    AssertionError
+        If ``a`` is less than 1.
 
     References
     ----------
@@ -227,19 +250,25 @@ def kernel_sinc(x: ArrayLike, a: float = 3) -> NDArrayFloat:
 
 def kernel_lanczos(x: ArrayLike, a: float = 3) -> NDArrayFloat:
     """
-    Return the *lanczos* kernel evaluated at specified samples.
+    Return the *Lanczos* kernel evaluated at specified samples.
+
+    The *Lanczos* kernel is a sinc-based windowing function commonly used
+    in signal processing and image resampling applications. It is defined
+    as :math:`L(x) = \\text{sinc}(x) \\cdot \\text{sinc}(x/a)` for
+    :math:`|x| < a`, and zero otherwise.
 
     Parameters
     ----------
     x
-        Samples at which to evaluate the *lanczos* kernel.
+        Samples at which to evaluate the *Lanczos* kernel.
     a
-        Size of the *lanczos* kernel.
+        Size of the *Lanczos* kernel, defining the support region
+        :math:`[-a, a]`.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        The *lanczos* kernel evaluated at specified samples.
+        The *Lanczos* kernel evaluated at specified samples.
 
     References
     ----------
@@ -271,7 +300,8 @@ def kernel_cardinal_spline(
 
     -   *Catmull-Rom*: :math:`(a=0.5, b=0)`
     -   *Cubic B-Spline*: :math:`(a=0, b=1)`
-    -   *Mitchell-Netravalli*: :math:`(a=\\cfrac{1}{3}, b=\\cfrac{1}{3})`
+    -   *Mitchell-Netravalli*:
+        :math:`(a=\\cfrac{1}{3}, b=\\cfrac{1}{3})`
 
     Parameters
     ----------
@@ -319,12 +349,12 @@ def kernel_cardinal_spline(
 
 class KernelInterpolator:
     """
-    Kernel based interpolation of a 1-D function.
+    Perform kernel-based interpolation of a 1-D function.
 
-    The reconstruction of a continuous signal can be described as a linear
-    convolution operation. Interpolation can be expressed as a convolution of
-    the specified discrete function :math:`g(x)` with some continuous interpolation
-    kernel :math:`k(w)`::
+    Reconstruct a continuous signal from discrete samples using linear
+    convolution. Express interpolation as the convolution of the specified
+    discrete function :math:`g(x)` with a continuous interpolation kernel
+    :math:`k(w)`:
 
         :math:`\\hat{g}(w_0) = [k * g](w_0) = \
 \\sum_{x=-\\infty}^{\\infty}k(w_0 - x)\\cdot g(x)`
@@ -335,17 +365,16 @@ class KernelInterpolator:
         Independent :math:`x` variable values corresponding with :math:`y`
         variable.
     y
-        Dependent and already known :math:`y` variable values to
-        interpolate.
+        Dependent and already known :math:`y` variable values to interpolate.
     window
         Width of the window in samples on each side.
     kernel
         Kernel to use for interpolation.
     kernel_kwargs
-         Arguments to use when calling the kernel.
+        Arguments to use when calling the kernel.
     padding_kwargs
-         Arguments to use when padding :math:`y` variable values with the
-         :func:`np.pad` definition.
+        Arguments to use when padding :math:`y` variable values with the
+        :func:`np.pad` definition.
     dtype
         Data type used for internal conversions.
 
@@ -439,7 +468,7 @@ class KernelInterpolator:
     @property
     def x(self) -> NDArrayFloat:
         """
-        Getter and setter property for the independent :math:`x` variable.
+        Getter and setter for the independent :math:`x` variable.
 
         Parameters
         ----------
@@ -488,8 +517,7 @@ class KernelInterpolator:
     @property
     def y(self) -> NDArrayFloat:
         """
-        Getter and setter property for the dependent and already known
-        :math:`y` variable.
+        Getter and setter for the dependent and already known :math:`y` variable.
 
         Parameters
         ----------
@@ -524,7 +552,12 @@ class KernelInterpolator:
     @property
     def window(self) -> float:
         """
-        Getter and setter property for the window.
+        Getter and setter for the filtering window size for the moving average.
+
+        The window determines the number of samples used in the moving
+        average calculation. A larger window produces smoother results
+        with greater lag, while a smaller window yields more responsive
+        but potentially noisier output.
 
         Parameters
         ----------
@@ -534,7 +567,7 @@ class KernelInterpolator:
         Returns
         -------
         :class:`float`
-            Window.
+            Window size for the moving average filter.
         """
 
         return self._window
@@ -558,17 +591,23 @@ class KernelInterpolator:
     @property
     def kernel(self) -> Callable:
         """
-        Getter and setter property for the kernel callable.
+        Getter and setter for the kernel callable for the interpolator.
 
         Parameters
         ----------
         value
-            Value to set the kernel callable.
+            Value to set the callable object to use as the interpolation kernel
+            with. Must be a callable that accepts numeric arguments.
 
         Returns
         -------
         Callable
-            Kernel callable.
+             Callable object to use as the interpolation kernel.
+
+        Raises
+        ------
+        AssertionError
+            If the provided value is not callable.
         """
 
         return self._kernel
@@ -587,17 +626,24 @@ class KernelInterpolator:
     @property
     def kernel_kwargs(self) -> dict:
         """
-        Getter and setter property for the kernel call time arguments.
+        Getter and setter for the kernel keyword arguments for the convolution
+        operation.
 
         Parameters
         ----------
         value
-            Value to call the interpolation kernel with.
+            Value to set the keyword arguments to pass to the kernel function
+            with.
 
         Returns
         -------
         :class:`dict`
-            Kernel call time arguments.
+            Keyword arguments to pass to the kernel function.
+
+        Raises
+        ------
+        AssertionError
+            If the provided value is not a :class:'dict` class instance.
         """
 
         return self._kernel_kwargs
@@ -616,17 +662,24 @@ class KernelInterpolator:
     @property
     def padding_kwargs(self) -> dict:
         """
-        Getter and setter property for the kernel call time arguments.
+        Getter and setter for the padding keyword arguments for edge handling.
 
         Parameters
         ----------
         value
-            Value to call the interpolation kernel with.
+            Value to set the keyword arguments to pass to the padding function
+            when handling edges during interpolation.
 
         Returns
         -------
         :class:`dict`
-            Kernel call time arguments.
+            Keyword arguments to pass to the padding function when handling
+            edges during interpolation.
+
+        Raises
+        ------
+        AssertionError
+            If the provided value is not a :class:`dict` class instance.
         """
 
         return self._padding_kwargs
@@ -636,8 +689,8 @@ class KernelInterpolator:
         """Setter for the **self.padding_kwargs** property."""
 
         attest(
-            isinstance(value, Mapping),
-            f'"padding_kwargs" property: "{value}" type is not a "Mapping" instance!',
+            isinstance(value, dict),
+            f'"padding_kwargs" property: "{value}" type is not a "dict" instance!',
         )
 
         self._padding_kwargs = value
@@ -669,17 +722,17 @@ class KernelInterpolator:
 
     def _evaluate(self, x: NDArrayFloat) -> NDArrayFloat:
         """
-        Perform the interpolator evaluation at specified points.
+        Evaluate the interpolating polynomial at the specified point.
 
         Parameters
         ----------
         x
-            Points to evaluate the interpolant at.
+            Point at which to evaluate the interpolant.
 
         Returns
         -------
         :class:`numpy.ndarray`
-            Interpolated points values.
+            Interpolated values at the specified point.
         """
 
         self._validate_dimensions()
@@ -704,7 +757,14 @@ class KernelInterpolator:
         )
 
     def _validate_dimensions(self) -> None:
-        """Validate that the variables dimensions are the same."""
+        """
+        Validate that the dimensions of the variables are equal.
+
+        Raises
+        ------
+        ValueError
+            If the x and y variable dimensions do not match.
+        """
 
         if len(self._x) != len(self._y):
             error = (
@@ -715,7 +775,23 @@ class KernelInterpolator:
             raise ValueError(error)
 
     def _validate_interpolation_range(self, x: NDArrayFloat) -> None:
-        """Validate specified point to be in interpolation range."""
+        """
+        Validate that the specified interpolation point is within the valid
+        interpolation range.
+
+        The interpolation point must be within the bounds defined by the first
+        and last x-coordinates of the interpolator's data.
+
+        Parameters
+        ----------
+        x
+            Point to validate for interpolation range compliance.
+
+        Raises
+        ------
+        ValueError
+            If the point is outside the valid interpolation range.
+        """
 
         below_interpolation_range = x < self._x[0]
         above_interpolation_range = x > self._x[-1]
@@ -733,15 +809,20 @@ class KernelInterpolator:
 
 class NearestNeighbourInterpolator(KernelInterpolator):
     """
-    A nearest-neighbour interpolator.
+    Perform nearest-neighbour interpolation on discrete data.
+
+    Implement a kernel-based interpolator that selects the closest known
+    data point for each query position. This interpolator provides fast,
+    discontinuous interpolation suitable for categorical data or when
+    preserving exact measured values is required.
 
     Other Parameters
     ----------------
     dtype
         Data type used for internal conversions.
     padding_kwargs
-         Arguments to use when padding :math:`y` variable values with the
-         :func:`np.pad` definition.
+        Arguments to use when padding :math:`y` variable values with the
+        :func:`np.pad` definition.
     window
         Width of the window in samples on each side.
     x
@@ -765,7 +846,10 @@ class NearestNeighbourInterpolator(KernelInterpolator):
 
 class LinearInterpolator:
     """
-    Interpolate linearly a 1-D function.
+    Perform linear interpolation of a 1-D function.
+
+    This class provides a wrapper around NumPy's linear interpolation
+    functionality for interpolating between specified data points.
 
     Parameters
     ----------
@@ -830,7 +914,7 @@ class LinearInterpolator:
     @property
     def x(self) -> NDArrayFloat:
         """
-        Getter and setter property for the independent :math:`x` variable.
+        Getter and setter for the independent :math:`x` variable.
 
         Parameters
         ----------
@@ -841,6 +925,11 @@ class LinearInterpolator:
         -------
         :class:`numpy.ndarray`
             Independent :math:`x` variable.
+
+        Raises
+        ------
+        AssertionError
+            If the provided value has not exactly one dimension.
         """
 
         return self._x
@@ -861,7 +950,7 @@ class LinearInterpolator:
     @property
     def y(self) -> NDArrayFloat:
         """
-        Getter and setter property for the dependent and already known
+        Getter and setter for the dependent and already known
         :math:`y` variable.
 
         Parameters
@@ -874,6 +963,11 @@ class LinearInterpolator:
         -------
         :class:`numpy.ndarray`
             Dependent and already known :math:`y` variable.
+
+        Raises
+        ------
+        AssertionError
+            If the provided value has not exactly one dimension.
         """
 
         return self._y
@@ -963,11 +1057,15 @@ class LinearInterpolator:
 
 class SpragueInterpolator:
     """
-    Construct a fifth-order polynomial that passes through :math:`y` dependent
-    variable.
+    Perform fifth-order polynomial interpolation using the *Sprague (1880)*
+    method for uniformly spaced data.
 
-    *Sprague (1880)* method is recommended by the *CIE* for interpolating
-    functions having a uniformly spaced independent variable.
+    Implement the *Sprague (1880)* interpolation method recommended by the
+    *CIE* for interpolating functions with uniformly spaced independent
+    variables. This interpolator constructs a fifth-order polynomial that
+    passes through specified dependent variable values, providing smooth
+    interpolation suitable for spectral data and other colour science
+    applications.
 
     Parameters
     ----------
@@ -1059,7 +1157,7 @@ class SpragueInterpolator:
     @property
     def x(self) -> NDArrayFloat:
         """
-        Getter and setter property for the independent :math:`x` variable.
+        Getter and setter for the independent :math:`x` variable.
 
         Parameters
         ----------
@@ -1070,6 +1168,11 @@ class SpragueInterpolator:
         -------
         :class:`numpy.ndarray`
             Independent :math:`x` variable.
+
+        Raises
+        ------
+        AssertionError
+            If the provided value has not exactly one dimension.
         """
 
         return self._x
@@ -1105,7 +1208,7 @@ class SpragueInterpolator:
     @property
     def y(self) -> NDArrayFloat:
         """
-        Getter and setter property for the dependent and already known
+        Getter and setter for the dependent and already known
         :math:`y` variable.
 
         Parameters
@@ -1118,6 +1221,12 @@ class SpragueInterpolator:
         -------
         :class:`numpy.ndarray`
             Dependent and already known :math:`y` variable.
+
+        Raises
+        ------
+        AssertionError
+            If the provided value has not exactly one dimension and its value
+            count is less than 6.
         """
 
         return self._y
@@ -1254,7 +1363,13 @@ class SpragueInterpolator:
 
 class CubicSplineInterpolator(scipy.interpolate.interp1d):
     """
-    Interpolate a 1-D function using cubic spline interpolation.
+    Perform cubic spline interpolation on one-dimensional data.
+
+    Provide smooth interpolation through specified data points using
+    piecewise cubic polynomials. The resulting interpolant maintains
+    continuity in the function and its first two derivatives at data
+    points, making it suitable for spectral data and colour science
+    applications requiring smooth transitions between measured values.
 
     Methods
     -------
@@ -1273,7 +1388,13 @@ class CubicSplineInterpolator(scipy.interpolate.interp1d):
 class PchipInterpolator(scipy.interpolate.PchipInterpolator):
     """
     Interpolate a 1-D function using Piecewise Cubic Hermite Interpolating
-    Polynomial interpolation.
+    Polynomial (PCHIP) interpolation.
+
+    PCHIP interpolation constructs a smooth curve through specified data
+    points while preserving monotonicity between consecutive points. This
+    method ensures that the interpolated values do not exhibit spurious
+    oscillations, making it particularly suitable for colour science
+    applications where physical constraints must be respected.
 
     Attributes
     ----------
@@ -1297,7 +1418,7 @@ class PchipInterpolator(scipy.interpolate.PchipInterpolator):
     @property
     def y(self) -> NDArrayFloat:
         """
-        Getter and setter property for the dependent and already known
+        Getter and setter for the dependent and already known
         :math:`y` variable.
 
         Parameters
@@ -1323,9 +1444,13 @@ class PchipInterpolator(scipy.interpolate.PchipInterpolator):
 
 class NullInterpolator:
     """
-    Perform 1-D function null interpolation, i.e., a call within specified
-    tolerances will return existing :math:`y` variable values and ``default``
-    if outside tolerances.
+    Implement 1-D function null interpolation.
+
+    This interpolator returns existing :math:`y` values when called with
+    :math:`x` values within specified tolerances, and returns a default
+    value when outside tolerances. Unlike traditional interpolators that
+    estimate intermediate values, this null interpolator only returns exact
+    matches within tolerance bounds.
 
     Parameters
     ----------
@@ -1402,7 +1527,7 @@ class NullInterpolator:
     @property
     def x(self) -> NDArrayFloat:
         """
-        Getter and setter property for the independent :math:`x` variable.
+        Getter and setter for the independent :math:`x` variable.
 
         Parameters
         ----------
@@ -1413,6 +1538,11 @@ class NullInterpolator:
         -------
         :class:`numpy.ndarray`
             Independent :math:`x` variable.
+
+        Raises
+        ------
+        AssertionError
+            If the provided value has not exactly one dimension.
         """
 
         return self._x
@@ -1433,7 +1563,7 @@ class NullInterpolator:
     @property
     def y(self) -> NDArrayFloat:
         """
-        Getter and setter property for the dependent and already known
+        Getter and setter for the dependent and already known
         :math:`y` variable.
 
         Parameters
@@ -1446,6 +1576,11 @@ class NullInterpolator:
         -------
         :class:`numpy.ndarray`
             Dependent and already known :math:`y` variable.
+
+        Raises
+        ------
+        AssertionError
+            If the provided value has not exactly one dimension.
         """
 
         return self._y
@@ -1466,17 +1601,23 @@ class NullInterpolator:
     @property
     def relative_tolerance(self) -> float:
         """
-        Getter and setter property for the relative tolerance.
+        Getter and setter property for the relative tolerance for numerical
+        comparisons.
 
         Parameters
         ----------
         value
-            Value to set the relative tolerance with.
+            Value to set the relative tolerance for numerical comparisons with.
 
         Returns
         -------
         :class:`float`
-            Relative tolerance.
+            Relative tolerance for numerical comparisons.
+
+        Raises
+        ------
+        AssertionError
+            If the value is not numeric.
         """
 
         return self._relative_tolerance
@@ -1495,17 +1636,23 @@ class NullInterpolator:
     @property
     def absolute_tolerance(self) -> float:
         """
-        Getter and setter property for the absolute tolerance.
+        Getter and setter property for the absolute tolerance for numerical
+        comparisons.
 
         Parameters
         ----------
         value
-            Value to set the absolute tolerance with.
+            Value to set the absolute tolerance for numerical comparisons with.
 
         Returns
         -------
         :class:`float`
-            Absolute tolerance.
+            Absolute tolerance for numerical comparisons.
+
+        Raises
+        ------
+        AssertionError
+            If the value is not numeric.
         """
 
         return self._absolute_tolerance
@@ -1530,12 +1677,17 @@ class NullInterpolator:
         Parameters
         ----------
         value
-            Value to set the default value with.
+            Value to set the default value with for call outside tolerances.
 
         Returns
         -------
         :class:`float`
-            Default value.
+            Default value for call outside tolerances.
+
+        Raises
+        ------
+        AssertionError
+            If the value is not numeric.
         """
 
         return self._default
@@ -1631,19 +1783,21 @@ class NullInterpolator:
 
 def lagrange_coefficients(r: float, n: int = 4) -> NDArrayFloat:
     """
-    Compute the *Lagrange Coefficients* at specified point :math:`r` for degree
-    :math:`n`.
+    Compute *Lagrange coefficients* at specified point :math:`r` for
+    polynomial interpolation of degree :math:`n`.
 
     Parameters
     ----------
     r
-        Point to get the *Lagrange Coefficients* at.
+        Point at which to compute the *Lagrange coefficients*.
     n
-        Degree of the *Lagrange Coefficients* being calculated.
+        Degree of the polynomial interpolation. The number of coefficients
+        returned will be :math:`n + 1`.
 
     Returns
     -------
     :class:`numpy.ndarray`
+        Array of *Lagrange coefficients* computed at point :math:`r`.
 
     References
     ----------
@@ -1669,7 +1823,8 @@ def vertices_and_relative_coordinates(
 ) -> Tuple[NDArrayFloat, NDArrayFloat]:
     """
     Compute the vertices coordinates and indexes relative :math:`V_{xyzr}`
-    coordinates from specified :math:`V_{xyzr}` values and interpolation table.
+    coordinates from the specified :math:`V_{xyz}` values and interpolation
+    table.
 
     Parameters
     ----------
@@ -1682,7 +1837,8 @@ def vertices_and_relative_coordinates(
     Returns
     -------
     :class:`tuple`
-        Vertices coordinates and indexes relative :math:`V_{xyzr}` coordinates.
+        Vertices coordinates and indexes relative :math:`V_{xyzr}`
+        coordinates.
 
     Examples
     --------
@@ -1764,7 +1920,7 @@ def vertices_and_relative_coordinates(
     i_f_c = i_f, i_c
 
     # Vertices computations by indexing ``table`` with the ``i_f`` and ``i_c``
-    # indexes. 8 encompassing vertices are computed for a specified V_xyz value
+    # indexes. 8 encompassing vertices are computed for the specified V_xyz value
     # forming a cube around it:
     vertices = np.array(
         [
@@ -1778,8 +1934,8 @@ def vertices_and_relative_coordinates(
 
 def table_interpolation_trilinear(V_xyz: ArrayLike, table: ArrayLike) -> NDArrayFloat:
     """
-    Perform the trilinear interpolation of specified :math:`V_{xyz}` values
-    using specified interpolation table.
+    Perform trilinear interpolation of the specified :math:`V_{xyz}` values using
+    the specified interpolation table.
 
     Parameters
     ----------
@@ -1854,8 +2010,8 @@ def table_interpolation_trilinear(V_xyz: ArrayLike, table: ArrayLike) -> NDArray
 
 def table_interpolation_tetrahedral(V_xyz: ArrayLike, table: ArrayLike) -> NDArrayFloat:
     """
-    Perform the tetrahedral interpolation of specified :math:`V_{xyz}` values
-    using specified interpolation table.
+    Perform tetrahedral interpolation of the specified :math:`V_{xyz}` values
+    using the specified 4-dimensional interpolation table.
 
     Parameters
     ----------
@@ -1952,22 +2108,30 @@ def table_interpolation(
     method: Literal["Trilinear", "Tetrahedral"] | str = "Trilinear",
 ) -> NDArrayFloat:
     """
-    Perform interpolation of specified :math:`V_{xyz}` values using specified
-    interpolation table.
+    Perform interpolation of the specified :math:`V_{xyz}` values using a
+    4-dimensional interpolation table.
+
+    Interpolate the input :math:`V_{xyz}` values through either trilinear
+    or tetrahedral interpolation methods using the specified lookup table.
 
     Parameters
     ----------
     V_xyz
-        :math:`V_{xyz}` values to interpolate.
+        :math:`V_{xyz}` values to interpolate, where each row represents
+        a three-dimensional coordinate within the interpolation table's
+        domain.
     table
-        4-Dimensional (NxNxNx3) interpolation table.
+        4-dimensional (NxNxNx3) interpolation table defining the mapping
+        from input coordinates to output values.
     method
-        Interpolation method.
+        Interpolation method to use. Either "Trilinear" for trilinear
+        interpolation or "Tetrahedral" for tetrahedral interpolation.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Interpolated :math:`V_{xyz}` values.
+        Interpolated :math:`V_{xyz}` values with the same shape as the
+        input array.
 
     References
     ----------

--- a/colour/algebra/prng.py
+++ b/colour/algebra/prng.py
@@ -47,29 +47,36 @@ def random_triplet_generator(
     random_state: np.random.RandomState = RANDOM_STATE,
 ) -> NDArrayFloat:
     """
-    Return a generator yielding random triplets.
+    Generate random triplets using a pseudo-random number generator.
+
+    Generate an array of random triplets with values constrained within
+    specified limits for each dimension. The triplets are generated using
+    a Mersenne Twister pseudo-random number generator.
 
     Parameters
     ----------
     size
-        Generator size.
+        Number of random triplets to generate.
     limits
-        Random values limits on each triplet axis.
+        Random value limits for each axis of the triplets, specified as a
+        sequence of [min, max] pairs. Default limits are [0, 1] for each
+        axis.
     random_state
-         Mersenne Twister pseudo-random number generator.
+         Mersenne Twister pseudo-random number generator instance used for
+         generating random values.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Random triplet generator.
+        Array of shape (size, 3) containing the generated random triplets.
 
     Notes
     -----
     -   The test is assuming that :func:`np.random.RandomState` definition
-        will return the same sequence no matter which *OS* or *Python* version
-        is used. There is however no formal promise about the *prng* sequence
-        reproducibility of either *Python* or *Numpy* implementations, see
-        :cite:`Laurent2012a`.
+        will return the same sequence no matter which *OS* or *Python*
+        version is used. There is however no formal promise about the
+        *prng* sequence reproducibility of either *Python* or *Numpy*
+        implementations, see :cite:`Laurent2012a`.
 
     Examples
     --------

--- a/colour/algebra/regression.py
+++ b/colour/algebra/regression.py
@@ -52,7 +52,7 @@ def least_square_mapping_MoorePenrose(y: ArrayLike, x: ArrayLike) -> NDArrayFloa
     Returns
     -------
     :class:`numpy.ndarray`
-        *Least-squares* mapping.
+        *Least-squares* mapping matrix.
 
     References
     ----------

--- a/colour/appearance/atd95.py
+++ b/colour/appearance/atd95.py
@@ -2,7 +2,7 @@
 ATD (1995) Colour Vision Model
 ==============================
 
-Define the *ATD (1995)* colour vision model objects:
+Define the *ATD (1995)* colour vision model.
 
 -   :class:`colour.CAM_Specification_ATD95`
 -   :func:`colour.XYZ_to_ATD95`
@@ -11,8 +11,8 @@ Notes
 -----
 -   According to *CIE TC1-34* definition of a colour appearance model, the
     *ATD (1995)* model cannot be considered as a colour appearance model.
-    It was developed with different aims and is described as a model of colour
-    vision.
+    It was developed with different aims and is described as a model of
+    colour vision.
 
 References
 ----------
@@ -69,8 +69,8 @@ class CAM_ReferenceSpecification_ATD95(MixinDataclassArithmetic):
     """
     Define the *ATD (1995)* colour vision model reference specification.
 
-    This specification has field names consistent with the *Fairchild (2013)*
-    reference.
+    This specification contains field names consistent with the *Fairchild
+    (2013)* reference.
 
     Parameters
     ----------
@@ -79,9 +79,9 @@ class CAM_ReferenceSpecification_ATD95(MixinDataclassArithmetic):
     C
         Correlate of *saturation* :math:`C`. *Guth (1995)* incorrectly uses
         the terms saturation and chroma interchangeably. However, :math:`C`
-        is here a measure of saturation rather than chroma since it is
-        measured relative to the achromatic response for the stimulus rather
-        than that of a similarly illuminated white.
+        represents a measure of saturation rather than chroma since it is
+        calculated relative to the achromatic response for the stimulus
+        rather than that of a similarly illuminated white.
     Br
         Correlate of *brightness* :math:`Br`.
     A_1
@@ -118,9 +118,11 @@ class CAM_Specification_ATD95(MixinDataclassArithmetic):
     """
     Define the *ATD (1995)* colour vision model specification.
 
-    This specification has field names consistent with the remaining colour
-    appearance models in :mod:`colour.appearance` but diverge from the
-    *Fairchild (2013)* reference.
+    This specification provides a standardized interface for the *ATD (1995)*
+    model with field names consistent across all colour appearance models in
+    :mod:`colour.appearance`. While the field names differ from the original
+    *Fairchild (2013)* reference notation, they map directly to the model's
+    perceptual correlates.
 
     Parameters
     ----------
@@ -129,7 +131,7 @@ class CAM_Specification_ATD95(MixinDataclassArithmetic):
     C
         Correlate of *saturation* :math:`C`. *Guth (1995)* incorrectly uses
         the terms saturation and chroma interchangeably. However, :math:`C`
-        is here a measure of saturation rather than chroma since it is
+        represents a measure of saturation rather than chroma since it is
         measured relative to the achromatic response for the stimulus rather
         than that of a similarly illuminated white.
     Q
@@ -143,7 +145,7 @@ class CAM_Specification_ATD95(MixinDataclassArithmetic):
     A_2
         Second stage :math:`A_2` response.
     T_2
-        Second stage :math:`A_2` response.
+        Second stage :math:`T_2` response.
     D_2
         Second stage :math:`D_2` response.
 
@@ -177,7 +179,8 @@ def XYZ_to_ATD95(
     sigma: ArrayLike = 300,
 ) -> CAM_Specification_ATD95:
     """
-    Compute the *ATD (1995)* colour vision model correlates.
+    Compute the *ATD (1995)* colour vision model correlates from the specified
+    *CIE XYZ* tristimulus values.
 
     Parameters
     ----------
@@ -215,8 +218,8 @@ def XYZ_to_ATD95(
     | ``CAM_Specification_ATD95.h`` | [0, 360]              | [0, 1]        |
     +-------------------------------+-----------------------+---------------+
 
-    -   For unrelated colors, there is only self-adaptation and :math:`k_1`
-        is set to 1.0 while :math:`k_2` is set to 0.0. For related colors
+    -   For unrelated colours, there is only self-adaptation and :math:`k_1`
+        is set to 1.0 while :math:`k_2` is set to 0.0. For related colours
         such as typical colorimetric applications, :math:`k_1` is set to 0.0
         and :math:`k_2` is set to a value between 15 and 50 *(Guth, 1995)*.
 
@@ -284,17 +287,22 @@ def luminance_to_retinal_illuminance(XYZ: ArrayLike, Y_c: ArrayLike) -> NDArrayF
     """
     Convert luminance in :math:`cd/m^2` to retinal illuminance in trolands.
 
+    This function converts photometric luminance values to retinal illuminance
+    by applying a power transformation that accounts for pupil area effects
+    under the specified adapting field luminance conditions.
+
     Parameters
     ----------
     XYZ
-        *CIE XYZ* tristimulus values.
+        *CIE XYZ* tristimulus values in photometric units.
     Y_c
         Absolute adapting field luminance in :math:`cd/m^2`.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Converted *CIE XYZ* tristimulus values in trolands.
+        Retinal illuminance values in trolands corresponding to the
+        tristimulus values.
 
     Examples
     --------
@@ -312,7 +320,8 @@ def luminance_to_retinal_illuminance(XYZ: ArrayLike, Y_c: ArrayLike) -> NDArrayF
 
 def XYZ_to_LMS_ATD95(XYZ: ArrayLike) -> NDArrayFloat:
     """
-    Convert *CIE XYZ* tristimulus values to *LMS* cone responses.
+    Convert *CIE XYZ* tristimulus values to *LMS* cone responses using the
+    *ATD95* colour appearance model.
 
     Parameters
     ----------
@@ -400,7 +409,7 @@ def final_response(value: ArrayLike) -> NDArrayFloat:
     Returns
     -------
     :class:`numpy.ndarray`
-        Final response of opponent colour dimension.
+        Final response of the opponent colour dimension.
 
     Examples
     --------

--- a/colour/appearance/cam16.py
+++ b/colour/appearance/cam16.py
@@ -2,7 +2,8 @@
 CAM16 Colour Appearance Model
 =============================
 
-Define the *CAM16* colour appearance model objects:
+Define the *CAM16* colour appearance model for predicting perceptual colour
+attributes under varying viewing conditions.
 
 -   :class:`colour.appearance.InductionFactors_CAM16`
 -   :attr:`colour.VIEWING_CONDITIONS_CAM16`
@@ -96,7 +97,7 @@ MATRIX_INVERSE_16: NDArrayFloat = np.linalg.inv(MATRIX_16)
 @dataclass(frozen=True)
 class InductionFactors_CAM16(MixinDataclassIterable):
     """
-    *CAM16* colour appearance model induction factors.
+    Define the *CAM16* colour appearance model induction factors.
 
     Parameters
     ----------
@@ -109,8 +110,9 @@ class InductionFactors_CAM16(MixinDataclassIterable):
 
     Notes
     -----
-    -   The *CAM16* colour appearance model induction factors are the same
-        as *CIECAM02* colour appearance model.
+    -   The *CAM16* colour appearance model induction factors are
+        identical to the *CIECAM02* colour appearance model
+        induction factors.
 
     References
     ----------
@@ -126,7 +128,7 @@ VIEWING_CONDITIONS_CAM16: CanonicalMapping = CanonicalMapping(
     VIEWING_CONDITIONS_CIECAM02
 )
 VIEWING_CONDITIONS_CAM16.__doc__ = """
-Reference *CAM16* colour appearance model viewing conditions.
+Define the reference *CAM16* colour appearance model viewing conditions.
 
 References
 ----------
@@ -199,18 +201,19 @@ def XYZ_to_CAM16(
         taken to be 20% of the luminance of a white object in the scene).
     Y_b
         Luminous factor of background :math:`Y_b` such as
-        :math:`Y_b = 100 x L_b / L_w` where :math:`L_w` is the luminance of
-        the light source and :math:`L_b` is the luminance of the background.
-        For viewing images, :math:`Y_b` can be the average :math:`Y` value
-        for the pixels in the entire image, or frequently, a :math:`Y` value
-        of 20, approximate an :math:`L^*` of 50 is used.
+        :math:`Y_b = 100 \\times L_b / L_w` where :math:`L_w` is the
+        luminance of the light source and :math:`L_b` is the luminance of
+        the background. For viewing images, :math:`Y_b` can be the average
+        :math:`Y` value for the pixels in the entire image, or frequently,
+        a :math:`Y` value of 20, approximating an :math:`L^*` of 50 is
+        used.
     surround
         Surround viewing conditions induction factors.
     discount_illuminant
         Truth value indicating if the illuminant should be discounted.
     compute_H
-        Whether to compute *Hue* :math:`h` quadrature :math:`H`. :math:`H`
-        is rarely used, and expensive to compute.
+        Whether to compute *Hue* :math:`h` quadrature :math:`H`.
+        :math:`H` is rarely used, and expensive to compute.
 
     Returns
     -------
@@ -361,7 +364,8 @@ def CAM16_to_XYZ(
     discount_illuminant: bool = False,
 ) -> NDArrayFloat:
     """
-    Convert *CAM16* specification to *CIE XYZ* tristimulus values.
+    Convert the *CAM16* colour appearance model specification to *CIE XYZ*
+    tristimulus values.
 
     Parameters
     ----------
@@ -377,15 +381,16 @@ def CAM16_to_XYZ(
         taken to be 20% of the luminance of a white object in the scene).
     Y_b
         Luminous factor of background :math:`Y_b` such as
-        :math:`Y_b = 100 x L_b / L_w` where :math:`L_w` is the luminance of
-        the light source and :math:`L_b` is the luminance of the background.
-        For viewing images, :math:`Y_b` can be the average :math:`Y` value
-        for the pixels in the entire image, or frequently, a :math:`Y` value
-        of 20, approximate an :math:`L^*` of 50 is used.
+        :math:`Y_b = 100 \\times L_b / L_w` where :math:`L_w` is the
+        luminance of the light source and :math:`L_b` is the luminance of
+        the background. For viewing images, :math:`Y_b` can be the average
+        :math:`Y` value for the pixels in the entire image, or frequently,
+        a :math:`Y` value of 20, approximating an :math:`L^*` of 50 is
+        used.
     surround
-        Surround viewing conditions.
+        Surround viewing conditions induction factors.
     discount_illuminant
-        Discount the illuminant.
+        Truth value indicating if the illuminant should be discounted.
 
     Returns
     -------
@@ -395,8 +400,8 @@ def CAM16_to_XYZ(
     Raises
     ------
     ValueError
-        If neither :math:`C` or :math:`M` correlates have been defined in
-        the ``specification`` argument.
+        If neither :math:`C` nor :math:`M` correlates have been defined
+        in the ``specification`` argument.
 
     Notes
     -----

--- a/colour/appearance/ciecam02.py
+++ b/colour/appearance/ciecam02.py
@@ -2,7 +2,8 @@
 CIECAM02 Colour Appearance Model
 ================================
 
-Define the *CIECAM02* colour appearance model objects:
+Define the *CIECAM02* colour appearance model for predicting perceptual colour
+attributes under varying viewing conditions.
 
 -   :class:`colour.appearance.InductionFactors_CIECAM02`
 -   :attr:`colour.VIEWING_CONDITIONS_CIECAM02`
@@ -122,7 +123,7 @@ CAT_INVERSE_CAT02: NDArrayFloat = np.linalg.inv(CAT_CAT02)
 @dataclass(frozen=True)
 class InductionFactors_CIECAM02(MixinDataclassIterable):
     """
-    *CIECAM02* colour appearance model induction factors.
+    Define the *CIECAM02* colour appearance model induction factors.
 
     Parameters
     ----------
@@ -152,7 +153,7 @@ VIEWING_CONDITIONS_CIECAM02: CanonicalMapping = CanonicalMapping(
     }
 )
 VIEWING_CONDITIONS_CIECAM02.__doc__ = """
-Reference *CIECAM02* colour appearance model viewing conditions.
+Define the reference *CIECAM02* colour appearance model viewing conditions.
 
 References
 ----------
@@ -236,8 +237,8 @@ def XYZ_to_CIECAM02(
     compute_H: bool = True,
 ) -> CAM_Specification_CIECAM02:
     """
-    Compute the *CIECAM02* colour appearance model correlates from the specified
-    *CIE XYZ* tristimulus values.
+    Compute the *CIECAM02* colour appearance model correlates from the
+    specified *CIE XYZ* tristimulus values.
 
     Parameters
     ----------
@@ -246,22 +247,22 @@ def XYZ_to_CIECAM02(
     XYZ_w
         *CIE XYZ* tristimulus values of reference white.
     L_A
-        Adapting field *luminance* :math:`L_A` in :math:`cd/m^2`, (often taken
-        to be 20% of the luminance of a white object in the scene).
+        Adapting field *luminance* :math:`L_A` in :math:`cd/m^2`, (often
+        taken to be 20% of the luminance of a white object in the scene).
     Y_b
-        Luminous factor of background :math:`Y_b` such as
-        :math:`Y_b = 100 x L_b / L_w` where :math:`L_w` is the luminance of the
-        light source and :math:`L_b` is the luminance of the background. For
-        viewing images, :math:`Y_b` can be the average :math:`Y` value for the
-        pixels in the entire image, or frequently, a :math:`Y` value of 20,
-        approximate an :math:`L^*` of 50 is used.
+        Luminous factor of background :math:`Y_b` such as :math:`Y_b = 100
+        \\times L_b / L_w` where :math:`L_w` is the luminance of the light
+        source and :math:`L_b` is the luminance of the background. For
+        viewing images, :math:`Y_b` can be the average :math:`Y` value for
+        the pixels in the entire image, or frequently, a :math:`Y` value of
+        20, approximate an :math:`L^*` of 50 is used.
     surround
         Surround viewing conditions induction factors.
     discount_illuminant
         Truth value indicating if the illuminant should be discounted.
     compute_H
-        Whether to compute *Hue* :math:`h` quadrature :math:`H`. :math:`H` is
-        rarely used, and expensive to compute.
+        Whether to compute *Hue* :math:`h` quadrature :math:`H`. :math:`H`
+        is rarely used, and expensive to compute.
 
     Returns
     -------
@@ -416,7 +417,8 @@ def CIECAM02_to_XYZ(
     discount_illuminant: bool = False,
 ) -> NDArrayFloat:
     """
-    Convert *CIECAM02* specification to *CIE XYZ* tristimulus values.
+    Convert the *CIECAM02* colour appearance model specification to *CIE XYZ*
+    tristimulus values.
 
     Parameters
     ----------
@@ -432,11 +434,11 @@ def CIECAM02_to_XYZ(
         to be 20% of the luminance of a white object in the scene).
     Y_b
         Luminous factor of background :math:`Y_b` such as
-        :math:`Y_b = 100 x L_b / L_w` where :math:`L_w` is the luminance of the
-        light source and :math:`L_b` is the luminance of the background. For
-        viewing images, :math:`Y_b` can be the average :math:`Y` value for the
-        pixels in the entire image, or frequently, a :math:`Y` value of 20,
-        approximate an :math:`L^*` of 50 is used.
+        :math:`Y_b = 100 \\times L_b / L_w` where :math:`L_w` is the luminance
+        of the light source and :math:`L_b` is the luminance of the background.
+        For viewing images, :math:`Y_b` can be the average :math:`Y` value for
+        the pixels in the entire image, or frequently, a :math:`Y` value of 20,
+        approximating an :math:`L^*` of 50 is used.
     surround
         Surround viewing conditions.
     discount_illuminant
@@ -450,7 +452,7 @@ def CIECAM02_to_XYZ(
     Raises
     ------
     ValueError
-        If neither :math:`C` or :math:`M` correlates have been defined in the
+        If neither :math:`C` nor :math:`M` correlates have been defined in the
         ``specification`` argument.
 
     Notes
@@ -680,7 +682,12 @@ def viewing_conditions_dependent_parameters(
     Returns
     -------
     :class:`tuple`
-        Viewing condition dependent parameters.
+        Viewing condition dependent parameters :math:`(n, F_L, F_{Lb},
+        F_{Lw}, z)` where :math:`n` is the background induction factor,
+        :math:`F_L` is the luminance adaptation factor, :math:`F_{Lb}` and
+        :math:`F_{Lw}` are the background and whitepoint luminance
+        adaptation factors respectively, and :math:`z` is the base linear
+        exponent for the nonlinear response compression.
 
     Examples
     --------
@@ -739,9 +746,9 @@ def full_chromatic_adaptation_forward(
     D: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Apply full chromatic adaptation to specified *CMCCAT2000* transform sharpened
-    *RGB* array using specified *CMCCAT2000* transform sharpened whitepoint
-    *RGB_w* array.
+    Apply full chromatic adaptation to the specified *CMCCAT2000* transform
+    sharpened *RGB* array using the specified *CMCCAT2000* transform sharpened
+    whitepoint *RGB_w* array.
 
     Parameters
     ----------
@@ -788,16 +795,16 @@ def full_chromatic_adaptation_inverse(
     D: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Revert full chromatic adaptation of specified *CMCCAT2000* transform sharpened
-    *RGB* array using specified *CMCCAT2000* transform sharpened whitepoint
-    *RGB_w* array.
+    Revert full chromatic adaptation of the specified *CMCCAT2000* transform
+    sharpened *RGB* array using the specified *CMCCAT2000* transform sharpened
+    whitepoint :math:`RGB_w` array.
 
     Parameters
     ----------
     RGB
         *CMCCAT2000* transform sharpened *RGB* array.
     RGB_w
-        *CMCCAT2000* transform sharpened whitepoint *RGB_w* array.
+        *CMCCAT2000* transform sharpened whitepoint :math:`RGB_w` array.
     Y_w
         Whitepoint *Y* tristimulus value :math:`Y_w`.
     D
@@ -856,8 +863,8 @@ def RGB_to_rgb(RGB: ArrayLike) -> NDArrayFloat:
 
 def rgb_to_RGB(rgb: ArrayLike) -> NDArrayFloat:
     """
-    Convert the specified *Hunt-Pointer-Estevez* :math:`\\rho\\gamma\\beta`
-    colourspace array to *RGB* array.
+    Convert from *Hunt-Pointer-Estevez* :math:`\\rho\\gamma\\beta`
+    colourspace array to adapted *RGB* array.
 
     Parameters
     ----------
@@ -867,7 +874,7 @@ def rgb_to_RGB(rgb: ArrayLike) -> NDArrayFloat:
     Returns
     -------
     :class:`numpy.ndarray`
-        *RGB* array.
+        Adapted *RGB* array.
 
     Examples
     --------
@@ -883,7 +890,7 @@ def post_adaptation_non_linear_response_compression_forward(
     RGB: ArrayLike, F_L: ArrayLike
 ) -> NDArrayFloat:
     """
-    Apply post adaptation non-linear response compression to the specified
+    Apply post-adaptation non-linear response compression to the specified
     *CMCCAT2000* transform sharpened *RGB* array.
 
     Parameters
@@ -924,7 +931,7 @@ def post_adaptation_non_linear_response_compression_inverse(
     RGB: ArrayLike, F_L: ArrayLike
 ) -> NDArrayFloat:
     """
-    Remove post adaptation non-linear response compression from the specified
+    Remove post-adaptation non-linear response compression from the specified
     *CMCCAT2000* transform sharpened *RGB* array.
 
     Parameters
@@ -964,9 +971,8 @@ def post_adaptation_non_linear_response_compression_inverse(
 
 def opponent_colour_dimensions_forward(RGB: ArrayLike) -> NDArrayFloat:
     """
-    Compute opponent colour dimensions from the specified compressed
-    *CMCCAT2000* transform sharpened *RGB* array for forward
-    *CIECAM02* implementation.
+    Compute opponent colour dimensions from compressed *CMCCAT2000* transform
+    sharpened *RGB* array for forward *CIECAM02* implementation.
 
     Parameters
     ----------
@@ -996,7 +1002,7 @@ def opponent_colour_dimensions_forward(RGB: ArrayLike) -> NDArrayFloat:
 def opponent_colour_dimensions_inverse(P_n: ArrayLike, h: ArrayLike) -> NDArrayFloat:
     """
     Compute opponent colour dimensions from the specified points :math:`P_n`
-    and hue :math:`h` in degrees for inverse *CIECAM02* implementation.
+    and hue :math:`h` in degrees for the inverse *CIECAM02* implementation.
 
     Parameters
     ----------
@@ -1079,7 +1085,8 @@ def opponent_colour_dimensions_inverse(P_n: ArrayLike, h: ArrayLike) -> NDArrayF
 
 def hue_angle(a: ArrayLike, b: ArrayLike) -> NDArrayFloat:
     """
-    Compute the *hue* angle :math:`h` in degrees.
+    Compute the *hue* angle :math:`h` in degrees from the specified opponent
+    colour dimensions.
 
     Parameters
     ----------
@@ -1111,8 +1118,7 @@ def hue_angle(a: ArrayLike, b: ArrayLike) -> NDArrayFloat:
 
 def hue_quadrature(h: ArrayLike) -> NDArrayFloat:
     """
-    Compute the hue quadrature from the specified hue :math:`h` angle in
-    degrees.
+    Compute hue quadrature from the specified hue :math:`h` angle in degrees.
 
     Parameters
     ----------
@@ -1227,10 +1233,10 @@ def achromatic_response_inverse(
 ) -> NDArrayFloat:
     """
     Compute the achromatic response :math:`A` from the specified achromatic
-    response
-    :math:`A_w` for the whitepoint, *Lightness* correlate :math:`J`, surround
-    exponential non-linearity :math:`c` and base exponential non-linearity
-    :math:`z` for inverse *CIECAM02* implementation.
+    response :math:`A_w` for the whitepoint, *Lightness* correlate
+    :math:`J`, surround exponential non-linearity :math:`c` and base
+    exponential non-linearity :math:`z` for inverse *CIECAM02*
+    implementation.
 
     Parameters
     ----------
@@ -1362,7 +1368,7 @@ def temporary_magnitude_quantity_forward(
     RGB_a: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Compute the temporary magnitude quantity :math:`t`. for forward
+    Compute the temporary magnitude quantity :math:`t` for forward
     *CIECAM02* implementation.
 
     Parameters
@@ -1383,7 +1389,7 @@ def temporary_magnitude_quantity_forward(
     Returns
     -------
     :class:`numpy.ndarray`
-         Temporary magnitude quantity :math:`t`.
+        Temporary magnitude quantity :math:`t`.
 
     Examples
     --------
@@ -1415,7 +1421,7 @@ def temporary_magnitude_quantity_inverse(
     C: ArrayLike, J: ArrayLike, n: ArrayLike
 ) -> NDArrayFloat:
     """
-    Compute the temporary magnitude quantity :math:`t`. for inverse
+    Compute the temporary magnitude quantity :math:`t` for inverse
     *CIECAM02* implementation.
 
     Parameters
@@ -1430,7 +1436,7 @@ def temporary_magnitude_quantity_inverse(
     Returns
     -------
     :class:`numpy.ndarray`
-         Temporary magnitude quantity :math:`t`.
+        Temporary magnitude quantity :math:`t`.
 
     Examples
     --------
@@ -1478,7 +1484,8 @@ def chroma_correlate(
     b
         Opponent colour dimension :math:`b`.
     RGB_a
-        Compressed stimulus *CMCCAT2000* transform sharpened *RGB* array.
+        Compressed stimulus *CMCCAT2000* transform sharpened *RGB*
+        array.
 
     Returns
     -------
@@ -1547,7 +1554,7 @@ def saturation_correlate(M: ArrayLike, Q: ArrayLike) -> NDArrayFloat:
     M
         *Colourfulness* correlate :math:`M`.
     Q
-        *Brightness* correlate :math:`C`.
+        *Brightness* correlate :math:`Q`.
 
     Returns
     -------
@@ -1591,7 +1598,7 @@ def P(
     t
         Temporary magnitude quantity :math:`t`.
     A
-        Achromatic response  :math:`A` for the stimulus.
+        Achromatic response :math:`A` for the stimulus.
     N_bb
         Chromatic induction factor :math:`N_{bb}`.
 
@@ -1632,21 +1639,23 @@ def matrix_post_adaptation_non_linear_response_compression(
     P_2: ArrayLike, a: ArrayLike, b: ArrayLike
 ) -> NDArrayFloat:
     """
-    Apply the post-adaptation non-linear-response compression matrix.
+    Apply post-adaptation non-linear response compression matrix to
+    specified opponent colour components.
 
     Parameters
     ----------
     P_2
-        Point :math:`P_2`.
+        Point :math:`P_2` representing the post-adaptation response value.
     a
-        Opponent colour dimension :math:`a`.
+        Opponent colour dimension :math:`a` component.
     b
-        Opponent colour dimension :math:`b`.
+        Opponent colour dimension :math:`b` component.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Points :math:`P`.
+        Array of compressed points :math:`P` containing three values
+        after non-linear response compression.
 
     Examples
     --------

--- a/colour/appearance/ciecam16.py
+++ b/colour/appearance/ciecam16.py
@@ -2,7 +2,8 @@
 CIECAM16 Colour Appearance Model
 ================================
 
-Define the *CIECAM16* colour appearance model objects:
+Define the *CIECAM16* colour appearance model for predicting perceptual colour
+attributes under varying viewing conditions.
 
 -   :class:`colour.appearance.InductionFactors_CIECAM16`
 -   :attr:`colour.VIEWING_CONDITIONS_CIECAM16`
@@ -91,7 +92,7 @@ __all__ = [
 @dataclass(frozen=True)
 class InductionFactors_CIECAM16(MixinDataclassIterable):
     """
-    *CIECAM16* colour appearance model induction factors.
+    Define the *CIECAM16* colour appearance model induction factors.
 
     Parameters
     ----------
@@ -121,7 +122,7 @@ VIEWING_CONDITIONS_CIECAM16: CanonicalMapping = CanonicalMapping(
     VIEWING_CONDITIONS_CIECAM02
 )
 VIEWING_CONDITIONS_CIECAM16.__doc__ = """
-Reference *CIECAM16* colour appearance model viewing conditions.
+Define the reference *CIECAM16* colour appearance model viewing conditions.
 
 References
 ----------
@@ -180,8 +181,8 @@ def XYZ_to_CIECAM16(
     compute_H: bool = True,
 ) -> CAM_Specification_CIECAM16:
     """
-    Compute the *CIECAM16* colour appearance model correlates from the specified
-    *CIE XYZ* tristimulus values.
+    Compute the *CIECAM16* colour appearance model correlates from the
+    specified *CIE XYZ* tristimulus values.
 
     Parameters
     ----------
@@ -190,22 +191,22 @@ def XYZ_to_CIECAM16(
     XYZ_w
         *CIE XYZ* tristimulus values of reference white.
     L_A
-        Adapting field *luminance* :math:`L_A` in :math:`cd/m^2`, (often taken
-        to be 20% of the luminance of a white object in the scene).
+        Adapting field *luminance* :math:`L_A` in :math:`cd/m^2`, (often
+        taken to be 20% of the luminance of a white object in the scene).
     Y_b
         Luminous factor of background :math:`Y_b` such as
-        :math:`Y_b = 100 x L_b / L_w` where :math:`L_w` is the luminance of the
-        light source and :math:`L_b` is the luminance of the background. For
-        viewing images, :math:`Y_b` can be the average :math:`Y` value for the
-        pixels in the entire image, or frequently, a :math:`Y` value of 20,
-        approximate an :math:`L^*` of 50 is used.
+        :math:`Y_b = 100 \\times L_b / L_w` where :math:`L_w` is the
+        luminance of the light source and :math:`L_b` is the luminance of
+        the background. For viewing images, :math:`Y_b` can be the average
+        :math:`Y` value for the pixels in the entire image, or frequently,
+        a :math:`Y` value of 20, approximate an :math:`L^*` of 50 is used.
     surround
         Surround viewing conditions induction factors.
     discount_illuminant
         Truth value indicating if the illuminant should be discounted.
     compute_H
-        Whether to compute *Hue* :math:`h` quadrature :math:`H`. :math:`H` is
-        rarely used, and expensive to compute.
+        Whether to compute *Hue* :math:`h` quadrature :math:`H`.
+        :math:`H` is rarely used, and expensive to compute.
 
     Returns
     -------
@@ -373,7 +374,8 @@ def CIECAM16_to_XYZ(
     discount_illuminant: bool = False,
 ) -> NDArrayFloat:
     """
-    Convert *CIECAM16* specification to *CIE XYZ* tristimulus values.
+    Convert the *CIECAM16* colour appearance model specification to *CIE XYZ*
+    tristimulus values.
 
     Parameters
     ----------
@@ -389,11 +391,11 @@ def CIECAM16_to_XYZ(
         to be 20% of the luminance of a white object in the scene).
     Y_b
         Luminous factor of background :math:`Y_b` such as
-        :math:`Y_b = 100 x L_b / L_w` where :math:`L_w` is the luminance of the
-        light source and :math:`L_b` is the luminance of the background. For
-        viewing images, :math:`Y_b` can be the average :math:`Y` value for the
-        pixels in the entire image, or frequently, a :math:`Y` value of 20,
-        approximate an :math:`L^*` of 50 is used.
+        :math:`Y_b = 100 \\times L_b / L_w` where :math:`L_w` is the luminance
+        of the light source and :math:`L_b` is the luminance of the background.
+        For viewing images, :math:`Y_b` can be the average :math:`Y` value for
+        the pixels in the entire image, or frequently, a :math:`Y` value of 20,
+        approximating an :math:`L^*` of 50 is used.
     surround
         Surround viewing conditions.
     discount_illuminant
@@ -571,8 +573,8 @@ def f_e_forward(RGB_c: ArrayLike, F_L: ArrayLike) -> NDArrayFloat:
     Notes
     -----
     -   This definition is different from :cite:`Li2017` and provides linear
-        extensions under 0.26 and above 150. It also omits the 0.1 offset that
-        is now part of the general model.
+        extensions under 0.26 and above 150. It also omits the 0.1 offset
+        that is now part of the general model.
 
     Examples
     --------
@@ -608,7 +610,8 @@ def f_e_forward(RGB_c: ArrayLike, F_L: ArrayLike) -> NDArrayFloat:
 
 def f_e_inverse(RGB_a: ArrayLike, F_L: ArrayLike) -> NDArrayFloat:
     """
-    Compute the modified cone-like responses.
+    Compute the inverse of the forward eccentricity factor modified cone-like
+    responses.
 
     Parameters
     ----------
@@ -625,8 +628,8 @@ def f_e_inverse(RGB_a: ArrayLike, F_L: ArrayLike) -> NDArrayFloat:
     Notes
     -----
     -   This definition is different from :cite:`Li2017` and provides linear
-        extensions under 0.26 and above 150. It also omits the 0.1 offset that
-        is now part of the general model.
+        extensions under 0.26 and above 150. It also omits the 0.1 offset
+        that is now part of the general model.
 
     Examples
     --------
@@ -661,7 +664,7 @@ def f_e_inverse(RGB_a: ArrayLike, F_L: ArrayLike) -> NDArrayFloat:
 
 def f_q(F_L: ArrayLike, q: ArrayLike) -> NDArrayFloat:
     """
-    Define the :math:`f(q)` function.
+    Evaluate the :math:`f(q)` function for chromatic adaptation.
 
     Parameters
     ----------
@@ -673,7 +676,7 @@ def f_q(F_L: ArrayLike, q: ArrayLike) -> NDArrayFloat:
     Returns
     -------
     :class:`numpy.ndarray`
-        Evaluated :math:`f(q)` function.
+        Evaluated :math:`f(q)` function result.
 
     Examples
     --------
@@ -691,7 +694,7 @@ def f_q(F_L: ArrayLike, q: ArrayLike) -> NDArrayFloat:
 
 def d_f_q(F_L: ArrayLike, q: ArrayLike) -> NDArrayFloat:
     """
-    Define the :math:`f'(q)` function derivative.
+    Compute the :math:`f'(q)` function derivative.
 
     Parameters
     ----------

--- a/colour/appearance/hellwig2022.py
+++ b/colour/appearance/hellwig2022.py
@@ -2,7 +2,8 @@
 Hellwig and Fairchild (2022) Colour Appearance Model
 ====================================================
 
-Define the *Hellwig and Fairchild (2022)* colour appearance model objects:
+Define the *Hellwig and Fairchild (2022)* colour appearance model for
+predicting perceptual colour attributes under varying viewing conditions.
 
 -   :class:`colour.appearance.InductionFactors_Hellwig2022`
 -   :attr:`colour.VIEWING_CONDITIONS_HELLWIG2022`
@@ -95,7 +96,8 @@ __all__ = [
 @dataclass(frozen=True)
 class InductionFactors_Hellwig2022(MixinDataclassIterable):
     """
-    *Hellwig and Fairchild (2022)* colour appearance model induction factors.
+    Define the *Hellwig and Fairchild (2022)* colour appearance model
+    induction factors.
 
     Parameters
     ----------
@@ -125,8 +127,8 @@ VIEWING_CONDITIONS_HELLWIG2022: CanonicalMapping = CanonicalMapping(
     VIEWING_CONDITIONS_CIECAM02
 )
 VIEWING_CONDITIONS_HELLWIG2022.__doc__ = """
-Reference *Hellwig and Fairchild (2022)* colour appearance model viewing
-conditions.
+Define the reference *Hellwig and Fairchild (2022)* colour appearance model
+viewing conditions.
 
 References
 ----------
@@ -140,8 +142,14 @@ class CAM_Specification_Hellwig2022(MixinDataclassArithmetic):
     Define the *Hellwig and Fairchild (2022)* colour appearance model
     specification.
 
-    This specification supports the *Helmholtz-Kohlrausch* effect extension
-    from :cite:`Hellwig2022a`.
+    Represent colour appearance attributes calculated by the
+    *Hellwig and Fairchild (2022)* colour appearance model. The
+    specification includes correlates for lightness, chroma, hue,
+    saturation, brightness, colourfulness, and hue quadrature. This
+    implementation supports the *Helmholtz-Kohlrausch* effect extension
+    from :cite:`Hellwig2022a`, providing adjusted lightness and brightness
+    correlates that account for the increased brightness perception of
+    highly saturated colours.
 
     Parameters
     ----------
@@ -214,11 +222,11 @@ def XYZ_to_Hellwig2022(
         to be 20% of the luminance of a white object in the scene).
     Y_b
         Luminous factor of background :math:`Y_b` such as
-        :math:`Y_b = 100 x L_b / L_w` where :math:`L_w` is the luminance of the
-        light source and :math:`L_b` is the luminance of the background. For
-        viewing images, :math:`Y_b` can be the average :math:`Y` value for the
-        pixels in the entire image, or frequently, a :math:`Y` value of 20,
-        approximate an :math:`L^*` of 50 is used.
+        :math:`Y_b = 100 \\times L_b / L_w` where :math:`L_w` is the luminance
+        of the light source and :math:`L_b` is the luminance of the background.
+        For viewing images, :math:`Y_b` can be the average :math:`Y` value for
+        the pixels in the entire image, or frequently, a :math:`Y` value of 20,
+        approximating an :math:`L^*` of 50 is used.
     surround
         Surround viewing conditions induction factors.
     discount_illuminant
@@ -408,8 +416,8 @@ def Hellwig2022_to_XYZ(
     discount_illuminant: bool = False,
 ) -> NDArrayFloat:
     """
-    Convert *Hellwig and Fairchild (2022)* specification to *CIE XYZ*
-    tristimulus values.
+    Convert the *Hellwig and Fairchild (2022)* colour appearance model
+    specification to *CIE XYZ* tristimulus values.
 
     This implementation supports the *Helmholtz-Kohlrausch* effect extension
     from :cite:`Hellwig2022a`.
@@ -418,21 +426,21 @@ def Hellwig2022_to_XYZ(
     ----------
     specification
         *Hellwig and Fairchild (2022)* colour appearance model specification.
-        Correlate of *lightness* :math:`J`, correlate of *chroma* :math:`C` or
-        correlate of *colourfulness* :math:`M` and *hue* angle :math:`h` in
-        degrees must be specified, e.g., :math:`JCh` or :math:`JMh`.
+        Correlate of *lightness* :math:`J`, correlate of *chroma* :math:`C`
+        or correlate of *colourfulness* :math:`M` and *hue* angle :math:`h`
+        in degrees must be specified, e.g., :math:`JCh` or :math:`JMh`.
     XYZ_w
         *CIE XYZ* tristimulus values of reference white.
     L_A
-        Adapting field *luminance* :math:`L_A` in :math:`cd/m^2`, (often taken
-        to be 20% of the luminance of a white object in the scene).
+        Adapting field *luminance* :math:`L_A` in :math:`cd/m^2`, (often
+        taken to be 20% of the luminance of a white object in the scene).
     Y_b
         Luminous factor of background :math:`Y_b` such as
-        :math:`Y_b = 100 x L_b / L_w` where :math:`L_w` is the luminance of the
-        light source and :math:`L_b` is the luminance of the background. For
-        viewing images, :math:`Y_b` can be the average :math:`Y` value for the
-        pixels in the entire image, or frequently, a :math:`Y` value of 20,
-        approximate an :math:`L^*` of 50 is used.
+        :math:`Y_b = 100 \\times L_b / L_w` where :math:`L_w` is the
+        luminance of the light source and :math:`L_b` is the luminance of the
+        background. For viewing images, :math:`Y_b` can be the average
+        :math:`Y` value for the pixels in the entire image, or frequently, a
+        :math:`Y` value of 20, approximating an :math:`L^*` of 50 is used.
     surround
         Surround viewing conditions.
     discount_illuminant
@@ -446,8 +454,8 @@ def Hellwig2022_to_XYZ(
     Raises
     ------
     ValueError
-        If neither :math:`C` or :math:`M` correlates have been defined in the
-        ``specification`` argument.
+        If neither :math:`C` or :math:`M` correlates have been defined in
+        the ``specification`` argument.
 
     Notes
     -----
@@ -663,8 +671,8 @@ def viewing_conditions_dependent_parameters(
 def achromatic_response_forward(RGB: ArrayLike) -> NDArrayFloat:
     """
     Compute the achromatic response :math:`A` from the specified compressed
-    *CAM16* transform sharpened *RGB* array and :math:`N_{bb}` chromatic
-    induction factor for forward *Hellwig and Fairchild (2022)* implementation.
+    *CAM16* transform sharpened *RGB* array for forward *Hellwig and Fairchild
+    (2022)* implementation.
 
     Parameters
     ----------
@@ -692,8 +700,8 @@ def opponent_colour_dimensions_inverse(
     P_p_1: ArrayLike, h: ArrayLike, M: ArrayLike
 ) -> NDArrayFloat:
     """
-    Compute opponent colour dimensions from the specified point :math:`P'_1`, hue
-    :math:`h` in degrees and correlate of *colourfulness* :math:`M` for
+    Compute opponent colour dimensions from the specified point :math:`P'_1`,
+    hue :math:`h` in degrees and correlate of *colourfulness* :math:`M` for
     inverse *Hellwig and Fairchild (2022)* implementation.
 
     Parameters
@@ -735,8 +743,8 @@ def opponent_colour_dimensions_inverse(
 
 def eccentricity_factor(h: ArrayLike) -> NDArrayFloat:
     """
-    Compute the eccentricity factor :math:`e_t` from the specified hue :math:`h` angle
-    in degrees for forward *CIECAM02* implementation.
+    Compute the eccentricity factor :math:`e_t` from the specified hue
+    :math:`h` angle in degrees for forward *CIECAM02* implementation.
 
     Parameters
     ----------
@@ -827,7 +835,7 @@ def colourfulness_correlate(
     Parameters
     ----------
     N_c
-        Surround chromatic induction factor :math:`N_{c}`.
+        Surround chromatic induction factor :math:`N_c`.
     e_t
         Eccentricity factor :math:`e_t`.
     a
@@ -901,7 +909,7 @@ def saturation_correlate(M: ArrayLike, Q: ArrayLike) -> NDArrayFloat:
     M
         *Colourfulness* correlate :math:`M`.
     Q
-        *Brightness* correlate :math:`C`.
+        *Brightness* correlate :math:`Q`.
 
     Returns
     -------
@@ -938,12 +946,13 @@ def P_p(
     e_t
         Eccentricity factor :math:`e_t`.
     A
-        Achromatic response  :math:`A` for the stimulus.
+        Achromatic response :math:`A` for the stimulus.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Points :math:`P'`.
+        Points :math:`P'` as an array containing :math:`P'_1` and
+        :math:`P'_2`.
 
     Examples
     --------
@@ -978,7 +987,7 @@ def hue_angle_dependency_Hellwig2022(
     Returns
     -------
     :class:`numpy.ndarray`
-        Hue angle dependency.
+        Hue angle dependency of the *Helmholtz-Kohlrausch* effect.
 
     References
     ----------

--- a/colour/appearance/hke.py
+++ b/colour/appearance/hke.py
@@ -2,19 +2,20 @@
 Helmholtz—Kohlrausch Effect
 ===========================
 
-Define the following methods for estimating Helmholtz-Kohlrausch effect (HKE):
+Define methods for estimating the Helmholtz—Kohlrausch effect (HKE).
 
--   :attr:`colour.HKE_NAYATANI1997_METHODS`: Nayatani HKE computation methods,
-    choice between variable achromatic colour ('VAC') and variable chromatic
-    colour ('VCC').
+-   :attr:`colour.HKE_NAYATANI1997_METHODS`: *Nayatani (1997)* HKE
+    computation methods, choice between variable achromatic colour (VAC)
+    and variable chromatic colour (VCC).
 -   :func:`colour.HelmholtzKohlrausch_effect_object_Nayatani1997`:
-    *Nayatani (1997)* HKE estimation for object colours.
+    Compute HKE value for object colours using *Nayatani (1997)* method.
 -   :func:`colour.HelmholtzKohlrausch_effect_luminous_Nayatani1997`:
-    *Nayatani (1997)* HKE estimation for luminous colours.
+    Compute HKE value for luminous colours using *Nayatani (1997)* method.
 -   :func:`colour.appearance.coefficient_q_Nayatani1997`:
-    Calculates :math:`WI` coefficient for *Nayatani 1997* HKE estimation.
+    Calculate :math:`q` coefficient for *Nayatani (1997)* HKE estimation.
 -   :func:`colour.appearance.coefficient_K_Br_Nayatani1997`:
-    Calculates :math:`K_{Br}` coefficient for *Nayatani 1997* HKE estimation.
+    Calculate :math:`K_{Br}` coefficient for *Nayatani (1997)* HKE
+    estimation.
 
 References
 ----------
@@ -58,8 +59,9 @@ HKE_NAYATANI1997_METHODS = CanonicalMapping(
     }
 )
 HKE_NAYATANI1997_METHODS.__doc__ = """
-*Nayatani (1997)* *HKE* computation methods, choice between variable
-achromatic colour ('VAC') and variable chromatic colour ('VCC')
+Define *Nayatani (1997)* *Helmholtz-Kohlrausch effect* (HKE) computation
+methods: variable achromatic colour ('VAC') and variable chromatic
+colour ('VCC').
 
 References
 ----------
@@ -74,24 +76,28 @@ def HelmholtzKohlrausch_effect_object_Nayatani1997(
     method: Literal["VAC", "VCC"] | str = "VCC",
 ) -> NDArrayFloat:
     """
-    Compute the *HKE* value for object colours using *Nayatani (1997)* method.
+    Compute the *Helmholtz-Kohlrausch effect* (HKE) value for object
+    colours using the *Nayatani (1997)* method.
 
     Parameters
     ----------
     uv
-        *CIE uv* chromaticity coordinates of samples.
+         *CIE L\\*u\\*v\\** colourspace :math:`uv^p` chromaticity coordinates
+         of the test samples.
     uv_c
-        *CIE uv* chromaticity coordinates of reference white.
+         *CIE L\\*u\\*v\\** colourspace :math:`uv^p` chromaticity coordinates
+         of the reference white.
     L_a
         Adapting luminance in :math:`cd/m^2`.
     method
-        Which estimation method to use, *VCC* or *VAC*.
+        Estimation method to use: *VCC* (Variable-Chromatic-Colour) or
+        *VAC* (Variable-Achromatic-Colour).
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Luminance factor (:math:`\\Gamma`) value(s) computed with Nayatani
-        object colour estimation method.
+        Luminance factor (:math:`\\Gamma`) values computed using the
+        *Nayatani (1997)* object colour estimation method.
 
     References
     ----------
@@ -131,24 +137,28 @@ def HelmholtzKohlrausch_effect_luminous_Nayatani1997(
     method: Literal["VAC", "VCC"] | str = "VCC",
 ) -> NDArrayFloat:
     """
-    Compute the *HKE* factor for luminous colours using *Nayatani (1997)* method.
+    Compute the *HKE* factor for luminous colours using the
+    *Nayatani (1997)* method.
 
     Parameters
     ----------
     uv
-        *CIE uv* chromaticity coordinates of samples.
+        *CIE L\\*u\\*v\\** colourspace :math:`uv^p` chromaticity coordinates of
+        test samples.
     uv_c
-        *CIE uv* chromaticity coordinates of reference white.
+        *CIE L\\*u\\*v\\** colourspace :math:`uv^p` chromaticity coordinates of
+        reference white.
     L_a
         Adapting luminance in :math:`cd/m^2`.
     method
-        Which estimation method to use, *VCC* or *VAC*.
+        Estimation method to use: *VCC* (Variable-Chromatic-Colour) or
+        *VAC* (Variable-Achromatic-Colour).
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Luminance factor (:math:`\\Gamma`) value(s) computed with Nayatani
-        luminous colour estimation method.
+        Luminance factor (:math:`\\Gamma`) values computed using the
+        Nayatani luminous colour estimation method.
 
     References
     ----------
@@ -190,9 +200,11 @@ def coefficient_q_Nayatani1997(
 
     :math:`tan^{-1}\\cfrac{v' - v'_c}{u' - u'_c}`
 
-    where :math:`u'` and :math:`v'` are the CIE 1976 chromaticity coordinates
-    of the test chromatic light and :math:`u'_c` and :math:`v'_c` are the CIE
-    1976 chromaticity coordinates of the reference white light.
+    where :math:`u'` and :math:`v'` are the *CIE L\\*u\\*v\\** colourspace
+    :math:`uv^p` chromaticity coordinates of the test chromatic light and
+    :math:`u'_c` and :math:`v'_c` are the *CIE L\\*u\\*v\\**
+    colourspace :math:`uv^p` chromaticity coordinates of the reference
+    white light.
 
     Parameters
     ----------

--- a/colour/appearance/hunt.py
+++ b/colour/appearance/hunt.py
@@ -2,7 +2,8 @@
 Hunt Colour Appearance Model
 ============================
 
-Define the *Hunt* colour appearance model objects:
+Define the *Hunt* colour appearance model for predicting perceptual colour
+attributes under varying viewing conditions.
 
 -   :class:`colour.appearance.InductionFactors_Hunt`
 -   :attr:`colour.VIEWING_CONDITIONS_HUNT`
@@ -87,7 +88,7 @@ __all__ = [
 @dataclass(frozen=True)
 class InductionFactors_Hunt(MixinDataclassIterable):
     """
-    *Hunt* colour appearance model induction factors.
+    Define the *Hunt* colour appearance model induction factors.
 
     Parameters
     ----------
@@ -126,7 +127,7 @@ VIEWING_CONDITIONS_HUNT: CanonicalMapping = CanonicalMapping(
     }
 )
 VIEWING_CONDITIONS_HUNT.__doc__ = """
-Reference *Hunt* colour appearance model viewing conditions.
+Define the reference *Hunt* colour appearance model viewing conditions.
 
 References
 ----------
@@ -139,7 +140,6 @@ Aliases:
 -   'tv_dim': 'Television & CRT, Dim Surrounds'
 -   'light_boxes': 'Large Transparencies On Light Boxes'
 -   'projected_dark': 'Projected Transparencies, Dark Surrounds'
-
 """
 VIEWING_CONDITIONS_HUNT["small_uniform"] = VIEWING_CONDITIONS_HUNT[
     "Small Areas, Uniform Background & Surrounds"
@@ -184,15 +184,15 @@ class CAM_ReferenceSpecification_Hunt(MixinDataclassArithmetic):
     """
     Define the *Hunt* colour appearance model reference specification.
 
-    This specification has field names consistent with *Fairchild (2013)*
-    reference.
+    This specification contains field names consistent with the *Fairchild
+    (2013)* reference.
 
     Parameters
     ----------
     J
         Correlate of *Lightness* :math:`J`.
     C_94
-        Correlate of *chroma* :math:`C_94`.
+        Correlate of *chroma* :math:`C_{94}`.
     h_S
         *Hue* angle :math:`h_S` in degrees.
     s
@@ -200,7 +200,7 @@ class CAM_ReferenceSpecification_Hunt(MixinDataclassArithmetic):
     Q
         Correlate of *brightness* :math:`Q`.
     M_94
-        Correlate of *colourfulness* :math:`M_94`.
+        Correlate of *colourfulness* :math:`M_{94}`.
     H
         *Hue* :math:`h` quadrature :math:`H`.
     H_C
@@ -226,24 +226,26 @@ class CAM_Specification_Hunt(MixinDataclassArithmetic):
     """
     Define the *Hunt* colour appearance model specification.
 
-    This specification has field names consistent with the remaining colour
-    appearance models in :mod:`colour.appearance` but diverge from
-    *Fairchild (2013)* reference.
+    This specification provides a standardized interface for the *Hunt* model
+    with field names consistent across all colour appearance models in
+    :mod:`colour.appearance`. While the field names differ from the original
+    *Fairchild (2013)* reference notation, they map directly to the model's
+    perceptual correlates.
 
     Parameters
     ----------
     J
-        Correlate of *Lightness* :math:`J`.
+        Correlate of *lightness* :math:`J`.
     C
-        Correlate of *chroma* :math:`C_94`.
+        Correlate of *chroma* :math:`C_{94}`.
     h
-        *Hue* angle :math:`h_S` in degrees.
+        *Hue* angle :math:`h_s` in degrees.
     s
         Correlate of *saturation* :math:`s`.
     Q
         Correlate of *brightness* :math:`Q`.
     M
-        Correlate of *colourfulness* :math:`M_94`.
+        Correlate of *colourfulness* :math:`M_{94}`.
     H
         *Hue* :math:`h` quadrature :math:`H`.
     HC
@@ -251,7 +253,8 @@ class CAM_Specification_Hunt(MixinDataclassArithmetic):
 
     Notes
     -----
-    -   This specification is the one used in the current model implementation.
+    -   This specification is the one used in the current model
+        implementation.
 
     References
     ----------
@@ -284,7 +287,8 @@ def XYZ_to_Hunt(
     discount_illuminant: bool = True,
 ) -> CAM_Specification_Hunt:
     """
-    Compute the *Hunt* colour appearance model correlates.
+    Compute the *Hunt* colour appearance model correlates from the specified
+    *CIE XYZ* tristimulus values.
 
     Parameters
     ----------
@@ -297,32 +301,31 @@ def XYZ_to_Hunt(
     L_A
         Adapting field *luminance* :math:`L_A` in :math:`cd/m^2`.
     surround
-         Surround viewing conditions induction factors.
+        Surround viewing conditions induction factors.
     L_AS
-        Scotopic luminance :math:`L_{AS}` of the illuminant, approximated if
-        not specified.
+        Scotopic luminance :math:`L_{AS}` of the illuminant,
+        approximated if not specified.
     CCT_w
-        Correlated color temperature :math:`T_{cp}` of the illuminant,
-        needed to approximate :math:`L_{AS}`.
+        Correlated colour temperature :math:`T_{cp}` of the illuminant,
+        required to approximate :math:`L_{AS}` when not specified.
     XYZ_p
-        *CIE XYZ* tristimulus values of proximal field, assumed to be equal
-        to background if not specified.
+        *CIE XYZ* tristimulus values of proximal field, assumed to equal
+        background if not specified.
     p
         Simultaneous contrast / assimilation factor :math:`p` with value
-        normalised to domain [-1, 0] when simultaneous contrast occurs and
-        normalised to domain [0, 1] when assimilation occurs.
+        normalised to domain [-1, 0] for simultaneous contrast and
+        normalised to domain [0, 1] for assimilation.
     S
         Scotopic response :math:`S` to the stimulus, approximated using
-        tristimulus values :math:`Y` of the stimulus if not specified.
+        tristimulus value :math:`Y` of the stimulus if not specified.
     S_w
-        Scotopic response :math:`S_w` for the reference white, approximated
-        using the tristimulus values :math:`Y_w` of the reference white if
-        not specified.
+        Scotopic response :math:`S_w` for the reference white,
+        approximated using tristimulus value :math:`Y_w` of the
+        reference white if not specified.
     helson_judd_effect
-        Truth value indicating whether the *Helson-Judd* effect should be
-        accounted for.
+        Whether to account for the *Helson-Judd* effect.
     discount_illuminant
-        Truth value indicating if the illuminant should be discounted.
+        Whether to discount the illuminant.
 
     Returns
     -------
@@ -575,14 +578,14 @@ def luminance_level_adaptation_factor(
 def illuminant_scotopic_luminance(L_A: ArrayLike, CCT: ArrayLike) -> NDArrayFloat:
     """
     Compute the approximate scotopic luminance :math:`L_{AS}` of the
-    illuminant.
+    specified illuminant.
 
     Parameters
     ----------
     L_A
         Adapting field *luminance* :math:`L_A` in :math:`cd/m^2`.
     CCT
-        Correlated color temperature :math:`T_{cp}` of the illuminant.
+        Correlated colour temperature :math:`T_{cp}` of the illuminant.
 
     Returns
     -------
@@ -605,7 +608,7 @@ def illuminant_scotopic_luminance(L_A: ArrayLike, CCT: ArrayLike) -> NDArrayFloa
 
 def XYZ_to_rgb(XYZ: ArrayLike) -> NDArrayFloat:
     """
-    Convert *CIE XYZ* tristimulus values to *Hunt-Pointer-Estevez*
+    Convert from *CIE XYZ* tristimulus values to *Hunt-Pointer-Estevez*
     :math:`\\rho\\gamma\\beta` colourspace.
 
     Parameters
@@ -616,7 +619,7 @@ def XYZ_to_rgb(XYZ: ArrayLike) -> NDArrayFloat:
     Returns
     -------
     :class:`numpy.ndarray`
-        *Hunt-Pointer-Estevez* :math:`\\rho\\gamma\\beta` colourspace.
+        *Hunt-Pointer-Estevez* :math:`\\rho\\gamma\\beta` colourspace values.
 
     Examples
     --------
@@ -642,7 +645,6 @@ def f_n(x: ArrayLike) -> NDArrayFloat:
     -------
     :class:`numpy.ndarray`
         Modeled visual response variable :math:`x`.
-
 
     Examples
     --------
@@ -687,7 +689,7 @@ def chromatic_adaptation(
         *CIE XYZ* tristimulus values of proximal field, assumed to be equal
         to background if not specified.
     p
-        Simultaneous contrast / assimilation factor :math:`p` with value
+        Simultaneous contrast/assimilation factor :math:`p` with value
         normalised to domain [-1, 0] when simultaneous contrast occurs and
         normalised to domain [0, 1] when assimilation occurs.
     helson_judd_effect
@@ -773,7 +775,12 @@ def adjusted_reference_white_signals(
     p: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Adjust the white point for simultaneous chromatic contrast.
+    Adjust reference white signals for simultaneous chromatic
+    contrast/assimilation effects.
+
+    Compute adjusted cone signals in the Hunt-Pointer-Estevez
+    :math:`\\rho\\gamma\\beta` colourspace based on the proximal field,
+    background, and simultaneous contrast/assimilation factor.
 
     Parameters
     ----------
@@ -911,7 +918,7 @@ def hue_angle(C: ArrayLike) -> NDArrayFloat:
 
 def eccentricity_factor(hue: ArrayLike) -> NDArrayFloat:
     """
-    Compute eccentricity factor :math:`e_s` from the specified hue angle
+    Compute the eccentricity factor :math:`e_s` from the specified hue angle
     :math:`h` in degrees.
 
     Parameters
@@ -980,7 +987,7 @@ def yellowness_blueness_response(
     F_t: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Compute the yellowness / blueness response :math:`M_{yb}`.
+    Compute the yellowness-blueness response :math:`M_{yb}`.
 
     Parameters
     ----------
@@ -998,7 +1005,7 @@ def yellowness_blueness_response(
     Returns
     -------
     :class:`numpy.ndarray`
-        Yellowness / blueness response :math:`M_{yb}`.
+        Yellowness-blueness response :math:`M_{yb}`.
 
     Examples
     --------
@@ -1030,7 +1037,7 @@ def redness_greenness_response(
     N_cb: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Compute the redness / greenness response :math:`M_{rg}`.
+    Compute the redness-greenness response :math:`M_{rg}`.
 
     Parameters
     ----------
@@ -1046,7 +1053,7 @@ def redness_greenness_response(
     Returns
     -------
     :class:`numpy.ndarray`
-        Redness / greenness response :math:`M_{rg}`.
+        Redness-greenness response :math:`M_{rg}`.
 
     Examples
     --------
@@ -1211,13 +1218,13 @@ def brightness_correlate(
     Parameters
     ----------
     A
-         Achromatic signal :math:`A`.
+        Achromatic signal :math:`A`.
     A_w
         Achromatic post adaptation signal of the reference white :math:`A_w`.
     M
         Overall chromatic response :math:`M`.
     N_b
-         Brightness surround induction factor :math:`N_b`.
+        Brightness surround induction factor :math:`N_b`.
 
     Returns
     -------
@@ -1257,13 +1264,13 @@ def lightness_correlate(
     Parameters
     ----------
     Y_b
-         Tristimulus values :math:`Y_b` the background.
+        Tristimulus value :math:`Y_b` of the background.
     Y_w
-         Tristimulus values :math:`Y_b` the reference white.
+        Tristimulus value :math:`Y_w` of the reference white.
     Q
         *Brightness* correlate :math:`Q` of the stimulus.
     Q_w
-        *Brightness* correlate :math:`Q` of the reference white.
+        *Brightness* correlate :math:`Q_w` of the reference white.
 
     Returns
     -------
@@ -1298,25 +1305,25 @@ def chroma_correlate(
     Q_w: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Compute the *chroma* correlate :math:`C_94`.
+    Compute the *chroma* correlate :math:`C_{94}`.
 
     Parameters
     ----------
     s
         *Saturation* correlate :math:`s`.
     Y_b
-         Tristimulus values :math:`Y_b` the background.
+        Tristimulus value :math:`Y_b` of the background.
     Y_w
-         Tristimulus values :math:`Y_b` the reference white.
+        Tristimulus value :math:`Y_w` of the reference white.
     Q
         *Brightness* correlate :math:`Q` of the stimulus.
     Q_w
-        *Brightness* correlate :math:`Q` of the reference white.
+        *Brightness* correlate :math:`Q_w` of the reference white.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        *Chroma* correlate :math:`C_94`.
+        *Chroma* correlate :math:`C_{94}`.
 
     Examples
     --------
@@ -1344,19 +1351,19 @@ def chroma_correlate(
 
 def colourfulness_correlate(F_L: ArrayLike, C_94: ArrayLike) -> NDArrayFloat:
     """
-    Compute the *colourfulness* correlate :math:`M_94`.
+    Compute the *colourfulness* correlate :math:`M_{94}`.
 
     Parameters
     ----------
     F_L
         Luminance adaptation factor :math:`F_L`.
     C_94
-        *Chroma* correlate :math:`C_94`.
+        *Chroma* correlate :math:`C_{94}`.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        *Colourfulness* correlate :math:`M_94`.
+        *Colourfulness* correlate :math:`M_{94}`.
 
     Examples
     --------

--- a/colour/appearance/kim2009.py
+++ b/colour/appearance/kim2009.py
@@ -2,7 +2,11 @@
 Kim, Weyrich and Kautz (2009) Colour Appearance Model
 =====================================================
 
-Define the *Kim, Weyrich and Kautz (2009)* colour appearance model objects:
+Define the *Kim, Weyrich and Kautz (2009)* colour appearance model for
+predicting perceptual colour attributes under varying viewing conditions.
+
+This model extends *CIECAM02* to handle high dynamic range viewing conditions
+by introducing media-specific parameters that modulate lightness prediction.
 
 -   :class:`colour.appearance.InductionFactors_Kim2009`
 -   :attr:`colour.VIEWING_CONDITIONS_KIM2009`
@@ -79,7 +83,8 @@ __all__ = [
 @dataclass(frozen=True)
 class InductionFactors_Kim2009(MixinDataclassIterable):
     """
-    *Kim, Weyrich and Kautz (2009)* colour appearance model induction factors.
+    Define the *Kim, Weyrich and Kautz (2009)* colour appearance model
+    surround induction factors.
 
     Parameters
     ----------
@@ -93,11 +98,11 @@ class InductionFactors_Kim2009(MixinDataclassIterable):
     Notes
     -----
     -   The *Kim, Weyrich and Kautz (2009)* colour appearance model induction
-        factors are the same as *CIECAM02* colour appearance model.
+        factors are the same as the *CIECAM02* colour appearance model.
     -   The *Kim, Weyrich and Kautz (2009)* colour appearance model separates
         the surround modelled by the
-        :class:`colour.appearance.InductionFactors_Kim2009` class instance from
-        the media, modeled with the
+        :class:`colour.appearance.InductionFactors_Kim2009` class instance
+        from the media, modelled with the
         :class:`colour.appearance.MediaParameters_Kim2009` class instance.
 
     References
@@ -114,8 +119,8 @@ VIEWING_CONDITIONS_KIM2009: CanonicalMapping = CanonicalMapping(
     VIEWING_CONDITIONS_CIECAM02
 )
 VIEWING_CONDITIONS_KIM2009.__doc__ = """
-Reference *Kim, Weyrich and Kautz (2009)* colour appearance model viewing
-conditions.
+Define the reference *Kim, Weyrich and Kautz (2009)* colour appearance model
+viewing conditions inherited from *CIECAM02*.
 
 References
 ----------
@@ -126,7 +131,8 @@ References
 @dataclass(frozen=True)
 class MediaParameters_Kim2009:
     """
-    *Kim, Weyrich and Kautz (2009)* colour appearance model media parameters.
+    Define the media parameters for the *Kim, Weyrich and Kautz (2009)* colour
+    appearance model.
 
     Parameters
     ----------
@@ -150,8 +156,8 @@ MEDIA_PARAMETERS_KIM2009: CanonicalMapping = CanonicalMapping(
     }
 )
 MEDIA_PARAMETERS_KIM2009.__doc__ = """
-Reference *Kim, Weyrich and Kautz (2009)* colour appearance model media
-parameters.
+Define the reference *Kim, Weyrich and Kautz (2009)* colour appearance model
+media parameters.
 
 References
 ----------
@@ -177,8 +183,8 @@ MEDIA_PARAMETERS_KIM2009["paper"] = MEDIA_PARAMETERS_KIM2009["Reflective Paper"]
 @dataclass
 class CAM_Specification_Kim2009(MixinDataclassArithmetic):
     """
-    Define the *Kim, Weyrich and Kautz (2009)* colour appearance model
-    specification.
+    Represent the *Kim, Weyrich and Kautz (2009)* colour appearance model
+    output specification.
 
     Parameters
     ----------
@@ -235,8 +241,8 @@ def XYZ_to_Kim2009(
     XYZ_w
         *CIE XYZ* tristimulus values of reference white.
     L_A
-        Adapting field *luminance* :math:`L_A` in :math:`cd/m^2`, (often taken
-        to be 20% of the luminance of a white object in the scene).
+        Adapting field *luminance* :math:`L_A` in :math:`cd/m^2`, (often
+        taken to be 20% of the luminance of a white object in the scene).
     media
         Media parameters.
     surround
@@ -244,15 +250,16 @@ def XYZ_to_Kim2009(
     discount_illuminant
         Truth value indicating if the illuminant should be discounted.
     compute_H
-        Whether to compute *Hue* :math:`h` quadrature :math:`H`. :math:`H` is
-        rarely used, and expensive to compute.
+        Whether to compute *Hue* :math:`h` quadrature :math:`H`.
+        :math:`H` is rarely used, and expensive to compute.
     n_c
         Cone response sigmoidal curve modulating factor :math:`n_c`.
 
     Returns
     -------
     :class:`colour.CAM_Specification_Kim2009`
-       *Kim, Weyrich and Kautz (2009)* colour appearance model specification.
+       *Kim, Weyrich and Kautz (2009)* colour appearance model
+       specification.
 
     Notes
     -----
@@ -392,8 +399,8 @@ def Kim2009_to_XYZ(
     discount_illuminant: bool = False,
 ) -> NDArrayFloat:
     """
-    Convert *Kim, Weyrich and Kautz (2009)* specification to *CIE XYZ*
-    tristimulus values.
+    Convert the *Kim, Weyrich and Kautz (2009)* colour appearance model
+    specification to *CIE XYZ* tristimulus values.
 
     Parameters
     ----------
@@ -409,12 +416,12 @@ def Kim2009_to_XYZ(
         to be 20% of the luminance of a white object in the scene).
     media
         Media parameters.
-    surroundl
+    surround
         Surround viewing conditions induction factors.
-    discount_illuminant
-        Discount the illuminant.
     n_c
         Cone response sigmoidal curve modulating factor :math:`n_c`.
+    discount_illuminant
+        Truth value indicating if the illuminant should be discounted.
 
     Returns
     -------
@@ -424,7 +431,7 @@ def Kim2009_to_XYZ(
     Raises
     ------
     ValueError
-        If neither :math:`C` or :math:`M` correlates have been defined in the
+        If neither :math:`C` nor :math:`M` correlates have been defined in the
         ``specification`` argument.
 
     Notes

--- a/colour/appearance/llab.py
+++ b/colour/appearance/llab.py
@@ -2,7 +2,8 @@
 :math:`LLAB(l:c)` Colour Appearance Model
 =========================================
 
-Define the *:math:`LLAB(l:c)`* colour appearance model objects:
+Define the *:math:`LLAB(l:c)`* colour appearance model for predicting
+perceptual colour attributes under varying viewing conditions.
 
 -   :class:`colour.appearance.InductionFactors_LLAB`
 -   :attr:`colour.VIEWING_CONDITIONS_LLAB`
@@ -79,7 +80,7 @@ __all__ = [
 @dataclass(frozen=True)
 class InductionFactors_LLAB(MixinDataclassIterable):
     """
-    *:math:`LLAB(l:c)`* colour appearance model induction factors.
+    Define the *:math:`LLAB(l:c)`* colour appearance model induction factors.
 
     Parameters
     ----------
@@ -121,7 +122,8 @@ VIEWING_CONDITIONS_LLAB: CanonicalMapping = CanonicalMapping(
     }
 )
 VIEWING_CONDITIONS_LLAB.__doc__ = """
-Reference :math:`LLAB(l:c)` colour appearance model viewing conditions.
+Define the reference :math:`LLAB(l:c)` colour appearance model viewing
+conditions.
 
 References
 ----------
@@ -178,8 +180,8 @@ class CAM_ReferenceSpecification_LLAB(MixinDataclassArithmetic):
     Define the *:math:`LLAB(l:c)`* colour appearance model reference
     specification.
 
-    This specification has field names consistent with *Fairchild (2013)*
-    reference.
+    This specification contains field names consistent with the *Fairchild
+    (2013)* reference.
 
     Parameters
     ----------
@@ -220,14 +222,16 @@ class CAM_Specification_LLAB(MixinDataclassArithmetic):
     """
     Define the *:math:`LLAB(l:c)`* colour appearance model specification.
 
-    This specification has field names consistent with the remaining colour
-    appearance models in :mod:`colour.appearance` but diverge from
-    *Fairchild (2013)* reference.
+    This specification provides a standardized interface for the *LLAB(l:c)*
+    model with field names consistent across all colour appearance models in
+    :mod:`colour.appearance`. While the field names differ from the original
+    *Fairchild (2013)* reference notation, they map directly to the model's
+    perceptual correlates.
 
     Parameters
     ----------
     J
-        Correlate of *Lightness* :math:`L_L`.
+        Correlate of *lightness* :math:`L_L`.
     C
         Correlate of *chroma* :math:`Ch_L`.
     h
@@ -272,7 +276,8 @@ def XYZ_to_LLAB(
     ],
 ) -> CAM_Specification_LLAB:
     """
-    Compute the *:math:`LLAB(l:c)`* colour appearance model correlates.
+    Compute the *:math:`LLAB(l:c)`* colour appearance model correlates from
+    the specified *CIE XYZ* tristimulus values.
 
     Parameters
     ----------
@@ -283,9 +288,10 @@ def XYZ_to_LLAB(
     Y_b
         Luminance factor of the background in :math:`cd/m^2`.
     L
-        Absolute luminance :math:`L` of reference white in :math:`cd/m^2`.
+        Absolute luminance :math:`L` of reference white in
+        :math:`cd/m^2`.
     surround
-         Surround viewing conditions induction factors.
+        Surround viewing conditions induction factors.
 
     Returns
     -------
@@ -384,7 +390,7 @@ s=0.0002395..., M=0.0190185..., HC=None, a=..., b=-0.0190185...)
 
 def XYZ_to_RGB_LLAB(XYZ: ArrayLike) -> NDArrayFloat:
     """
-    Convert *CIE XYZ* tristimulus values to normalised cone responses.
+    Convert from *CIE XYZ* tristimulus values to normalised cone responses.
 
     Parameters
     ----------
@@ -417,22 +423,23 @@ def chromatic_adaptation(
     D: ArrayLike = 1,
 ) -> NDArrayFloat:
     """
-    Apply chromatic adaptation to the specified *RGB* normalised cone responses
-    array.
+    Apply chromatic adaptation to the specified *RGB* normalised cone
+    responses array.
 
     Parameters
     ----------
     RGB
-        *RGB* normalised cone responses array of test sample / stimulus.
+        *RGB* normalised cone responses array of the test sample / stimulus.
     RGB_0
-        *RGB* normalised cone responses array of reference white.
+        *RGB* normalised cone responses array of the reference white.
     RGB_0r
-        *RGB* normalised cone responses array of reference illuminant
+        *RGB* normalised cone responses array of the reference illuminant
         *CIE Standard Illuminant D Series* *D65*.
     Y
-        Tristimulus values :math:`Y` of the stimulus.
+        Tristimulus value :math:`Y` of the stimulus.
     D
-         *Discounting-the-Illuminant* factor normalised to domain [0, 1].
+        *Discounting-the-Illuminant* factor normalised to domain [0, 1].
+        Default is 1.
 
     Returns
     -------
@@ -470,8 +477,8 @@ def chromatic_adaptation(
 
 def f(x: ArrayLike, F_S: ArrayLike) -> NDArrayFloat:
     """
-    Define the nonlinear response function of the *:math:`LLAB(l:c)`* colour
-    appearance model used to model the nonlinear behaviour of various visual
+    Model the nonlinear response function of the *:math:`LLAB(l:c)`* colour
+    appearance model to simulate the nonlinear behaviour of various visual
     responses.
 
     Parameters
@@ -513,11 +520,11 @@ def opponent_colour_dimensions(
     F_S: ArrayLike,
     F_L: ArrayLike,
 ) -> NDArrayFloat:
-    """
-    Compute opponent colour dimensions from the specified adapted *CIE XYZ* tristimulus
-    values.
+    r"""
+    Compute opponent colour dimensions from the specified adapted *CIE XYZ*
+    tristimulus values.
 
-    The opponent colour dimensions are based on a modified *CIE L\\*a\\*b\\**
+    The opponent colour dimensions are based on a modified *CIE L\*a\*b\**
     colourspace formulae.
 
     Parameters
@@ -564,7 +571,8 @@ def opponent_colour_dimensions(
 
 def hue_angle(a: ArrayLike, b: ArrayLike) -> NDArrayFloat:
     """
-    Compute the *hue* angle :math:`h_L` in degrees.
+    Compute the *hue* angle :math:`h_L` in degrees from the specified
+    opponent colour dimensions.
 
     Parameters
     ----------
@@ -594,7 +602,8 @@ def hue_angle(a: ArrayLike, b: ArrayLike) -> NDArrayFloat:
 
 def chroma_correlate(a: ArrayLike, b: ArrayLike) -> NDArrayFloat:
     """
-    Compute the correlate of *chroma* :math:`Ch_L`.
+    Compute the correlate of *chroma* :math:`Ch_L` from the specified
+    opponent colour dimensions.
 
     Parameters
     ----------
@@ -637,7 +646,8 @@ def colourfulness_correlate(
     Parameters
     ----------
     L
-        Absolute luminance :math:`L` of reference white in :math:`cd/m^2`.
+        Absolute luminance :math:`L` of the reference white in
+        :math:`cd/m^2`.
     L_L
         Correlate of *Lightness* :math:`L_L`.
     Ch_L
@@ -681,7 +691,7 @@ def saturation_correlate(Ch_L: ArrayLike, L_L: ArrayLike) -> NDArrayFloat:
     Ch_L
         Correlate of *chroma* :math:`Ch_L`.
     L_L
-        Correlate of *Lightness* :math:`L_L`.
+        Correlate of *lightness* :math:`L_L`.
 
     Returns
     -------

--- a/colour/appearance/nayatani95.py
+++ b/colour/appearance/nayatani95.py
@@ -2,7 +2,8 @@
 Nayatani (1995) Colour Appearance Model
 =======================================
 
-Define the *Nayatani (1995)* colour appearance model objects:
+Define the *Nayatani (1995)* colour appearance model for predicting
+perceptual colour attributes under varying viewing conditions.
 
 -   :class:`colour.CAM_Specification_Nayatani95`
 -   :func:`colour.XYZ_to_Nayatani95`
@@ -93,13 +94,13 @@ class CAM_ReferenceSpecification_Nayatani95(MixinDataclassArithmetic):
     Define the *Nayatani (1995)* colour appearance model reference
     specification.
 
-    This specification has field names consistent with *Fairchild (2013)*
-    reference.
+    This specification contains field names consistent with the *Fairchild
+    (2013)* reference.
 
     Parameters
     ----------
     L_star_P
-        Correlate of *achromatic Lightness* :math:`L_p^\\star`.
+        Correlate of *achromatic lightness* :math:`L_p^\\star`.
     C
         Correlate of *chroma* :math:`C`.
     theta
@@ -115,7 +116,7 @@ class CAM_ReferenceSpecification_Nayatani95(MixinDataclassArithmetic):
     H_C
         *Hue* :math:`h` composition :math:`H_C`.
     L_star_N
-        Correlate of *normalised achromatic Lightness* :math:`L_n^\\star`.
+        Correlate of *normalised achromatic lightness* :math:`L_n^\\star`.
 
     References
     ----------
@@ -138,14 +139,16 @@ class CAM_Specification_Nayatani95(MixinDataclassArithmetic):
     """
     Define the *Nayatani (1995)* colour appearance model specification.
 
-    This specification has field names consistent with the remaining colour
-    appearance models in :mod:`colour.appearance` but diverge from
-    *Fairchild (2013)* reference.
+    This specification provides a standardized interface for the
+    *Nayatani (1995)* model with field names consistent across all colour
+    appearance models in :mod:`colour.appearance`. While the field names differ
+    from the original *Fairchild (2013)* reference notation, they map directly
+    to the model's perceptual correlates.
 
     Parameters
     ----------
     L_star_P
-        Correlate of *achromatic Lightness* :math:`L_p^\\star`.
+        Correlate of *achromatic lightness* :math:`L_p^\\star`.
     C
         Correlate of *chroma* :math:`C`.
     h
@@ -161,11 +164,12 @@ class CAM_Specification_Nayatani95(MixinDataclassArithmetic):
     HC
         *Hue* :math:`h` composition :math:`H_C`.
     L_star_N
-        Correlate of *normalised achromatic Lightness* :math:`L_n^\\star`.
+        Correlate of *normalised achromatic lightness* :math:`L_n^\\star`.
 
     Notes
     -----
-    -   This specification is the one used in the current model implementation.
+    -   This specification is the one used in the current model
+        implementation.
 
     References
     ----------
@@ -192,7 +196,8 @@ def XYZ_to_Nayatani95(
     n: ArrayLike = 1,
 ) -> CAM_Specification_Nayatani95:
     """
-    Compute the *Nayatani (1995)* colour appearance model correlates.
+    Compute the *Nayatani (1995)* colour appearance model correlates from the
+    specified *CIE XYZ* tristimulus values.
 
     Parameters
     ----------
@@ -202,7 +207,8 @@ def XYZ_to_Nayatani95(
         *CIE XYZ* tristimulus values of reference white.
     Y_o
         Luminance factor :math:`Y_o` of achromatic background as percentage
-        normalised to domain [0.18, 1.0] in **'Reference'** domain-range scale.
+        normalised to domain [0.18, 1.0] in **'Reference'** domain-range
+        scale.
     E_o
         Illuminance :math:`E_o` of the viewing field in lux.
     E_or
@@ -340,8 +346,8 @@ H=None, HC=None, L_star_N=50.0039154...)
 
 def illuminance_to_luminance(E: ArrayLike, Y_f: ArrayLike) -> NDArrayFloat:
     """
-    Convert the specified *illuminance* :math:`E` value in lux to *luminance* in
-    :math:`cd/m^2`.
+    Convert the specified *illuminance* :math:`E` value in lux to *luminance*
+    :math:`Y` in :math:`cd/m^2`.
 
     Parameters
     ----------
@@ -431,25 +437,25 @@ def achromatic_response(
     n: ArrayLike = 1,
 ) -> NDArrayFloat:
     """
-    Compute the achromatic response :math:`Q` from the specified stimulus cone
-    responses.
+    Compute the achromatic response :math:`Q` from the specified stimulus
+    cone responses.
 
     Parameters
     ----------
     RGB
-         Stimulus cone responses.
+        Stimulus cone responses.
     bRGB_o
-         Chromatic adaptation exponential factors :math:`\\beta_1(R_o)`,
-         :math:`\\beta_1(G_o)` and :math:`\\beta_2(B_o)`.
+        Chromatic adaptation exponential factors :math:`\\beta_1(R_o)`,
+        :math:`\\beta_1(G_o)` and :math:`\\beta_2(B_o)`.
     xez
         Intermediate values :math:`\\xi`, :math:`\\eta`, :math:`\\zeta`.
     bL_or
-         Normalising chromatic adaptation exponential factor
-         :math:`\\beta_1(B_or)`.
+        Normalising chromatic adaptation exponential factor
+        :math:`\\beta_1(B_{or})`.
     eR
-         Scaling coefficient :math:`e(R)`.
+        Scaling coefficient :math:`e(R)`.
     eG
-         Scaling coefficient :math:`e(G)`.
+        Scaling coefficient :math:`e(G)`.
     n
         Noise term used in the non-linear chromatic adaptation model.
 
@@ -496,10 +502,10 @@ def tritanopic_response(
     Parameters
     ----------
     RGB
-         Stimulus cone responses.
+        Stimulus cone responses.
     bRGB_o
-         Chromatic adaptation exponential factors :math:`\\beta_1(R_o)`,
-         :math:`\\beta_1(G_o)` and :math:`\\beta_2(B_o)`.
+        Chromatic adaptation exponential factors :math:`\\beta_1(R_o)`,
+        :math:`\\beta_1(G_o)` and :math:`\\beta_2(B_o)`.
     xez
         Intermediate values :math:`\\xi`, :math:`\\eta`, :math:`\\zeta`.
     n
@@ -541,10 +547,10 @@ def protanopic_response(
     Parameters
     ----------
     RGB
-         Stimulus cone responses.
+        Stimulus cone responses.
     bRGB_o
-         Chromatic adaptation exponential factors :math:`\\beta_1(R_o)`,
-         :math:`\\beta_1(G_o)` and :math:`\\beta_2(B_o)`.
+        Chromatic adaptation exponential factors :math:`\\beta_1(R_o)`,
+        :math:`\\beta_1(G_o)` and :math:`\\beta_2(B_o)`.
     xez
         Intermediate values :math:`\\xi`, :math:`\\eta`, :math:`\\zeta`.
     n
@@ -585,11 +591,11 @@ def brightness_correlate(
     Parameters
     ----------
     bRGB_o
-         Chromatic adaptation exponential factors :math:`\\beta_1(R_o)`,
-         :math:`\\beta_1(G_o)` and :math:`\\beta_2(B_o)`.
+        Chromatic adaptation exponential factors :math:`\\beta_1(R_o)`,
+        :math:`\\beta_1(G_o)` and :math:`\\beta_2(B_o)`.
     bL_or
-         Normalising chromatic adaptation exponential factor
-         :math:`\\beta_1(B_or)`.
+        Normalising chromatic adaptation exponential factor
+        :math:`\\beta_1(B_{or})`.
     Q
         Achromatic response :math:`Q`.
 
@@ -628,13 +634,13 @@ def ideal_white_brightness_correlate(
     Parameters
     ----------
     bRGB_o
-         Chromatic adaptation exponential factors :math:`\\beta_1(R_o)`,
-         :math:`\\beta_1(G_o)` and :math:`\\beta_2(B_o)`.
+        Chromatic adaptation exponential factors :math:`\\beta_1(R_o)`,
+        :math:`\\beta_1(G_o)` and :math:`\\beta_2(B_o)`.
     xez
         Intermediate values :math:`\\xi`, :math:`\\eta`, :math:`\\zeta`.
     bL_or
-         Normalising chromatic adaptation exponential factor
-         :math:`\\beta_1(B_or)`.
+        Normalising chromatic adaptation exponential factor
+        :math:`\\beta_1(B_{or})`.
     n
         Noise term used in the non-linear chromatic adaptation model.
 
@@ -699,7 +705,8 @@ def normalised_achromatic_lightness_correlate(
     B_r: ArrayLike, B_rw: ArrayLike
 ) -> NDArrayFloat:
     """
-    Compute the *normalised achromatic lightness* correlate :math:`L_n^\\star`.
+    Compute the *normalised achromatic lightness* correlate
+    :math:`L_n^\\star`.
 
     Parameters
     ----------
@@ -730,7 +737,8 @@ def normalised_achromatic_lightness_correlate(
 
 def hue_angle(p: ArrayLike, t: ArrayLike) -> NDArrayFloat:
     """
-    Compute the *hue* angle :math:`h` in degrees.
+    Compute the *hue* angle :math:`h` in degrees from the specified
+    protanopic and tritanopic responses.
 
     Parameters
     ----------
@@ -765,7 +773,7 @@ def chromatic_strength_function(
 ) -> NDArrayFloat:
     """
     Define the chromatic strength function :math:`E_s(\\theta)` used to
-    correct saturation scale as function of hue angle :math:`\\theta` in
+    correct saturation scale as a function of hue angle :math:`\\theta` in
     degrees.
 
     Parameters

--- a/colour/appearance/rlab.py
+++ b/colour/appearance/rlab.py
@@ -2,7 +2,8 @@
 RLAB Colour Appearance Model
 ============================
 
-Define the *RLAB* colour appearance model objects:
+Define the *RLAB* colour appearance model for predicting perceptual colour
+attributes under varying viewing conditions.
 
 -   :attr:`colour.VIEWING_CONDITIONS_RLAB`
 -   :attr:`colour.D_FACTOR_RLAB`
@@ -71,7 +72,7 @@ VIEWING_CONDITIONS_RLAB: CanonicalMapping = CanonicalMapping(
     {"Average": 1 / 2.3, "Dim": 1 / 2.9, "Dark": 1 / 3.5}
 )
 VIEWING_CONDITIONS_RLAB.__doc__ = """
-Reference *RLAB* colour appearance model viewing conditions.
+Define the reference *RLAB* colour appearance model viewing conditions.
 
 References
 ----------
@@ -86,7 +87,8 @@ D_FACTOR_RLAB: CanonicalMapping = CanonicalMapping(
     }
 )
 D_FACTOR_RLAB.__doc__ = """
-*RLAB* colour appearance model *Discounting-the-Illuminant* factor values.
+Define the *RLAB* colour appearance model *Discounting-the-Illuminant*
+factor values for the specified media types.
 
 References
 ----------
@@ -108,8 +110,8 @@ class CAM_ReferenceSpecification_RLAB(MixinDataclassArray):
     """
     Define the *RLAB* colour appearance model reference specification.
 
-    This specification has field names consistent with *Fairchild (2013)*
-    reference.
+    This specification contains field names consistent with the *Fairchild
+    (2013)* reference.
 
     Parameters
     ----------
@@ -147,9 +149,11 @@ class CAM_Specification_RLAB(MixinDataclassArray):
     """
     Define the *RLAB* colour appearance model specification.
 
-    This specification has field names consistent with the remaining colour
-    appearance models in :mod:`colour.appearance` but diverge from
-    *Fairchild (2013)* reference.
+    This specification provides a standardized interface for the *RLAB* model
+    with field names consistent across all colour appearance models in
+    :mod:`colour.appearance`. While the field names differ from the original
+    *Fairchild (2013)* reference notation, they map directly to the model's
+    perceptual correlates.
 
     Parameters
     ----------
@@ -170,7 +174,8 @@ class CAM_Specification_RLAB(MixinDataclassArray):
 
     Notes
     -----
-    -   This specification is the one used in the current model implementation.
+    -   This specification is the one used in the current model
+        implementation.
 
     References
     ----------
@@ -194,7 +199,8 @@ def XYZ_to_RLAB(
     D: ArrayLike = D_FACTOR_RLAB["Hard Copy Images"],
 ) -> CAM_Specification_RLAB:
     """
-    Compute the *RLAB* model color appearance correlates.
+    Compute the *RLAB* colour appearance model correlates from the specified
+    *CIE XYZ* tristimulus values.
 
     Parameters
     ----------

--- a/colour/appearance/scam.py
+++ b/colour/appearance/scam.py
@@ -2,7 +2,8 @@
 sCAM Colour Appearance Model
 ============================
 
-Define the *sCAM* colour appearance model objects:
+Define the *sCAM* colour appearance model for predicting perceptual colour
+attributes under varying viewing conditions.
 
 -   :class:`colour.appearance.InductionFactors_sCAM`
 -   :attr:`colour.VIEWING_CONDITIONS_sCAM`
@@ -10,8 +11,8 @@ Define the *sCAM* colour appearance model objects:
 -   :func:`colour.XYZ_to_sCAM`
 -   :func:`colour.sCAM_to_XYZ`
 
-The sCAM (Simple Colour Appearance Model) is based on the sUCS (Simple Uniform
-Colour Space).
+The *sCAM* (Simple Colour Appearance Model) is based on the *sUCS* (Simple
+Uniform Colour Space).
 
 References
 ----------
@@ -87,7 +88,7 @@ HUE_DATA_FOR_HUE_QUADRATURE_sCAM: dict = {
 @dataclass(frozen=True)
 class InductionFactors_sCAM(MixinDataclassIterable):
     """
-    *sCAM* colour appearance model induction factors.
+    Define the *sCAM* colour appearance model induction factors.
 
     Parameters
     ----------
@@ -116,14 +117,20 @@ VIEWING_CONDITIONS_sCAM: CanonicalMapping = CanonicalMapping(
     }
 )
 VIEWING_CONDITIONS_sCAM.__doc__ = """
-Reference *sCAM* colour appearance model viewing conditions.
+Define the reference *sCAM* colour appearance model
+viewing conditions.
+
+Provide standardized surround conditions (*Average*, *Dim*, *Dark*) with
+their corresponding induction factors that characterize chromatic
+adaptation and perceptual non-linearities under different viewing
+environments.
 """
 
 
 @dataclass
 class CAM_Specification_sCAM(MixinDataclassArithmetic):
     """
-    Define the *sCAM* colour appearance model specification.
+    Define the specification for the *sCAM* colour appearance model.
 
     Parameters
     ----------
@@ -140,7 +147,8 @@ class CAM_Specification_sCAM(MixinDataclassArithmetic):
     H
         *Hue* :math:`h` composition :math:`H`.
     HC
-        *Hue* :math:`h` composition :math:`H^C` (currently not implemented).
+        *Hue* :math:`h` composition :math:`H^C` (currently not
+        implemented).
     V
         Correlate of *vividness* :math:`V`.
     K
@@ -191,11 +199,12 @@ def XYZ_to_sCAM(
         taken to be 20% of the luminance of a white object in the scene).
     Y_b
         Luminous factor of background :math:`Y_b` such as
-        :math:`Y_b = 100 x L_b / L_w` where :math:`L_w` is the luminance of
-        the light source and :math:`L_b` is the luminance of the background.
-        For viewing images, :math:`Y_b` can be the average :math:`Y` value
-        for the pixels in the entire image, or frequently, a :math:`Y` value
-        of 20, approximate an :math:`L^*` of 50 is used.
+        :math:`Y_b = 100 \\times L_b / L_w` where :math:`L_w` is the
+        luminance of the light source and :math:`L_b` is the luminance of
+        the background. For viewing images, :math:`Y_b` can be the average
+        :math:`Y` value for the pixels in the entire image, or frequently,
+        a :math:`Y` value of 20, approximating an :math:`L^*` of 50 is
+        used.
     surround
         Surround viewing conditions induction factors.
     discount_illuminant
@@ -329,7 +338,7 @@ def sCAM_to_XYZ(
     discount_illuminant: bool = False,
 ) -> NDArrayFloat:
     """
-    Convert from *sCAM* colour appearance model specification to *CIE XYZ*
+    Convert the *sCAM* colour appearance model specification to *CIE XYZ*
     tristimulus values.
 
     Parameters
@@ -343,8 +352,9 @@ def sCAM_to_XYZ(
         taken to be 20% of the luminance of a white object in the scene).
     Y_b
         Luminous factor of background :math:`Y_b` such as
-        :math:`Y_b = 100 x L_b / L_w` where :math:`L_w` is the luminance of
-        the light source and :math:`L_b` is the luminance of the background.
+        :math:`Y_b = 100 \\times L_b / L_w` where :math:`L_w` is the
+        luminance of the light source and :math:`L_b` is the luminance of
+        the background.
     surround
         Surround viewing conditions induction factors.
     discount_illuminant
@@ -462,7 +472,8 @@ def sCAM_to_XYZ(
 
 def hue_quadrature(h: ArrayLike) -> NDArrayFloat:
     """
-    Compute the *hue* quadrature :math:`H` from *hue* angle :math:`h`.
+    Compute the *hue* quadrature :math:`H` from the specified *hue* angle
+    :math:`h`.
 
     Parameters
     ----------

--- a/colour/appearance/tests/test_cam16.py
+++ b/colour/appearance/tests/test_cam16.py
@@ -309,7 +309,7 @@ class TestCAM16_to_XYZ:
         XYZ = CAM16_to_XYZ(specification, XYZ_w, L_A, Y_b, surround)
 
         specification = CAM_Specification_CAM16(
-            *np.transpose(np.tile(tsplit(specification), (6, 1))).tolist()  # pyright: ignore
+            *np.transpose(np.tile(tsplit(specification), (6, 1))).tolist()
         )
         XYZ = np.tile(XYZ, (6, 1))
         np.testing.assert_allclose(
@@ -326,7 +326,7 @@ class TestCAM16_to_XYZ:
         )
 
         specification = CAM_Specification_CAM16(
-            *tsplit(np.reshape(specification, (2, 3, 8))).tolist()  # pyright: ignore
+            *tsplit(np.reshape(specification, (2, 3, 8))).tolist()
         )
         XYZ_w = np.reshape(XYZ_w, (2, 3, 3))
         XYZ = np.reshape(XYZ, (2, 3, 3))

--- a/colour/appearance/tests/test_ciecam02.py
+++ b/colour/appearance/tests/test_ciecam02.py
@@ -292,7 +292,7 @@ class TestCIECAM02_to_XYZ:
         XYZ = CIECAM02_to_XYZ(specification, XYZ_w, L_A, Y_b, surround)
 
         specification = CAM_Specification_CIECAM02(
-            *np.transpose(np.tile(tsplit(specification), (6, 1))).tolist()  # pyright: ignore
+            *np.transpose(np.tile(tsplit(specification), (6, 1))).tolist()
         )
         XYZ = np.tile(XYZ, (6, 1))
         np.testing.assert_allclose(
@@ -309,7 +309,7 @@ class TestCIECAM02_to_XYZ:
         )
 
         specification = CAM_Specification_CIECAM02(
-            *tsplit(np.reshape(specification, (2, 3, 8))).tolist()  # pyright: ignore
+            *tsplit(np.reshape(specification, (2, 3, 8))).tolist()
         )
         XYZ_w = np.reshape(XYZ_w, (2, 3, 3))
         XYZ = np.reshape(XYZ, (2, 3, 3))

--- a/colour/appearance/tests/test_ciecam16.py
+++ b/colour/appearance/tests/test_ciecam16.py
@@ -356,7 +356,7 @@ class TestCIECAM16_to_XYZ:
         XYZ = CIECAM16_to_XYZ(specification, XYZ_w, L_A, Y_b, surround)
 
         specification = CAM_Specification_CIECAM16(
-            *np.transpose(np.tile(tsplit(specification), (6, 1))).tolist()  # pyright: ignore
+            *np.transpose(np.tile(tsplit(specification), (6, 1))).tolist()
         )
         XYZ = np.tile(XYZ, (6, 1))
         np.testing.assert_allclose(
@@ -373,7 +373,7 @@ class TestCIECAM16_to_XYZ:
         )
 
         specification = CAM_Specification_CIECAM16(
-            *tsplit(np.reshape(specification, (2, 3, 8))).tolist()  # pyright: ignore
+            *tsplit(np.reshape(specification, (2, 3, 8))).tolist()
         )
         XYZ_w = np.reshape(XYZ_w, (2, 3, 3))
         XYZ = np.reshape(XYZ, (2, 3, 3))

--- a/colour/appearance/tests/test_hellwig2022.py
+++ b/colour/appearance/tests/test_hellwig2022.py
@@ -327,7 +327,7 @@ class TestHellwig2022_to_XYZ:
         XYZ = Hellwig2022_to_XYZ(specification, XYZ_w, L_A, Y_b, surround)
 
         specification = CAM_Specification_Hellwig2022(
-            *np.transpose(np.tile(tsplit(specification), (6, 1))).tolist()  # pyright: ignore
+            *np.transpose(np.tile(tsplit(specification), (6, 1))).tolist()
         )
         XYZ = np.tile(XYZ, (6, 1))
         np.testing.assert_allclose(
@@ -344,7 +344,7 @@ class TestHellwig2022_to_XYZ:
         )
 
         specification = CAM_Specification_Hellwig2022(
-            *tsplit(np.reshape(specification, (2, 3, 10))).tolist()  # pyright: ignore
+            *tsplit(np.reshape(specification, (2, 3, 10))).tolist()
         )
         XYZ_w = np.reshape(XYZ_w, (2, 3, 3))
         XYZ = np.reshape(XYZ, (2, 3, 3))

--- a/colour/appearance/tests/test_kim2009.py
+++ b/colour/appearance/tests/test_kim2009.py
@@ -321,7 +321,7 @@ class TestKim2009_to_XYZ:
         XYZ = Kim2009_to_XYZ(specification, XYZ_w, L_a, media, surround)
 
         specification = CAM_Specification_Kim2009(
-            *np.transpose(np.tile(tsplit(specification), (6, 1))).tolist()  # pyright: ignore
+            *np.transpose(np.tile(tsplit(specification), (6, 1))).tolist()
         )
         XYZ = np.tile(XYZ, (6, 1))
         np.testing.assert_allclose(
@@ -338,7 +338,7 @@ class TestKim2009_to_XYZ:
         )
 
         specification = CAM_Specification_Kim2009(
-            *tsplit(np.reshape(specification, (2, 3, 8))).tolist()  # pyright: ignore
+            *tsplit(np.reshape(specification, (2, 3, 8))).tolist()
         )
         XYZ_w = np.reshape(XYZ_w, (2, 3, 3))
         XYZ = np.reshape(XYZ, (2, 3, 3))

--- a/colour/appearance/tests/test_llab.py
+++ b/colour/appearance/tests/test_llab.py
@@ -321,7 +321,7 @@ class TestKim2009_to_XYZ:
         XYZ = Kim2009_to_XYZ(specification, XYZ_w, L_a, media, surround)
 
         specification = CAM_Specification_Kim2009(
-            *np.transpose(np.tile(tsplit(specification), (6, 1))).tolist()  # pyright: ignore
+            *np.transpose(np.tile(tsplit(specification), (6, 1))).tolist()
         )
         XYZ = np.tile(XYZ, (6, 1))
         np.testing.assert_allclose(
@@ -338,7 +338,7 @@ class TestKim2009_to_XYZ:
         )
 
         specification = CAM_Specification_Kim2009(
-            *tsplit(np.reshape(specification, (2, 3, 8))).tolist()  # pyright: ignore
+            *tsplit(np.reshape(specification, (2, 3, 8))).tolist()
         )
         XYZ_w = np.reshape(XYZ_w, (2, 3, 3))
         XYZ = np.reshape(XYZ, (2, 3, 3))

--- a/colour/appearance/tests/test_scam.py
+++ b/colour/appearance/tests/test_scam.py
@@ -269,7 +269,7 @@ class TestsCAM_to_XYZ:
         XYZ = sCAM_to_XYZ(specification, XYZ_w, L_A, Y_b, surround)
 
         specification = CAM_Specification_sCAM(
-            *np.transpose(np.tile(tsplit(specification), (6, 1))).tolist()  # pyright: ignore
+            *np.transpose(np.tile(tsplit(specification), (6, 1))).tolist()
         )
         XYZ = np.tile(XYZ, (6, 1))
         np.testing.assert_allclose(
@@ -286,7 +286,7 @@ class TestsCAM_to_XYZ:
         )
 
         specification = CAM_Specification_sCAM(
-            *tsplit(np.reshape(specification, (2, 3, 11))).tolist()  # pyright: ignore
+            *tsplit(np.reshape(specification, (2, 3, 11))).tolist()
         )
         XYZ_w = np.reshape(XYZ_w, (2, 3, 3))
         XYZ = np.reshape(XYZ, (2, 3, 3))

--- a/colour/appearance/tests/test_zcam.py
+++ b/colour/appearance/tests/test_zcam.py
@@ -399,7 +399,7 @@ class TestZCAM_to_XYZ:
         XYZ = ZCAM_to_XYZ(specification, XYZ_w, L_a, Y_b, surround)
 
         specification = CAM_Specification_ZCAM(
-            *np.transpose(np.tile(tsplit(specification), (6, 1))).tolist()  # pyright: ignore
+            *np.transpose(np.tile(tsplit(specification), (6, 1))).tolist()
         )
         XYZ = np.tile(XYZ, (6, 1))
         np.testing.assert_almost_equal(
@@ -412,7 +412,7 @@ class TestZCAM_to_XYZ:
         )
 
         specification = CAM_Specification_ZCAM(
-            *tsplit(np.reshape(specification, (2, 3, 11))).tolist()  # pyright: ignore
+            *tsplit(np.reshape(specification, (2, 3, 11))).tolist()
         )
         XYZ_w = np.reshape(XYZ_w, (2, 3, 3))
         XYZ = np.reshape(XYZ, (2, 3, 3))

--- a/colour/appearance/zcam.py
+++ b/colour/appearance/zcam.py
@@ -2,7 +2,8 @@
 ZCAM Colour Appearance Model
 ============================
 
-Define the *ZCAM* colour appearance model objects:
+Define the *ZCAM* colour appearance model for predicting perceptual colour
+attributes under varying viewing conditions.
 
 -   :class:`colour.appearance.InductionFactors_ZCAM`
 -   :attr:`colour.VIEWING_CONDITIONS_ZCAM`
@@ -81,7 +82,7 @@ __all__ = [
 @dataclass(frozen=True)
 class InductionFactors_ZCAM(MixinDataclassIterable):
     """
-    *ZCAM* colour appearance model induction factors.
+    Define the *ZCAM* colour appearance model induction factors.
 
     Parameters
     ----------
@@ -96,8 +97,8 @@ class InductionFactors_ZCAM(MixinDataclassIterable):
 
     Notes
     -----
-    -   The *ZCAM* colour appearance model induction factors are inherited from
-        the *CIECAM02* colour appearance model.
+    -   The *ZCAM* colour appearance model induction factors are inherited
+        from the *CIECAM02* colour appearance model.
 
     References
     ----------
@@ -122,7 +123,20 @@ VIEWING_CONDITIONS_ZCAM: CanonicalMapping = CanonicalMapping(
     }
 )
 VIEWING_CONDITIONS_ZCAM.__doc__ = """
-Reference *ZCAM* colour appearance model viewing conditions.
+Define the reference *ZCAM* colour appearance model
+viewing conditions.
+
+Provide three standard viewing conditions (*Average*, *Dim*, and *Dark*)
+with corresponding induction factors. Each condition specifies a unique
+surround impact factor (:math:`F_s`) alongside inherited *CIECAM02*
+parameters for maximum degree of adaptation (:math:`F`), exponential
+non-linearity (:math:`c`), and chromatic induction factor (:math:`N_c`).
+
+Notes
+-----
+-   The *ZCAM* viewing conditions inherit parameters from *CIECAM02* while
+    introducing model-specific surround impact factors: 0.69 (*Average*),
+    0.59 (*Dim*), and 0.525 (*Dark*).
 
 References
 ----------
@@ -141,8 +155,8 @@ class CAM_ReferenceSpecification_ZCAM(MixinDataclassArithmetic):
     """
     Define the *ZCAM* colour appearance model reference specification.
 
-    This specification has field names consistent with :cite:`Safdar2021`
-    reference.
+    This specification contains field names consistent with the *Fairchild
+    (2013)* reference.
 
     Parameters
     ----------
@@ -191,6 +205,12 @@ class CAM_ReferenceSpecification_ZCAM(MixinDataclassArithmetic):
 class CAM_Specification_ZCAM(MixinDataclassArithmetic):
     """
     Define the *ZCAM* colour appearance model specification.
+
+    This specification provides a standardized interface for the *ZCAM* model
+    with field names consistent across all colour appearance models in
+    :mod:`colour.appearance`. While the field names differ from the original
+    *Fairchild (2013)* reference notation, they map directly to the model's
+    perceptual correlates.
 
     Parameters
     ----------
@@ -318,8 +338,8 @@ def XYZ_to_ZCAM(
     compute_H: bool = True,
 ) -> CAM_Specification_ZCAM:
     """
-    Compute the *ZCAM* colour appearance model correlates from the specified *CIE XYZ*
-    tristimulus values.
+    Compute the *ZCAM* colour appearance model correlates from the specified
+    *CIE XYZ* tristimulus values.
 
     Parameters
     ----------
@@ -334,18 +354,18 @@ def XYZ_to_ZCAM(
         reference white and :math:`Y_b` is the background luminance factor).
     Y_b
         Luminous factor of background :math:`Y_b` such as
-        :math:`Y_b = 100 * L_b / L_w` where :math:`L_w` is the luminance of the
-        light source and :math:`L_b` is the luminance of the background. For
-        viewing images, :math:`Y_b` can be the average :math:`Y` value for the
-        pixels in the entire image, or frequently, a :math:`Y` value of 20,
-        approximate an :math:`L^*` of 50 is used.
+        :math:`Y_b = 100 * L_b / L_w` where :math:`L_w` is the luminance of
+        the light source and :math:`L_b` is the luminance of the background.
+        For viewing images, :math:`Y_b` can be the average :math:`Y` value
+        for the pixels in the entire image, or frequently, a :math:`Y` value
+        of 20, approximating an :math:`L^*` of 50 is used.
     surround
         Surround viewing conditions induction factors.
     discount_illuminant
         Truth value indicating if the illuminant should be discounted.
     compute_H
-        Whether to compute *Hue* :math:`h` quadrature :math:`H`. :math:`H` is
-        rarely used, and expensive to compute.
+        Whether to compute *Hue* :math:`h` quadrature :math:`H`. :math:`H`
+        is rarely used, and expensive to compute.
 
     Returns
     -------
@@ -359,22 +379,23 @@ def XYZ_to_ZCAM(
 
     Notes
     -----
-    -   *Safdar, Hardeberg and Luo (2021)* does not specify how the chromatic
-        adaptation to *CIE Standard Illuminant D65* in *Step 0* should be
-        performed. A one-step *Von Kries* chromatic adaptation transform is not
-        symmetrical or transitive when a degree of adaptation is involved.
-        *Safdar, Hardeberg and Luo (2018)* uses *Zhai and Luo (2018)* two-steps
-        chromatic adaptation transform, thus it seems sensible to adopt this
-        transform for the *ZCAM* colour appearance model until more information
-        is available. It is worth noting that a one-step *Von Kries* chromatic
-        adaptation transform with support for degree of adaptation produces
-        values closer to the supplemental document compared to the
-        *Zhai and Luo (2018)* two-steps chromatic adaptation transform but then
-        the *ZCAM* colour appearance model does not round-trip properly.
+    -   *Safdar, Hardeberg and Luo (2021)* does not specify how the
+        chromatic adaptation to *CIE Standard Illuminant D65* in *Step 0*
+        should be performed. A one-step *Von Kries* chromatic adaptation
+        transform is not symmetrical or transitive when a degree of
+        adaptation is involved. *Safdar, Hardeberg and Luo (2018)* uses
+        *Zhai and Luo (2018)* two-steps chromatic adaptation transform, thus
+        it seems sensible to adopt this transform for the *ZCAM* colour
+        appearance model until more information is available. It is worth
+        noting that a one-step *Von Kries* chromatic adaptation transform
+        with support for degree of adaptation produces values closer to the
+        supplemental document compared to the *Zhai and Luo (2018)*
+        two-steps chromatic adaptation transform but then the *ZCAM* colour
+        appearance model does not round-trip properly.
     -   The underlying *SMPTE ST 2084:2014* transfer function is an absolute
-        transfer function, thus the domain and range values for the *Reference*
-        and *1* scales are only indicative that the data is not affected by
-        scale transformations.
+        transfer function, thus the domain and range values for the
+        *Reference* and *1* scales are only indicative that the data is not
+        affected by scale transformations.
 
     +------------+-----------------------+---------------+
     | **Domain** | **Scale - Reference** | **Scale - 1** |
@@ -522,15 +543,15 @@ def ZCAM_to_XYZ(
     discount_illuminant: bool = False,
 ) -> NDArrayFloat:
     """
-    Convert *ZCAM* specification to *CIE XYZ* tristimulus values.
+    Convert the *ZCAM* specification to *CIE XYZ* tristimulus values.
 
     Parameters
     ----------
     specification
-         *ZCAM* colour appearance model specification.
-         Correlate of *lightness* :math:`J`, correlate of *chroma* :math:`C` or
-         correlate of *colourfulness* :math:`M` and *hue* angle :math:`h` in
-         degrees must be specified, e.g., :math:`JCh` or :math:`JMh`.
+        *ZCAM* colour appearance model specification.
+        Correlate of *lightness* :math:`J`, correlate of *chroma* :math:`C` or
+        correlate of *colourfulness* :math:`M` and *hue* angle :math:`h` in
+        degrees must be specified, e.g., :math:`JCh` or :math:`JMh`.
     XYZ_w
         Absolute *CIE XYZ* tristimulus values of the white under reference
         illuminant.
@@ -540,11 +561,11 @@ def ZCAM_to_XYZ(
         reference white and :math:`Y_b` is the background luminance factor).
     Y_b
         Luminous factor of background :math:`Y_b` such as
-        :math:`Y_b = 100 x L_b / L_w` where :math:`L_w` is the luminance of the
-        light source and :math:`L_b` is the luminance of the background. For
-        viewing images, :math:`Y_b` can be the average :math:`Y` value for the
-        pixels in the entire image, or frequently, a :math:`Y` value of 20,
-        approximate an :math:`L^*` of 50 is used.
+        :math:`Y_b = 100 x L_b / L_w` where :math:`L_w` is the luminance of
+        the light source and :math:`L_b` is the luminance of the background.
+        For viewing images, :math:`Y_b` can be the average :math:`Y` value for
+        the pixels in the entire image, or frequently, a :math:`Y` value of
+        20, approximating an :math:`L^*` of 50 is used.
     surround
         Surround viewing conditions induction factors.
     discount_illuminant
@@ -568,28 +589,29 @@ def ZCAM_to_XYZ(
 
     Notes
     -----
-    -   *Safdar, Hardeberg and Luo (2021)* does not specify how the chromatic
-        adaptation to *CIE Standard Illuminant D65* in *Step 0* should be
-        performed. A one-step *Von Kries* chromatic adaptation transform is not
-        symmetrical or transitive when a degree of adptation is involved.
-        *Safdar, Hardeberg and Luo (2018)* uses *Zhai and Luo (2018)* two-steps
-        chromatic adaptation transform, thus it seems sensible to adopt this
-        transform for the *ZCAM* colour appearance model until more information
-        is available. It is worth noting that a one-step *Von Kries* chromatic
-        adaptation transform with support for degree of adaptation produces
-        values closer to the supplemental document compared to the
-        *Zhai and Luo (2018)* two-steps chromatic adaptation transform but then
-        the *ZCAM* colour appearance model does not round-trip properly.
+    -   *Safdar, Hardeberg and Luo (2021)* does not specify how the
+        chromatic adaptation to *CIE Standard Illuminant D65* in *Step 0*
+        should be performed. A one-step *Von Kries* chromatic adaptation
+        transform is not symmetrical or transitive when a degree of
+        adaptation is involved. *Safdar, Hardeberg and Luo (2018)* uses
+        *Zhai and Luo (2018)* two-steps chromatic adaptation transform, thus
+        it seems sensible to adopt this transform for the *ZCAM* colour
+        appearance model until more information is available. It is worth
+        noting that a one-step *Von Kries* chromatic adaptation transform
+        with support for degree of adaptation produces values closer to the
+        supplemental document compared to the *Zhai and Luo (2018)*
+        two-steps chromatic adaptation transform but then the *ZCAM* colour
+        appearance model does not round-trip properly.
+    -   The underlying *SMPTE ST 2084:2014* transfer function is an absolute
+        transfer function, thus the domain and range values for the
+        *Reference* and *1* scales are only indicative that the data is not
+        affected by scale transformations.
     -   *Step 4* of the inverse model uses a rounded exponent of 1.3514
-        preventing the model to round-trip properly. specified that this
+        preventing the model to round-trip properly. Given that this
         implementation takes some liberties with respect to the chromatic
         adaptation transform to use, it was deemed appropriate to use an
         exponent value that enables the *ZCAM* colour appearance model to
         round-trip.
-    -   The underlying *SMPTE ST 2084:2014* transfer function is an absolute
-        transfer function, thus the domain and range values for the *Reference*
-        and *1* scales are only indicative that the data is not affected by
-        scale transformations.
 
     +-------------------------------+-----------------------+---------------+
     | **Domain**                    | **Scale - Reference** | **Scale - 1** |
@@ -726,7 +748,8 @@ def ZCAM_to_XYZ(
 
 def hue_quadrature(h: ArrayLike) -> NDArrayFloat:
     """
-    Compute the hue quadrature from the specified hue :math:`h` angle in degrees.
+    Compute the hue quadrature from the specified hue :math:`h` angle in
+    degrees.
 
     Parameters
     ----------

--- a/colour/biochemistry/michaelis_menten.py
+++ b/colour/biochemistry/michaelis_menten.py
@@ -2,7 +2,8 @@
 Michaelis-Menten Kinetics
 =========================
 
-Define *Michaelis-Menten* kinetics, a model of enzyme kinetics:
+Define the *Michaelis-Menten* kinetics model for enzyme-catalyzed reactions,
+describing the relationship between reaction rate and substrate concentration:
 
 -   :func:`colour.biochemistry.reaction_rate_MichaelisMenten_Michaelis1913`
 -   :func:`colour.biochemistry.reaction_rate_MichaelisMenten_Abebe2017`
@@ -66,18 +67,20 @@ def reaction_rate_MichaelisMenten_Michaelis1913(
 ) -> NDArrayFloat:
     """
     Compute the rate of enzymatic reactions by relating reaction rate
-    :math:`v` to the concentration of a substrate :math:`S`.
+    :math:`v` to substrate concentration :math:`S` using the
+    *Michaelis-Menten* kinetics equation.
 
     Parameters
     ----------
     S
-        Concentration of a substrate :math:`S`.
+        Substrate concentration :math:`S`.
     V_max
-        Maximum rate :math:`V_{max}` achieved by the system at saturating
-        substrate concentration.
+        Maximum reaction rate :math:`V_{max}` achieved by the system at
+        saturating substrate concentration.
     K_m
-        Substrate concentration :math:`K_m` at which the reaction rate is
-        half of :math:`V_{max}`.
+        Michaelis constant :math:`K_m` representing the substrate
+        concentration at which the reaction rate is half of
+        :math:`V_{max}`.
 
     Returns
     -------
@@ -111,9 +114,9 @@ def reaction_rate_MichaelisMenten_Abebe2017(
 ) -> NDArrayFloat:
     """
     Compute the rate of enzymatic reactions by relating reaction rate
-    :math:`v` to the concentration of a substrate :math:`S` according to the
-    modified *Michaelis-Menten* kinetics equation as specified by
-    *Abebe, Pouli, Larabi and Reinhard (2017)*.
+    :math:`v` to the concentration of a substrate :math:`S` using the
+    modified *Michaelis-Menten* kinetics equation as specified by *Abebe,
+    Pouli, Larabi and Reinhard (2017)*.
 
     Parameters
     ----------
@@ -180,19 +183,19 @@ def reaction_rate_MichaelisMenten(
 ) -> NDArrayFloat:
     """
     Compute the rate of enzymatic reactions by relating reaction rate
-    :math:`v` to the concentration of a substrate :math:`S` according to the
-    specified method.
+    :math:`v` to substrate concentration :math:`S` using the
+    *Michaelis-Menten* kinetics equation using the specified method.
 
     Parameters
     ----------
     S
-        Concentration of a substrate :math:`S`.
+        Concentration of substrate :math:`S`.
     V_max
-        Maximum rate :math:`V_{max}` achieved by the system at saturating
-        substrate concentration.
+        Maximum reaction rate :math:`V_{max}` achieved at saturating substrate
+        concentration.
     K_m
-        Substrate concentration :math:`K_m` at which the reaction rate is
-        half of :math:`V_{max}`.
+        Michaelis constant :math:`K_m` representing substrate concentration at
+        which reaction rate equals half of :math:`V_{max}`.
     method
         Computation method.
 
@@ -234,8 +237,9 @@ def substrate_concentration_MichaelisMenten_Michaelis1913(
     K_m: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Compute the substrate concentration by relating the concentration of a
-    substrate :math:`S` to the reaction rate :math:`v`.
+    Compute substrate concentration by relating the concentration of a
+    substrate :math:`S` to the reaction rate :math:`v` using the
+    *Michaelis-Menten* kinetics equation..
 
     Parameters
     ----------
@@ -280,10 +284,10 @@ def substrate_concentration_MichaelisMenten_Abebe2017(
     b_m: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Compute the substrate concentration by relating the concentration of a
-    substrate :math:`S` to the reaction rate :math:`v` according to the
-    modified *Michaelis-Menten* kinetics equation as specified by
-    *Abebe, Pouli, Larabi and Reinhard (2017)*.
+    Compute substrate concentration by relating the concentration of a
+    substrate :math:`S` to the reaction rate :math:`v` using the
+    *Michaelis-Menten* kinetics equation as specified by *Abebe, Pouli, Larabi
+    and Reinhard (2017)*.
 
     Parameters
     ----------
@@ -349,9 +353,9 @@ def substrate_concentration_MichaelisMenten(
     **kwargs: Any,
 ) -> NDArrayFloat:
     """
-    Compute the substrate concentration by relating the concentration of a
-    substrate :math:`S` to the reaction rate :math:`v` according to the specified
-    method.
+    Compute substrate concentration by relating the concentration of a
+    substrate :math:`S` to the reaction rate :math:`v` using the
+    *Michaelis-Menten* kinetics equation using the specified method.
 
     Parameters
     ----------

--- a/colour/blindness/machado2009.py
+++ b/colour/blindness/machado2009.py
@@ -2,8 +2,8 @@
 Simulation of CVD - Machado, Oliveira and Fernandes (2009)
 ==========================================================
 
-Define the *Machado et al. (2009)* objects for simulation of colour vision
-deficiency:
+Define the *Machado et al. (2009)* physiologically-based model for
+simulation of colour vision deficiency.
 
 -   :func:`colour.msds_cmfs_anomalous_trichromacy_Machado2009`
 -   :func:`colour.matrix_anomalous_trichromacy_Machado2009`
@@ -96,7 +96,8 @@ def matrix_RGB_to_WSYBRG(
     Returns
     -------
     :class:`numpy.ndarray`
-        Matrix transforming from *RGB* colourspace to opponent-colour space.
+        Matrix transforming from *RGB* colourspace to opponent-colour
+        space.
 
     Examples
     --------
@@ -153,16 +154,17 @@ def msds_cmfs_anomalous_trichromacy_Machado2009(
     cmfs: LMS_ConeFundamentals, d_LMS: ArrayLike
 ) -> LMS_ConeFundamentals:
     """
-    Shift specified *LMS* cone fundamentals colour matching functions with specified
-    :math:`\\Delta_{LMS}` shift amount in nanometers to simulate anomalous
-    trichromacy using *Machado et al. (2009)* method.
+    Shift the specified *LMS* cone fundamentals colour matching functions
+    with the specified :math:`\\Delta_{LMS}` shift amount in nanometers to
+    simulate anomalous trichromacy using *Machado et al. (2009)* method.
 
     Parameters
     ----------
     cmfs
         *LMS* cone fundamentals colour matching functions.
     d_LMS
-        :math:`\\Delta_{LMS}` shift amount in nanometers.
+        :math:`\\Delta_{LMS}` wavelength shift amount in nanometers for each
+        cone type.
 
     Notes
     -----
@@ -256,8 +258,8 @@ def matrix_anomalous_trichromacy_Machado2009(
 ) -> NDArrayFloat:
     """
     Compute the *Machado et al. (2009)* colour vision deficiency matrix for
-    specified *LMS* cone fundamentals colour matching functions and display
-    primaries tri-spectral distributions with specified :math:`\\Delta_{LMS}` shift
+    anomalous trichromacy simulation.
+    primaries tri-spectral distributions with the specified :math:`\\Delta_{LMS}` shift
     amount in nanometers to simulate anomalous trichromacy.
 
     Parameters
@@ -267,7 +269,13 @@ def matrix_anomalous_trichromacy_Machado2009(
     primaries
         *RGB* display primaries tri-spectral distributions.
     d_LMS
-        :math:`\\Delta_{LMS}` shift amount in nanometers.
+        :math:`\\Delta_{LMS}` wavelength shift amount in nanometers for each
+        cone type.
+
+    Returns
+    -------
+    :class:`numpy.ndarray`
+        Anomalous trichromacy transformation matrix.
 
     Notes
     -----
@@ -275,11 +283,6 @@ def matrix_anomalous_trichromacy_Machado2009(
         expected to be 1 nanometer, incompatible input will be interpolated
         at 1 nanometer interval.
     -   Input :math:`\\Delta_{LMS}` shift amount is in domain [0, 20].
-
-    Returns
-    -------
-    :class:`numpy.ndarray`
-        Anomalous trichromacy matrix.
 
     References
     ----------
@@ -320,22 +323,23 @@ def matrix_cvd_Machado2009(
     severity: float,
 ) -> NDArrayFloat:
     """
-    Compute *Machado et al. (2009)* colour vision deficiency matrix for specified
-    deficiency and severity using the pre-computed matrices dataset.
+    Compute the *Machado et al. (2009)* colour vision deficiency matrix for
+    the specified deficiency and severity using pre-computed matrices.
 
     Parameters
     ----------
     deficiency
-        Colour blindness / vision deficiency types :
-        - *Protanomaly* : defective long-wavelength cones (L-cones). The
-        complete absence of L-cones is known as *Protanopia* or
-        *red-dichromacy*.
-        - *Deuteranomaly* : defective medium-wavelength cones (M-cones) with
-        peak of sensitivity moved towards the red sensitive cones. The complete
-        absence of M-cones is known as *Deuteranopia*.
-        - *Tritanomaly* : defective short-wavelength cones (S-cones), an
-        alleviated form of blue-yellow colour blindness. The complete absence of
-        S-cones is known as *Tritanopia*.
+        Colour vision deficiency type:
+
+        - *Protanomaly*: Defective long-wavelength cones (L-cones) with
+          reduced sensitivity. Complete absence of L-cones is
+          *Protanopia* or *red-dichromacy*.
+        - *Deuteranomaly*: Defective medium-wavelength cones (M-cones)
+          with peak sensitivity shifted towards red-sensitive cones.
+          Complete absence of M-cones is *Deuteranopia*.
+        - *Tritanomaly*: Defective short-wavelength cones (S-cones),
+          representing an alleviated form of blue-yellow colour
+          blindness. Complete absence of S-cones is *Tritanopia*.
     severity
         Severity of the colour vision deficiency in domain [0, 1].
 

--- a/colour/blindness/machado2009.py
+++ b/colour/blindness/machado2009.py
@@ -124,17 +124,17 @@ def matrix_RGB_to_WSYBRG(
 
     R, G, B = tsplit(primaries.values)
 
-    WS_R = np.trapezoid(R * WS, wavelengths)  # pyright: ignore
-    WS_G = np.trapezoid(G * WS, wavelengths)  # pyright: ignore
-    WS_B = np.trapezoid(B * WS, wavelengths)  # pyright: ignore
+    WS_R = np.trapezoid(R * WS, wavelengths)
+    WS_G = np.trapezoid(G * WS, wavelengths)
+    WS_B = np.trapezoid(B * WS, wavelengths)
 
-    YB_R = np.trapezoid(R * YB, wavelengths)  # pyright: ignore
-    YB_G = np.trapezoid(G * YB, wavelengths)  # pyright: ignore
-    YB_B = np.trapezoid(B * YB, wavelengths)  # pyright: ignore
+    YB_R = np.trapezoid(R * YB, wavelengths)
+    YB_G = np.trapezoid(G * YB, wavelengths)
+    YB_B = np.trapezoid(B * YB, wavelengths)
 
-    RG_R = np.trapezoid(R * RG, wavelengths)  # pyright: ignore
-    RG_G = np.trapezoid(G * RG, wavelengths)  # pyright: ignore
-    RG_B = np.trapezoid(B * RG, wavelengths)  # pyright: ignore
+    RG_R = np.trapezoid(R * RG, wavelengths)
+    RG_G = np.trapezoid(G * RG, wavelengths)
+    RG_B = np.trapezoid(B * RG, wavelengths)
 
     M_G = as_float_array(
         [
@@ -223,8 +223,8 @@ def msds_cmfs_anomalous_trichromacy_Machado2009(
             "deuteranomaly simulation."
         )
 
-    area_L = np.trapezoid(L, cmfs.wavelengths)  # pyright: ignore
-    area_M = np.trapezoid(M, cmfs.wavelengths)  # pyright: ignore
+    area_L = np.trapezoid(L, cmfs.wavelengths)
+    area_M = np.trapezoid(M, cmfs.wavelengths)
 
     def alpha(x: NDArrayFloat) -> NDArrayFloat:
         """Compute :math:`alpha` factor."""

--- a/colour/characterisation/aces_it.py
+++ b/colour/characterisation/aces_it.py
@@ -2,7 +2,8 @@
 Academy Color Encoding System - Input Transform
 ===============================================
 
-Define the *Academy Color Encoding System* (ACES) *Input Transform* utilities:
+Define the *Academy Color Encoding System* (ACES) *Input Transform* utilities
+for camera RAW data processing and colour space transformations:
 
 -   :func:`colour.sd_to_aces_relative_exposure_values`
 -   :func:`colour.sd_to_ACES2065_1`
@@ -163,8 +164,8 @@ def sd_to_aces_relative_exposure_values(
     **kwargs: Any,
 ) -> NDArrayFloat:
     """
-    Convert spectral distribution to *ACES2065-1* colourspace relative exposure
-    values.
+    Convert spectral distribution to *ACES2065-1* colourspace relative
+    exposure values.
 
     Parameters
     ----------
@@ -191,8 +192,8 @@ def sd_to_aces_relative_exposure_values(
 
     -   The chromatic adaptation method implemented here is a bit unusual
         as it involves building a new colourspace based on *ACES2065-1*
-        colourspace primaries but using the whitepoint of the illuminant that
-        the spectral distribution was measured under.
+        colourspace primaries but using the whitepoint of the illuminant
+        that the spectral distribution was measured under.
 
     References
     ----------
@@ -302,12 +303,13 @@ _TRAINING_DATA_RAWTOACES_V1: MultiSpectralDistributions | None = None
 
 def read_training_data_rawtoaces_v1() -> MultiSpectralDistributions:
     """
-    Read the *RAW to ACES* v1 190 patches.
+    Read the *RAW to ACES* v1 training data comprising 190 reflectance
+    patches.
 
     Returns
     -------
     :class:`colour.MultiSpectralDistributions`
-        *RAW to ACES* v1 190 patches.
+        *RAW to ACES* v1 190 patches multi-spectral distributions.
 
     References
     ----------
@@ -409,12 +411,12 @@ def white_balance_multipliers(
 ) -> NDArrayFloat:
     """
     Compute *RGB* white balance multipliers for camera *RGB* spectral
-    sensitivities and illuminant.
+    sensitivities and the specified illuminant spectral distribution.
 
     Parameters
     ----------
     sensitivities
-         Camera *RGB* spectral sensitivities.
+        Camera *RGB* spectral sensitivities.
     illuminant
         Illuminant spectral distribution.
 
@@ -457,22 +459,27 @@ def best_illuminant(
     illuminants: Mapping,
 ) -> SpectralDistribution:
     """
-    Select the best illuminant for *RGB* white balance multipliers and
-    sensitivities in series of illuminants.
+    Select the best illuminant for the specified *RGB* white balance
+    multipliers from a series of candidate illuminants based on camera
+    sensitivities.
+
+    The best illuminant is determined by finding the illuminant that produces
+    white balance multipliers closest to the specified values, minimizing the
+    sum of squared errors after normalization.
 
     Parameters
     ----------
     RGB_w
         *RGB* white balance multipliers.
     sensitivities
-         Camera *RGB* spectral sensitivities.
+        Camera *RGB* spectral sensitivities.
     illuminants
         Illuminant spectral distributions to choose the best illuminant from.
 
     Returns
     -------
     :class:`colour.SpectralDistribution`
-        Best illuminant.
+        Best illuminant spectral distribution.
 
     Examples
     --------
@@ -505,7 +512,8 @@ def normalise_illuminant(
     illuminant: SpectralDistribution, sensitivities: RGB_CameraSensitivities
 ) -> SpectralDistribution:
     """
-    Normalise illuminant with camera *RGB* spectral sensitivities.
+    Normalise the specified illuminant with camera *RGB* spectral
+    sensitivities.
 
     The multiplicative inverse scaling factor :math:`k` is computed by
     multiplying the illuminant by the sensitivities channel with the maximum
@@ -516,7 +524,7 @@ def normalise_illuminant(
     illuminant
         Illuminant spectral distribution.
     sensitivities
-         Camera *RGB* spectral sensitivities.
+        Camera *RGB* spectral sensitivities.
 
     Returns
     -------
@@ -555,15 +563,15 @@ def training_data_sds_to_RGB(
     illuminant: SpectralDistribution,
 ) -> Tuple[NDArrayFloat, NDArrayFloat]:
     """
-    Convert training data to *RGB* tristimulus values using illuminant and
-    camera *RGB* spectral sensitivities.
+    Convert training data to *RGB* tristimulus values using the specified
+    illuminant and camera *RGB* spectral sensitivities.
 
     Parameters
     ----------
     training_data
         Training data multi-spectral distributions.
     sensitivities
-         Camera *RGB* spectral sensitivities.
+        Camera *RGB* spectral sensitivities.
     illuminant
         Illuminant spectral distribution.
 
@@ -625,8 +633,8 @@ def training_data_sds_to_XYZ(
     ) = "CAT02",
 ) -> NDArrayFloat:
     """
-    Convert training data to *CIE XYZ* tristimulus values using illuminant
-    and standard observer colour matching functions.
+    Convert training data to *CIE XYZ* tristimulus values using the specified
+    illuminant and standard observer colour matching functions.
 
     Parameters
     ----------
@@ -637,8 +645,8 @@ def training_data_sds_to_XYZ(
     illuminant
         Illuminant spectral distribution.
     chromatic_adaptation_transform
-        *Chromatic adaptation* transform, if *None* no chromatic adaptation is
-        performed.
+        *Chromatic adaptation* transform, if *None* no chromatic adaptation
+        is performed.
 
     Returns
     -------
@@ -702,7 +710,8 @@ def whitepoint_preserving_matrix(
     M: ArrayLike, RGB_w: ArrayLike = (1, 1, 1)
 ) -> NDArrayFloat:
     """
-    Normalise matrix :math:`M` to preserve white point :math:`RGB_w`.
+    Normalise the specified matrix :math:`M` to preserve the white point
+    :math:`RGB_w`.
 
     Parameters
     ----------
@@ -737,14 +746,14 @@ def optimisation_factory_rawtoaces_v1() -> Tuple[
     NDArrayFloat, Callable, Callable, Callable
 ]:
     """
-    Produce the objective function and *CIE XYZ* colourspace to optimisation
-    colourspace/colour model function according to *RAW to ACES* v1.
+    Generate the objective function and *CIE XYZ* colourspace to optimisation
+    colourspace/colour model function based according to *RAW to ACES* v1.
 
-    The objective function returns the Euclidean distance between the training
-    data *RGB* tristimulus values and the training data *CIE XYZ* tristimulus
-    values** in *CIE L\\*a\\*b\\** colourspace.
+    The objective function computes the Euclidean distance between the
+    training data *RGB* tristimulus values and the training data *CIE XYZ*
+    tristimulus values in the *CIE L\\*a\\*b\\** colourspace.
 
-    It implements whitepoint preservation as an optimisation constraint.
+    Implement whitepoint preservation as an optimisation constraint.
 
     Returns
     -------
@@ -800,15 +809,15 @@ def optimisation_factory_rawtoaces_v1() -> Tuple[
 
 def optimisation_factory_Jzazbz() -> Tuple[NDArrayFloat, Callable, Callable, Callable]:
     """
-    Produce the objective function and *CIE XYZ* colourspace to optimisation
+    Generate the objective function and *CIE XYZ* colourspace to optimisation
     colourspace/colour model function based on the :math:`J_za_zb_z`
     colourspace.
 
-    The objective function returns the Euclidean distance between the training
-    data *RGB* tristimulus values and the training data *CIE XYZ* tristimulus
-    values** in the :math:`J_za_zb_z` colourspace.
+    The objective function computes the Euclidean distance between the
+    training data *RGB* tristimulus values and the training data *CIE XYZ*
+    tristimulus values in the :math:`J_za_zb_z` colourspace.
 
-    It implements whitepoint preservation as a post-optimisation step.
+    Implement whitepoint preservation as a post-optimisation step.
 
     Returns
     -------
@@ -864,15 +873,15 @@ def optimisation_factory_Oklab_15() -> Tuple[
     NDArrayFloat, Callable, Callable, Callable
 ]:
     """
-    Produce the objective function and *CIE XYZ* colourspace to optimisation
+    Generate the objective function and *CIE XYZ* colourspace to optimisation
     colourspace/colour model function based on the *Oklab* colourspace.
 
-    The objective function returns the Euclidean distance between the training
-    data *RGB* tristimulus values and the training data *CIE XYZ* tristimulus
-    values** in the *Oklab* colourspace.
+    The objective function computes the Euclidean distance between the
+    training data *RGB* tristimulus values and the training data *CIE XYZ*
+    tristimulus values in the *Oklab* colourspace.
 
-    It implements support for *Finlayson et al. (2015)* root-polynomials of
-    degree 2 and produces 15 terms.
+    Implement support for *Finlayson et al. (2015)* root-polynomials of
+    degree 2 and produce 15 terms.
 
     Returns
     -------
@@ -998,15 +1007,15 @@ def matrix_idt(
     | Tuple[NDArrayFloat, NDArrayFloat]
 ):
     """
-    Compute an *Input Device Transform* (IDT) matrix for camera *RGB* spectral
-    sensitivities, illuminant, training data, standard observer colour matching
-    functions and optimisation settings according to *RAW to ACES* v1 and
-    *P-2013-001* procedures.
+    Compute an *Input Device Transform* (IDT) matrix for camera *RGB*
+    spectral sensitivities, illuminant, training data, standard observer
+    colour matching functions and optimisation settings according to
+    *RAW to ACES* v1 and *P-2013-001* procedures.
 
     Parameters
     ----------
     sensitivities
-         Camera *RGB* spectral sensitivities.
+        Camera *RGB* spectral sensitivities.
     illuminant
         Illuminant spectral distribution.
     training_data
@@ -1021,16 +1030,18 @@ def matrix_idt(
     optimisation_kwargs
         Parameters for :func:`scipy.optimize.minimize` definition.
     chromatic_adaptation_transform
-        *Chromatic adaptation* transform, if *None* no chromatic adaptation is
-        performed.
+        *Chromatic adaptation* transform, if *None* no chromatic adaptation
+        is performed.
     additional_data
-        If *True*, the *XYZ* and *RGB* tristimulus values are also returned.
+        If *True*, the *XYZ* and *RGB* tristimulus values are also
+        returned.
 
     Returns
     -------
     :class:`tuple`
         Tuple of IDT matrix and white balance multipliers or tuple of IDT
-        matrix, white balance multipliers, *XYZ* and *RGB* tristimulus values.
+        matrix, white balance multipliers, *XYZ* and *RGB* tristimulus
+        values.
 
     References
     ----------
@@ -1152,25 +1163,25 @@ def camera_RGB_to_ACES2065_1(
 ) -> NDArrayFloat:
     """
     Convert camera *RGB* colourspace array to *ACES2065-1* colourspace using
-    the *Input Device Transform* (IDT) matrix :math:`B`, the white balance
-    multipliers :math:`b` and the exposure factor :math:`k` according to
-    *P-2013-001* procedure.
+    the specified *Input Device Transform* (IDT) matrix :math:`B`, white
+    balance multipliers :math:`b`, and exposure factor :math:`k` according to
+    the *P-2013-001* procedure.
 
     Parameters
     ----------
     RGB
         Camera *RGB* colourspace array.
     B
-         *Input Device Transform* (IDT) matrix :math:`B`.
+        *Input Device Transform* (IDT) matrix :math:`B`.
     b
-         White balance multipliers :math:`b`.
+        White balance multipliers :math:`b`.
     k
-        Exposure factor :math:`k` that results in a nominally "18% gray" object
-        in the scene producing ACES values [0.18, 0.18, 0.18].
+        Exposure factor :math:`k` that results in a nominally "18% gray"
+        object in the scene producing ACES values [0.18, 0.18, 0.18].
     clip
         Whether to clip the white balanced camera *RGB* colourspace array
-        between :math:`-\\infty` and 1. The intent is to keep sensor saturated
-        values achromatic after white balancing.
+        between :math:`-\\infty` and 1. The intent is to keep sensor
+        saturated values achromatic after white balancing.
 
     Returns
     -------

--- a/colour/characterisation/cameras.py
+++ b/colour/characterisation/cameras.py
@@ -2,8 +2,8 @@
 Cameras Sensitivities
 =====================
 
-Define the spectral distributions classes for the datasets from
-the :mod:`colour.characterisation.datasets.cameras` module:
+Define spectral distribution classes for camera sensor characterisation
+datasets from the :mod:`colour.characterisation.datasets.cameras` module.
 
 -   :class:`colour.characterisation.RGB_CameraSensitivities`: Define support
     for camera *RGB* sensitivities.
@@ -52,17 +52,18 @@ __all__ = [
 
 class RGB_CameraSensitivities(MultiSpectralDistributions):
     """
-    Define support for camera *RGB* sensitivities.
+    Define a container for camera *RGB* spectral sensitivities.
 
     Parameters
     ----------
     data
         Data to be stored in the multi-spectral distributions.
     domain
-        Values to initialise the multiple :class:`colour.SpectralDistribution`
-        class instances :attr:`colour.continuous.Signal.wavelengths` attribute
-        with. If both ``data`` and ``domain`` arguments are defined, the latter
-        will be used to initialise the
+        Values to initialise the multiple
+        :class:`colour.SpectralDistribution` class instances
+        :attr:`colour.continuous.Signal.wavelengths` attribute with. If
+        both ``data`` and ``domain`` arguments are defined, the latter will
+        be used to initialise the
         :attr:`colour.continuous.Signal.wavelengths` property.
     labels
         Names to use for the :class:`colour.SpectralDistribution` class
@@ -74,16 +75,16 @@ class RGB_CameraSensitivities(MultiSpectralDistributions):
         Extrapolator class type to use as extrapolating function for the
         :class:`colour.SpectralDistribution` class instances.
     extrapolator_kwargs
-        Arguments to use when instantiating the extrapolating function
-        of the :class:`colour.SpectralDistribution` class instances.
+        Arguments to use when instantiating the extrapolating function of
+        the :class:`colour.SpectralDistribution` class instances.
     interpolator
         Interpolator class type to use as interpolating function for the
         :class:`colour.SpectralDistribution` class instances.
     interpolator_kwargs
-        Arguments to use when instantiating the interpolating function
-        of the :class:`colour.SpectralDistribution` class instances.
+        Arguments to use when instantiating the interpolating function of
+        the :class:`colour.SpectralDistribution` class instances.
     name
-       Multi-spectral distributions name.
+        Multi-spectral distributions name.
     display_labels
         Multi-spectral distributions labels for figures, default to
         :attr:`colour.colorimetry.RGB_CameraSensitivities.labels` property

--- a/colour/characterisation/correction.py
+++ b/colour/characterisation/correction.py
@@ -2,51 +2,52 @@
 Colour Correction
 =================
 
-Define various objects for colour correction, like colour matching two images:
+Define objects for colour correction, including methods for colour matching
+between images:
 
--   :func:`colour.characterisation.matrix_augmented_Cheung2004` : Polynomial
-    expansion using *Cheung, Westland, Connah and Ripamonti (2004)* method.
--   :func:`colour.characterisation.polynomial_expansion_Finlayson2015` :
-    Polynomial expansion using *Finlayson, MacKiewicz and Hurlbert (2015)*
+-   :func:`colour.characterisation.matrix_augmented_Cheung2004`: Perform
+    polynomial expansion using *Cheung, Westland, Connah and Ripamonti (2004)*
     method.
--   :func:`colour.characterisation.polynomial_expansion_Vandermonde` :
-    Polynomial expansion using *Vandermonde* method.
--   :attr:`colour.POLYNOMIAL_EXPANSION_METHODS` : Supported polynomial
+-   :func:`colour.characterisation.polynomial_expansion_Finlayson2015`:
+    Perform polynomial expansion using *Finlayson, MacKiewicz and Hurlbert
+    (2015)* method.
+-   :func:`colour.characterisation.polynomial_expansion_Vandermonde`: Perform
+    polynomial expansion using *Vandermonde* method.
+-   :attr:`colour.POLYNOMIAL_EXPANSION_METHODS`: Supported polynomial
     expansion methods.
--   :func:`colour.polynomial_expansion`: Polynomial expansion of
+-   :func:`colour.polynomial_expansion`: Perform polynomial expansion of
     :math:`a` array.
--   :func:`colour.characterisation.matrix_colour_correction_Cheung2004` :
-    Colour correction matrix computation using *Cheung et al. (2004)* method.
--   :func:`colour.characterisation.matrix_colour_correction_Finlayson2015` :
-    Colour correction matrix computation using *Finlayson et al. (2015)*
-    method.
--   :func:`colour.characterisation.matrix_colour_correction_Vandermonde` :
-    Colour correction matrix computation using *Vandermonde* method.
--   :attr:`colour.MATRIX_COLOUR_CORRECTION_METHODS` : Supported colour
+-   :func:`colour.characterisation.matrix_colour_correction_Cheung2004`:
+    Compute colour correction matrix using *Cheung et al. (2004)* method.
+-   :func:`colour.characterisation.matrix_colour_correction_Finlayson2015`:
+    Compute colour correction matrix using *Finlayson et al. (2015)* method.
+-   :func:`colour.characterisation.matrix_colour_correction_Vandermonde`:
+    Compute colour correction matrix using *Vandermonde* method.
+-   :attr:`colour.MATRIX_COLOUR_CORRECTION_METHODS`: Supported colour
     correction matrix methods.
--   :func:`colour.matrix_colour_correction` : Colour correction matrix
-    computation from :math:`M_T` colour array to :math:`M_R` colour array.
--   :func:`colour.apply_matrix_colour_correction_Cheung2004` : Apply a colour
+-   :func:`colour.matrix_colour_correction`: Compute colour correction matrix
+    from :math:`M_T` colour array to :math:`M_R` colour array.
+-   :func:`colour.apply_matrix_colour_correction_Cheung2004`: Apply colour
     correction matrix computed using *Cheung et al. (2004)* method.
--   :func:`colour.apply_matrix_colour_correction_Finlayson2015 `: Apply a
-    colour correction matrix computed using *Finlayson et al. (2015)* method.
--   :func:`colour.apply_matrix_colour_correction_Vandermonde` : Apply a colour
+-   :func:`colour.apply_matrix_colour_correction_Finlayson2015`: Apply colour
+    correction matrix computed using *Finlayson et al. (2015)* method.
+-   :func:`colour.apply_matrix_colour_correction_Vandermonde`: Apply colour
     correction matrix computed using *Vandermonde* method.
--   :attr:`colour.APPLY_MATRIX_COLOUR_CORRECTION_METHODS` : Supported methods
-    to apply a colour correction matrix .
--   :func:`colour.apply_matrix_colour_correction` : Apply a colour correction
+-   :attr:`colour.APPLY_MATRIX_COLOUR_CORRECTION_METHODS`: Supported methods
+    to apply colour correction matrices.
+-   :func:`colour.apply_matrix_colour_correction`: Apply colour correction
     matrix.
--   :func:`colour.characterisation.colour_correction_Cheung2004` :
-    Colour correction using *Cheung et al. (2004)* method.
--   :func:`colour.characterisation.colour_correction_Finlayson2015` :
-    Colour correction using *Finlayson et al. (2015)* method.
--   :func:`colour.characterisation.colour_correction_Vandermonde` :
-    Colour correction using *Vandermonde* method.
--   :attr:`colour.COLOUR_CORRECTION_METHODS` : Supported colour correction
+-   :func:`colour.characterisation.colour_correction_Cheung2004`: Perform
+    colour correction using *Cheung et al. (2004)* method.
+-   :func:`colour.characterisation.colour_correction_Finlayson2015`: Perform
+    colour correction using *Finlayson et al. (2015)* method.
+-   :func:`colour.characterisation.colour_correction_Vandermonde`: Perform
+    colour correction using *Vandermonde* method.
+-   :attr:`colour.COLOUR_CORRECTION_METHODS`: Supported colour correction
     methods.
--   :func:`colour.colour_correction` : Colour correction of *RGB*
-    colourspace array using the colour correction matrix from :math:`M_T`
-    colour array to :math:`M_R` colour array.
+-   :func:`colour.colour_correction`: Perform colour correction of *RGB*
+    colourspace array using colour correction matrix from :math:`M_T` colour
+    array to :math:`M_R` colour array.
 
 References
 ----------
@@ -131,14 +132,14 @@ def matrix_augmented_Cheung2004(
     Parameters
     ----------
     RGB
-        *RGB* colourspace array to expand.
+        *RGB* colourspace array to expand using polynomial expansion.
     terms
         Number of terms of the expanded polynomial.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Expanded *RGB* colourspace array.
+        Polynomial-expanded *RGB* colourspace array.
 
     Notes
     -----
@@ -430,13 +431,13 @@ def polynomial_expansion_Finlayson2015(
     root_polynomial_expansion: bool = True,
 ) -> NDArrayFloat:
     """
-    Perform polynomial expansion of *RGB* colourspace array using
-    *Finlayson et al. (2015)* method.
+    Perform polynomial expansion of the specified *RGB* colourspace
+    array using the *Finlayson et al. (2015)* method.
 
     Parameters
     ----------
     RGB
-        *RGB* colourspace array to expand.
+        *RGB* colourspace array to expand using polynomial expansion.
     degree
         Expanded polynomial degree.
     root_polynomial_expansion
@@ -445,7 +446,7 @@ def polynomial_expansion_Finlayson2015(
     Returns
     -------
     :class:`numpy.ndarray`
-        Expanded *RGB* colourspace array.
+        Polynomial-expanded *RGB* colourspace array.
 
     References
     ----------
@@ -621,20 +622,20 @@ def polynomial_expansion_Finlayson2015(
 
 def polynomial_expansion_Vandermonde(a: ArrayLike, degree: int = 1) -> NDArrayFloat:
     """
-    Perform polynomial expansion of :math:`a` array using *Vandermonde*
-    method.
+    Perform polynomial expansion of the specified :math:`a` array using the
+    *Vandermonde* method.
 
     Parameters
     ----------
     a
-        :math:`a` array to expand.
+        Array :math:`a` to expand using polynomial expansion.
     degree
-        Expanded polynomial degree.
+        Degree of the expanded polynomial.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Expanded :math:`a` array.
+        Polynomial-expanded :math:`a` array.
 
     References
     ----------
@@ -680,14 +681,14 @@ def polynomial_expansion(
     **kwargs: Any,
 ) -> NDArrayFloat:
     """
-    Perform polynomial expansion of :math:`a` array.
+    Perform polynomial expansion of the :math:`a` array.
 
     Parameters
     ----------
     a
-        :math:`a` array to expand.
+        Array to expand using polynomial expansion.
     method
-        Computation method.
+        Computation method for the polynomial expansion.
 
     Other Parameters
     ----------------
@@ -707,7 +708,7 @@ def polynomial_expansion(
     Returns
     -------
     :class:`numpy.ndarray`
-        Expanded :math:`a` array.
+        Polynomial-expanded :math:`a` array.
 
     References
     ----------
@@ -736,22 +737,27 @@ def matrix_colour_correction_Cheung2004(
     terms: Literal[3, 4, 5, 7, 8, 10, 11, 14, 16, 17, 19, 20, 22, 35] | int = 3,
 ) -> NDArrayFloat:
     """
-    Compute a colour correction matrix from :math:`M_T` colour array to
-    :math:`M_R` colour array using *Cheung et al. (2004)* method.
+    Compute a colour correction matrix from test array :math:`M_T` to
+    reference array :math:`M_R` using the *Cheung et al. (2004)* polynomial
+    expansion method.
 
     Parameters
     ----------
     M_T
-        Test array :math:`M_T` to fit onto array :math:`M_R`.
+        Test array :math:`M_T` to fit onto reference array :math:`M_R`.
     M_R
-        Reference array the array :math:`M_T` will be colour fitted against.
+        Reference array that the test array :math:`M_T` will be colour
+        fitted against.
     terms
-        Number of terms of the expanded polynomial.
+        Number of terms of the expanded polynomial. The value must be one
+        of the supported term counts: 3, 4, 5, 7, 8, 10, 11, 14, 16, 17,
+        19, 20, 22, or 35.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Colour correction matrix.
+        Colour correction matrix mapping expanded test colours to reference
+        colours.
 
     References
     ----------
@@ -780,24 +786,29 @@ def matrix_colour_correction_Finlayson2015(
     root_polynomial_expansion: bool = True,
 ) -> NDArrayFloat:
     """
-    Compute a colour correction matrix from :math:`M_T` colour array to
-    :math:`M_R` colour array using *Finlayson et al. (2015)* method.
+    Compute a colour correction matrix from test colour array :math:`M_T` to
+    reference colour array :math:`M_R` using *Finlayson et al. (2015)*
+    root-polynomial colour correction method.
 
     Parameters
     ----------
     M_T
-        Test array :math:`M_T` to fit onto array :math:`M_R`.
+        Test array :math:`M_T` to fit onto reference array :math:`M_R`.
     M_R
-        Reference array the array :math:`M_T` will be colour fitted against.
+        Reference array the test array :math:`M_T` will be colour fitted
+        against.
     degree
-        Expanded polynomial degree.
+        Polynomial expansion degree for the root-polynomial basis. The value
+        must be one of the degrees: 1, 2, 3, 4.
     root_polynomial_expansion
-        Whether to use the root-polynomials set for the expansion.
+        Whether to use the root-polynomial basis set for the expansion. If
+        *False*, uses standard polynomial expansion.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Colour correction matrix.
+        Colour correction matrix mapping expanded test colours to reference
+        colours.
 
     References
     ----------
@@ -824,8 +835,8 @@ def matrix_colour_correction_Vandermonde(
     M_T: ArrayLike, M_R: ArrayLike, degree: int = 1
 ) -> NDArrayFloat:
     """
-    Compute a colour correction matrix from :math:`M_T` colour array to
-    :math:`M_R` colour array using *Vandermonde* method.
+    Compute a colour correction matrix from :math:`M_T` test colour array
+    to :math:`M_R` reference colour array using the *Vandermonde* method.
 
     Parameters
     ----------
@@ -839,7 +850,8 @@ def matrix_colour_correction_Vandermonde(
     Returns
     -------
     :class:`numpy.ndarray`
-        Colour correction matrix.
+        Colour correction matrix mapping expanded test colours to reference
+        colours.
 
     References
     ----------
@@ -869,7 +881,7 @@ MATRIX_COLOUR_CORRECTION_METHODS: CanonicalMapping = CanonicalMapping(
     }
 )
 MATRIX_COLOUR_CORRECTION_METHODS.__doc__ = """
-Supported colour correction matrix methods.
+Supported colour correction matrix computation methods.
 
 References
 ----------
@@ -890,10 +902,10 @@ def matrix_colour_correction(
     Compute a colour correction matrix from :math:`M_T` colour array to
     :math:`M_R` colour array.
 
-    The resulting colour correction matrix is computed using multiple linear or
-    polynomial regression using specified method. The purpose of that object
-    is for example the matching of two *ColorChecker* colour rendition charts
-    together.
+    Compute the colour correction matrix using multiple linear or polynomial
+    regression with the specified method. The resulting matrix enables colour
+    matching between two arrays, such as matching two *ColorChecker* colour
+    rendition charts together.
 
     Parameters
     ----------
@@ -907,22 +919,23 @@ def matrix_colour_correction(
     Other Parameters
     ----------------
     degree
-        {:func:`colour.characterisation.polynomial_expansion_Finlayson2015`,
-        :func:`colour.characterisation.polynomial_expansion_Vandermonde`},
+        {:func:`colour.characterisation.matrix_colour_correction_Finlayson2015`,
+        :func:`colour.characterisation.matrix_colour_correction_Vandermonde`},
         Expanded polynomial degree, must be one of *[1, 2, 3, 4]* for
-        :func:`colour.characterisation.polynomial_expansion_Finlayson2015`
+        :func:`colour.characterisation.matrix_colour_correction_Finlayson2015`
         definition.
     root_polynomial_expansion
-        {:func:`colour.characterisation.polynomial_expansion_Finlayson2015`},
+        {:func:`colour.characterisation.matrix_colour_correction_Finlayson2015`},
         Whether to use the root-polynomials set for the expansion.
     terms
-        {:func:`colour.characterisation.matrix_augmented_Cheung2004`},
+        {:func:`colour.characterisation.matrix_colour_correction_Cheung2004`},
         Number of terms of the expanded polynomial.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Colour correction matrix.
+        Colour correction matrix mapping expanded test colours to reference
+        colours.
 
     References
     ----------
@@ -1006,14 +1019,14 @@ def apply_matrix_colour_correction_Cheung2004(
     terms: Literal[3, 4, 5, 7, 8, 10, 11, 14, 16, 17, 19, 20, 22, 35] | int = 3,
 ) -> NDArrayFloat:
     """
-    Apply colour correction matrix :math:`CCM` computed using
-    *Cheung et al. (2004)* method to *RGB* colourspace array.
+    Apply colour correction matrix :math:`CCM` computed using *Cheung et al.
+    (2004)* method to the specified *RGB* colourspace array.
 
     Parameters
     ----------
     RGB
-        *RGB* colourspace array to apply the colour correction matrix
-        :math:`CCM` to.
+        *RGB* colourspace array to which the colour correction matrix
+        :math:`CCM` is applied.
     CCM
         Colour correction matrix :math:`CCM`.
     terms
@@ -1060,13 +1073,13 @@ def apply_matrix_colour_correction_Finlayson2015(
 ) -> NDArrayFloat:
     """
     Apply colour correction matrix :math:`CCM` computed using
-    *Finlayson et al. (2015)* method to *RGB* colourspace array.
+    *Finlayson et al. (2015)* method to the specified *RGB* colourspace array.
 
     Parameters
     ----------
     RGB
-        *RGB* colourspace array to apply the colour correction matrix
-        :math:`CCM` to.
+        *RGB* colourspace array to which the colour correction matrix
+        :math:`CCM` is applied.
     CCM
         Colour correction matrix :math:`CCM`.
     degree
@@ -1111,14 +1124,14 @@ def apply_matrix_colour_correction_Vandermonde(
     RGB: ArrayLike, CCM: ArrayLike, degree: int = 1
 ) -> NDArrayFloat:
     """
-    Apply colour correction matrix :math:`CCM` computed using
-    *Vandermonde* method to *RGB* colourspace array.
+    Apply colour correction matrix :math:`CCM` computed using the
+    *Vandermonde* method to the specified *RGB* colourspace array.
 
     Parameters
     ----------
     RGB
-        *RGB* colourspace array to apply the colour correction matrix
-        :math:`CCM` to.
+        *RGB* colourspace array to which the colour correction matrix
+        :math:`CCM` is applied.
     CCM
         Colour correction matrix :math:`CCM`.
     degree
@@ -1183,13 +1196,19 @@ def apply_matrix_colour_correction(
     **kwargs: Any,
 ) -> NDArrayFloat:
     """
-    Apply colour correction matrix :math:`CCM` to *RGB* colourspace array.
+    Apply colour correction matrix :math:`CCM` to the specified *RGB*
+    colourspace array.
+
+    The colour correction matrix transforms the input *RGB* values through
+    polynomial expansion and matrix multiplication to produce colour
+    corrected output values. The computation method determines the
+    polynomial expansion approach used before applying the matrix.
 
     Parameters
     ----------
     RGB
-        *RGB* colourspace array to apply the colour correction matrix
-        :math:`CCM` to.
+        *RGB* colourspace array to which the colour correction matrix
+        :math:`CCM` is applied.
     CCM
         Colour correction matrix :math:`CCM`.
     method
@@ -1198,16 +1217,16 @@ def apply_matrix_colour_correction(
     Other Parameters
     ----------------
     degree
-        {:func:`colour.characterisation.polynomial_expansion_Finlayson2015`,
-        :func:`colour.characterisation.polynomial_expansion_Vandermonde`},
+        {:func:`colour.characterisation.apply_matrix_colour_correction_Finlayson2015`,
+        :func:`colour.characterisation.apply_matrix_colour_correction_Vandermonde`},
         Expanded polynomial degree, must be one of *[1, 2, 3, 4]* for
-        :func:`colour.characterisation.polynomial_expansion_Finlayson2015`
+        :func:`colour.characterisation.apply_matrix_colour_correction_Finlayson2015`
         definition.
     root_polynomial_expansion
-        {:func:`colour.characterisation.polynomial_expansion_Finlayson2015`},
+        {:func:`colour.characterisation.apply_matrix_colour_correction_Finlayson2015`},
         Whether to use the root-polynomials set for the expansion.
     terms
-        {:func:`colour.characterisation.matrix_augmented_Cheung2004`},
+        {:func:`colour.characterisation.apply_matrix_colour_correction_Cheung2004`},
         Number of terms of the expanded polynomial.
 
     Returns
@@ -1248,18 +1267,19 @@ def colour_correction_Cheung2004(
     terms: Literal[3, 4, 5, 7, 8, 10, 11, 14, 16, 17, 19, 20, 22, 35] | int = 3,
 ) -> NDArrayFloat:
     """
-    Perform colour correction of *RGB* colourspace array using the colour
-    correction matrix from :math:`M_T` colour array to :math:`M_R` colour
-    array using *Cheung et al. (2004)* method.
+    Perform colour correction of the specified *RGB* colourspace array using
+    the colour correction matrix derived from test array :math:`M_T` to
+    reference array :math:`M_R` using the *Cheung et al. (2004)* method.
 
     Parameters
     ----------
     RGB
         *RGB* colourspace array to colour correct.
     M_T
-        Test array :math:`M_T` to fit onto array :math:`M_R`.
+        Test array :math:`M_T` to fit onto reference array :math:`M_R`.
     M_R
-        Reference array the array :math:`M_T` will be colour fitted against.
+        Reference array that the test array :math:`M_T` will be colour
+        fitted against.
     terms
         Number of terms of the expanded polynomial.
 
@@ -1296,21 +1316,22 @@ def colour_correction_Finlayson2015(
 ) -> NDArrayFloat:
     """
     Perform colour correction of *RGB* colourspace array using the colour
-    correction matrix from :math:`M_T` colour array to :math:`M_R` colour
-    array using *Finlayson et al. (2015)* method.
+    correction matrix from test array :math:`M_T` to reference array
+    :math:`M_R` using the *Finlayson et al. (2015)* method.
 
     Parameters
     ----------
     RGB
         *RGB* colourspace array to colour correct.
     M_T
-        Test array :math:`M_T` to fit onto array :math:`M_R`.
+        Test array :math:`M_T` to fit onto reference array :math:`M_R`.
     M_R
-        Reference array the array :math:`M_T` will be colour fitted against.
+        Reference array that the test array :math:`M_T` will be fitted
+        against.
     degree
-        Expanded polynomial degree.
+        Polynomial expansion degree.
     root_polynomial_expansion
-        Whether to use the root-polynomials set for the expansion.
+        Whether to use the root-polynomial set for the expansion.
 
     Returns
     -------
@@ -1392,7 +1413,7 @@ COLOUR_CORRECTION_METHODS = CanonicalMapping(
     }
 )
 COLOUR_CORRECTION_METHODS.__doc__ = """
-Supported colour correction methods.
+Define the supported colour correction methods.
 
 References
 ----------
@@ -1429,16 +1450,16 @@ def colour_correction(
     Other Parameters
     ----------------
     degree
-        {:func:`colour.characterisation.polynomial_expansion_Finlayson2015`,
-        :func:`colour.characterisation.polynomial_expansion_Vandermonde`},
+        {:func:`colour.characterisation.colour_correction_Finlayson2015`,
+        :func:`colour.characterisation.colour_correction_Vandermonde`},
         Expanded polynomial degree, must be one of *[1, 2, 3, 4]* for
-        :func:`colour.characterisation.polynomial_expansion_Finlayson2015`
+        :func:`colour.characterisation.colour_correction_Finlayson2015`
         definition.
     root_polynomial_expansion
-        {:func:`colour.characterisation.polynomial_expansion_Finlayson2015`},
+        {:func:`colour.characterisation.colour_correction_Finlayson2015`},
         Whether to use the root-polynomials set for the expansion.
     terms
-        {:func:`colour.characterisation.matrix_augmented_Cheung2004`},
+        {:func:`colour.characterisation.colour_correction_Cheung2004`},
         Number of terms of the expanded polynomial.
 
     Returns

--- a/colour/characterisation/correction.py
+++ b/colour/characterisation/correction.py
@@ -123,7 +123,7 @@ __all__ = [
 def matrix_augmented_Cheung2004(
     RGB: ArrayLike,
     terms: Literal[3, 4, 5, 7, 8, 10, 11, 14, 16, 17, 19, 20, 22, 35] | int = 3,
-) -> NDArrayFloat:  # pyright: ignore
+) -> NDArrayFloat:
     """
     Perform polynomial expansion of *RGB* colourspace array using
     *Cheung et al. (2004)* method.
@@ -428,7 +428,7 @@ def polynomial_expansion_Finlayson2015(
     RGB: ArrayLike,
     degree: Literal[1, 2, 3, 4] | int = 1,
     root_polynomial_expansion: bool = True,
-) -> NDArrayFloat:  # pyright: ignore
+) -> NDArrayFloat:
     """
     Perform polynomial expansion of *RGB* colourspace array using
     *Finlayson et al. (2015)* method.

--- a/colour/characterisation/datasets/colour_checkers/chromaticity_coordinates.py
+++ b/colour/characterisation/datasets/colour_checkers/chromaticity_coordinates.py
@@ -4,8 +4,8 @@ Chromaticity Coordinates of the Colour Checkers
 
 Define the chromaticity coordinates of the colour checkers.
 
-Each colour checker data is in the form of an :class:`dict` class instance of
-24 samples as follows::
+Each colour checker data is in the form of a :class:`dict` class instance
+of 24 or more samples as follows::
 
     {'name': 'xyY', ..., 'name': 'xyY'}
 

--- a/colour/characterisation/datasets/colour_checkers/sds.py
+++ b/colour/characterisation/datasets/colour_checkers/sds.py
@@ -4,12 +4,12 @@ Spectral Distributions of the Colour Checkers
 
 Define the spectral distributions of the colour checkers.
 
-Each colour checker data is in the form of :class:`dict` class instance of
+Each colour checker data is in the form of a :class:`dict` instance of
 :class:`colour.SpectralDistribution` classes as follows::
 
     {'name': SpectralDistribution, ..., 'name': SpectralDistribution}
 
-The following the colour checkers are available:
+The following colour checkers are available:
 
 -   :attr:`colour.characterisation.datasets.colour_checkers.sds.\
 SDS_BABELCOLOR_AVERAGE`: Average data derived from measurements
@@ -4022,24 +4022,24 @@ SDS_COLOURCHECKERS: CanonicalMapping = CanonicalMapping(
     }
 )
 SDS_COLOURCHECKERS.__doc__ = """
-Spectral distributions of the colour checkers.
-
-References
-----------
-:cite:`BabelColor2012b`, :cite:`BabelColor2012c`,
-:cite:`InternationalOrganizationforStandardization2012`, :cite:`Luo2024`,
-:cite:`MunsellColorScienceb`, :cite:`Ohta1997a`,
+Spectral distributions of available colour checkers.
 
 Notes
 -----
--   Data from :cite:`InternationalOrganizationforStandardization2012` and
-    :cite:`Ohta1997a` has been verified to be the same.
+-   Data from :cite:`InternationalOrganizationforStandardization2012`
+    and :cite:`Ohta1997a` has been verified to be identical.
 
 Aliases:
 
 -   'babel_average': 'BabelColor Average'
 -   'cc_ohta': 'ColorChecker N Ohta'
 -   'ISO 17321-1': 'ColorChecker N Ohta'
+
+References
+----------
+:cite:`BabelColor2012b`, :cite:`BabelColor2012c`,
+:cite:`InternationalOrganizationforStandardization2012`, :cite:`Luo2024`,
+:cite:`MunsellColorScienceb`, :cite:`Ohta1997a`
 """
 SDS_COLOURCHECKERS["babel_average"] = SDS_COLOURCHECKERS["BabelColor Average"]
 SDS_COLOURCHECKERS["cc_ohta"] = SDS_COLOURCHECKERS["ColorChecker N Ohta"]

--- a/colour/characterisation/datasets/displays/__init__.py
+++ b/colour/characterisation/datasets/displays/__init__.py
@@ -19,7 +19,7 @@ from .lcd import MSDS_DISPLAY_PRIMARIES_LCD
 MSDS_DISPLAY_PRIMARIES = LazyCanonicalMapping(MSDS_DISPLAY_PRIMARIES_CRT)
 MSDS_DISPLAY_PRIMARIES.update(MSDS_DISPLAY_PRIMARIES_LCD)
 MSDS_DISPLAY_PRIMARIES.__doc__ = """
-Primaries multi-spectral distributions of displays.
+Multi-spectral distributions of display primaries.
 
 References
 ----------

--- a/colour/characterisation/datasets/filters/sds.py
+++ b/colour/characterisation/datasets/filters/sds.py
@@ -4,8 +4,9 @@ Spectral Distributions of Filters
 
 Define the spectral distributions of filters.
 
-Each filter data is in the form of :class:`dict` class instance of
-:class:`colour.SpectralDistribution` classes as follows::
+Each filter dataset is provided as a :class:`dict` mapping filter names to
+:class:`colour.SpectralDistribution` class instances with the following
+structure::
 
     {'name': SpectralDistribution, ..., 'name': SpectralDistribution}
 

--- a/colour/characterisation/datasets/lenses/sds.py
+++ b/colour/characterisation/datasets/lenses/sds.py
@@ -4,7 +4,7 @@ Spectral Distributions of Lenses
 
 Define the spectral distributions of lenses.
 
-Each lens data is in the form of :class:`dict` class instance of
+Each lens data is in the form of a :class:`dict` class instance of
 :class:`colour.SpectralDistribution` classes as follows::
 
     {'name': SpectralDistribution, ..., 'name': SpectralDistribution}

--- a/colour/characterisation/displays.py
+++ b/colour/characterisation/displays.py
@@ -2,11 +2,11 @@
 RGB Display Primaries
 =====================
 
-Define the spectral distributions classes for the datasets from
-the :mod:`colour.characterisation.datasets.displays` module:
+Define the spectral distribution classes for datasets from the
+:mod:`colour.characterisation.datasets.displays` module.
 
--   :class:`colour.characterisation.RGB_DisplayPrimaries`: Define support for
-    *RGB* display (such as *CRT* or *LCD*) primaries multi-spectral
+-   :class:`colour.characterisation.RGB_DisplayPrimaries`: Provide support
+    for *RGB* display (such as *CRT* or *LCD*) primaries multi-spectral
     distributions.
 """
 
@@ -53,18 +53,23 @@ __all__ = [
 
 class RGB_DisplayPrimaries(MultiSpectralDistributions):
     """
-    Define support for *RGB* display (such as *CRT* or *LCD*) primaries
-    multi-spectral distributions.
+    Define a container for *RGB* display primaries as multi-spectral
+    distributions.
+
+    Support *RGB* display technologies (such as *CRT* or *LCD*) by storing
+    their primary colours as multi-spectral distributions for accurate colour
+    science computations.
 
     Parameters
     ----------
     data
         Data to be stored in the multi-spectral distributions.
     domain
-        Values to initialise the multiple :class:`colour.SpectralDistribution`
-        class instances :attr:`colour.continuous.Signal.wavelengths` attribute
-        with. If both ``data`` and ``domain`` arguments are defined, the latter
-        will be used to initialise the
+        Values to initialise the multiple
+        :class:`colour.SpectralDistribution` class instances
+        :attr:`colour.continuous.Signal.wavelengths` attribute with. If
+        both ``data`` and ``domain`` arguments are defined, the latter will
+        be used to initialise the
         :attr:`colour.continuous.Signal.wavelengths` property.
     labels
         Names to use for the :class:`colour.SpectralDistribution` class
@@ -76,16 +81,16 @@ class RGB_DisplayPrimaries(MultiSpectralDistributions):
         Extrapolator class type to use as extrapolating function for the
         :class:`colour.SpectralDistribution` class instances.
     extrapolator_kwargs
-        Arguments to use when instantiating the extrapolating function
-        of the :class:`colour.SpectralDistribution` class instances.
+        Arguments to use when instantiating the extrapolating function of
+        the :class:`colour.SpectralDistribution` class instances.
     interpolator
         Interpolator class type to use as interpolating function for the
         :class:`colour.SpectralDistribution` class instances.
     interpolator_kwargs
-        Arguments to use when instantiating the interpolating function
-        of the :class:`colour.SpectralDistribution` class instances.
+        Arguments to use when instantiating the interpolating function of
+        the :class:`colour.SpectralDistribution` class instances.
     name
-       Multi-spectral distributions name.
+        Multi-spectral distributions name.
     display_labels
         Multi-spectral distributions labels for figures, default to
         :attr:`colour.colorimetry.RGB_DisplayPrimaries.labels` property

--- a/colour/colorimetry/blackbody.py
+++ b/colour/colorimetry/blackbody.py
@@ -2,7 +2,7 @@
 Blackbody - Planckian Radiator
 ==============================
 
-Define the objects to compute the spectral radiance of a planckian radiator
+Define objects to compute the spectral radiance of a planckian radiator
 and its spectral distribution.
 
 References
@@ -68,9 +68,9 @@ def planck_law(
     n: float = CONSTANT_N,
 ) -> NDArrayFloat:
     """
-    Compute the spectral radiance of a blackbody as a function of wavelength at
-    specified thermodynamic temperature :math:`T[K]` in a medium with index of
-    refraction :math:`n`.
+    Compute the spectral radiance of a blackbody as a function of
+    wavelength at specified thermodynamic temperature :math:`T[K]` in a
+    medium with index of refraction :math:`n`.
 
     Parameters
     ----------
@@ -79,40 +79,42 @@ def planck_law(
     temperature
         Temperature :math:`T[K]` in kelvin degrees.
     c1
-        The official value of :math:`c1` is provided by the Committee on Data
-        for Science and Technology (CODATA) and is
-        :math:`c1=3,741771x10.16\\ W/m_2` *(Mohr and Taylor, 2000)*.
+        The official value of :math:`c1` is provided by the Committee on
+        Data for Science and Technology (CODATA) and is
+        :math:`c1=3.741771 \\times 10^{-16}\\ \\mathrm{W/m^2}` *(Mohr and
+        Taylor, 2000)*.
     c2
-        Since :math:`T` is measured on the International Temperature Scale,
-        the value of :math:`c2` used in colorimetry should follow that adopted
-        in the current International Temperature Scale (ITS-90)
-        *(Preston-Thomas, 1990; Mielenz et aI., 1991)*, namely
-        :math:`c2=1,4388x10.2\\ m/K`.
+        Since :math:`T` is measured on the International Temperature
+        Scale, the value of :math:`c2` used in colorimetry should follow
+        that adopted in the current International Temperature Scale
+        (ITS-90) *(Preston-Thomas, 1990; Mielenz et al., 1991)*, namely
+        :math:`c2=1.4388 \\times 10^{-2}\\ \\mathrm{m \\cdot K}`.
     n
-        Medium index of refraction. For dry air at 15C and 101 325 Pa,
-        containing 0,03 percent by volume of carbon dioxide, it is
-        approximately 1,00028 throughout the visible region although
+        Medium index of refraction. For dry air at 15°C and 101 325 Pa,
+        containing 0.03 percent by volume of carbon dioxide, it is
+        approximately 1.00028 throughout the visible region although
         *CIE 15:2004* recommends using :math:`n=1`.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Radiance in *watts per steradian per square metre* (:math:`W/sr/m^2`).
+        Radiance in *watts per steradian per square metre*
+        (:math:`\\mathrm{W \\cdot sr^{-1} \\cdot m^{-2}}`).
 
     Warnings
     --------
     The :func:`colour.colorimetry.planck_law` definition behaviour with
-    n-dimensional arrays is unusual: The ``wavelength`` and ``temperature``
-    parameters are first raveled using :func:`numpy.ravel`. Then, they are
-    *broadcasted* together by transposing the ``temperature`` parameter.
-    Finally, and for convenience, the return value is squeezed using
-    :func:`numpy.squeeze`.
+    n-dimensional arrays is unusual: The ``wavelength`` and
+    ``temperature`` parameters are first raveled using
+    :func:`numpy.ravel`. Then, they are *broadcasted* together by
+    transposing the ``temperature`` parameter. Finally, and for
+    convenience, the return value is squeezed using :func:`numpy.squeeze`.
 
     Notes
     -----
     -   The following implementation is expressed in terms of wavelength.
-    -   The SI unit of radiance is *watts per steradian per square metre*
-        (:math:`W/sr/m^2`).
+    -   The SI unit of radiance is *watts per steradian per square
+        metre* (:math:`\\mathrm{W \\cdot sr^{-1} \\cdot m^{-2}}`).
 
     References
     ----------
@@ -151,39 +153,39 @@ def sd_blackbody(
     n: float = CONSTANT_N,
 ) -> SpectralDistribution:
     """
-    Generate the spectral distribution of the planckian radiator for specified
-    temperature :math:`T[K]` with values in *watts per steradian per square
-    metre per nanometer* (:math:`W/sr/m^2/nm`).
+    Generate the spectral distribution of the planckian radiator for the
+    specified temperature :math:`T[K]` with values in *watts per steradian
+    per square metre per nanometre* (:math:`W/sr/m^2/nm`).
 
     Parameters
     ----------
     temperature
-        Temperature :math:`T[K]` in kelvin degrees.
+        Temperature :math:`T[K]` in kelvins.
     shape
         Spectral shape used to create the spectral distribution of the
         planckian radiator.
     c1
-        The official value of :math:`c1` is provided by the Committee on Data
-        for Science and Technology (CODATA) and is
-        :math:`c1=3,741771x10.16\\ W/m_2` *(Mohr and Taylor, 2000)*.
+        The official value of :math:`c_1` is provided by the Committee on
+        Data for Science and Technology (CODATA) and is
+        :math:`c_1=3.741771 \\times 10^{16}\\ W/m^2` *(Mohr and Taylor,
+        2000)*.
     c2
-        Since :math:`T` is measured on the International Temperature Scale,
-        the value of :math:`c2` used in colorimetry should follow that adopted
-        in the current International Temperature Scale (ITS-90)
-        *(Preston-Thomas, 1990; Mielenz et aI., 1991)*, namely
-        :math:`c2=1,4388x10.2\\ m/K`.
+        Since :math:`T` is measured on the International Temperature
+        Scale, the value of :math:`c_2` used in colorimetry should follow
+        that adopted in the current International Temperature Scale
+        (ITS-90) *(Preston-Thomas, 1990; Mielenz et al., 1991)*, namely
+        :math:`c_2=1.4388 \\times 10^{-2}\\ m \\cdot K`.
     n
-        Medium index of refraction. For dry air at 15C and 101 325 Pa,
-        containing 0,03 percent by volume of carbon dioxide, it is
-        approximately 1,00028 throughout the visible region although
+        Medium index of refraction. For dry air at 15°C and 101 325 Pa,
+        containing 0.03 percent by volume of carbon dioxide, it is
+        approximately 1.00028 throughout the visible region although
         *CIE 15:2004* recommends using :math:`n=1`.
 
     Returns
     -------
     :class:`colour.SpectralDistribution`
-        Blackbody spectral distribution with values in
-        *watts per steradian per square metre per nanometer*
-        (:math:`W/sr/m^2/nm`).
+        Blackbody spectral distribution with values in *watts per
+        steradian per square metre per nanometre* (:math:`W/sr/m^2/nm`).
 
     Examples
     --------
@@ -223,8 +225,8 @@ def sd_blackbody(
 def rayleigh_jeans_law(wavelength: ArrayLike, temperature: ArrayLike) -> NDArrayFloat:
     """
     Approximate the spectral radiance of a blackbody as a function of
-    wavelength at specified thermodynamic temperature :math:`T[K]` according to
-    *Rayleigh-Jeans* law.
+    wavelength at specified thermodynamic temperature :math:`T[K]` according
+    to the *Rayleigh-Jeans* law.
 
     Parameters
     ----------
@@ -236,24 +238,25 @@ def rayleigh_jeans_law(wavelength: ArrayLike, temperature: ArrayLike) -> NDArray
     Returns
     -------
     :class:`numpy.ndarray`
-        Radiance in *watts per steradian per square metre* (:math:`W/sr/m^2`).
+        Radiance in *watts per steradian per square metre*
+        (:math:`W/sr/m^2`).
 
     Warnings
     --------
-    The :func:`colour.colorimetry.rayleigh_jeans_law` definition behaviour with
-    n-dimensional arrays is unusual: The ``wavelength`` and ``temperature``
-    parameters are first raveled using :func:`numpy.ravel`. Then, they are
-    *broadcasted* together by transposing the ``temperature`` parameter.
-    Finally, and for convenience, the return value is squeezed using
-    :func:`numpy.squeeze`.
+    The :func:`colour.colorimetry.rayleigh_jeans_law` definition behaviour
+    with n-dimensional arrays is unusual: The ``wavelength`` and
+    ``temperature`` parameters are first raveled using :func:`numpy.ravel`.
+    Then, they are *broadcasted* together by transposing the
+    ``temperature`` parameter. Finally, and for convenience, the return
+    value is squeezed using :func:`numpy.squeeze`.
 
     Notes
     -----
     -   The *Rayleigh-Jeans* law agrees with experimental results at large
         wavelengths (low frequencies) but strongly disagrees at short
-        wavelengths (high frequencies). This inconsistency between observations
-        and the predictions of classical physics is commonly known as the
-        *ultraviolet catastrophe*.
+        wavelengths (high frequencies). This inconsistency between
+        observations and the predictions of classical physics is commonly
+        known as the *ultraviolet catastrophe*.
     -   The following implementation is expressed in terms of wavelength.
     -   The SI unit of radiance is *watts per steradian per square metre*
         (:math:`W/sr/m^2`).
@@ -290,15 +293,15 @@ def sd_rayleigh_jeans(
     shape: SpectralShape = SPECTRAL_SHAPE_DEFAULT,
 ) -> SpectralDistribution:
     """
-    Generate the spectral distribution of the planckian radiator for specified
-    temperature :math:`T[K]` with values in *watts per steradian per square
-    metre per nanometer* (:math:`W/sr/m^2/nm`) according to
+    Generate the spectral distribution of the planckian radiator for the
+    specified temperature :math:`T[K]` with values in *watts per steradian
+    per square metre per nanometre* (:math:`W/sr/m^2/nm`) according to the
     *Rayleigh-Jeans* law.
 
     Parameters
     ----------
     temperature
-        Temperature :math:`T[K]` in kelvin degrees.
+        Temperature :math:`T[K]` in kelvins.
     shape
         Spectral shape used to create the spectral distribution of the
         planckian radiator.
@@ -306,17 +309,16 @@ def sd_rayleigh_jeans(
     Returns
     -------
     :class:`colour.SpectralDistribution`
-        Blackbody spectral distribution with values in
-        *watts per steradian per square metre per nanometer*
-        (:math:`W/sr/m^2/nm`).
+        Blackbody spectral distribution with values in *watts per steradian
+        per square metre per nanometre* (:math:`W/sr/m^2/nm`).
 
     Notes
     -----
     -   The *Rayleigh-Jeans* law agrees with experimental results at large
         wavelengths (low frequencies) but strongly disagrees at short
-        wavelengths (high frequencies). This inconsistency between observations
-        and the predictions of classical physics is commonly known as the
-        *ultraviolet catastrophe*.
+        wavelengths (high frequencies). This inconsistency between
+        observations and the predictions of classical physics is commonly
+        known as the *ultraviolet catastrophe*.
 
     Examples
     --------

--- a/colour/colorimetry/cmfs.py
+++ b/colour/colorimetry/cmfs.py
@@ -58,18 +58,19 @@ __all__ = [
 
 class LMS_ConeFundamentals(MultiSpectralDistributions):
     """
-    Provide support for *Stockman and Sharpe* *LMS* cone fundamentals colour
-    matching functions.
+    Define a container for *Stockman and Sharpe* *LMS* cone fundamentals
+    colour matching functions.
 
     Parameters
     ----------
     data
         Data to be stored in the multi-spectral distributions.
     domain
-        Values to initialise the multiple :class:`colour.SpectralDistribution`
-        class instances :attr:`colour.continuous.Signal.wavelengths` attribute
-        with. If both ``data`` and ``domain`` arguments are defined, the latter
-        will be used to initialise the
+        Values to initialise the multiple
+        :class:`colour.SpectralDistribution` class instances
+        :attr:`colour.continuous.Signal.wavelengths` attribute with. If
+        both ``data`` and ``domain`` arguments are defined, the latter will
+        be used to initialise the
         :attr:`colour.continuous.Signal.wavelengths` property.
     labels
         Names to use for the :class:`colour.SpectralDistribution` class
@@ -81,16 +82,16 @@ class LMS_ConeFundamentals(MultiSpectralDistributions):
         Extrapolator class type to use as extrapolating function for the
         :class:`colour.SpectralDistribution` class instances.
     extrapolator_kwargs
-        Arguments to use when instantiating the extrapolating function
-        of the :class:`colour.SpectralDistribution` class instances.
+        Arguments to use when instantiating the extrapolating function of
+        the :class:`colour.SpectralDistribution` class instances.
     interpolator
         Interpolator class type to use as interpolating function for the
         :class:`colour.SpectralDistribution` class instances.
     interpolator_kwargs
-        Arguments to use when instantiating the interpolating function
-        of the :class:`colour.SpectralDistribution` class instances.
+        Arguments to use when instantiating the interpolating function of
+        the :class:`colour.SpectralDistribution` class instances.
     name
-       Multi-spectral distributions name.
+        Multi-spectral distributions name.
     display_labels
         Multi-spectral distributions labels for figures, default to
         :attr:`colour.colorimetry.LMS_ConeFundamentals.labels` property
@@ -127,17 +128,18 @@ class LMS_ConeFundamentals(MultiSpectralDistributions):
 
 class RGB_ColourMatchingFunctions(MultiSpectralDistributions):
     """
-    Provide support for *CIE RGB* colour matching functions.
+    Define a container for *CIE RGB* colour matching functions.
 
     Parameters
     ----------
     data
         Data to be stored in the multi-spectral distributions.
     domain
-        Values to initialise the multiple :class:`colour.SpectralDistribution`
-        class instances :attr:`colour.continuous.Signal.wavelengths` attribute
-        with. If both ``data`` and ``domain`` arguments are defined, the latter
-        will be used to initialise the
+        Values to initialise the multiple
+        :class:`colour.SpectralDistribution` class instances
+        :attr:`colour.continuous.Signal.wavelengths` attribute with. If
+        both ``data`` and ``domain`` arguments are defined, the latter will
+        be used to initialise the
         :attr:`colour.continuous.Signal.wavelengths` property.
     labels
         Names to use for the :class:`colour.SpectralDistribution` class
@@ -149,16 +151,16 @@ class RGB_ColourMatchingFunctions(MultiSpectralDistributions):
         Extrapolator class type to use as extrapolating function for the
         :class:`colour.SpectralDistribution` class instances.
     extrapolator_kwargs
-        Arguments to use when instantiating the extrapolating function
-        of the :class:`colour.SpectralDistribution` class instances.
+        Arguments to use when instantiating the extrapolating function of
+        the :class:`colour.SpectralDistribution` class instances.
     interpolator
         Interpolator class type to use as interpolating function for the
         :class:`colour.SpectralDistribution` class instances.
     interpolator_kwargs
-        Arguments to use when instantiating the interpolating function
-        of the :class:`colour.SpectralDistribution` class instances.
+        Arguments to use when instantiating the interpolating function of
+        the :class:`colour.SpectralDistribution` class instances.
     name
-       Multi-spectral distributions name.
+        Multi-spectral distributions name.
     display_labels
         Multi-spectral distributions labels for figures, default to
         :attr:`colour.colorimetry.RGB_ColourMatchingFunctions.labels` property
@@ -195,7 +197,7 @@ class RGB_ColourMatchingFunctions(MultiSpectralDistributions):
 
 class XYZ_ColourMatchingFunctions(MultiSpectralDistributions):
     """
-    Provide support for *CIE* Standard Observers *XYZ* colour matching
+    Define a container for *CIE* Standard Observers *XYZ* colour matching
     functions.
 
     Parameters
@@ -203,10 +205,11 @@ class XYZ_ColourMatchingFunctions(MultiSpectralDistributions):
     data
         Data to be stored in the multi-spectral distributions.
     domain
-        Values to initialise the multiple :class:`colour.SpectralDistribution`
-        class instances :attr:`colour.continuous.Signal.wavelengths` attribute
-        with. If both ``data`` and ``domain`` arguments are defined, the latter
-        will be used to initialise the
+        Values to initialise the multiple
+        :class:`colour.SpectralDistribution` class instances
+        :attr:`colour.continuous.Signal.wavelengths` attribute with. If
+        both ``data`` and ``domain`` arguments are defined, the latter will
+        be used to initialise the
         :attr:`colour.continuous.Signal.wavelengths` property.
     labels
         Names to use for the :class:`colour.SpectralDistribution` class
@@ -218,16 +221,16 @@ class XYZ_ColourMatchingFunctions(MultiSpectralDistributions):
         Extrapolator class type to use as extrapolating function for the
         :class:`colour.SpectralDistribution` class instances.
     extrapolator_kwargs
-        Arguments to use when instantiating the extrapolating function
-        of the :class:`colour.SpectralDistribution` class instances.
+        Arguments to use when instantiating the extrapolating function of
+        the :class:`colour.SpectralDistribution` class instances.
     interpolator
         Interpolator class type to use as interpolating function for the
         :class:`colour.SpectralDistribution` class instances.
     interpolator_kwargs
-        Arguments to use when instantiating the interpolating function
-        of the :class:`colour.SpectralDistribution` class instances.
+        Arguments to use when instantiating the interpolating function of
+        the :class:`colour.SpectralDistribution` class instances.
     name
-       Multi-spectral distributions name.
+        Multi-spectral distributions name.
     display_labels
         Multi-spectral distributions labels for figures, default to
         :attr:`colour.colorimetry.XYZ_ColourMatchingFunctions.labels` property

--- a/colour/colorimetry/correction.py
+++ b/colour/colorimetry/correction.py
@@ -2,7 +2,7 @@
 Spectral Bandpass Dependence Correction
 =======================================
 
-Define the objects to perform spectral bandpass dependence correction.
+Define objects to perform spectral bandpass dependence correction.
 
 The following correction methods are available:
 
@@ -12,7 +12,7 @@ The following correction methods are available:
 -   :attr:`colour.BANDPASS_CORRECTION_METHODS`: Supported spectral bandpass
     dependence correction methods.
 -   :func:`colour.bandpass_correction`: Spectral bandpass dependence
-    correction using specified method.
+    correction using the specified method.
 
 References
 ----------
@@ -54,8 +54,8 @@ def bandpass_correction_Stearns1988(
     sd: SpectralDistribution,
 ) -> SpectralDistribution:
     """
-    Perform spectral bandpass dependence correction on spectral distribution
-    using *Stearns and Stearns (1988)* method.
+    Apply spectral bandpass dependence correction to the specified spectral
+    distribution using *Stearns and Stearns (1988)* method.
 
     Parameters
     ----------
@@ -126,20 +126,26 @@ def bandpass_correction(
     method: Literal["Stearns 1988"] | str = "Stearns 1988",
 ) -> SpectralDistribution:
     """
-    Perform spectral bandpass dependence correction on spectral distribution
-    using specified method.
+    Apply spectral bandpass dependence correction to the specified spectral
+    distribution.
+
+    Correct for the systematic errors introduced by finite bandpass
+    measurements in spectrophotometry. The correction compensates for the
+    deviation between the measured spectral values and the true spectral
+    values that would be obtained with infinitesimal bandpass width.
 
     Parameters
     ----------
     sd
-        Spectral distribution.
+        Spectral distribution requiring bandpass correction.
     method
-        Correction method.
+        Bandpass correction method to apply.
 
     Returns
     -------
     :class:`colour.SpectralDistribution`
-        Spectral bandpass dependence corrected spectral distribution.
+        Spectral distribution with bandpass dependence correction applied,
+        preserving the original wavelength sampling.
 
     References
     ----------

--- a/colour/colorimetry/datasets/illuminants/chromaticity_coordinates.py
+++ b/colour/colorimetry/datasets/illuminants/chromaticity_coordinates.py
@@ -31,7 +31,7 @@ The following *ISO* illuminants are available:
 -   ISO 7589 Sensitometric Photoflood
 -   ISO 7589 Sensitometric Printer
 
-The following other illuminants are available for the
+The following additional illuminants are available for the
 *CIE 1931 2 Degree Standard Observer* only:
 
 -   ACES
@@ -40,8 +40,8 @@ The following other illuminants are available for the
 -   ICC D50
 -   PLASA ANSI E1.54
 
-Illuminants whose chromaticity coordinates are defined at 15 decimal places
-have been computed according to practise *ASTM E308-15* method.
+Illuminants whose chromaticity coordinates are defined at 15 decimal
+places have been computed using practise *ASTM E308-15* method.
 
 References
 ----------
@@ -414,11 +414,11 @@ computed as follows::
         )
     )
 
--   *CIE Illuminant D Series D50* illuminant and
-    *CIE Standard Illuminant D Series D65* chromaticity coordinates are rounded
-    to 4 decimals as specified in the typical RGB colourspaces literature. Their
-    chromaticity coordinates as specified in :cite:`CIETC1-482004h` are
-    (0.34567, 0.35851) and (0.31272, 0.32903) respectively.
+-   *CIE Illuminant D Series D50* illuminant and *CIE Standard Illuminant
+    D Series D65* chromaticity coordinates are rounded to 4 decimals as
+    specified in typical RGB colourspaces literature. Their chromaticity
+    coordinates as specified in :cite:`CIETC1-482004h` are (0.34567,
+    0.35851) and (0.31272, 0.32903) respectively.
 -   *CIE* illuminants with chromaticity coordinates not defined in the
     reference :cite:`Wikipedia2006a` have been calculated using their
     correlated colour temperature and
@@ -426,15 +426,16 @@ computed as follows::
     :func:`colour.sd_CIE_illuminant_D_series` and / or
     :func:`colour.sd_to_XYZ` definitions.
 -   *ICC D50* chromaticity coordinates were computed with
-    :func:`colour.XYZ_to_xy` definition from the *CIE XYZ* tristimulus values
-    as specified by *ICC*: [96.42, 100.00, 82.49].
+    :func:`colour.XYZ_to_xy` definition from the *CIE XYZ* tristimulus
+    values as specified by *ICC*: [96.42, 100.00, 82.49].
 
 References
 ----------
 :cite:`CIETC1-482004h`, :cite:`DigitalCinemaInitiatives2007b`,
 :cite:`InternationalOrganizationforStandardization2002`,
 :cite:`InternationalColorConsortium2010`, :cite:`PLASANorthAmerica2015`
-:cite:`TheAcademyofMotionPictureArtsandSciences2014q`, :cite:`Wikipedia2006a`
+:cite:`TheAcademyofMotionPictureArtsandSciences2014q`,
+:cite:`Wikipedia2006a`
 
 Aliases:
 

--- a/colour/colorimetry/datasets/illuminants/hunterlab.py
+++ b/colour/colorimetry/datasets/illuminants/hunterlab.py
@@ -7,8 +7,8 @@ dataset for the *CIE 1931 2 Degree Standard Observer* and
 *CIE 1964 10 Degree Standard Observer*.
 
 The currently implemented data has been extracted from :cite:`HunterLab2008b`,
-however you may want to use different data according to the tables specified in
-:cite:`HunterLab2008c`.
+however you may want to use different data according to the tables specified
+in :cite:`HunterLab2008c`.
 
 References
 ----------
@@ -57,11 +57,12 @@ class Illuminant_Specification_HunterLab:
     Parameters
     ----------
     name
-        Illuminant name
+        Illuminant name.
     XYZ_n
-        Illuminant *CIE XYZ* tristimulus values
+        Illuminant *CIE XYZ* tristimulus values.
     K_ab
-        Illuminant :math:`K_{a}` and :math:`K_{b}` chromaticity coefficients.
+        Illuminant :math:`K_{a}` and :math:`K_{b}` chromaticity
+        coefficients.
     """
 
     name: str

--- a/colour/colorimetry/datasets/illuminants/sds.py
+++ b/colour/colorimetry/datasets/illuminants/sds.py
@@ -16,13 +16,13 @@ The following *CIE* illuminants are available:
 -   CIE Illuminant C
 -   CIE Illuminant D Series (D50, D55, D60, D65, D75)
 -   CIE Illuminant E
--   Illuminants F Series (FL1, FL2, FL3, FL4, FL5, FL6, FL7, FL8, FL9, FL10,
-    FL11, FL12, FL3.1, FL3.10, FL3.11, FL3.12, FL3.13, FL3.14, FL3.15, FL3.2,
-    FL3.3, FL3.4, FL3.5, FL3.6, FL3.7, FL3.8, FL3.9)
+-   Illuminants F Series (FL1, FL2, FL3, FL4, FL5, FL6, FL7, FL8, FL9,
+    FL10, FL11, FL12, FL3.1, FL3.10, FL3.11, FL3.12, FL3.13, FL3.14,
+    FL3.15, FL3.2, FL3.3, FL3.4, FL3.5, FL3.6, FL3.7, FL3.8, FL3.9)
 -   High Pressure Discharge Lamps (HP1, HP2, HP3, HP4, HP5)
--   Typical LED illuminants (LED-B1, LED-B2, LED-B3, LED-B4, LED-B5, LED-BH1,
-    LED-RGB1, LED-V1, LED-V2)
--   Recommended indoor illuminants ID65 and ID50.
+-   Typical LED illuminants (LED-B1, LED-B2, LED-B3, LED-B4, LED-B5,
+    LED-BH1, LED-RGB1, LED-V1, LED-V2)
+-   Recommended indoor illuminants ID65 and ID50
 
 The following *ISO* illuminants are available:
 
@@ -36,9 +36,10 @@ The following *ISO* illuminants are available:
 
 Notes
 -----
--   The spectral distributions are typically provided at 5nm or 10nm interval.
--   *CIE Illuminant D Series* *D60* spectral distribution is calculated using
-    :func:`colour.sd_CIE_illuminant_D_series` definition.
+-   The spectral distributions are typically provided at 5nm or 10nm
+    interval.
+-   *CIE Illuminant D Series* *D60* spectral distribution is calculated
+    using :func:`colour.sd_CIE_illuminant_D_series` definition.
 
 References
 ----------
@@ -4602,7 +4603,7 @@ computed as follows::
     CCT = 6000 * 1.4388 / 1.438
     xy = colour.temperature.CCT_to_xy_CIE_D(CCT)
 
-    sd = colour.sd_CIE_illuminant_D_series(xy)
+        sd = colour.sd_CIE_illuminant_D_series(xy)
 
 References
 ----------
@@ -4875,10 +4876,11 @@ Spectral distributions of the *ISO* illuminants.
 
 Notes
 -----
--   All the *ISO 7589 Sensitometric* spectral distributions are transmitted by
-    the *ISO Standard Lens* specified in :attr:`colour.SDS_LENSES` attribute except
-    for the *ISO 7589 Sensitometric Printer* spectral distribution which is
-    modulated by both the *ISO Standard Lens* and the *ISO 7589 Diffuser* specified
+-   All the *ISO 7589 Sensitometric* spectral distributions are
+    transmitted by the *ISO Standard Lens* specified in
+    :attr:`colour.SDS_LENSES` attribute except for the *ISO 7589
+    Sensitometric Printer* spectral distribution which is modulated by
+    both the *ISO Standard Lens* and the *ISO 7589 Diffuser* specified
     in :attr:`colour.FILTERS_SDS` attribute:
 
     -   *ISO 7589 Sensitometric Daylight* = \
@@ -4901,9 +4903,9 @@ Spectral distributions of the illuminants.
 
 Notes
 -----
--   *CIE 15:2004* recommends using linear interpolation for
-    *CIE Standard Illuminant D Series*, for consistency all the illuminants are
-    using a linear interpolator.
+-   *CIE 15:2004* recommends using linear interpolation for the
+    *CIE Standard Illuminant D Series*. For consistency, all illuminants
+    use a linear interpolator.
 
 References
 ----------

--- a/colour/colorimetry/datasets/illuminants/sds_d_illuminant_series.py
+++ b/colour/colorimetry/datasets/illuminants/sds_d_illuminant_series.py
@@ -388,7 +388,8 @@ SDS_BASIS_FUNCTIONS_CIE_ILLUMINANT_D_SERIES: LazyCanonicalMapping = (
     )
 )
 SDS_BASIS_FUNCTIONS_CIE_ILLUMINANT_D_SERIES.__doc__ = """
-*CIE Illuminant D Series* :math:`S_n(\\lambda)` spectral distributions.
+*CIE Illuminant D Series* :math:`S_n(\\lambda)` basis function spectral
+distributions.
 
 References
 ----------

--- a/colour/colorimetry/datasets/illuminants/tristimulus_values.py
+++ b/colour/colorimetry/datasets/illuminants/tristimulus_values.py
@@ -16,11 +16,12 @@ Notes
 -----
 -   The intent of the data in this module is to provide a practical reference
     if it is required to use the exact *CIE XYZ* tristimulus values of the
-    *CIE* illuminants as specified in :cite:`Carter2018`. Indeed different rounding
-    practises in the colorimetric conversions yield different values for those
-    illuminants, as a related example, *CIE Standard Illuminant D Series D65*
-    chromaticity coordinates are commonly specified as (0.31270, 0.32900) but
-    :cite:`Carter2018` defines them as (0.31271, 0.32903).
+    *CIE* illuminants as specified in :cite:`Carter2018`. Indeed, different
+    rounding practices in the colorimetric conversions yield different values
+    for those illuminants. As a related example, *CIE Standard Illuminant D
+    Series D65* chromaticity coordinates are commonly specified as
+    (0.31270, 0.32900) but :cite:`Carter2018` defines them as
+    (0.31271, 0.32903).
 
 References
 ----------

--- a/colour/colorimetry/datasets/light_sources/chromaticity_coordinates.py
+++ b/colour/colorimetry/datasets/light_sources/chromaticity_coordinates.py
@@ -9,8 +9,8 @@ The following light sources are available:
 -   *RIT* *PointerData.xls* spreadsheet light sources: Natural,
     Philips TL-84, T8 Luxline Plus White, SA, SC, T8 Polylux 3000,
     T8 Polylux 4000, Thorn Kolor-rite
--   *NIST* *NIST CQS simulation 7.4.xls* spreadsheet traditional light sources:
-    Cool White FL, Daylight FL, HPS, Incandescent, LPS, Mercury,
+-   *NIST* *NIST CQS simulation 7.4.xls* spreadsheet traditional light
+    sources: Cool White FL, Daylight FL, HPS, Incandescent, LPS, Mercury,
     Metal Halide, Neodimium Incandescent, Super HPS, Triphosphor FL
 -   *NIST* *NIST CQS simulation 7.4.xls* spreadsheet LED light sources:
     3-LED-1 (457/540/605), 3-LED-2 (473/545/616), 3-LED-2 Yellow,

--- a/colour/colorimetry/datasets/light_sources/sds.py
+++ b/colour/colorimetry/datasets/light_sources/sds.py
@@ -2,7 +2,7 @@
 Spectral Distributions of the Light Sources
 ===========================================
 
-Define the spectral distributions of the light sources.
+Define the spectral distributions of various light sources.
 
 The light sources data is in the form of a *dict* of
 :class:`colour.SpectralDistribution` classes as follows::
@@ -14,15 +14,14 @@ The following light sources are available:
 -   *RIT* *PointerData.xls* spreadsheet light sources: Natural,
     Philips TL-84, T8 Luxline Plus White, SA, SC, T8 Polylux 3000,
     T8 Polylux 4000, Thorn Kolor-rite
--   *NIST* *NIST CQS simulation 7.4.xls* spreadsheet traditional light sources:
-    Cool White FL, Daylight FL, HPS, Incandescent, LPS, Mercury,
+-   *NIST* *NIST CQS simulation 7.4.xls* spreadsheet traditional light
+    sources: Cool White FL, Daylight FL, HPS, Incandescent, LPS, Mercury,
     Metal Halide, Neodimium Incandescent, Super HPS, Triphosphor FL
 -   *NIST* *NIST CQS simulation 7.4.xls* spreadsheet LED light sources:
     3-LED-1 (457/540/605), 3-LED-2 (473/545/616), 3-LED-2 Yellow,
     3-LED-3 (465/546/614), 3-LED-4 (455/547/623), 4-LED No Yellow,
     4-LED Yellow, 4-LED-1 (461/526/576/624), 4-LED-2 (447/512/573/627),
-    Luxeon WW 2880, PHOS-1, PHOS-2, PHOS-3, PHOS-4,
-    Phosphor LED YAG
+    Luxeon WW 2880, PHOS-1, PHOS-2, PHOS-3, PHOS-4, Phosphor LED YAG
 -   *NIST* *NIST CQS simulation 7.4.xls* spreadsheet Philips light sources:
     60 A/W (Soft White), C100S54 (HPS), C100S54C (HPS),
     F32T8/TL830 (Triphosphor), F32T8/TL835 (Triphosphor),
@@ -33,8 +32,7 @@ The following light sources are available:
     F40/CWX (Broadband FL), F40/DX (Broadband FL), F40/DXTP (Delux FL),
     F40/N (Natural FL), H38HT-100 (Mercury), H38JA-100/DX (Mercury DX),
     MHC100/U/MP/3K, MHC100/U/MP/4K, SDW-T 100W/LV (Super HPS)
--   Projectors and Xenon Arc Lamps:
-    Kinoton 75P
+-   Projectors and Xenon Arc Lamps: Kinoton 75P
 
 References
 ----------
@@ -762,9 +760,9 @@ spreadsheet.
 
 Warnings
 --------
-The spectral distributions have been extracted from
-*PointerData.xls* spreadsheet that doesn't mention the data source thus the
-light source names cannot be accurately verified.
+The spectral distributions have been extracted from the
+*PointerData.xls* spreadsheet that does not specify the data source,
+thus the light source names cannot be accurately verified.
 
 References
 ----------
@@ -2886,8 +2884,12 @@ SDS_LIGHT_SOURCES_NIST_LED: LazyCanonicalMapping = LazyCanonicalMapping(
     for key, value in DATA_LIGHT_SOURCES_NIST_LED.items()
 )
 SDS_LIGHT_SOURCES_NIST_LED.__doc__ = """
-Spectral distributions of the LED light sources from the *NIST*
-*NIST CQS simulation 7.4.xls* spreadsheet.
+Spectral distributions of LED light sources from the *NIST* *CQS
+simulation 7.4* spreadsheet.
+
+References
+----------
+:cite:`Ohno2008a`
 """
 
 DATA_LIGHT_SOURCES_NIST_PHILIPS: dict = {
@@ -4732,8 +4734,12 @@ SDS_LIGHT_SOURCES_NIST_PHILIPS: LazyCanonicalMapping = LazyCanonicalMapping(
     for key, value in DATA_LIGHT_SOURCES_NIST_PHILIPS.items()
 )
 SDS_LIGHT_SOURCES_NIST_PHILIPS.__doc__ = """
-Spectral distributions of the Philips light sources from the *NIST*
-*NIST CQS simulation 7.4.xls* spreadsheet.
+*Philips* light sources spectral distributions from the *NIST* *CQS
+simulation 7.4.xls* spreadsheet.
+
+References
+----------
+:cite:`Ohno2008a`
 """
 
 DATA_LIGHT_SOURCES_COMMON: dict = {
@@ -4966,9 +4972,9 @@ Spectral distributions of the light sources.
 
 Notes
 -----
--   *CIE 15:2004* recommends using linear interpolation for
-    *CIE Standard Illuminant D Series*, for consistency all the illuminants are
-    using a linear interpolator.
+-   *CIE 15:2004* recommends using linear interpolation for the
+    *CIE Standard Illuminant D Series*. For consistency, all the light sources
+    use a linear interpolator.
 
 References
 ----------

--- a/colour/colorimetry/dominant.py
+++ b/colour/colorimetry/dominant.py
@@ -60,7 +60,7 @@ def closest_spectral_locus_wavelength(
     """
     Compute the coordinates and closest spectral locus wavelength index to the
     point where the line defined by the achromatic stimulus :math:`xy_n` to
-    colour stimulus :math:`xy_n` *CIE xy* chromaticity coordinates intersects
+    colour stimulus :math:`xy` *CIE xy* chromaticity coordinates intersects
     the spectral locus.
 
     Parameters
@@ -136,12 +136,12 @@ def dominant_wavelength(
     intersection coordinates with the spectral locus.
 
     In the eventuality where the :math:`xy_wl` first intersection coordinates
-    are on the line of purples, the *complementary wavelength* will be computed
-    in lieu.
+    are on the line of purples, the *complementary wavelength* will be
+    computed in lieu.
 
     The *complementary wavelength* is indicated by a negative sign and the
-    :math:`xy_{cw}` second intersection coordinates which are set by default to
-    the same value as :math:`xy_wl` first intersection coordinates will be
+    :math:`xy_{cw}` second intersection coordinates which are set by default
+    to the same value as :math:`xy_wl` first intersection coordinates will be
     set to the *complementary dominant wavelength* intersection coordinates
     with the spectral locus.
 
@@ -225,19 +225,20 @@ def complementary_wavelength(
     cmfs: MultiSpectralDistributions | None = None,
 ) -> Tuple[NDArrayFloat, NDArrayFloat, NDArrayFloat]:
     """
-    Compute the *complementary wavelength* :math:`\\lambda_c` for colour
-    stimulus :math:`xy` and the related :math:`xy_wl` first and :math:`xy_{cw}`
-    second intersection coordinates with the spectral locus.
+    Compute the *complementary wavelength* :math:`\\lambda_c` for the
+    specified colour stimulus :math:`xy` and the related :math:`xy_wl` first
+    and :math:`xy_{cw}` second intersection coordinates with the spectral
+    locus.
 
     In the eventuality where the :math:`xy_wl` first intersection coordinates
     are on the line of purples, the *dominant wavelength* will be computed in
     lieu.
 
     The *dominant wavelength* is indicated by a negative sign and the
-    :math:`xy_{cw}` second intersection coordinates which are set by default to
-    the same value as :math:`xy_wl` first intersection coordinates will be
-    set to the *dominant wavelength* intersection coordinates with the spectral
-    locus.
+    :math:`xy_{cw}` second intersection coordinates which are set by default
+    to the same value as :math:`xy_wl` first intersection coordinates will be
+    set to the *dominant wavelength* intersection coordinates with the
+    spectral locus.
 
     Parameters
     ----------
@@ -293,7 +294,8 @@ def excitation_purity(
     cmfs: MultiSpectralDistributions | None = None,
 ) -> NDArrayFloat:
     """
-    Compute the *excitation purity* :math:`P_e` for colour stimulus :math:`xy`.
+    Compute the *excitation purity* :math:`P_e` for the specified colour
+    stimulus :math:`xy`.
 
     Parameters
     ----------
@@ -339,8 +341,8 @@ def colorimetric_purity(
     cmfs: MultiSpectralDistributions | None = None,
 ) -> NDArrayFloat:
     """
-    Compute the *colorimetric purity* :math:`P_c` for colour stimulus
-    :math:`xy`.
+    Compute the *colorimetric purity* :math:`P_c` for the specified
+    colour stimulus :math:`xy`.
 
     Parameters
     ----------

--- a/colour/colorimetry/generation.py
+++ b/colour/colorimetry/generation.py
@@ -2,7 +2,8 @@
 Spectral Generation
 ===================
 
-Define various objects performing spectral generation:
+Define objects for generating spectral distributions and multi-spectral
+distributions with the specified characteristics.
 
 -   :func:`colour.sd_constant`
 -   :func:`colour.sd_zeros`
@@ -94,7 +95,7 @@ def sd_constant(
     k: float, shape: SpectralShape = SPECTRAL_SHAPE_DEFAULT, **kwargs: Any
 ) -> SpectralDistribution:
     """
-    Generate a spectral distribution of specified spectral shape filled with
+    Generate a spectral distribution of the specified spectral shape filled with
     constant :math:`k` values.
 
     Parameters
@@ -142,7 +143,7 @@ def sd_zeros(
     shape: SpectralShape = SPECTRAL_SHAPE_DEFAULT, **kwargs: Any
 ) -> SpectralDistribution:
     """
-    Generate a spectral distribution of specified spectral shape filled with
+    Generate a spectral distribution of the specified spectral shape filled with
     zeros.
 
     Parameters
@@ -159,7 +160,7 @@ def sd_zeros(
     Returns
     -------
     :class:`colour.SpectralDistribution`
-        Zeros filled spectral distribution.
+        Zeros-filled spectral distribution.
 
     Notes
     -----
@@ -183,8 +184,8 @@ def sd_ones(
     shape: SpectralShape = SPECTRAL_SHAPE_DEFAULT, **kwargs: Any
 ) -> SpectralDistribution:
     """
-    Generate a spectral distribution of specified spectral shape filled with
-    ones.
+    Generate a spectral distribution of the specified spectral shape filled
+    with ones.
 
     Parameters
     ----------
@@ -200,7 +201,7 @@ def sd_ones(
     Returns
     -------
     :class:`colour.SpectralDistribution`
-        Ones filled spectral distribution.
+        Ones-filled spectral distribution.
 
     Notes
     -----
@@ -227,8 +228,8 @@ def msds_constant(
     **kwargs: Any,
 ) -> MultiSpectralDistributions:
     """
-    Generate multi-spectral distributions with specified labels and specified
-    spectral shape filled with constant :math:`k` values.
+    Generate multi-spectral distributions with the specified labels and spectral
+    shape filled with constant :math:`k` values.
 
     Parameters
     ----------
@@ -253,8 +254,8 @@ def msds_constant(
 
     Notes
     -----
-    -   By default, the multi-spectral distributions will use the shape specified
-        by :attr:`colour.SPECTRAL_SHAPE_DEFAULT` attribute.
+    -   By default, the multi-spectral distributions will use the shape
+        specified by :attr:`colour.SPECTRAL_SHAPE_DEFAULT` attribute.
     -   The interpolator is set to :class:`colour.LinearInterpolator` class.
 
     Examples
@@ -283,8 +284,8 @@ def msds_zeros(
     **kwargs: Any,
 ) -> MultiSpectralDistributions:
     """
-    Generate multi-spectral distributions with specified labels and specified
-    spectral shape filled with zeros.
+    Generate multi-spectral distributions with the specified labels and spectral
+    shape filled with zeros.
 
     Parameters
     ----------
@@ -303,12 +304,12 @@ def msds_zeros(
     Returns
     -------
     :class:`colour.MultiSpectralDistributions`
-        Zeros filled multi-spectral distributions.
+        Zero-filled multi-spectral distributions.
 
     Notes
     -----
-    -   By default, the multi-spectral distributions will use the shape specified
-        by :attr:`colour.SPECTRAL_SHAPE_DEFAULT` attribute.
+    -   By default, the multi-spectral distributions will use the shape
+        specified by :attr:`colour.SPECTRAL_SHAPE_DEFAULT` attribute.
     -   The interpolator is set to :class:`colour.LinearInterpolator` class.
 
     Examples
@@ -331,7 +332,7 @@ def msds_ones(
     **kwargs: Any,
 ) -> MultiSpectralDistributions:
     """
-    Generate multi-spectral distributions with specified labels and specified
+    Generate multi-spectral distributions with the specified labels and
     spectral shape filled with ones.
 
     Parameters
@@ -351,13 +352,14 @@ def msds_ones(
     Returns
     -------
     :class:`colour.MultiSpectralDistributions`
-        Ones filled multi-spectral distributions.
+        Ones-filled multi-spectral distributions.
 
     Notes
     -----
-    -   By default, the multi-spectral distributions will use the shape specified
-        by :attr:`colour.SPECTRAL_SHAPE_DEFAULT` attribute.
-    -   The interpolator is set to :class:`colour.LinearInterpolator` class.
+    -   By default, the multi-spectral distributions will use the shape
+        specified by :attr:`colour.SPECTRAL_SHAPE_DEFAULT` attribute.
+    -   The interpolator is set to :class:`colour.LinearInterpolator`
+        class.
 
     Examples
     --------
@@ -379,18 +381,19 @@ def sd_gaussian_normal(
     shape: SpectralShape = SPECTRAL_SHAPE_DEFAULT,
     **kwargs: Any,
 ) -> SpectralDistribution:
-    """
-    Generate a gaussian spectral distribution of specified spectral shape at
-    specified mean wavelength :math:`\\mu` and standard deviation
-    :math:`sigma`.
+    r"""
+    Generate a Gaussian spectral distribution of the specified spectral shape at
+    specified mean wavelength :math:`\mu` and standard deviation
+    :math:`\sigma`.
 
     Parameters
     ----------
     mu
-        Mean wavelength :math:`\\mu` the gaussian spectral distribution will
-        peak at.
+        Mean wavelength :math:`\mu` at which the Gaussian spectral
+        distribution will peak.
     sigma
-        Standard deviation :math:`sigma` of the gaussian spectral distribution.
+        Standard deviation :math:`\sigma` of the Gaussian spectral
+        distribution.
     shape
         Spectral shape used to create the spectral distribution.
 
@@ -436,15 +439,15 @@ def sd_gaussian_fwhm(
     **kwargs: Any,
 ) -> SpectralDistribution:
     """
-    Generate a gaussian spectral distribution of specified spectral shape at
-    specified peak wavelength and full width at half maximum.
+    Generate a Gaussian spectral distribution of the specified spectral shape at
+    specified peak wavelength and full width at half maximum (FWHM).
 
     Parameters
     ----------
     peak_wavelength
-        Wavelength the gaussian spectral distribution will peak at.
+        Wavelength at which the Gaussian spectral distribution peaks.
     fwhm
-        Full width at half maximum, i.e., width of the gaussian spectral
+        Full width at half maximum, i.e., width of the Gaussian spectral
         distribution measured between those points on the *y* axis which are
         half the maximum amplitude.
     shape
@@ -490,7 +493,7 @@ SD_GAUSSIAN_METHODS: CanonicalMapping = CanonicalMapping(
     {"Normal": sd_gaussian_normal, "FWHM": sd_gaussian_fwhm}
 )
 SD_GAUSSIAN_METHODS.__doc__ = """
-Supported gaussian spectral distribution computation methods.
+Supported gaussian spectral distribution generation methods.
 """
 
 
@@ -502,19 +505,19 @@ def sd_gaussian(
     **kwargs: Any,
 ) -> SpectralDistribution:
     """
-    Return a gaussian spectral distribution of specified spectral shape using
-    specified method.
+    Generate a Gaussian spectral distribution with the specified spectral
+    shape using the specified method.
 
     Parameters
     ----------
     mu_peak_wavelength
-        Mean wavelength :math:`\\mu` the gaussian spectral distribution will
-        peak at.
+        Mean wavelength :math:`\\mu` at which the Gaussian spectral
+        distribution will peak.
     sigma_fwhm
-        Standard deviation :math:`sigma` of the gaussian spectral distribution
-        or full width at half maximum, i.e., width of the gaussian spectral
-        distribution measured between those points on the *y* axis which are
-        half the maximum amplitude.
+        Standard deviation :math:`\\sigma` of the Gaussian spectral
+        distribution or full width at half maximum (FWHM), i.e., the width
+        of the Gaussian spectral distribution measured between those points
+        on the *y* axis which are half the maximum amplitude.
     shape
         Spectral shape used to create the spectral distribution.
     method
@@ -534,8 +537,8 @@ def sd_gaussian(
 
     Notes
     -----
-    -   By default, the spectral distribution will use the shape specified by
-        :attr:`colour.SPECTRAL_SHAPE_DEFAULT` attribute.
+    -   By default, the spectral distribution will use the shape specified
+        by :attr:`colour.SPECTRAL_SHAPE_DEFAULT` attribute.
 
     Examples
     --------
@@ -567,14 +570,14 @@ def sd_single_led_Ohno2005(
     **kwargs: Any,
 ) -> SpectralDistribution:
     """
-    Return a single *LED* spectral distribution of specified spectral shape at
-    specified peak wavelength and half spectral width :math:`\\Delta\\lambda_{0.5}`
-    according to *Ohno (2005)* method.
+    Generate a single *LED* spectral distribution with the specified spectral
+    shape at specified peak wavelength and half spectral width
+    :math:`\\Delta\\lambda_{0.5}` using *Ohno (2005)* method.
 
     Parameters
     ----------
     peak_wavelength
-        Wavelength the single *LED* spectral distribution will peak at.
+        Wavelength at which the single *LED* spectral distribution peaks.
     half_spectral_width
         Half spectral width :math:`\\Delta\\lambda_{0.5}`.
     shape
@@ -593,8 +596,8 @@ def sd_single_led_Ohno2005(
 
     Notes
     -----
-    -   By default, the spectral distribution will use the shape specified by
-        :attr:`colour.SPECTRAL_SHAPE_DEFAULT` attribute.
+    -   By default, the spectral distribution will use the shape specified
+        by :attr:`colour.SPECTRAL_SHAPE_DEFAULT` attribute.
 
     References
     ----------
@@ -640,8 +643,8 @@ def sd_single_led(
     **kwargs: Any,
 ) -> SpectralDistribution:
     """
-    Return a single *LED* spectral distribution of specified spectral shape at
-    specified peak wavelength according to specified method.
+    Generate a single *LED* spectral distribution with the specified spectral
+    shape at the specified peak wavelength using the specified method.
 
     Parameters
     ----------
@@ -695,24 +698,27 @@ def sd_multi_leds_Ohno2005(
     **kwargs: Any,
 ) -> SpectralDistribution:
     """
-    Return a multi *LED* spectral distribution of specified spectral shape at
-    specified peak wavelengths, half spectral widths :math:`\\Delta\\lambda_{0.5}`
-    and peak power ratios according to *Ohno (2005)* method.
+    Generate a multi-*LED* spectral distribution with the specified spectral
+    shape at specified peak wavelengths, half spectral widths
+    :math:`\\Delta\\lambda_{0.5}`, and peak power ratios according to the
+    *Ohno (2005)* method.
 
-    The multi *LED* spectral distribution is generated using many single *LED*
-    spectral distributions generated with :func:`colour.sd_single_led_Ohno2005`
-    definition.
+    The multi-*LED* spectral distribution is computed by summing multiple
+    single *LED* spectral distributions generated with the
+    :func:`colour.sd_single_led_Ohno2005` function.
 
     Parameters
     ----------
     peak_wavelengths
-        Wavelengths the multi *LED* spectral distribution will peak at, i.e.,
-        the peaks for each generated single *LED* spectral distributions.
+        Wavelengths at which the multi-*LED* spectral distribution will
+        peak, i.e., the peak wavelengths for each constituent single *LED*
+        spectral distribution.
     half_spectral_widths
-        Half spectral widths :math:`\\Delta\\lambda_{0.5}`.
+        Half spectral widths :math:`\\Delta\\lambda_{0.5}` for each
+        constituent single *LED* spectral distribution.
     peak_power_ratios
-        Peak power ratios for each generated single *LED* spectral
-        distributions.
+        Peak power ratios for each constituent single *LED* spectral
+        distribution. If not specified, defaults to unity for all *LEDs*.
     shape
         Spectral shape used to create the spectral distribution.
 
@@ -725,12 +731,12 @@ def sd_multi_leds_Ohno2005(
     Returns
     -------
     :class:`colour.SpectralDistribution`
-        Multi *LED* spectral distribution.
+        Multi-*LED* spectral distribution.
 
     Notes
     -----
-    -   By default, the spectral distribution will use the shape specified by
-        :attr:`colour.SPECTRAL_SHAPE_DEFAULT` attribute.
+    -   By default, the spectral distribution will use the shape specified
+        by :attr:`colour.SPECTRAL_SHAPE_DEFAULT` attribute.
 
     References
     ----------
@@ -787,7 +793,7 @@ SD_MULTI_LEDS_METHODS: CanonicalMapping = CanonicalMapping(
     }
 )
 SD_MULTI_LEDS_METHODS.__doc__ = """
-Supported multi *LED* spectral distribution computation methods.
+Supported multi-*LED* spectral distribution computation methods.
 """
 
 
@@ -798,14 +804,15 @@ def sd_multi_leds(
     **kwargs: Any,
 ) -> SpectralDistribution:
     """
-    Return a multi *LED* spectral distribution of specified spectral shape at
-    specified peak wavelengths.
+    Generate a multi-*LED* spectral distribution with the specified spectral
+    shape at specified peak wavelengths.
 
     Parameters
     ----------
     peak_wavelengths
-        Wavelengths the multi *LED* spectral distribution will peak at, i.e.,
-        the peaks for each generated single *LED* spectral distributions.
+        Wavelengths at which the multi-*LED* spectral distribution will
+        peak, i.e., the peak wavelengths for each generated single *LED*
+        spectral distribution.
     shape
         Spectral shape used to create the spectral distribution.
     method
@@ -820,12 +827,12 @@ def sd_multi_leds(
     Returns
     -------
     :class:`colour.SpectralDistribution`
-        Multi *LED* spectral distribution.
+        Multi-*LED* spectral distribution.
 
     Notes
     -----
-    -   By default, the spectral distribution will use the shape specified by
-        :attr:`colour.SPECTRAL_SHAPE_DEFAULT` attribute.
+    -   By default, the spectral distribution will use the shape specified
+        by :attr:`colour.SPECTRAL_SHAPE_DEFAULT` attribute.
 
     References
     ----------

--- a/colour/colorimetry/illuminants.py
+++ b/colour/colorimetry/illuminants.py
@@ -2,7 +2,8 @@
 Illuminants
 ===========
 
-Define the *CIE* illuminants computation related objects:
+Define objects for computing *CIE* standard illuminants and related daylight
+calculations:
 
 -   :func:`colour.sd_CIE_standard_illuminant_A`
 -   :func:`colour.sd_CIE_illuminant_D_series`
@@ -62,13 +63,14 @@ def sd_CIE_standard_illuminant_A(
     shape: SpectralShape = SPECTRAL_SHAPE_DEFAULT,
 ) -> SpectralDistribution:
     """
-    *CIE Standard Illuminant A* is intended to represent typical, domestic,
-    tungsten-filament lighting.
+    Represent typical domestic tungsten-filament lighting according to
+    *CIE Standard Illuminant A*.
 
-    Its spectral distribution is that of a Planckian radiator at a temperature
-    of approximately 2856 K. *CIE Standard Illuminant A* should be used in all
-    applications of colorimetry involving the use of incandescent lighting,
-    unless there are specific reasons for using a different illuminant.
+    Generate spectral distribution of *CIE Standard Illuminant A*, which
+    represents the spectral characteristics of a Planckian radiator at a
+    temperature of approximately 2856 K. This illuminant should be used in
+    all colorimetry applications involving incandescent lighting, unless
+    there are specific reasons for using a different illuminant.
 
     Parameters
     ----------
@@ -79,7 +81,7 @@ def sd_CIE_standard_illuminant_A(
     Returns
     -------
     :class:`colour.SpectralDistribution`
-        *CIE Standard Illuminant A*. spectral distribution.
+        *CIE Standard Illuminant A* spectral distribution.
 
     References
     ----------
@@ -147,8 +149,8 @@ def sd_CIE_illuminant_D_series(
     shape: SpectralShape | None = None,
 ) -> SpectralDistribution:
     """
-    Return the spectral distribution of specified *CIE Illuminant D Series* using
-    specified *CIE xy* chromaticity coordinates.
+    Return the spectral distribution of the specified *CIE Illuminant D
+    Series* using the specified *CIE xy* chromaticity coordinates.
 
     Parameters
     ----------
@@ -168,12 +170,12 @@ def sd_CIE_illuminant_D_series(
 
     Notes
     -----
-    -   The nominal *CIE xy* chromaticity coordinates which have been computed
-        with :func:`colour.temperature.CCT_to_xy_CIE_D` must be specified according
-        to *CIE 015:2004* recommendation and thus multiplied by
-        1.4388 / 1.4380.
+    -   The nominal *CIE xy* chromaticity coordinates which have been
+        computed with :func:`colour.temperature.CCT_to_xy_CIE_D` must be
+        specified according to *CIE 015:2004* recommendation and thus
+        multiplied by 1.4388 / 1.4380.
     -   :math:`M1` and :math:`M2` variables are rounded to 3 decimal places
-         according to *CIE 015:2004* recommendation.
+        according to *CIE 015:2004* recommendation.
 
     References
     ----------
@@ -333,17 +335,23 @@ def sd_CIE_illuminant_D_series(
 
 def daylight_locus_function(x_D: ArrayLike) -> NDArrayFloat:
     """
-    Return the daylight locus as *CIE xy* chromaticity coordinates.
+    Compute the *CIE y* chromaticity coordinate on the daylight locus.
+
+    Calculate the *CIE y* chromaticity coordinate on the daylight locus
+    for the specified *CIE x* chromaticity coordinate :math:`x_D` using
+    the quadratic relationship defined by *Wyszecki and Stiles*.
 
     Parameters
     ----------
     x_D
-        Chromaticity coordinate :math:`x_D`.
+        *CIE x* chromaticity coordinate :math:`x_D` for which to compute
+        the corresponding *CIE y* coordinate on the daylight locus.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Daylight locus as *CIE xy* chromaticity coordinates.
+        *CIE y* chromaticity coordinate on the daylight locus
+        corresponding to the specified :math:`x_D`.
 
     References
     ----------

--- a/colour/colorimetry/lefs.py
+++ b/colour/colorimetry/lefs.py
@@ -2,7 +2,8 @@
 Luminous Efficiency Functions Spectral Distributions
 ====================================================
 
-Define the luminous efficiency functions computation related objects.
+Define the luminous efficiency functions and their computation objects for
+photopic, scotopic, and mesopic vision conditions.
 
 References
 ----------
@@ -50,8 +51,13 @@ def mesopic_weighting_function(
     scotopic_lef: SpectralDistribution | None = None,
 ) -> NDArrayFloat:
     """
-    Calculate the mesopic weighting function factor :math:`V_m` at specified
-    wavelength :math:`\\lambda` using the photopic luminance :math:`L_p`.
+    Calculate the mesopic weighting function factor :math:`V_m` at the specified
+    wavelength :math:`\\lambda` using the specified photopic luminance
+    :math:`L_p`.
+
+    The mesopic weighting function provides a transition between photopic and
+    scotopic vision, accounting for the combined response of rods and cones
+    under intermediate lighting conditions.
 
     Parameters
     ----------
@@ -65,11 +71,11 @@ def mesopic_weighting_function(
     method
         Method to calculate the weighting factor.
     photopic_lef
-        :math:`V(\\lambda)` photopic luminous efficiency function, default to
+        :math:`V(\\lambda)` photopic luminous efficiency function, defaults to
         the *CIE 1924 Photopic Standard Observer*.
     scotopic_lef
         :math:`V^\\prime(\\lambda)` scotopic luminous efficiency function,
-        default to the *CIE 1951 Scotopic Standard Observer*.
+        defaults to the *CIE 1951 Scotopic Standard Observer*.
 
     Returns
     -------
@@ -119,7 +125,7 @@ def sd_mesopic_luminous_efficiency_function(
 ) -> SpectralDistribution:
     """
     Return the mesopic luminous efficiency function :math:`V_m(\\lambda)` for
-    specified photopic luminance :math:`L_p`.
+    the specified photopic luminance :math:`L_p`.
 
     Parameters
     ----------

--- a/colour/colorimetry/lightness.py
+++ b/colour/colorimetry/lightness.py
@@ -2,31 +2,31 @@
 Lightness :math:`L`
 ===================
 
-Define the *Lightness* :math:`L` computation objects.
-
-The following methods are available:
+Define the *lightness* :math:`L` computation methods.
 
 -   :func:`colour.colorimetry.lightness_Glasser1958`: *Lightness* :math:`L`
-    computation of specified *luminance* :math:`Y` using
+    computation of the specified *luminance* :math:`Y` using
     *Glasser, Mckinney, Reilly and Schnelle (1958)* method.
--   :func:`colour.colorimetry.lightness_Wyszecki1963`: *Lightness* :math:`W`
-    computation of specified *luminance* :math:`Y` using *Wyszecki (1963)* method.
+-   :func:`colour.colorimetry.lightness_Wyszecki1963`: *Lightness*
+    :math:`W` computation of the specified *luminance* :math:`Y` using
+    *Wyszecki (1963)* method.
 -   :func:`colour.colorimetry.lightness_CIE1976`: *Lightness* :math:`L^*`
-    computation of specified *luminance* :math:`Y` as per *CIE 1976*
+    computation of the specified *luminance* :math:`Y` as per *CIE 1976*
     recommendation.
 -   :func:`colour.colorimetry.lightness_Fairchild2010`: *Lightness*
-    :math:`L_{hdr}` computation of specified *luminance* :math:`Y` using
+    :math:`L_{hdr}` computation of the specified *luminance* :math:`Y` using
     *Fairchild and Wyble (2010)* method.
 -   :func:`colour.colorimetry.lightness_Fairchild2011`: *Lightness*
-    :math:`L_{hdr}` computation of specified *luminance* :math:`Y` using
+    :math:`L_{hdr}` computation of the specified *luminance* :math:`Y` using
     *Fairchild and Chen (2011)* method.
 -   :func:`colour.colorimetry.lightness_Abebe2017`: *Lightness* :math:`L`
-    computation of specified *luminance* :math:`Y` using
-    *Abebe, Pouli, Larabi and Reinhard (2017)* method.
+    computation of the specified *luminance* :math:`Y` using
+    *Abebe, Pouli, Larabi and Reinhard (2017)* adaptive method for
+    high-dynamic-range imaging.
 -   :attr:`colour.LIGHTNESS_METHODS`: Supported *Lightness* :math:`L`
     computation methods.
--   :func:`colour.lightness`: *Lightness* :math:`L` computation of specified
-    *luminance* :math:`Y` using specified method.
+-   :func:`colour.lightness`: *Lightness* :math:`L` computation of
+    specified *luminance* :math:`Y` using the specified method.
 
 References
 ----------
@@ -110,8 +110,8 @@ __all__ = [
 
 def lightness_Glasser1958(Y: ArrayLike) -> NDArrayFloat:
     """
-    Compute the *Lightness* :math:`L` of specified *luminance* :math:`Y` using
-    *Glasser et al. (1958)* method.
+    Compute *lightness* :math:`L` from the specified *luminance* :math:`Y` using
+    the *Glasser et al. (1958)* method.
 
     Parameters
     ----------
@@ -156,9 +156,8 @@ def lightness_Glasser1958(Y: ArrayLike) -> NDArrayFloat:
 
 def lightness_Wyszecki1963(Y: ArrayLike) -> NDArrayFloat:
     """
-    Compute the *Lightness* :math:`W` of specified *luminance* :math:`Y` using
-    *Wyszecki (1963)* method.
-
+    Compute *lightness* :math:`W` from the specified *luminance* :math:`Y`
+    using the *Wyszecki (1963)* method.
 
     Parameters
     ----------
@@ -211,9 +210,9 @@ def intermediate_lightness_function_CIE1976(
     Y: ArrayLike, Y_n: ArrayLike = 100
 ) -> NDArrayFloat:
     """
-    Compute the intermediate value :math:`f(Y/Yn)` in the *Lightness*
-    :math:`L^*` computation for specified *luminance* :math:`Y` using specified
-    reference white *luminance* :math:`Y_n` as per *CIE 1976* recommendation.
+    Compute the intermediate value :math:`f(Y/Y_n)` from the specified *luminance*
+    :math:`Y` using the specified reference white *luminance* :math:`Y_n` as per
+    *CIE 1976* recommendation.
 
     Parameters
     ----------
@@ -225,7 +224,7 @@ def intermediate_lightness_function_CIE1976(
     Returns
     -------
     :class:`numpy.ndarray`
-        Intermediate value :math:`f(Y/Yn)`.
+        Intermediate value :math:`f(Y/Y_n)`.
 
     Notes
     -----
@@ -271,8 +270,8 @@ def intermediate_lightness_function_CIE1976(
 
 def lightness_CIE1976(Y: ArrayLike, Y_n: ArrayLike = 100) -> NDArrayFloat:
     """
-    Compute the *Lightness* :math:`L^*` of specified *luminance* :math:`Y` using
-    specified reference white *luminance* :math:`Y_n` as per *CIE 1976*
+    Compute the *lightness* :math:`L^*` of the specified *luminance* :math:`Y`
+    using the specified reference white *luminance* :math:`Y_n` as per *CIE 1976*
     recommendation.
 
     Parameters
@@ -321,8 +320,8 @@ def lightness_CIE1976(Y: ArrayLike, Y_n: ArrayLike = 100) -> NDArrayFloat:
 
 def lightness_Fairchild2010(Y: ArrayLike, epsilon: ArrayLike = 1.836) -> NDArrayFloat:
     """
-    Compute *Lightness* :math:`L_{hdr}` of specified *luminance* :math:`Y` using
-    *Fairchild and Wyble (2010)* method according to *Michaelis-Menten*
+    Compute *lightness* :math:`L_{hdr}` from the specified *luminance* :math:`Y`
+    using *Fairchild and Wyble (2010)* method according to *Michaelis-Menten*
     kinetics.
 
     Parameters
@@ -381,8 +380,8 @@ def lightness_Fairchild2011(
     method: Literal["hdr-CIELAB", "hdr-IPT"] | str = "hdr-CIELAB",
 ) -> NDArrayFloat:
     """
-    Compute *Lightness* :math:`L_{hdr}` of specified *luminance* :math:`Y` using
-    *Fairchild and Chen (2011)* method according to *Michaelis-Menten*
+    Compute *lightness* :math:`L_{hdr}` from the specified *luminance* :math:`Y`
+    using *Fairchild and Chen (2011)* method according to *Michaelis-Menten*
     kinetics.
 
     Parameters
@@ -447,9 +446,10 @@ def lightness_Abebe2017(
     method: Literal["Michaelis-Menten", "Stevens"] | str = "Michaelis-Menten",
 ) -> NDArrayFloat:
     """
-    Compute *Lightness* :math:`L` of specified *luminance* :math:`Y` using
-    *Abebe, Pouli, Larabi and Reinhard (2017)* method according to
-    *Michaelis-Menten* kinetics or *Stevens's Power Law*.
+    Compute *lightness* :math:`L` from the specified *luminance* :math:`Y` using
+    *Abebe, Pouli, Larabi and Reinhard (2017)* adaptive method for
+    high-dynamic-range imaging according to *Michaelis-Menten* kinetics or
+    *Stevens's Power Law*.
 
     Parameters
     ----------
@@ -468,9 +468,9 @@ def lightness_Abebe2017(
     Notes
     -----
     -   *Abebe, Pouli, Larabi and Reinhard (2017)* method uses absolute
-        luminance levels, thus the domain and range values for the *Reference*
-        and *1* scales are only indicative that the data is not affected by
-        scale transformations.
+        luminance levels, thus the domain and range values for the
+        *Reference* and *1* scales are only indicative that the data is
+        not affected by scale transformations.
 
     +------------+-----------------------+---------------+
     | **Domain** | **Scale - Reference** | **Scale - 1** |
@@ -535,7 +535,7 @@ LIGHTNESS_METHODS: CanonicalMapping = CanonicalMapping(
     }
 )
 LIGHTNESS_METHODS.__doc__ = """
-Supported *Lightness* computation methods.
+Supported *lightness* computation methods.
 
 References
 ----------
@@ -565,8 +565,7 @@ def lightness(
     **kwargs: Any,
 ) -> NDArrayFloat:
     """
-    Compute the *Lightness* :math:`L` of specified *luminance* :math:`Y` using
-    specified method.
+    Compute the *lightness* :math:`L` from the specified *luminance* :math:`Y`.
 
     Parameters
     ----------

--- a/colour/colorimetry/luminance.py
+++ b/colour/colorimetry/luminance.py
@@ -2,32 +2,30 @@
 Luminance :math:`Y`
 ===================
 
-Define the *luminance* :math:`Y` computation objects.
+Define *luminance* :math:`Y` computation methods.
 
-The following methods are available:
-
--   :func:`colour.colorimetry.luminance_Newhall1943`: *luminance* :math:`Y`
-    computation of specified *Munsell* value :math:`V` using
-    *Newhall, Nickerson and Judd (1943)* method.
--   :func:`colour.colorimetry.luminance_ASTMD1535`: *luminance* :math:`Y`
-    computation of specified *Munsell* value :math:`V` using *ASTM D1535-08e1*
-    method.
--   :func:`colour.colorimetry.luminance_CIE1976`: *luminance* :math:`Y`
-    computation of specified *Lightness* :math:`L^*` as per *CIE 1976*
-    recommendation.
--   :func:`colour.colorimetry.luminance_Fairchild2010`: *luminance* :math:`Y`
-    computation of specified *Lightness* :math:`L_{hdr}` using
-    *Fairchild and Wyble (2010)* method.
--   :func:`colour.colorimetry.luminance_Fairchild2011`: *luminance* :math:`Y`
-    computation of specified *Lightness* :math:`L_{hdr}` using
-    *Fairchild and Chen (2011)* method.
--   :func:`colour.colorimetry.luminance_Abebe2017`: *Luminance* :math:`Y`
-    computation of specified *Lightness* :math:`L` using
-    *Abebe, Pouli, Larabi and Reinhard (2017)* method.
+-   :func:`colour.colorimetry.luminance_Newhall1943`: Compute *luminance*
+    :math:`Y` from *Munsell* value :math:`V` using *Newhall, Nickerson and
+    Judd (1943)* polynomial approximation.
+-   :func:`colour.colorimetry.luminance_ASTMD1535`: Compute *luminance*
+    :math:`Y` from *Munsell* value :math:`V` using *ASTM D1535-08e1*
+    standard polynomial.
+-   :func:`colour.colorimetry.luminance_CIE1976`: Compute *luminance*
+    :math:`Y` from *CIE 1976* *Lightness* :math:`L^*` using the inverse
+    of the standard lightness function.
+-   :func:`colour.colorimetry.luminance_Fairchild2010`: Compute *luminance*
+    :math:`Y` from *lightness* :math:`L_{hdr}` using *Fairchild and
+    Wyble (2010)* method according to *Michaelis-Menten* kinetics.
+-   :func:`colour.colorimetry.luminance_Fairchild2011`: Compute *luminance*
+    :math:`Y` from *lightness* :math:`L_{hdr}` using *Fairchild and
+    Chen (2011)* method according to *Michaelis-Menten* kinetics.
+-   :func:`colour.colorimetry.luminance_Abebe2017`: Compute *luminance*
+    :math:`Y` from *lightness* :math:`L` using *Abebe, Pouli, Larabi and
+    Reinhard (2017)* adaptive method for high-dynamic-range imaging.
 -   :attr:`colour.LUMINANCE_METHODS`: Supported *luminance* :math:`Y`
-    computation methods.
--   :func:`colour.luminance`: *Luminance* :math:`Y` computation of specified
-    *Lightness* :math:`L^*` or specified *Munsell* value :math:`V` using specified
+    computation methods registry.
+-   :func:`colour.luminance`: Compute *luminance* :math:`Y` from
+    *Lightness* :math:`L^*` or *Munsell* value :math:`V` using the specified
     method.
 
 References
@@ -111,8 +109,8 @@ __all__ = [
 
 def luminance_Newhall1943(V: ArrayLike) -> NDArrayFloat:
     """
-    Compute the *luminance* :math:`R_Y` of specified *Munsell* value :math:`V`
-    using *Newhall et al. (1943)* method.
+    Compute the *luminance* :math:`R_Y` from the specified *Munsell* value
+    :math:`V` using *Newhall et al. (1943)* method.
 
     Parameters
     ----------
@@ -163,8 +161,8 @@ def luminance_Newhall1943(V: ArrayLike) -> NDArrayFloat:
 
 def luminance_ASTMD1535(V: ArrayLike) -> NDArrayFloat:
     """
-    Compute the *luminance* :math:`Y` of specified *Munsell* value :math:`V` using
-    *ASTM D1535-08e1* method.
+    Compute *luminance* :math:`Y` from the specified *Munsell* value :math:`V`
+    using *ASTM D1535-08e1* method.
 
     Parameters
     ----------
@@ -217,14 +215,14 @@ def intermediate_luminance_function_CIE1976(
     f_Y_Y_n: ArrayLike, Y_n: ArrayLike = 100
 ) -> NDArrayFloat:
     """
-    Compute the *luminance* :math:`Y` in the *luminance* :math:`Y`
-    computation for specified intermediate value :math:`f(Y/Yn)` using specified
-    reference white *luminance* :math:`Y_n` as per *CIE 1976* recommendation.
+    Compute *luminance* :math:`Y` from the specified intermediate value
+    :math:`f(Y/Y_n)` using the specified reference white *luminance* :math:`Y_n`
+    as per *CIE 1976* recommendation.
 
     Parameters
     ----------
     f_Y_Y_n
-        Intermediate value :math:`f(Y/Yn)`.
+        Intermediate value :math:`f(Y/Y_n)`.
     Y_n
         White reference *luminance* :math:`Y_n`.
 
@@ -275,13 +273,13 @@ def intermediate_luminance_function_CIE1976(
 
 def luminance_CIE1976(L_star: ArrayLike, Y_n: ArrayLike = 100) -> NDArrayFloat:
     """
-    Compute the *luminance* :math:`Y` of specified *Lightness* :math:`L^*` with
-    specified reference white *luminance* :math:`Y_n`.
+    Compute the *luminance* :math:`Y` from the specified *lightness* :math:`L^*`
+    with the specified reference white *luminance* :math:`Y_n`.
 
     Parameters
     ----------
     L_star
-        *Lightness* :math:`L^*`
+        *Lightness* :math:`L^*`.
     Y_n
         White reference *luminance* :math:`Y_n`.
 
@@ -330,8 +328,8 @@ def luminance_Fairchild2010(
     L_hdr: ArrayLike, epsilon: ArrayLike = 1.836
 ) -> NDArrayFloat:
     """
-    Compute *luminance* :math:`Y` of specified *Lightness* :math:`L_{hdr}` using
-    *Fairchild and Wyble (2010)* method according to *Michaelis-Menten*
+    Compute *luminance* :math:`Y` from the specified *lightness* :math:`L_{hdr}`
+    using *Fairchild and Wyble (2010)* method according to *Michaelis-Menten*
     kinetics.
 
     Parameters
@@ -391,8 +389,8 @@ def luminance_Fairchild2011(
     method: Literal["hdr-CIELAB", "hdr-IPT"] | str = "hdr-CIELAB",
 ) -> NDArrayFloat:
     """
-    Compute *luminance* :math:`Y` of specified *Lightness* :math:`L_{hdr}` using
-    *Fairchild and Chen (2011)* method according to *Michaelis-Menten*
+    Compute *luminance* :math:`Y` from the specified *lightness* :math:`L_{hdr}`
+    using *Fairchild and Chen (2011)* method according to *Michaelis-Menten*
     kinetics.
 
     Parameters
@@ -459,9 +457,10 @@ def luminance_Abebe2017(
     method: Literal["Michaelis-Menten", "Stevens"] | str = "Michaelis-Menten",
 ) -> NDArrayFloat:
     """
-    Compute *luminance* :math:`Y` of *Lightness* :math:`L` using
-    *Abebe, Pouli, Larabi and Reinhard (2017)* method according to
-    *Michaelis-Menten* kinetics or *Stevens's Power Law*.
+    Compute *luminance* :math:`Y` from *lightness* :math:`L` using
+    *Abebe, Pouli, Larabi and Reinhard (2017)* adaptive method for
+    high-dynamic-range imaging according to *Michaelis-Menten* kinetics or
+    *Stevens's Power Law*.
 
     Parameters
     ----------
@@ -480,9 +479,9 @@ def luminance_Abebe2017(
     Notes
     -----
     -   *Abebe, Pouli, Larabi and Reinhard (2017)* method uses absolute
-        luminance levels, thus the domain and range values for the *Reference*
-        and *1* scales are only indicative that the data is not affected by
-        scale transformations.
+        luminance levels, thus the domain and range values for the
+        *Reference* and *1* scales are only indicative that the data is not
+        affected by scale transformations.
 
     +------------+-----------------------+---------------+
     | **Domain** | **Scale - Reference** | **Scale - 1** |
@@ -557,8 +556,9 @@ Supported *luminance* computation methods.
 
 References
 ----------
-:cite:`ASTMInternational2008a`, :cite:`CIETC1-482004m`, :cite:`Fairchild2010`,
-:cite:`Fairchild2011`, :cite:`Newhall1943a`, :cite:`Wyszecki2000bd`
+:cite:`ASTMInternational2008a`, :cite:`CIETC1-482004m`,
+:cite:`Fairchild2010`, :cite:`Fairchild2011`, :cite:`Newhall1943a`,
+:cite:`Wyszecki2000bd`
 
 Aliases:
 
@@ -585,8 +585,8 @@ def luminance(
     **kwargs: Any,
 ) -> NDArrayFloat:
     """
-    Compute the *luminance* :math:`Y` of specified *Lightness* :math:`L^*` or specified
-    *Munsell* value :math:`V`.
+    Compute the *luminance* :math:`Y` from the specified *lightness*
+    :math:`L^*` or *Munsell* value :math:`V`.
 
     Parameters
     ----------
@@ -602,8 +602,8 @@ def luminance(
         :func:`colour.colorimetry.luminance_CIE1976`},
         White reference *luminance* :math:`Y_n`.
     epsilon
-        {:func:`colour.colorimetry.lightness_Fairchild2010`,
-        :func:`colour.colorimetry.lightness_Fairchild2011`},
+        {:func:`colour.colorimetry.luminance_Fairchild2010`,
+        :func:`colour.colorimetry.luminance_Fairchild2011`},
         :math:`\\epsilon` exponent.
 
     Returns
@@ -627,9 +627,9 @@ def luminance(
 
     References
     ----------
-    :cite:`Abebe2017`, :cite:`ASTMInternational2008a`, :cite:`CIETC1-482004m`,
-    :cite:`Fairchild2010`, :cite:`Fairchild2011`, :cite:`Newhall1943a`,
-    :cite:`Wikipedia2001b`, :cite:`Wyszecki2000bd`
+    :cite:`Abebe2017`, :cite:`ASTMInternational2008a`,
+    :cite:`CIETC1-482004m`, :cite:`Fairchild2010`, :cite:`Fairchild2011`,
+    :cite:`Newhall1943a`, :cite:`Wikipedia2001b`, :cite:`Wyszecki2000bd`
 
     Examples
     --------

--- a/colour/colorimetry/photometry.py
+++ b/colour/colorimetry/photometry.py
@@ -80,7 +80,7 @@ def luminous_flux(
         extrapolator_kwargs={"method": "Constant", "left": 0, "right": 0},
     )
 
-    flux = K_m * np.trapezoid(lef.values * sd.values, sd.wavelengths)  # pyright: ignore
+    flux = K_m * np.trapezoid(lef.values * sd.values, sd.wavelengths)
 
     return as_float_scalar(flux)
 
@@ -126,9 +126,7 @@ def luminous_efficiency(
         extrapolator_kwargs={"method": "Constant", "left": 0, "right": 0},
     )
 
-    efficiency = np.trapezoid(  # pyright: ignore
-        lef.values * sd.values, sd.wavelengths
-    ) / np.trapezoid(  # pyright: ignore
+    efficiency = np.trapezoid(lef.values * sd.values, sd.wavelengths) / np.trapezoid(
         sd.values, sd.wavelengths
     )
 

--- a/colour/colorimetry/photometry.py
+++ b/colour/colorimetry/photometry.py
@@ -2,7 +2,7 @@
 Photometry
 ==========
 
-Define the photometric quantities computation related objects.
+Define photometric quantities computation objects.
 
 References
 ----------
@@ -41,23 +41,23 @@ def luminous_flux(
     K_m: float = CONSTANT_K_M,
 ) -> float:
     """
-    Compute the *luminous flux* for specified spectral distribution using specified
-    luminous efficiency function.
+    Compute the *luminous flux* for the specified spectral distribution
+    using the specified *luminous efficiency* function.
 
     Parameters
     ----------
     sd
-        test spectral distribution
+        Spectral distribution to compute the *luminous flux* for.
     lef
-        :math:`V(\\lambda)` luminous efficiency function, default to the
+        :math:`V(\\lambda)` *luminous efficiency* function, defaults to the
         *CIE 1924 Photopic Standard Observer*.
     K_m
-        :math:`lm\\cdot W^{-1}` maximum photopic luminous efficiency.
+        :math:`lm\\cdot W^{-1}` maximum photopic luminous efficacy.
 
     Returns
     -------
     :class:`float`
-        Luminous flux.
+        *Luminous flux* in lumens.
 
     References
     ----------
@@ -89,21 +89,26 @@ def luminous_efficiency(
     sd: SpectralDistribution, lef: SpectralDistribution | None = None
 ) -> float:
     """
-    Compute the *luminous efficiency* of specified spectral distribution using
+    Compute the *luminous efficiency* of the specified spectral distribution using
     specified luminous efficiency function.
+
+    The *luminous efficiency* quantifies the ratio of *luminous flux* to
+    *radiant flux* for a light source, representing how efficiently radiant
+    energy is converted to luminous energy as perceived by the human visual
+    system.
 
     Parameters
     ----------
     sd
-        test spectral distribution
+        Test spectral distribution to evaluate.
     lef
-        :math:`V(\\lambda)` luminous efficiency function, default to the
+        :math:`V(\\lambda)` *luminous efficiency* function, defaults to the
         *CIE 1924 Photopic Standard Observer*.
 
     Returns
     -------
     :class:`float`
-        Luminous efficiency.
+        *Luminous efficiency*.
 
     References
     ----------
@@ -137,21 +142,26 @@ def luminous_efficacy(
     sd: SpectralDistribution, lef: SpectralDistribution | None = None
 ) -> float:
     """
-    Compute the *luminous efficacy* in :math:`lm\\cdot W^{-1}` of specified
-    spectral distribution using specified luminous efficiency function.
+    Compute the *luminous efficacy* in :math:`lm\\cdot W^{-1}` of the
+    specified spectral distribution using the specified *luminous efficiency*
+    function.
+
+    *Luminous efficacy* quantifies how effectively a light source converts
+    radiant power into *luminous flux* as perceived by the human visual
+    system.
 
     Parameters
     ----------
     sd
-        test spectral distribution
+        Test spectral distribution to evaluate.
     lef
-        :math:`V(\\lambda)` luminous efficiency function, default to the
+        :math:`V(\\lambda)` *luminous efficiency* function, defaults to the
         *CIE 1924 Photopic Standard Observer*.
 
     Returns
     -------
     :class:`float`
-        Luminous efficacy in :math:`lm\\cdot W^{-1}`.
+        *Luminous efficacy* in :math:`lm\\cdot W^{-1}`.
 
     References
     ----------

--- a/colour/colorimetry/spectrum.py
+++ b/colour/colorimetry/spectrum.py
@@ -2,7 +2,7 @@
 Spectrum
 ========
 
-Define the classes and objects handling spectral data computations:
+Define classes and objects for handling spectral data computations.
 
 -   :class:`colour.SPECTRAL_SHAPE_DEFAULT`
 -   :class:`colour.SpectralShape`
@@ -114,6 +114,11 @@ class SpectralShape:
     """
     Define the base object for spectral distribution shape.
 
+    The :class:`colour.SpectralShape` class represents the shape of spectral
+    data by defining its wavelength range and sampling interval. It provides
+    a structured way to handle spectral data boundaries and generate
+    wavelength arrays for spectral computations.
+
     Parameters
     ----------
     start
@@ -161,17 +166,17 @@ class SpectralShape:
     @property
     def start(self) -> Real:
         """
-        Getter and setter property for the spectral shape start.
+        Getter and setter for the spectral shape start.
 
         Parameters
         ----------
         value
-            Value to set the spectral shape start with.
+            Value to set the spectral shape start wavelength with.
 
         Returns
         -------
         Real
-            Spectral shape start.
+            Start wavelength of the spectral shape in nanometres.
         """
 
         return self._start
@@ -195,17 +200,18 @@ class SpectralShape:
     @property
     def end(self) -> Real:
         """
-        Getter and setter property for the spectral shape end.
+         Getter and setter for the spectral shape end.
 
         Parameters
         ----------
-        value
-            Value to set the spectral shape end with.
+         value
+             Value to set the spectral shape end wavelength with.
 
         Returns
         -------
-        Real
-            Spectral shape end.
+         Real
+             End wavelength of the spectral shape in nanometres.
+        .
         """
 
         return self._end
@@ -229,7 +235,10 @@ class SpectralShape:
     @property
     def interval(self) -> Real:
         """
-        Getter and setter property for the spectral shape interval.
+        Getter and setter for the spectral shape interval.
+
+        The interval defines the wavelength spacing between consecutive
+        samples in the spectral distribution.
 
         Parameters
         ----------
@@ -258,7 +267,10 @@ class SpectralShape:
     @property
     def boundaries(self) -> tuple:
         """
-        Getter and setter property for the spectral shape boundaries.
+        Getter and setter for the boundaries of the spectral shape.
+
+        The boundaries define the start and end points of the spectral
+        range as a tuple of two values.
 
         Parameters
         ----------
@@ -289,7 +301,7 @@ class SpectralShape:
     @property
     def wavelengths(self) -> NDArrayFloat:
         """
-        Getter property for the spectral shape wavelengths.
+        Getter for the spectral shape wavelengths.
 
         Returns
         -------
@@ -325,24 +337,27 @@ class SpectralShape:
 
     def __hash__(self) -> int:
         """
-        Return the spectral shape hash.
+        Return the hash value of the spectral shape.
+
+        The hash is computed based on the spectral shape's start wavelength,
+        end wavelength, and wavelength interval.
 
         Returns
         -------
         :class:`int`
-            Object hash.
+            Hash value of the spectral shape.
         """
 
         return hash((self.start, self.end, self.interval))
 
     def __iter__(self) -> Generator:
         """
-        Return a generator for the spectral shape data.
+        Generate wavelengths for the spectral shape range.
 
         Yields
         ------
         Generator
-            Spectral shape data generator.
+            Wavelength values from start to end at the specified interval.
 
         Examples
         --------
@@ -366,19 +381,19 @@ class SpectralShape:
 
     def __contains__(self, wavelength: ArrayLike) -> bool:
         """
-        Return if the spectral shape contains specified wavelength
+        Determine if the spectral shape contains the specified wavelength
         :math:`\\lambda`.
 
         Parameters
         ----------
         wavelength
-            Wavelength :math:`\\lambda`.
+            Wavelength :math:`\\lambda` to check for containment.
 
         Returns
         -------
         :class:`bool`
-            Whether wavelength :math:`\\lambda` is contained in the spectral
-            shape.
+            Whether  the wavelength :math:`\\lambda` is contained within the
+            spectral shape.
 
         Examples
         --------
@@ -430,17 +445,18 @@ class SpectralShape:
 
     def __eq__(self, other: object) -> bool:
         """
-        Return whether the spectral shape is equal to specified other object.
+        Determine whether the spectral shape is equal to the specified other
+        object.
 
         Parameters
         ----------
         other
-            Object to test whether it is equal to the spectral shape.
+            Object to determine whether it is equal to the spectral shape.
 
         Returns
         -------
         :class:`bool`
-            Whether specified object is equal to the spectral shape.
+            Whether the specified object is equal to the spectral shape.
 
         Examples
         --------
@@ -457,17 +473,20 @@ class SpectralShape:
 
     def __ne__(self, other: object) -> bool:
         """
-        Return whether the spectral shape is not equal to specified other object.
+        Determine whether the spectral shape is not equal to the specified
+        other object.
 
         Parameters
         ----------
         other
-            Object to test whether it is not equal to the spectral shape.
+            Object to determine whether it is not equal to the spectral
+            shape.
 
         Returns
         -------
         :class:`bool`
-            Whether specified object is not equal to the spectral shape.
+            Whether the specified object is not equal to the spectral
+            shape.
 
         Examples
         --------
@@ -491,7 +510,7 @@ class SpectralShape:
         Returns
         -------
         :class:`numpy.ndarray`
-            Iterable range for the spectral distribution shape
+            Iterable range for the spectral distribution shape.
 
         Examples
         --------
@@ -549,16 +568,16 @@ class SpectralDistribution(Signal):
     Define the spectral distribution: the base object for spectral
     computations.
 
-    The spectral distribution will be initialised according to *CIE 15:2004*
-    recommendation: the method developed by *Sprague (1880)* will be used for
-    interpolating functions having a uniformly spaced independent variable and
-    the *Cubic Spline* method for non-uniformly spaced independent variable.
-    Extrapolation is performed according to *CIE 167:2005* recommendation.
+    Initialise spectral distribution according to *CIE 15:2004* recommendation:
+    use the method developed by *Sprague (1880)* for interpolating functions
+    having uniformly spaced independent variables and the *Cubic Spline* method
+    for non-uniformly spaced independent variables. Perform extrapolation
+    according to *CIE 167:2005* recommendation.
 
     .. important::
 
-        Specific documentation about getting, setting, indexing and slicing the
-        spectral power distribution values is available in the
+        Specific documentation about getting, setting, indexing and slicing
+        the spectral power distribution values is available in the
         :ref:`spectral-representation-and-continuous-signal` section.
 
     Parameters
@@ -568,8 +587,8 @@ class SpectralDistribution(Signal):
     domain
         Values to initialise the
         :attr:`colour.SpectralDistribution.wavelength` property with.
-        If both ``data`` and ``domain`` arguments are defined, the latter will
-        be used to initialise the
+        If both ``data`` and ``domain`` arguments are defined, the latter
+        will be used to initialise the
         :attr:`colour.SpectralDistribution.wavelength` property.
 
     Other Parameters
@@ -714,7 +733,28 @@ class SpectralDistribution(Signal):
     def _on_domain_changed(
         sd: SpectralDistribution, name: str, value: NDArrayFloat
     ) -> NDArrayFloat:
-        """Invalidate *sd._shape* when *sd._domain* is changed."""
+        """
+        Invalidate the cached spectral shape when the spectral
+        distribution domain is modified.
+
+        This callback ensures that the internal *_shape* attribute is reset
+        to *None* whenever the domain values change, maintaining consistency
+        between the domain and its derived shape representation.
+
+        Parameters
+        ----------
+        sd
+            Spectral distribution instance whose domain has changed.
+        name
+            Name of the modified attribute (expected to be "_domain").
+        value
+            New domain values that triggered the callback.
+
+        Returns
+        -------
+        :class:`numpy.ndarray`
+            The specified domain values, unchanged.
+        """
 
         if name == "_domain":
             sd._shape = None
@@ -724,17 +764,21 @@ class SpectralDistribution(Signal):
     @property
     def display_name(self) -> str:
         """
-        Getter and setter property for the spectral distribution display name.
+        Getter and setter for the spectral distribution's display name.
+
+        The display name provides a human-readable identifier for the
+        spectral distribution, used for visualization and reporting purposes.
 
         Parameters
         ----------
         value
-            Value to set the spectral distribution display name with.
+            Value to set the spectral distribution's display name
+            with.
 
         Returns
         -------
         :class:`str`
-            Spectral distribution display name.
+            Spectral distribution's display name.
         """
 
         return self._display_name
@@ -753,7 +797,7 @@ class SpectralDistribution(Signal):
     @property
     def wavelengths(self) -> NDArrayFloat:
         """
-        Getter and setter property for the spectral distribution wavelengths
+        Getter and setter for the spectral distribution wavelengths
         :math:`\\lambda_n`.
 
         Parameters
@@ -779,7 +823,7 @@ class SpectralDistribution(Signal):
     @property
     def values(self) -> NDArrayFloat:
         """
-        Getter and setter property for the spectral distribution values.
+        Getter and setter for the spectral distribution values.
 
         Parameters
         ----------
@@ -864,8 +908,8 @@ class SpectralDistribution(Signal):
     ) -> Self:
         """
         Interpolate the spectral distribution in-place according to
-        *CIE 167:2005* recommendation (if the interpolator has not been changed
-        at instantiation time) or specified interpolation arguments.
+        *CIE 167:2005* recommendation (if the interpolator has not been
+        changed at instantiation time) or specified interpolation arguments.
 
         The logic for choosing the interpolator class when ``interpolator`` is
         not specified is as follows:
@@ -911,8 +955,8 @@ class SpectralDistribution(Signal):
 
         Notes
         -----
-        -   Interpolation will be performed over boundaries range, if you need
-            to extend the range of the spectral distribution use the
+        -   Interpolation will be performed over boundaries range, if it is
+            required to extend the range of the spectral distribution use the
             :meth:`colour.SpectralDistribution.extrapolate` or
             :meth:`colour.SpectralDistribution.align` methods.
 
@@ -929,8 +973,8 @@ class SpectralDistribution(Signal):
 
         Examples
         --------
-        Spectral distribution with a uniformly spaced independent variable uses
-        *Sprague (1880)* interpolation:
+        Spectral distribution with a uniformly spaced independent variable
+        uses *Sprague (1880)* interpolation:
 
         >>> from colour.utilities import numpy_print_options
         >>> data = {
@@ -1047,8 +1091,8 @@ class SpectralDistribution(Signal):
          [ 599.            0.1349201...]
          [ 600.            0.136    ...]]
 
-        Spectral distribution with a non-uniformly spaced independent variable
-        uses *Cubic Spline* interpolation:
+        Spectral distribution with a non-uniformly spaced independent
+        variable uses *Cubic Spline* interpolation:
 
         >>> sd = SpectralDistribution(data)
         >>> sd[510] = np.pi / 10
@@ -1324,15 +1368,15 @@ class SpectralDistribution(Signal):
         extrapolator_kwargs: dict | None = None,
     ) -> Self:
         """
-        Align the spectral distribution in-place to specified spectral shape:
-        Interpolates first then extrapolates to fit the specified range.
+        Align the spectral distribution in-place to the specified spectral
+        shape: Interpolate first then extrapolate to fit the specified range.
 
-        Interpolation is performed according to *CIE 167:2005* recommendation
-        (if the interpolator has not been changed at instantiation time) or
-        specified interpolation arguments.
+        Interpolation is performed according to *CIE 167:2005*
+        recommendation (if the interpolator has not been changed at
+        instantiation time) or specified interpolation arguments.
 
-        The logic for choosing the interpolator class when ``interpolator`` is
-        not specified is as follows:
+        The logic for choosing the interpolator class when ``interpolator``
+        is not specified is as follows:
 
         .. code-block:: python
 
@@ -1462,7 +1506,7 @@ class SpectralDistribution(Signal):
 
     def trim(self, shape: SpectralShape) -> Self:
         """
-        Trim the spectral distribution wavelengths to specified spectral shape.
+        Trim the spectral distribution wavelengths to the specified spectral shape.
 
         Parameters
         ----------
@@ -1573,12 +1617,13 @@ class SpectralDistribution(Signal):
 
     def normalise(self, factor: Real = 1) -> Self:
         """
-        Normalise the spectral distribution using specified normalization factor.
+        Normalise the spectral distribution with the specified normalization
+        factor.
 
         Parameters
         ----------
         factor
-            Normalization factor.
+            Normalisation factor.
 
         Returns
         -------
@@ -1615,21 +1660,21 @@ class SpectralDistribution(Signal):
 
 class MultiSpectralDistributions(MultiSignals):
     """
-    Define the multi-spectral distributions: the base object for multi
-    spectral computations. It is used to model colour matching functions,
-    display primaries, camera sensitivities, etc...
+    Define multi-spectral distributions: the base object for multi-spectral
+    computations. Model colour matching functions, display primaries, camera
+    sensitivities, and related spectral data sets.
 
-    The multi-spectral distributions will be initialised according to
-    *CIE 15:2004* recommendation: the method developed by *Sprague (1880)* will
-    be used for interpolating functions having a uniformly spaced independent
-    variable and the *Cubic Spline* method for non-uniformly spaced independent
-    variable. Extrapolation is performed according to *CIE 167:2005*
+    Initialise multi-spectral distributions according to *CIE 15:2004*
+    recommendation: use the method developed by *Sprague (1880)* for
+    interpolating functions having uniformly spaced independent variables
+    and the *Cubic Spline* method for non-uniformly spaced independent
+    variables. Perform extrapolation according to *CIE 167:2005*
     recommendation.
 
     .. important::
 
-        Specific documentation about getting, setting, indexing and slicing the
-        multi-spectral power distributions values is available in the
+        Specific documentation about getting, setting, indexing and slicing
+        the multi-spectral power distributions values is available in the
         :ref:`spectral-representation-and-continuous-signal` section.
 
     Parameters
@@ -1639,8 +1684,8 @@ class MultiSpectralDistributions(MultiSignals):
     domain
         Values to initialise the multiple :class:`colour.SpectralDistribution`
         class instances :attr:`colour.continuous.Signal.wavelengths` attribute
-        with. If both ``data`` and ``domain`` arguments are defined, the latter
-        will be used to initialise the
+        with. If both ``data`` and ``domain`` arguments are defined, the
+        latter will be used to initialise the
         :attr:`colour.continuous.Signal.wavelengths` property.
     labels
         Names to use for the :class:`colour.SpectralDistribution` class
@@ -1831,18 +1876,22 @@ class MultiSpectralDistributions(MultiSignals):
     @property
     def display_name(self) -> str:
         """
-        Getter and setter property for the multi-spectral distributions display
-        name.
+        Getter and setter for the multi-spectral distributions' display name.
+
+        The display name provides a human-readable identifier for the
+        multi-spectral distribution collection, used for visualization
+        and reporting purposes.
 
         Parameters
         ----------
         value
-            Value to set the multi-spectral distributions display name with.
+            Value to set the multi-spectral distributions' display name
+            with.
 
         Returns
         -------
         :class:`str`
-            Multi-spectral distributions display name.
+            Multi-spectral distributions' display name.
         """
 
         return self._display_name
@@ -1861,8 +1910,12 @@ class MultiSpectralDistributions(MultiSignals):
     @property
     def display_labels(self) -> List[str]:
         """
-        Getter and setter property for the multi-spectral distributions display
-        labels.
+        Getter and setter for the display labels of the multi-spectral
+        distributions.
+
+        The display labels provide human-readable identifiers for each spectral
+        distribution in the multi-spectral collection, facilitating data
+        visualization and interpretation.
 
         Parameters
         ----------
@@ -1903,7 +1956,7 @@ class MultiSpectralDistributions(MultiSignals):
     @property
     def wavelengths(self) -> NDArrayFloat:
         """
-        Getter and setter property for the multi-spectral distributions
+        Getter and setter for the multi-spectral distributions
         wavelengths :math:`\\lambda_n`.
 
         Parameters
@@ -1929,7 +1982,7 @@ class MultiSpectralDistributions(MultiSignals):
     @property
     def values(self) -> NDArrayFloat:
         """
-        Getter and setter property for the multi-spectral distributions values.
+        Getter and setter for the multi-spectral distributions values.
 
         Parameters
         ----------
@@ -2317,7 +2370,7 @@ class MultiSpectralDistributions(MultiSignals):
         extrapolator_kwargs: dict | None = None,
     ) -> Self:
         """
-        Align the multi-spectral distributions in-place to specified spectral
+        Align the multi-spectral distributions in-place to the specified spectral
         shape: Interpolates first then extrapolates to fit the specified range.
 
         Interpolation is performed according to *CIE 167:2005* recommendation
@@ -2462,7 +2515,7 @@ class MultiSpectralDistributions(MultiSignals):
 
     def trim(self, shape: SpectralShape) -> Self:
         """
-        Trim the multi-spectral distributions wavelengths to specified shape.
+        Trim the multi-spectral distributions wavelengths to the specified shape.
 
         Parameters
         ----------
@@ -2541,7 +2594,7 @@ class MultiSpectralDistributions(MultiSignals):
 
     def normalise(self, factor: Real = 1) -> Self:
         """
-        Normalise the multi-spectral distributions with specified normalization
+        Normalise the multi-spectral distributions with the specified normalization
         factor.
 
         Parameters
@@ -2660,22 +2713,23 @@ def reshape_sd(
     **kwargs: Any,
 ) -> TypeSpectralDistribution:
     """
-    Reshape specified spectral distribution with specified spectral shape.
+    Reshape the specified spectral distribution to match the specified spectral
+    shape.
 
-    The reshaped object is cached, thus another call to the definition with the
-    same arguments will yield the cached object immediately.
+    The reshaped object is cached, thus another call to the definition with
+    the same arguments will yield the cached object immediately.
 
     Parameters
     ----------
     sd
         Spectral distribution to reshape.
     shape
-        Spectral shape to reshape the spectral distribution with.
+        Target spectral shape for reshaping the spectral distribution.
     method
-        Reshape method.
+        Method to use for reshaping.
     copy
-        Whether to return a copy of the cached spectral distribution. Default
-        is *True*.
+        Whether to return a copy of the cached spectral distribution.
+        Default is *True*.
 
     Other Parameters
     ----------------
@@ -2734,19 +2788,20 @@ def reshape_msds(
     **kwargs: Any,
 ) -> TypeMultiSpectralDistributions:
     """
-    Reshape specified multi-spectral distributions with specified spectral shape.
+    Reshape the specified multi-spectral distributions to match the specified
+    spectral shape.
 
-    The reshaped object is cached, thus another call to the definition with the
-    same arguments will yield the cached object immediately.
+    The reshaped object is cached, thus another call to the definition with
+    the same arguments will yield the cached object immediately.
 
     Parameters
     ----------
     msds
-        Spectral distribution to reshape.
+        Multi-spectral distributions to reshape.
     shape
-        Spectral shape to reshape the multi-spectral distributions with.
+        Target spectral shape for reshaping the multi-spectral distributions.
     method
-        Reshape method.
+        Method to use for reshaping.
     copy
         Whether to return a copy of the cached multi-spectral distributions.
         Default is *True*.
@@ -2766,7 +2821,7 @@ def reshape_msds(
 
     Warnings
     --------
-    Contrary to *Numpy*, reshaping a multi-spectral distributions alters its
+    Contrary to *Numpy*, reshaping multi-spectral distributions alters their
     data!
     """
 
@@ -2789,12 +2844,14 @@ def sds_and_msds_to_sds(
     ----------
     sds
         Spectral and multi-spectral distributions to convert to a list of
-        spectral distributions.
+        spectral distributions. Each multi-spectral distribution is expanded
+        into its constituent spectral distributions.
 
     Returns
     -------
     :class:`list`
-        List of spectral distributions.
+        List of spectral distributions where multi-spectral distributions
+        have been expanded into individual spectral distributions.
 
     Examples
     --------

--- a/colour/colorimetry/spectrum.py
+++ b/colour/colorimetry/spectrum.py
@@ -398,7 +398,7 @@ class SpectralShape:
 
         return bool(
             np.all(
-                np.isin(  # pyright: ignore
+                np.isin(
                     np.around(
                         wavelength,  # pyright: ignore
                         decimals,

--- a/colour/colorimetry/transformations.py
+++ b/colour/colorimetry/transformations.py
@@ -2,8 +2,8 @@
 Colour Matching Functions Transformations
 =========================================
 
-Define various educational objects for colour matching functions
-transformations:
+Define educational objects for transformations between colour matching
+functions in various colour spaces and observer standards.
 
 -   :func:`colour.colorimetry.RGB_2_degree_cmfs_to_XYZ_2_degree_cmfs`
 -   :func:`colour.colorimetry.RGB_10_degree_cmfs_to_XYZ_10_degree_cmfs`
@@ -69,8 +69,9 @@ def RGB_2_degree_cmfs_to_XYZ_2_degree_cmfs(
     wavelength: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Convert *Wright & Guild 1931 2 Degree RGB CMFs* colour matching functions
-    into the *CIE 1931 2 Degree Standard Observer* colour matching functions.
+    Convert the *Wright & Guild 1931 2 Degree RGB CMFs* colour matching
+    functions to the *CIE 1931 2 Degree Standard Observer* colour matching
+    functions.
 
     Parameters
     ----------
@@ -143,8 +144,8 @@ def RGB_10_degree_cmfs_to_XYZ_10_degree_cmfs(
     wavelength: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Convert *Stiles & Burch 1959 10 Degree RGB CMFs* colour matching
-    functions into the *CIE 1964 10 Degree Standard Observer* colour matching
+    Convert the *Stiles & Burch 1959 10 Degree RGB CMFs* colour matching
+    functions to the *CIE 1964 10 Degree Standard Observer* colour matching
     functions.
 
     Parameters
@@ -155,12 +156,13 @@ def RGB_10_degree_cmfs_to_XYZ_10_degree_cmfs(
     Returns
     -------
     :class:`numpy.ndarray`
-        *CIE 1964 10 Degree Standard Observer* spectral tristimulus values.
+        *CIE 1964 10 Degree Standard Observer* spectral tristimulus
+        values.
 
     Notes
     -----
-    -   Data for the *CIE 1964 10 Degree Standard Observer* already exists,
-        this definition is intended for educational purpose.
+    -   Data for the *CIE 1964 10 Degree Standard Observer* already
+        exists, this definition is intended for educational purpose.
 
     References
     ----------
@@ -193,8 +195,8 @@ def RGB_10_degree_cmfs_to_LMS_10_degree_cmfs(
     wavelength: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Convert *Stiles & Burch 1959 10 Degree RGB CMFs* colour matching
-    functions into the *Stockman & Sharpe 10 Degree Cone Fundamentals*
+    Convert the *Stiles & Burch 1959 10 Degree RGB CMFs* colour matching
+    functions to the *Stockman & Sharpe 10 Degree Cone Fundamentals*
     spectral sensitivity functions.
 
     Parameters
@@ -205,13 +207,14 @@ def RGB_10_degree_cmfs_to_LMS_10_degree_cmfs(
     Returns
     -------
     :class:`numpy.ndarray`
-        *Stockman & Sharpe 10 Degree Cone Fundamentals* spectral tristimulus
-        values.
+        *Stockman & Sharpe 10 Degree Cone Fundamentals* spectral
+        tristimulus values.
 
     Notes
     -----
-    -   Data for the *Stockman & Sharpe 10 Degree Cone Fundamentals* already
-        exists, this definition is intended for educational purpose.
+    -   Data for the *Stockman & Sharpe 10 Degree Cone Fundamentals*
+        already exists, this definition is intended for educational
+        purpose.
 
     References
     ----------
@@ -247,8 +250,8 @@ def LMS_2_degree_cmfs_to_XYZ_2_degree_cmfs(
     wavelength: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Convert *Stockman & Sharpe 2 Degree Cone Fundamentals* colour matching
-    functions into the *CIE 2015 2 Degree Standard Observer* colour matching
+    Convert the *Stockman & Sharpe 2 Degree Cone Fundamentals* colour matching
+    functions to the *CIE 2015 2 Degree Standard Observer* colour matching
     functions.
 
     Parameters
@@ -297,8 +300,8 @@ def LMS_10_degree_cmfs_to_XYZ_10_degree_cmfs(
     wavelength: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Convert *Stockman & Sharpe 10 Degree Cone Fundamentals* colour matching
-    functions into the *CIE 2015 10 Degree Standard Observer* colour matching
+    Convert the *Stockman & Sharpe 10 Degree Cone Fundamentals* colour matching
+    functions to the *CIE 2015 10 Degree Standard Observer* colour matching
     functions.
 
     Parameters

--- a/colour/colorimetry/tristimulus_values.py
+++ b/colour/colorimetry/tristimulus_values.py
@@ -1258,8 +1258,8 @@ def sd_to_XYZ(
             (
                 sd
                 if isinstance(sd, (SpectralDistribution, MultiSpectralDistributions))
-                else int_digest(np.asarray(sd).tobytes())  # pyright: ignore
-            ),  # pyright: ignore
+                else int_digest(np.asarray(sd).tobytes())
+            ),
             cmfs,
             illuminant,
             k,

--- a/colour/colorimetry/tristimulus_values.py
+++ b/colour/colorimetry/tristimulus_values.py
@@ -2,7 +2,12 @@
 Tristimulus Values
 ==================
 
-Define the objects for tristimulus values computation from spectral data:
+Define objects for computing CIE tristimulus values from spectral data.
+
+This module provides comprehensive functionality for converting spectral
+distributions to CIE XYZ tristimulus values using various integration and
+summation methods. The default implementation follows the *ASTM E308-15*
+standard practice.
 
 -   :attr:`colour.SPECTRAL_SHAPE_ASTME308`
 -   :func:`colour.colorimetry.handle_spectral_arguments`
@@ -18,8 +23,6 @@ sd_to_XYZ_tristimulus_weighting_factors_ASTME308`
 -   :attr:`colour.MSDS_TO_XYZ_METHODS`
 -   :func:`colour.msds_to_XYZ`
 -   :func:`colour.wavelength_to_XYZ`
-
-The default implementation is based on practise *ASTM E308-15* method.
 
 References
 ----------
@@ -103,7 +106,8 @@ __all__ = [
 
 SPECTRAL_SHAPE_ASTME308: SpectralShape = SPECTRAL_SHAPE_DEFAULT
 SPECTRAL_SHAPE_ASTME308.__doc__ = """
-Shape for *ASTM E308-15* practise: (360, 780, 1).
+Define the spectral shape for *ASTM E308-15* practice with wavelength range
+from 360 to 780 nm at 1 nm intervals: (360, 780, 1).
 
 References
 ----------
@@ -130,17 +134,17 @@ def handle_spectral_arguments(
     issue_runtime_warnings: bool = True,
 ) -> Tuple[MultiSpectralDistributions, SpectralDistribution]:
     """
-    Handle the spectral arguments of various *Colour* definitions performing
+    Handle spectral arguments for various *Colour* definitions that perform
     spectral computations.
 
-    -   If ``cmfs`` is not specified, one is chosen according to ``cmfs_default``.
-        The returned colour matching functions adopt the spectral shape specified
-        by ``shape_default``.
-    -   If ``illuminant`` is not specified, one is chosen according to
+    -   If ``cmfs`` is not specified, select one according to
+        ``cmfs_default``. The returned colour matching functions adopt the
+        spectral shape specified by ``shape_default``.
+    -   If ``illuminant`` is not specified, select one according to
         ``illuminant_default``. The returned illuminant adopts the spectral
         shape of the returned colour matching functions.
-    -   If ``illuminant`` is specified, the returned illuminant spectral shape is
-        aligned to that of the returned colour matching functions.
+    -   If ``illuminant`` is specified, align the returned illuminant's
+        spectral shape to that of the returned colour matching functions.
 
     Parameters
     ----------
@@ -151,14 +155,15 @@ def handle_spectral_arguments(
         Illuminant spectral distribution, default to
         *CIE Standard Illuminant D65*.
     cmfs_default
-        The default colour matching functions to use if ``cmfs`` is not specified.
+        Default colour matching functions to use if ``cmfs`` is not
+        specified.
     illuminant_default
-        The default illuminant to use if ``illuminant`` is not specified.
+        Default illuminant to use if ``illuminant`` is not specified.
     shape_default
-        The default spectral shape to align the final colour matching functions
+        Default spectral shape to align the final colour matching functions
         and illuminant.
     issue_runtime_warnings
-        Whether to issue the runtime warnings.
+        Whether to issue runtime warnings.
 
     Returns
     -------
@@ -205,15 +210,15 @@ def lagrange_coefficients_ASTME2022(
     interval_type: Literal["Boundary", "Inner"] | str = "Inner",
 ) -> NDArrayFloat:
     """
-    Compute the *Lagrange Coefficients* for specified interval size using practise
-    *ASTM E2022-11* method.
+    Compute *Lagrange Coefficients* for the specified interval size using
+    practice *ASTM E2022-11* method.
 
     Parameters
     ----------
     interval
         Interval size in nm.
     interval_type
-        If the interval is an *inner* interval *Lagrange Coefficients* are
+        If the interval is an *inner* interval, *Lagrange Coefficients* are
         computed for degree 4. Degree 3 is used for a *boundary* interval.
 
     Returns
@@ -284,8 +289,8 @@ def tristimulus_weighting_factors_ASTME2022(
     k: Real | None = None,
 ) -> NDArrayFloat:
     """
-    Return a table of tristimulus weighting factors for specified colour matching
-    functions and illuminant using practise *ASTM E2022-11* method.
+    Compute a table of tristimulus weighting factors for the specified colour
+    matching functions and illuminant using practise *ASTM E2022-11* method.
 
     The computed table of tristimulus weighting factors should be used with
     spectral data that has been corrected for spectral bandpass dependence.
@@ -299,20 +304,22 @@ def tristimulus_weighting_factors_ASTME2022(
     shape
         Shape used to build the table, only the interval is needed.
     k
-        Normalisation constant :math:`k`. For reflecting or transmitting object
-        colours, :math:`k` is chosen so that :math:`Y = 100` for objects for
-        which the spectral reflectance factor :math:`R(\\lambda)` of the object
-        colour or the spectral transmittance factor :math:`\\tau(\\lambda)` of
-        the object is equal to unity for all wavelengths. For self-luminous
-        objects and illuminants, the constants :math:`k` is usually chosen on
-        the grounds of convenience. If, however, in the CIE 1931 standard
-        colorimetric system, the :math:`Y` value is required to be numerically
-        equal to the absolute value of a photometric quantity, the constant,
-        :math:`k`, must be put equal to the numerical value of :math:`K_m`, the
-        maximum spectral luminous efficacy (which is equal to
-        683 :math:`lm\\cdot W^{-1}`) and :math:`\\Phi_\\lambda(\\lambda)` must
-        be the spectral concentration of the radiometric quantity corresponding
-        to the photometric quantity required.
+        Normalisation constant :math:`k`. For reflecting or transmitting
+        object colours, :math:`k` is chosen so that :math:`Y = 100` for
+        objects for which the spectral reflectance factor
+        :math:`R(\\lambda)` of the object colour or the spectral
+        transmittance factor :math:`\\tau(\\lambda)` of the object is equal
+        to unity for all wavelengths. For self-luminous objects and
+        illuminants, the constants :math:`k` is usually chosen on the
+        grounds of convenience. If, however, in the CIE 1931 standard
+        colorimetric system, the :math:`Y` value is required to be
+        numerically equal to the absolute value of a photometric quantity,
+        the constant, :math:`k`, must be put equal to the numerical value
+        of :math:`K_m`, the maximum spectral luminous efficacy (which is
+        equal to 683 :math:`lm\\cdot W^{-1}`) and
+        :math:`\\Phi_\\lambda(\\lambda)` must be the spectral concentration
+        of the radiometric quantity corresponding to the photometric
+        quantity required.
 
     Returns
     -------
@@ -322,18 +329,18 @@ def tristimulus_weighting_factors_ASTME2022(
     Raises
     ------
     ValueError
-        If the colour matching functions or illuminant intervals are not equal
-        to 1 nm.
+        If the colour matching functions or illuminant intervals are not
+        equal to 1 nm.
 
     Notes
     -----
-    -   Input colour matching functions and illuminant intervals are expected
-        to be equal to 1 nm. If the illuminant data is not available at 1 nm
-        interval, it needs to be interpolated using *CIE* recommendations:
-        The method developed by *Sprague (1880)* should be used for
-        interpolating functions having a uniformly spaced independent variable
-        and a *Cubic Spline* method for non-uniformly spaced independent
-        variable.
+    -   Input colour matching functions and illuminant intervals are
+        expected to be equal to 1 nm. If the illuminant data is not
+        available at 1 nm interval, it needs to be interpolated using *CIE*
+        recommendations: The method developed by *Sprague (1880)* should be
+        used for interpolating functions having a uniformly spaced
+        independent variable and a *Cubic Spline* method for non-uniformly
+        spaced independent variable.
 
     References
     ----------
@@ -459,12 +466,13 @@ def adjust_tristimulus_weighting_factors_ASTME308(
     W: ArrayLike, shape_r: SpectralShape, shape_t: SpectralShape
 ) -> NDArrayFloat:
     """
-    Adjust specified table of tristimulus weighting factors to account for a
-    shorter wavelengths range of the test spectral shape compared to the
-    reference spectral shape using practise *ASTM E308-15* method:
-    Weights at the wavelengths for which data are not available are added to
-    the weights at the shortest and longest wavelength for which spectral data
-    are available.
+    Adjust the specified table of tristimulus weighting factors to account for a
+    shorter wavelength range of the test spectral shape compared to the
+    reference spectral shape using practice *ASTM E308-15* method.
+
+    The adjustment redistributes weights at wavelengths for which data are
+    not available by adding them to the weights at the shortest and longest
+    wavelengths for which spectral data are available.
 
     Parameters
     ----------
@@ -542,9 +550,9 @@ def sd_to_XYZ_integration(
     shape: SpectralShape | None = None,
 ) -> NDArrayFloat:
     """
-    Convert specified spectral distribution to *CIE XYZ* tristimulus values
-    using specified colour matching functions and illuminant according to classical
-    integration method.
+    Convert the specified spectral distribution to *CIE XYZ* tristimulus
+    values using the specified colour matching functions and illuminant
+    using the classical integration method.
 
     The spectral distribution can be either a
     :class:`colour.SpectralDistribution` class instance or an `ArrayLike` in
@@ -562,23 +570,25 @@ def sd_to_XYZ_integration(
     illuminant
         Illuminant spectral distribution, default to *CIE Illuminant E*.
     k
-        Normalisation constant :math:`k`. For reflecting or transmitting object
-        colours, :math:`k` is chosen so that :math:`Y = 100` for objects for
-        which the spectral reflectance factor :math:`R(\\lambda)` of the object
-        colour or the spectral transmittance factor :math:`\\tau(\\lambda)` of
-        the object is equal to unity for all wavelengths. For self-luminous
-        objects and illuminants, the constants :math:`k` is usually chosen on
-        the grounds of convenience. If, however, in the CIE 1931 standard
-        colorimetric system, the :math:`Y` value is required to be numerically
-        equal to the absolute value of a photometric quantity, the constant,
-        :math:`k`, must be put equal to the numerical value of :math:`K_m`, the
-        maximum spectral luminous efficacy (which is equal to
-        683 :math:`lm\\cdot W^{-1}`) and :math:`\\Phi_\\lambda(\\lambda)` must
-        be the spectral concentration of the radiometric quantity corresponding
-        to the photometric quantity required.
+        Normalisation constant :math:`k`. For reflecting or transmitting
+        object colours, :math:`k` is chosen so that :math:`Y = 100` for
+        objects for which the spectral reflectance factor
+        :math:`R(\\lambda)` of the object colour or the spectral
+        transmittance factor :math:`\\tau(\\lambda)` of the object is equal
+        to unity for all wavelengths. For self-luminous objects and
+        illuminants, the constants :math:`k` is usually chosen on the
+        grounds of convenience. If, however, in the CIE 1931 standard
+        colorimetric system, the :math:`Y` value is required to be
+        numerically equal to the absolute value of a photometric quantity,
+        the constant, :math:`k`, must be put equal to the numerical value
+        of :math:`K_m`, the maximum spectral luminous efficacy (which is
+        equal to 683 :math:`lm\\cdot W^{-1}`) and
+        :math:`\\Phi_\\lambda(\\lambda)` must be the spectral concentration
+        of the radiometric quantity corresponding to the photometric
+        quantity required.
     shape
         Spectral shape that ``sd``, ``cmfs`` and ``illuminant`` will be
-        aligned to it if passed.
+        aligned to if passed.
 
     Returns
     -------
@@ -599,10 +609,10 @@ def sd_to_XYZ_integration(
     -   The code path using the `ArrayLike` spectral distribution produces
         results different to the code path using a
         :class:`colour.SpectralDistribution` class instance: the former
-        favours execution speed by aligning the colour matching functions and
-        illuminant to the specified spectral shape while the latter favours
-        precision by aligning the spectral distribution to the colour matching
-        functions.
+        favours execution speed by aligning the colour matching functions
+        and illuminant to the specified spectral shape while the latter
+        favours precision by aligning the spectral distribution to the
+        colour matching functions.
 
     References
     ----------
@@ -738,9 +748,10 @@ def sd_to_XYZ_tristimulus_weighting_factors_ASTME308(
     k: Real | None = None,
 ) -> NDArrayFloat:
     """
-    Convert specified spectral distribution to *CIE XYZ* tristimulus values
-    using specified colour matching functions and illuminant using a table of
-    tristimulus weighting factors according to practise *ASTM E308-15* method.
+    Convert the specified spectral distribution to *CIE XYZ* tristimulus
+    values using the specified colour matching functions and illuminant
+    with a table of tristimulus weighting factors according to the
+    *ASTM E308-15* method.
 
     Parameters
     ----------
@@ -752,20 +763,22 @@ def sd_to_XYZ_tristimulus_weighting_factors_ASTME308(
     illuminant
         Illuminant spectral distribution, default to *CIE Illuminant E*.
     k
-        Normalisation constant :math:`k`. For reflecting or transmitting object
-        colours, :math:`k` is chosen so that :math:`Y = 100` for objects for
-        which the spectral reflectance factor :math:`R(\\lambda)` of the object
-        colour or the spectral transmittance factor :math:`\\tau(\\lambda)` of
-        the object is equal to unity for all wavelengths. For self-luminous
-        objects and illuminants, the constants :math:`k` is usually chosen on
-        the grounds of convenience. If, however, in the CIE 1931 standard
-        colorimetric system, the :math:`Y` value is required to be numerically
-        equal to the absolute value of a photometric quantity, the constant,
-        :math:`k`, must be put equal to the numerical value of :math:`K_m`, the
-        maximum spectral luminous efficacy (which is equal to
-        683 :math:`lm\\cdot W^{-1}`) and :math:`\\Phi_\\lambda(\\lambda)` must
-        be the spectral concentration of the radiometric quantity corresponding
-        to the photometric quantity required.
+        Normalisation constant :math:`k`. For reflecting or transmitting
+        object colours, :math:`k` is chosen so that :math:`Y = 100` for
+        objects for which the spectral reflectance factor
+        :math:`R(\\lambda)` of the object colour or the spectral
+        transmittance factor :math:`\\tau(\\lambda)` of the object is equal
+        to unity for all wavelengths. For self-luminous objects and
+        illuminants, the constants :math:`k` is usually chosen on the
+        grounds of convenience. If, however, in the CIE 1931 standard
+        colorimetric system, the :math:`Y` value is required to be
+        numerically equal to the absolute value of a photometric quantity,
+        the constant, :math:`k`, must be put equal to the numerical value
+        of :math:`K_m`, the maximum spectral luminous efficacy (which is
+        equal to 683 :math:`lm\\cdot W^{-1}`) and
+        :math:`\\Phi_\\lambda(\\lambda)` must be the spectral concentration
+        of the radiometric quantity corresponding to the photometric
+        quantity required.
 
     Returns
     -------
@@ -884,9 +897,9 @@ def sd_to_XYZ_ASTME308(
     k: Real | None = None,
 ) -> NDArrayFloat:
     """
-    Convert specified spectral distribution to *CIE XYZ* tristimulus values using
-    specified colour matching functions and illuminant according to practise
-    *ASTM E308-15* method.
+    Convert the specified spectral distribution to *CIE XYZ* tristimulus values
+    using the specified colour matching functions and illuminant according to
+    practice *ASTM E308-15* method.
 
     Parameters
     ----------
@@ -898,7 +911,7 @@ def sd_to_XYZ_ASTME308(
     illuminant
         Illuminant spectral distribution, default to *CIE Illuminant E*.
     use_practice_range
-        Practise *ASTM E308-15* working wavelengths range is [360, 780],
+        Practice *ASTM E308-15* working wavelengths range is [360, 780],
         if *True* this argument will trim the colour matching functions
         appropriately.
     mi_5nm_omission_method
@@ -910,20 +923,22 @@ def sd_to_XYZ_ASTME308(
         tristimulus values will use a dedicated interpolation method instead
         of a table of tristimulus weighting factors.
     k
-        Normalisation constant :math:`k`. For reflecting or transmitting object
-        colours, :math:`k` is chosen so that :math:`Y = 100` for objects for
-        which the spectral reflectance factor :math:`R(\\lambda)` of the object
-        colour or the spectral transmittance factor :math:`\\tau(\\lambda)` of
-        the object is equal to unity for all wavelengths. For self-luminous
-        objects and illuminants, the constants :math:`k` is usually chosen on
-        the grounds of convenience. If, however, in the CIE 1931 standard
-        colorimetric system, the :math:`Y` value is required to be numerically
-        equal to the absolute value of a photometric quantity, the constant,
-        :math:`k`, must be put equal to the numerical value of :math:`K_m`, the
-        maximum spectral luminous efficacy (which is equal to
-        683 :math:`lm\\cdot W^{-1}`) and :math:`\\Phi_\\lambda(\\lambda)` must
-        be the spectral concentration of the radiometric quantity corresponding
-        to the photometric quantity required.
+        Normalisation constant :math:`k`. For reflecting or transmitting
+        object colours, :math:`k` is chosen so that :math:`Y = 100` for
+        objects for which the spectral reflectance factor
+        :math:`R(\\lambda)` of the object colour or the spectral
+        transmittance factor :math:`\\tau(\\lambda)` of the object is equal
+        to unity for all wavelengths. For self-luminous objects and
+        illuminants, the constants :math:`k` is usually chosen on the
+        grounds of convenience. If, however, in the CIE 1931 standard
+        colorimetric system, the :math:`Y` value is required to be
+        numerically equal to the absolute value of a photometric quantity,
+        the constant, :math:`k`, must be put equal to the numerical value
+        of :math:`K_m`, the maximum spectral luminous efficacy (which is
+        equal to 683 :math:`lm\\cdot W^{-1}`) and
+        :math:`\\Phi_\\lambda(\\lambda)` must be the spectral concentration
+        of the radiometric quantity corresponding to the photometric
+        quantity required.
 
     Returns
     -------
@@ -1129,20 +1144,22 @@ def sd_to_XYZ(
     illuminant
         Illuminant spectral distribution, default to *CIE Illuminant E*.
     k
-        Normalisation constant :math:`k`. For reflecting or transmitting object
-        colours, :math:`k` is chosen so that :math:`Y = 100` for objects for
-        which the spectral reflectance factor :math:`R(\\lambda)` of the object
-        colour or the spectral transmittance factor :math:`\\tau(\\lambda)` of
-        the object is equal to unity for all wavelengths. For self-luminous
-        objects and illuminants, the constants :math:`k` is usually chosen on
-        the grounds of convenience. If, however, in the CIE 1931 standard
-        colorimetric system, the :math:`Y` value is required to be numerically
-        equal to the absolute value of a photometric quantity, the constant,
-        :math:`k`, must be put equal to the numerical value of :math:`K_m`, the
-        maximum spectral luminous efficacy (which is equal to
-        683 :math:`lm\\cdot W^{-1}`) and :math:`\\Phi_\\lambda(\\lambda)` must
-        be the spectral concentration of the radiometric quantity corresponding
-        to the photometric quantity required.
+        Normalisation constant :math:`k`. For reflecting or transmitting
+        object colours, :math:`k` is chosen so that :math:`Y = 100` for
+        objects for which the spectral reflectance factor
+        :math:`R(\\lambda)` of the object colour or the spectral
+        transmittance factor :math:`\\tau(\\lambda)` of the object is equal
+        to unity for all wavelengths. For self-luminous objects and
+        illuminants, the constants :math:`k` is usually chosen on the
+        grounds of convenience. If, however, in the CIE 1931 standard
+        colorimetric system, the :math:`Y` value is required to be
+        numerically equal to the absolute value of a photometric quantity,
+        the constant, :math:`k`, must be put equal to the numerical value
+        of :math:`K_m`, the maximum spectral luminous efficacy (which is
+        equal to 683 :math:`lm\\cdot W^{-1}`) and
+        :math:`\\Phi_\\lambda(\\lambda)` must be the spectral concentration
+        of the radiometric quantity corresponding to the photometric
+        quantity required.
     method
         Computation method.
 
@@ -1161,7 +1178,7 @@ def sd_to_XYZ(
     shape
         {:func:`colour.colorimetry.sd_to_XYZ_integration`},
         Spectral shape that ``sd``, ``cmfs`` and ``illuminant`` will be
-        aligned to it if passed.
+        aligned to if passed.
     use_practice_range
         {:func:`colour.colorimetry.sd_to_XYZ_ASTME308`},
         Practise *ASTM E308-15* working wavelengths range is [360, 780],
@@ -1295,8 +1312,8 @@ def msds_to_XYZ_integration(
     shape: SpectralShape | None = None,
 ) -> NDArrayFloat:
     """
-    Convert specified multi-spectral distributions to *CIE XYZ* tristimulus values
-    using specified colour matching functions and illuminant.
+    Convert the specified multi-spectral distributions to *CIE XYZ* tristimulus
+    values using the specified colour matching functions and illuminant.
 
     The multi-spectral distributions can be either a
     :class:`colour.MultiSpectralDistributions` class instance or an
@@ -1314,23 +1331,25 @@ def msds_to_XYZ_integration(
     illuminant
         Illuminant spectral distribution, default to *CIE Illuminant E*.
     k
-        Normalisation constant :math:`k`. For reflecting or transmitting object
-        colours, :math:`k` is chosen so that :math:`Y = 100` for objects for
-        which the spectral reflectance factor :math:`R(\\lambda)` of the object
-        colour or the spectral transmittance factor :math:`\\tau(\\lambda)` of
-        the object is equal to unity for all wavelengths. For self-luminous
-        objects and illuminants, the constants :math:`k` is usually chosen on
-        the grounds of convenience. If, however, in the CIE 1931 standard
-        colorimetric system, the :math:`Y` value is required to be numerically
-        equal to the absolute value of a photometric quantity, the constant,
-        :math:`k`, must be put equal to the numerical value of :math:`K_m`, the
-        maximum spectral luminous efficacy (which is equal to
-        683 :math:`lm\\cdot W^{-1}`) and :math:`\\Phi_\\lambda(\\lambda)` must
-        be the spectral concentration of the radiometric quantity corresponding
-        to the photometric quantity required.
+        Normalisation constant :math:`k`. For reflecting or transmitting
+        object colours, :math:`k` is chosen so that :math:`Y = 100` for
+        objects for which the spectral reflectance factor
+        :math:`R(\\lambda)` of the object colour or the spectral
+        transmittance factor :math:`\\tau(\\lambda)` of the object is equal
+        to unity for all wavelengths. For self-luminous objects and
+        illuminants, the constants :math:`k` is usually chosen on the
+        grounds of convenience. If, however, in the CIE 1931 standard
+        colorimetric system, the :math:`Y` value is required to be
+        numerically equal to the absolute value of a photometric quantity,
+        the constant, :math:`k`, must be put equal to the numerical value
+        of :math:`K_m`, the maximum spectral luminous efficacy (which is
+        equal to 683 :math:`lm\\cdot W^{-1}`) and
+        :math:`\\Phi_\\lambda(\\lambda)` must be the spectral concentration
+        of the radiometric quantity corresponding to the photometric
+        quantity required.
     shape
         Spectral shape that ``sd``, ``cmfs`` and ``illuminant`` will be
-        aligned to it if passed.
+        aligned to if passed.
 
     Returns
     -------
@@ -1351,11 +1370,11 @@ def msds_to_XYZ_integration(
         converted from percentages by a final division by 100.
     -   The code path using the `ArrayLike` multi-spectral distributions
         produces results different to the code path using a
-        :class:`colour.MultiSpectralDistributions` class instance: the former
-        favours execution speed by aligning the colour matching functions and
-        illuminant to the specified spectral shape while the latter favours
-        precision by aligning the multi-spectral distributions to the colour
-        matching functions.
+        :class:`colour.MultiSpectralDistributions` class instance: the
+        former favours execution speed by aligning the colour matching
+        functions and illuminant to the specified spectral shape while the
+        latter favours precision by aligning the multi-spectral distributions
+        to the colour matching functions.
     -   If precision is required, it is possible to interpolate the
         multi-spectral distributions with :py:class:`scipy.interpolate.interp1d`
         class on the last / tail axis as follows:
@@ -1533,9 +1552,9 @@ def msds_to_XYZ_ASTME308(
     mi_20nm_interpolation_method: bool = True,
 ) -> NDArrayFloat:
     """
-    Convert specified multi-spectral distributions to *CIE XYZ* tristimulus values
-    using specified colour matching functions and illuminant according to practise
-    *ASTM E308-15* method.
+    Convert specified multi-spectral distributions to *CIE XYZ* tristimulus
+    values using the specified colour matching functions and illuminant according
+    to practise *ASTM E308-15* method.
 
     Parameters
     ----------
@@ -1547,20 +1566,22 @@ def msds_to_XYZ_ASTME308(
     illuminant
         Illuminant spectral distribution, default to *CIE Illuminant E*.
     k
-        Normalisation constant :math:`k`. For reflecting or transmitting object
-        colours, :math:`k` is chosen so that :math:`Y = 100` for objects for
-        which the spectral reflectance factor :math:`R(\\lambda)` of the object
-        colour or the spectral transmittance factor :math:`\\tau(\\lambda)` of
-        the object is equal to unity for all wavelengths. For self-luminous
-        objects and illuminants, the constants :math:`k` is usually chosen on
-        the grounds of convenience. If, however, in the CIE 1931 standard
-        colorimetric system, the :math:`Y` value is required to be numerically
-        equal to the absolute value of a photometric quantity, the constant,
-        :math:`k`, must be put equal to the numerical value of :math:`K_m`, the
-        maximum spectral luminous efficacy (which is equal to
-        683 :math:`lm\\cdot W^{-1}`) and :math:`\\Phi_\\lambda(\\lambda)` must
-        be the spectral concentration of the radiometric quantity corresponding
-        to the photometric quantity required.
+        Normalisation constant :math:`k`. For reflecting or transmitting
+        object colours, :math:`k` is chosen so that :math:`Y = 100` for
+        objects for which the spectral reflectance factor
+        :math:`R(\\lambda)` of the object colour or the spectral
+        transmittance factor :math:`\\tau(\\lambda)` of the object is equal
+        to unity for all wavelengths. For self-luminous objects and
+        illuminants, the constants :math:`k` is usually chosen on the
+        grounds of convenience. If, however, in the CIE 1931 standard
+        colorimetric system, the :math:`Y` value is required to be
+        numerically equal to the absolute value of a photometric quantity,
+        the constant, :math:`k`, must be put equal to the numerical value
+        of :math:`K_m`, the maximum spectral luminous efficacy (which is
+        equal to 683 :math:`lm\\cdot W^{-1}`) and
+        :math:`\\Phi_\\lambda(\\lambda)` must be the spectral concentration
+        of the radiometric quantity corresponding to the photometric
+        quantity required.
     use_practice_range
         Practise *ASTM E308-15* working wavelengths range is [360, 780],
         if *True* this argument will trim the colour matching functions
@@ -1761,8 +1782,8 @@ MSDS_TO_XYZ_METHODS = CanonicalMapping(
     {"ASTM E308": msds_to_XYZ_ASTME308, "Integration": msds_to_XYZ_integration}
 )
 MSDS_TO_XYZ_METHODS.__doc__ = """
-Supported multi-spectral array to *CIE XYZ* tristimulus values conversion
-methods.
+Supported multi-spectral distributions to *CIE XYZ* tristimulus values
+conversion methods.
 
 References
 ----------
@@ -1785,9 +1806,9 @@ def msds_to_XYZ(
     **kwargs: Any,
 ) -> NDArrayFloat:
     """
-    Convert specified multi-spectral distributions to *CIE XYZ* tristimulus values
-    using specified colour matching functions and illuminant. For the *Integration*
-    method, the multi-spectral distributions can be either a
+    Convert specified multi-spectral distributions to *CIE XYZ* tristimulus
+    values using the specified colour matching functions and illuminant. For the
+    *Integration* method, the multi-spectral distributions can be either a
     :class:`colour.MultiSpectralDistributions` class instance or an
     `ArrayLike` in which case the ``shape`` must be passed.
 
@@ -1803,20 +1824,22 @@ def msds_to_XYZ(
     illuminant
         Illuminant spectral distribution, default to *CIE Illuminant E*.
     k
-        Normalisation constant :math:`k`. For reflecting or transmitting object
-        colours, :math:`k` is chosen so that :math:`Y = 100` for objects for
-        which the spectral reflectance factor :math:`R(\\lambda)` of the object
-        colour or the spectral transmittance factor :math:`\\tau(\\lambda)` of
-        the object is equal to unity for all wavelengths. For self-luminous
-        objects and illuminants, the constants :math:`k` is usually chosen on
-        the grounds of convenience. If, however, in the CIE 1931 standard
-        colorimetric system, the :math:`Y` value is required to be numerically
-        equal to the absolute value of a photometric quantity, the constant,
-        :math:`k`, must be put equal to the numerical value of :math:`K_m`, the
-        maximum spectral luminous efficacy (which is equal to
-        683 :math:`lm\\cdot W^{-1}`) and :math:`\\Phi_\\lambda(\\lambda)` must
-        be the spectral concentration of the radiometric quantity corresponding
-        to the photometric quantity required.
+        Normalisation constant :math:`k`. For reflecting or transmitting
+        object colours, :math:`k` is chosen so that :math:`Y = 100` for
+        objects for which the spectral reflectance factor
+        :math:`R(\\lambda)` of the object colour or the spectral
+        transmittance factor :math:`\\tau(\\lambda)` of the object is equal
+        to unity for all wavelengths. For self-luminous objects and
+        illuminants, the constants :math:`k` is usually chosen on the
+        grounds of convenience. If, however, in the CIE 1931 standard
+        colorimetric system, the :math:`Y` value is required to be
+        numerically equal to the absolute value of a photometric quantity,
+        the constant, :math:`k`, must be put equal to the numerical value
+        of :math:`K_m`, the maximum spectral luminous efficacy (which is
+        equal to 683 :math:`lm\\cdot W^{-1}`) and
+        :math:`\\Phi_\\lambda(\\lambda)` must be the spectral concentration
+        of the radiometric quantity corresponding to the photometric
+        quantity required.
     method
         Computation method.
 
@@ -1834,8 +1857,8 @@ def msds_to_XYZ(
         of a table of tristimulus weighting factors.
     shape
         {:func:`colour.colorimetry.msds_to_XYZ_integration`},
-        Spectral shape that ``sd``, ``cmfs`` and ``illuminant`` will be
-        aligned to it if passed.
+        Spectral shape that ``msds``, ``cmfs`` and ``illuminant`` will be
+        aligned to if passed.
     use_practice_range
         {:func:`colour.colorimetry.msds_to_XYZ_ASTME308`},
         Practise *ASTM E308-15* working wavelengths range is [360, 780],
@@ -1845,8 +1868,8 @@ def msds_to_XYZ(
     Returns
     -------
     :class:`numpy.ndarray`
-        *CIE XYZ* tristimulus values, for a 512x384 multi-spectral image with
-        77 wavelengths, the output shape will be (384, 512, 3).
+        *CIE XYZ* tristimulus values, for a 512x384 multi-spectral image
+        with 77 wavelengths, the output shape will be (384, 512, 3).
 
     Notes
     -----
@@ -1861,14 +1884,15 @@ def msds_to_XYZ(
         converted from percentages by a final division by 100.
     -   The code path using the `ArrayLike` multi-spectral distributions
         produces results different to the code path using a
-        :class:`colour.MultiSpectralDistributions` class instance: the former
-        favours execution speed by aligning the colour matching functions and
-        illuminant to the specified spectral shape while the latter favours
-        precision by aligning the multi-spectral distributions to the colour
-        matching functions.
+        :class:`colour.MultiSpectralDistributions` class instance: the
+        former favours execution speed by aligning the colour matching
+        functions and illuminant to the specified spectral shape while the
+        latter favours precision by aligning the multi-spectral distributions
+        to the colour matching functions.
     -   If precision is required, it is possible to interpolate the
-        multi-spectral distributions with :py:class:`scipy.interpolate.interp1d`
-        class on the last / tail axis as follows:
+        multi-spectral distributions with
+        :py:class:`scipy.interpolate.interp1d` class on the last / tail axis
+        as follows:
 
         .. code-block:: python
 
@@ -2043,14 +2067,15 @@ def wavelength_to_XYZ(
     cmfs: MultiSpectralDistributions | None = None,
 ) -> NDArrayFloat:
     """
-    Convert specified wavelength :math:`\\lambda` to *CIE XYZ* tristimulus values
-    using specified colour matching functions.
+    Convert the specified wavelength :math:`\\lambda` to *CIE XYZ* tristimulus
+    values using the specified colour matching functions.
 
-    If the wavelength :math:`\\lambda` is not available in the colour matching
-    function, its value will be calculated according to *CIE 15:2004*
-    recommendation: the method developed by *Sprague (1880)* will be used for
-    interpolating functions having a uniformly spaced independent variable and
-    the *Cubic Spline* method for non-uniformly spaced independent variable.
+    If the wavelength :math:`\\lambda` is not available in the colour
+    matching function, its value will be calculated according to
+    *CIE 15:2004* recommendation: the method developed by *Sprague (1880)*
+    will be used for interpolating functions having a uniformly spaced
+    independent variable and the *Cubic Spline* method for non-uniformly
+    spaced independent variable.
 
     Parameters
     ----------
@@ -2068,8 +2093,8 @@ def wavelength_to_XYZ(
     Raises
     ------
     ValueError
-        If wavelength :math:`\\lambda` is not contained in the colour matching
-        functions domain.
+        If wavelength :math:`\\lambda` is not contained in the colour
+        matching functions domain.
 
     Notes
     -----

--- a/colour/colorimetry/uniformity.py
+++ b/colour/colorimetry/uniformity.py
@@ -2,8 +2,8 @@
 Spectral Uniformity
 ===================
 
-Define the objects to compute the *spectral uniformity*
-(or *spectral flatness*) of spectral distributions.
+Define objects to compute the *spectral uniformity* (or *spectral flatness*)
+of spectral distributions.
 
 References
 ----------
@@ -53,12 +53,12 @@ def spectral_uniformity(
     use_second_order_derivatives: bool = False,
 ) -> NDArrayFloat:
     """
-    Compute the *spectral uniformity* (or *spectral flatness*) of specified
+    Compute the *spectral uniformity* (or *spectral flatness*) of the specified
     spectral distributions.
 
     Spectral uniformity :math:`(r')^2` is computed as follows:
 
-    :math:`mean((r'_1)^2, (r'_2)^2, ..., (r'_n)^2)`
+    :math:`\\text{mean}((r'_1)^2, (r'_2)^2, ..., (r'_n)^2)`
 
     where :math:`(r'_i)^2` is the first-order derivative, squared, of the
     reflectance :math:`r_i` of a test sample.
@@ -66,11 +66,11 @@ def spectral_uniformity(
     Parameters
     ----------
     sds
-        Spectral distributions or multi-spectral distributions to
-        compute the spectral uniformity of. `sds` can be a single
+        Spectral distributions or multi-spectral distributions to compute
+        the spectral uniformity of. `sds` can be a single
         :class:`colour.MultiSpectralDistributions` class instance, a list
-        of :class:`colour.MultiSpectralDistributions` class instances or a
-        List of :class:`colour.SpectralDistribution` class instances.
+        of :class:`colour.MultiSpectralDistributions` class instances or
+        a list of :class:`colour.SpectralDistribution` class instances.
     use_second_order_derivatives
         Whether to use the second-order derivatives in the computations.
 

--- a/colour/colorimetry/whiteness.py
+++ b/colour/colorimetry/whiteness.py
@@ -2,29 +2,31 @@
 Whiteness Index :math:`W`
 =========================
 
-Define the *whiteness* index :math:`W` computation objects:
+Define *whiteness* index :math:`W` computation methods.
 
--   :func:`colour.colorimetry.whiteness_Berger1959`: *Whiteness* index
-    :math:`WI` computation of specified sample *CIE XYZ* tristimulus values using
-    *Berger (1959)* method.
--   :func:`colour.colorimetry.whiteness_Taube1960`: *Whiteness* index
-    :math:`WI` computation of specified sample *CIE XYZ* tristimulus values using
-    *Taube (1960)* method.
--   :func:`colour.colorimetry.whiteness_Stensby1968`: *Whiteness* index
-    :math:`WI` computation of specified sample *CIE L\\*a\\*b\\** colourspace array
-    using *Stensby (1968)* method.
--   :func:`colour.colorimetry.whiteness_ASTME313`: *Whiteness* index :math:`WI`
-    of specified sample *CIE XYZ* tristimulus values using *ASTM E313* method.
--   :func:`colour.colorimetry.whiteness_Ganz1979`: *Whiteness* index :math:`W`
-    and *tint* :math:`T` computation of specified sample *CIE xy* chromaticity
-    coordinates using *Ganz and Griesser (1979)* method.
--   :func:`colour.colorimetry.whiteness_CIE2004`: *Whiteness* :math:`W` or
-    :math:`W_{10}` and *tint* :math:`T` or :math:`T_{10}` computation of specified
-    sample *CIE xy* chromaticity coordinates using *CIE 2004* method.
--   :attr:`colour.WHITENESS_METHODS`: Supported *whiteness* computations
+-   :func:`colour.colorimetry.whiteness_Berger1959`: Compute *whiteness*
+    index :math:`WI` from the specified sample *CIE XYZ* tristimulus values
+    using *Berger (1959)* method.
+-   :func:`colour.colorimetry.whiteness_Taube1960`: Compute *whiteness*
+    index :math:`WI` from the specified sample *CIE XYZ* tristimulus values
+    using *Taube (1960)* method.
+-   :func:`colour.colorimetry.whiteness_Stensby1968`: Compute *whiteness*
+    index :math:`WI` from the specified sample *CIE L\\*a\\*b\\** colourspace
+    array using *Stensby (1968)* method.
+-   :func:`colour.colorimetry.whiteness_ASTME313`: Compute *whiteness*
+    index :math:`WI` from the specified sample *CIE XYZ* tristimulus values
+    using *ASTM E313* method.
+-   :func:`colour.colorimetry.whiteness_Ganz1979`: Compute *whiteness*
+    index :math:`W` and *tint* :math:`T` from the specified sample *CIE xy*
+    chromaticity coordinates using *Ganz and Griesser (1979)* method.
+-   :func:`colour.colorimetry.whiteness_CIE2004`: Compute *whiteness*
+    :math:`W` or :math:`W_{10}` and *tint* :math:`T` or :math:`T_{10}`
+    from the specified sample *CIE xy* chromaticity coordinates using
+    *CIE 2004* method.
+-   :attr:`colour.WHITENESS_METHODS`: Supported *whiteness* computation
     methods.
--   :func:`colour.whiteness`: *Whiteness* :math:`W` computation using specified
-    method.
+-   :func:`colour.whiteness`: Compute *whiteness* :math:`W` using
+    specified method.
 
 References
 ----------
@@ -83,8 +85,8 @@ __all__ = [
 
 def whiteness_Berger1959(XYZ: ArrayLike, XYZ_0: ArrayLike) -> NDArrayFloat:
     """
-    Return the *whiteness* index :math:`WI` of specified sample *CIE XYZ*
-    tristimulus values using *Berger (1959)* method.
+    Compute the *whiteness* index :math:`WI` of the specified sample *CIE XYZ*
+    tristimulus values using the *Berger (1959)* method.
 
     Parameters
     ----------
@@ -95,8 +97,8 @@ def whiteness_Berger1959(XYZ: ArrayLike, XYZ_0: ArrayLike) -> NDArrayFloat:
 
     Returns
     -------
-    :class:`np.float` or :class:`numpy.ndarray`
-        *Whiteness* :math:`WI`.
+    :class:`numpy.ndarray`
+        *Whiteness* index :math:`WI`.
 
     Notes
     -----
@@ -140,8 +142,8 @@ def whiteness_Berger1959(XYZ: ArrayLike, XYZ_0: ArrayLike) -> NDArrayFloat:
 
 def whiteness_Taube1960(XYZ: ArrayLike, XYZ_0: ArrayLike) -> NDArrayFloat:
     """
-    Return the *whiteness* index :math:`WI` of specified sample *CIE XYZ*
-    tristimulus values using *Taube (1960)* method.
+    Compute the *whiteness* index :math:`WI` of the specified sample *CIE XYZ*
+    tristimulus values using the *Taube (1960)* method.
 
     Parameters
     ----------
@@ -152,8 +154,8 @@ def whiteness_Taube1960(XYZ: ArrayLike, XYZ_0: ArrayLike) -> NDArrayFloat:
 
     Returns
     -------
-    :class:`np.float` or :class:`numpy.ndarray`
-        *Whiteness* :math:`WI`.
+    :class:`numpy.ndarray`
+        *Whiteness* index :math:`WI`.
 
     Notes
     -----
@@ -197,8 +199,8 @@ def whiteness_Taube1960(XYZ: ArrayLike, XYZ_0: ArrayLike) -> NDArrayFloat:
 
 def whiteness_Stensby1968(Lab: ArrayLike) -> NDArrayFloat:
     """
-    Return the *whiteness* index :math:`WI` of specified sample *CIE L\\*a\\*b\\**
-    colourspace array using *Stensby (1968)* method.
+    Compute the *whiteness* index :math:`WI` of the specified sample
+    *CIE L\\*a\\*b\\** colourspace array using the *Stensby (1968)* method.
 
     Parameters
     ----------
@@ -207,8 +209,8 @@ def whiteness_Stensby1968(Lab: ArrayLike) -> NDArrayFloat:
 
     Returns
     -------
-    :class:`np.float` or :class:`numpy.ndarray`
-        *Whiteness* :math:`WI`.
+    :class:`numpy.ndarray`
+        *Whiteness* index :math:`WI`.
 
     Notes
     -----
@@ -252,8 +254,8 @@ def whiteness_Stensby1968(Lab: ArrayLike) -> NDArrayFloat:
 
 def whiteness_ASTME313(XYZ: ArrayLike) -> NDArrayFloat:
     """
-    Return the *whiteness* index :math:`WI` of specified sample *CIE XYZ*
-    tristimulus values using *ASTM E313* method.
+    Compute the *whiteness* index :math:`WI` of the specified sample *CIE XYZ*
+    tristimulus values using the *ASTM E313* method.
 
     Parameters
     ----------
@@ -262,8 +264,8 @@ def whiteness_ASTME313(XYZ: ArrayLike) -> NDArrayFloat:
 
     Returns
     -------
-    :class:`np.float` or :class:`numpy.ndarray`
-        *Whiteness* :math:`WI`.
+    :class:`numpy.ndarray`
+        *Whiteness* index :math:`WI`.
 
     Notes
     -----
@@ -300,9 +302,9 @@ def whiteness_ASTME313(XYZ: ArrayLike) -> NDArrayFloat:
 
 def whiteness_Ganz1979(xy: ArrayLike, Y: ArrayLike) -> NDArrayFloat:
     """
-    Return the *whiteness* index :math:`W` and *tint* :math:`T` of specified
-    sample *CIE xy* chromaticity coordinates using *Ganz and Griesser (1979)*
-    method.
+    Compute the *whiteness* index :math:`W` and *tint* :math:`T` of the
+    specified sample *CIE xy* chromaticity coordinates using the
+    *Ganz and Griesser (1979)* method.
 
     Parameters
     ----------
@@ -333,8 +335,8 @@ def whiteness_Ganz1979(xy: ArrayLike, Y: ArrayLike) -> NDArrayFloat:
     -   The formula coefficients are valid for
         *CIE Standard Illuminant D Series* *D65* and
         *CIE 1964 10 Degree Standard Observer*.
-    -   Positive output *tint* :math:`T` values indicate a greener tint while
-        negative values indicate a redder tint.
+    -   Positive output *tint* :math:`T` values indicate a greener tint
+        while negative values indicate a redder tint.
     -   Whiteness differences of less than 5 Ganz units appear to be
         indistinguishable to the human eye.
     -   Tint differences of less than 0.5 Ganz units appear to be
@@ -373,9 +375,9 @@ def whiteness_CIE2004(
     ] = ("CIE 1931 2 Degree Standard Observer"),
 ) -> NDArrayFloat:
     """
-    Return the *whiteness* :math:`W` or :math:`W_{10}` and *tint* :math:`T`
-    or :math:`T_{10}` of specified sample *CIE xy* chromaticity coordinates using
-    *CIE 2004* method.
+    Compute the *whiteness* :math:`W` or :math:`W_{10}` and *tint*
+    :math:`T` or :math:`T_{10}` of the specified sample *CIE xy* chromaticity
+    coordinates using the *CIE 2004* method.
 
     Parameters
     ----------
@@ -393,7 +395,7 @@ def whiteness_CIE2004(
     -------
     :class:`numpy.ndarray`
         *Whiteness* :math:`W` or :math:`W_{10}` and *tint* :math:`T` or
-        :math:`T_{10}` of specified sample.
+        :math:`T_{10}` of the specified sample.
 
     Notes
     -----
@@ -409,17 +411,17 @@ def whiteness_CIE2004(
     | ``WT``     | [0, 100]              | [0, 1]        |
     +------------+-----------------------+---------------+
 
-    -   This method may be used only for samples whose values of :math:`W` or
-        :math:`W_{10}` lie within the following limits: greater than 40 and
-        less than 5Y - 280, or 5Y10 - 280.
-    -   This method may be used only for samples whose values of :math:`T` or
-        :math:`T_{10}` lie within the following limits: greater than -4 and
-        less than +2.
-    -   Output *whiteness* :math:`W` or :math:`W_{10}` values larger than 100
-        indicate a bluish white while values smaller than 100 indicate a
-        yellowish white.
-    -   Positive output *tint* :math:`T` or :math:`T_{10}` values indicate a
-        greener tint while negative values indicate a redder tint.
+    -   This method may be used only for samples whose values of :math:`W`
+        or :math:`W_{10}` lie within the following limits: greater than 40
+        and less than 5Y - 280, or 5Y10 - 280.
+    -   This method may be used only for samples whose values of :math:`T`
+        or :math:`T_{10}` lie within the following limits: greater than -4
+        and less than +2.
+    -   Output *whiteness* :math:`W` or :math:`W_{10}` values larger than
+        100 indicate a bluish white while values smaller than 100 indicate
+        a yellowish white.
+    -   Positive output *tint* :math:`T` or :math:`T_{10}` values indicate
+        a greener tint while negative values indicate a redder tint.
 
     References
     ----------
@@ -487,7 +489,8 @@ def whiteness(
     **kwargs: Any,
 ) -> NDArrayFloat:
     """
-    Return the *whiteness* :math:`W` using specified method.
+    Compute the *whiteness* index :math:`W` of the specified sample *CIE XYZ*
+    tristimulus values using the specified method.
 
     Parameters
     ----------
@@ -507,25 +510,24 @@ def whiteness(
 
     Returns
     -------
-    :class:`np.float` or :class:`numpy.ndarray`
-        *Whiteness* :math:`W`.
+    :class:`numpy.ndarray`
+        *Whiteness* index :math:`W`.
 
     Notes
     -----
-    +------------+-----------------------+-----------------+
-    | **Domain** | **Scale - Reference** |   **Scale - 1** |
-    +============+=======================+=================+
-    +------------+-----------------------+-----------------+
-    | ``XYZ``    | [0, 100]              |   [0, 1]        |
-    +------------+-----------------------+-----------------+
-    | ``XYZ_0``  | [0, 100]              |   [0, 1]        |
-    +------------+-----------------------+-----------------+
+    +------------+-----------------------+---------------+
+    | **Domain** | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``XYZ``    | [0, 100]              | [0, 1]        |
+    +------------+-----------------------+---------------+
+    | ``XYZ_0``  | [0, 100]              | [0, 1]        |
+    +------------+-----------------------+---------------+
 
-    +------------+-----------------------+-----------------+
-    | **Range**  | **Scale - Reference** |   **Scale - 1** |
-    +============+=======================+=================+
-    | ``W``      | [0, 100]              |   [0, 1]        |
-    +------------+-----------------------+-----------------+
+    +------------+-----------------------+---------------+
+    | **Range**  | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``W``      | [0, 100]              | [0, 1]        |
+    +------------+-----------------------+---------------+
 
     References
     ----------

--- a/colour/colorimetry/yellowness.py
+++ b/colour/colorimetry/yellowness.py
@@ -2,21 +2,18 @@
 Yellowness Index :math:`Y`
 ==========================
 
-Define the *yellowness* index :math:`Y` computation objects:
+Define the *yellowness* index :math:`Y` computation methods.
 
--   :func:`colour.colorimetry.yellowness_ASTMD1925`: *Yellowness* index
-    :math:`YI` computation of specified sample *CIE XYZ* tristimulus values using
-    *ASTM D1925* method.
--   :func:`colour.colorimetry.yellowness_ASTME313_alternative`: *Yellowness*
-    index :math:`YI` computation of specified sample *CIE XYZ* tristimulus values
-    using the alternative *ASTM E313* method.
--   :func:`colour.colorimetry.yellowness_ASTME313`: *Yellowness*
-    index :math:`YI` computation of specified sample *CIE XYZ* tristimulus values
-    using the recommended *ASTM E313* method.
--   :attr:`colour.YELLOWNESS_METHODS`: Supported *yellowness* computations
+-   :func:`colour.colorimetry.yellowness_ASTMD1925`: Compute *yellowness*
+    index :math:`YI` using *ASTM D1925* method for plastics.
+-   :func:`colour.colorimetry.yellowness_ASTME313_alternative`: Compute
+    *yellowness* index :math:`YI` using the alternative *ASTM E313* method.
+-   :func:`colour.colorimetry.yellowness_ASTME313`: Compute *yellowness*
+    index :math:`YI` using the recommended *ASTM E313* method.
+-   :attr:`colour.YELLOWNESS_METHODS`: Supported *yellowness* computation
     methods.
--   :func:`colour.yellownes`: *Yellowness* :math:`YI` computation using specified
-    method.
+-   :func:`colour.yellowness`: Compute *yellowness* :math:`YI` using
+    specified method.
 
 References
 ----------
@@ -69,14 +66,14 @@ __all__ = [
 
 def yellowness_ASTMD1925(XYZ: ArrayLike) -> NDArrayFloat:
     """
-    Return the *yellowness* index :math:`YI` of specified sample *CIE XYZ*
-    tristimulus values using *ASTM D1925* method.
+    Compute the *yellowness* index :math:`YI` of the specified sample *CIE XYZ*
+    tristimulus values using the *ASTM D1925* method.
 
-    ASTM D1925 has been specifically developed for the definition of the
+    The *ASTM D1925* method has been specifically developed for defining the
     yellowness of homogeneous, non-fluorescent, almost neutral-transparent,
-    white-scattering or opaque plastics as they will be reviewed under daylight
-    condition. It can be other materials as well, as long as they fit into this
-    description.
+    white-scattering or opaque plastics as they will be evaluated under
+    daylight conditions. The method can be applied to other materials as
+    well, provided they fit this description.
 
     Parameters
     ----------
@@ -85,8 +82,8 @@ def yellowness_ASTMD1925(XYZ: ArrayLike) -> NDArrayFloat:
 
     Returns
     -------
-    :class:`np.float` or :class:`numpy.ndarray`
-        *Yellowness* :math:`YI`.
+    :class:`numpy.ndarray`
+        *Yellowness* index :math:`YI`.
 
     Notes
     -----
@@ -126,16 +123,17 @@ def yellowness_ASTMD1925(XYZ: ArrayLike) -> NDArrayFloat:
 
 def yellowness_ASTME313_alternative(XYZ: ArrayLike) -> NDArrayFloat:
     """
-    Return the *yellowness* index :math:`YI` of specified sample *CIE XYZ*
+    Compute the *yellowness* index :math:`YI` of the specified sample *CIE XYZ*
     tristimulus values using the alternative *ASTM E313* method.
 
     In the original form of *Test Method E313*, an alternative equation was
     recommended for a *yellowness* index. In terms of colorimeter readings,
     it was :math:`YI = 100(1 - B/G)` where :math:`B` and :math:`G` are,
-    respectively, blue and green colorimeter readings. Its derivation assumed
-    that, because of the limitation of the concept to yellow (or blue) colors,
-    it was not necessary to take account of variations in the amber or red
-    colorimeter reading :math:`A`. This equation is no longer recommended.
+    respectively, blue and green colorimeter readings. Its derivation
+    assumed that, because of the limitation of the concept to yellow (or
+    blue) colors, it was not necessary to take account of variations in the
+    amber or red colorimeter reading :math:`A`. This equation is no longer
+    recommended.
 
     Parameters
     ----------
@@ -144,8 +142,8 @@ def yellowness_ASTME313_alternative(XYZ: ArrayLike) -> NDArrayFloat:
 
     Returns
     -------
-    :class:`np.float` or :class:`numpy.ndarray`
-        *Yellowness* :math:`YI`.
+    :class:`numpy.ndarray`
+        *Yellowness* index :math:`YI`.
 
     Notes
     -----
@@ -178,9 +176,9 @@ def yellowness_ASTME313_alternative(XYZ: ArrayLike) -> NDArrayFloat:
     _X, Y, Z = tsplit(to_domain_100(XYZ))
 
     with sdiv_mode():
-        WI = 100 * (1 - sdiv(0.847 * Z, Y))
+        YI = 100 * (1 - sdiv(0.847 * Z, Y))
 
-    return as_float(from_range_100(WI))
+    return as_float(from_range_100(YI))
 
 
 YELLOWNESS_COEFFICIENTS_ASTME313: CanonicalMapping = CanonicalMapping(
@@ -200,8 +198,8 @@ YELLOWNESS_COEFFICIENTS_ASTME313: CanonicalMapping = CanonicalMapping(
     }
 )
 YELLOWNESS_COEFFICIENTS_ASTME313.__doc__ = """
-Coefficients :math:`C_X` and :math:`C_Z` for the *ASTM E313* *yellowness* index
-:math:`YI` computation method.
+Coefficients :math:`C_X` and :math:`C_Z` for the *ASTM E313*
+*yellowness* index :math:`YI` computation method.
 
 References
 ----------
@@ -227,11 +225,11 @@ def yellowness_ASTME313(
     ]["D65"],
 ) -> NDArrayFloat:
     """
-    Return the *yellowness* index :math:`YI` of specified sample *CIE XYZ*
-    tristimulus values using *ASTM E313* method.
+    Compute the *yellowness* index :math:`YI` of the specified sample *CIE XYZ*
+    tristimulus values using the *ASTM E313* method.
 
-    ASTM E313 has successfully been used for a variety of white or near white
-    materials. This includes coatings, plastics, textiles.
+    *ASTM E313* has been successfully used for a variety of white or near white
+    materials. This includes coatings, plastics, and textiles.
 
     Parameters
     ----------
@@ -240,13 +238,13 @@ def yellowness_ASTME313(
     C_XZ
         Coefficients :math:`C_X` and :math:`C_Z` for the
         *CIE 1931 2 Degree Standard Observer* and
-        *CIE 1964 10 Degree Standard Observer* and *CIE Illuminant C* and
+        *CIE 1964 10 Degree Standard Observer* with *CIE Illuminant C* and
         *CIE Standard Illuminant D65*.
 
     Returns
     -------
-    :class:`np.float` or :class:`numpy.ndarray`
-        *Yellowness* :math:`YI`.
+    :class:`numpy.ndarray`
+        *Yellowness* index :math:`YI`.
 
     Notes
     -----
@@ -277,9 +275,9 @@ def yellowness_ASTME313(
     C_X, C_Z = tsplit(C_XZ)
 
     with sdiv_mode():
-        WI = 100 * sdiv(C_X * X - C_Z * Z, Y)
+        YI = 100 * sdiv(C_X * X - C_Z * Z, Y)
 
-    return as_float(from_range_100(WI))
+    return as_float(from_range_100(YI))
 
 
 YELLOWNESS_METHODS = CanonicalMapping(
@@ -306,7 +304,7 @@ def yellowness(
     **kwargs: Any,
 ) -> NDArrayFloat:
     """
-    Return the *yellowness* :math:`W` using specified method.
+    Compute the *yellowness* index :math:`YI` using the specified method.
 
     Parameters
     ----------
@@ -321,13 +319,13 @@ def yellowness(
         {:func:`colour.colorimetry.yellowness_ASTME313`},
         Coefficients :math:`C_X` and :math:`C_Z` for the
         *CIE 1931 2 Degree Standard Observer* and
-        *CIE 1964 10 Degree Standard Observer* and *CIE Illuminant C* and
+        *CIE 1964 10 Degree Standard Observer* with *CIE Illuminant C* and
         *CIE Standard Illuminant D65*.
 
     Returns
     -------
-    :class:`np.float` or :class:`numpy.ndarray`
-        *Yellowness* :math:`Y`.
+    :class:`numpy.ndarray`
+        *Yellowness* index :math:`YI`.
 
     Notes
     -----

--- a/colour/continuous/abstract.py
+++ b/colour/continuous/abstract.py
@@ -2,10 +2,10 @@
 Abstract Continuous Function
 ============================
 
-Define an abstract class implementing support for abstract continuous
-function:
+Define an abstract base class for continuous mathematical functions with
+support for interpolation, extrapolation, and arithmetical operations:
 
--   :class:`colour.continuous.AbstractContinuousFunction`.
+-   :class:`colour.continuous.AbstractContinuousFunction`
 """
 
 from __future__ import annotations
@@ -61,12 +61,12 @@ class AbstractContinuousFunction(ABC, MixinCallback):
 
     The sub-classes are expected to implement the
     :meth:`colour.continuous.AbstractContinuousFunction.function` method so
-    that evaluating the function for any independent domain
-    variable :math:`x \\in\\mathbb{R}` returns a corresponding range variable
+    that evaluating the function for any independent domain variable
+    :math:`x \\in\\mathbb{R}` returns a corresponding range variable
     :math:`y \\in\\mathbb{R}`. A conventional implementation adopts an
     interpolating function encapsulated inside an extrapolating function.
-    The resulting function independent domain, stored as discrete values in the
-    :attr:`colour.continuous.AbstractContinuousFunction.domain` attribute
+    The resulting function independent domain, stored as discrete values in
+    the :attr:`colour.continuous.AbstractContinuousFunction.domain` attribute,
     corresponds with the function dependent and already known range stored in
     the :attr:`colour.continuous.AbstractContinuousFunction.range` property.
 
@@ -129,7 +129,7 @@ arithmetical_operation`
     @property
     def name(self) -> str:
         """
-        Getter and setter property for the abstract continuous function name.
+        Getter and setter for the abstract continuous function name.
 
         Parameters
         ----------
@@ -159,8 +159,9 @@ arithmetical_operation`
     @abstractmethod
     def dtype(self) -> Type[DTypeFloat]:
         """
-        Getter and setter property for the abstract continuous function dtype,
-        must be reimplemented by sub-classes.
+        Getter and setter for the abstract continuous function dtype.
+
+        This property must be reimplemented by sub-classes.
 
         Parameters
         ----------
@@ -189,9 +190,10 @@ arithmetical_operation`
     @abstractmethod
     def domain(self) -> NDArrayFloat:
         """
-        Getter and setter property for the abstract continuous function
-        independent domain variable :math:`x`, must be reimplemented by
-        sub-classes.
+        Getter and setter for the abstract continuous function's independent
+        domain variable :math:`x`.
+
+        This property must be reimplemented by sub-classes.
 
         Parameters
         ----------
@@ -202,7 +204,8 @@ arithmetical_operation`
         Returns
         -------
         :class:`numpy.ndarray`
-            Abstract continuous function independent domain variable :math:`x`.
+            Abstract continuous function independent domain variable
+            :math:`x`.
         """
 
         ...  # pragma: no cover
@@ -221,21 +224,21 @@ arithmetical_operation`
     @abstractmethod
     def range(self) -> NDArrayFloat:
         """
-        Getter and setter property for the abstract continuous function
-        corresponding range variable :math:`y`, must be reimplemented by
-        sub-classes.
+        Getter and setter for the abstract continuous function's range
+        variable :math:`y`.
+
+        This property must be reimplemented by sub-classes.
 
         Parameters
         ----------
         value
-            Value to set the abstract continuous function corresponding range
-            variable :math:`y` with.
+            Value to set the abstract continuous function's range variable
+            :math:`y` with.
 
         Returns
         -------
         :class:`numpy.ndarray`
-            Abstract continuous function corresponding range variable
-            :math:`y`.
+            Abstract continuous function's range variable :math:`y`.
         """
 
         ...  # pragma: no cover
@@ -254,8 +257,10 @@ arithmetical_operation`
     @abstractmethod
     def interpolator(self) -> Type[ProtocolInterpolator]:
         """
-        Getter and setter property for the abstract continuous function
-        interpolator type, must be reimplemented by sub-classes.
+        Getter and setter for the abstract continuous function interpolator
+        type.
+
+        This property must be reimplemented by sub-classes.
 
         Parameters
         ----------
@@ -285,9 +290,9 @@ arithmetical_operation`
     @abstractmethod
     def interpolator_kwargs(self) -> dict:
         """
-        Getter and setter property for the abstract continuous function
-        interpolator instantiation time arguments, must be reimplemented by
-        sub-classes.
+        Getter and setter for the interpolator instantiation time arguments.
+
+        This property must be reimplemented by sub-classes.
 
         Parameters
         ----------
@@ -318,8 +323,10 @@ arithmetical_operation`
     @abstractmethod
     def extrapolator(self) -> Type[ProtocolExtrapolator]:
         """
-        Getter and setter property for the abstract continuous function
-        extrapolator type, must be reimplemented by sub-classes.
+        Getter and setter for the abstract continuous function extrapolator
+        type.
+
+        This property must be reimplemented by sub-classes.
 
         Parameters
         ----------
@@ -349,9 +356,10 @@ arithmetical_operation`
     @abstractmethod
     def extrapolator_kwargs(self) -> dict:
         """
-        Getter and setter property for the abstract continuous function
-        extrapolator instantiation time arguments, must be reimplemented by
-        sub-classes.
+        Getter and setter for the abstract continuous function extrapolator
+        instantiation time arguments.
+
+        This property must be reimplemented by sub-classes.
 
         Parameters
         ----------
@@ -382,8 +390,9 @@ arithmetical_operation`
     @abstractmethod
     def function(self) -> Callable:
         """
-        Getter property for the abstract continuous function callable, must be
-        reimplemented by sub-classes.
+        Getter for the abstract continuous function callable.
+
+        This property must be reimplemented by sub-classes.
 
         Returns
         -------
@@ -397,7 +406,9 @@ arithmetical_operation`
     def __str__(self) -> str:
         """
         Return a formatted string representation of the abstract continuous
-        function, must be reimplemented by sub-classes.
+        function.
+
+        This method must be reimplemented by sub-classes.
 
         Returns
         -------
@@ -424,7 +435,7 @@ arithmetical_operation`
     @abstractmethod
     def __hash__(self) -> int:
         """
-        Return the abstract continuous function hash.
+        Compute the hash of the abstract continuous function.
 
         Returns
         -------
@@ -437,8 +448,10 @@ arithmetical_operation`
     @abstractmethod
     def __getitem__(self, x: ArrayLike | slice) -> NDArrayFloat:
         """
-        Return the corresponding range variable :math:`y` for independent
-        domain variable :math:`x`, must be reimplemented by sub-classes.
+        Return the corresponding range variable :math:`y` for the specified
+        independent domain variable :math:`x`.
+
+        This abstract method must be reimplemented by sub-classes.
 
         Parameters
         ----------
@@ -456,8 +469,10 @@ arithmetical_operation`
     @abstractmethod
     def __setitem__(self, x: ArrayLike | slice, y: ArrayLike) -> None:
         """
-        Set the corresponding range variable :math:`y` for independent domain
-        variable :math:`x`, must be reimplemented by sub-classes.
+        Set the corresponding range variable :math:`y` for the specified
+        independent domain variable :math:`x`.
+
+        This abstract method must be reimplemented by sub-classes.
 
         Parameters
         ----------
@@ -472,9 +487,10 @@ arithmetical_operation`
     @abstractmethod
     def __contains__(self, x: ArrayLike | slice) -> bool:
         """
-        Return whether the abstract continuous function contains specified
-        independent domain variable :math:`x`, must be reimplemented by
-        sub-classes.
+        Determine whether the abstract continuous function contains the
+        specified independent domain variable :math:`x`.
+
+        This abstract method must be reimplemented by sub-classes.
 
         Parameters
         ----------
@@ -496,21 +512,20 @@ arithmetical_operation`
         Yields
         ------
         Generator
-           Abstract continuous function generator.
+            Abstract continuous function generator.
         """
 
         yield from np.column_stack([self.domain, self.range])
 
     def __len__(self) -> int:
         """
-        Return the abstract continuous function independent domain :math:`x`
-        variable elements count.
-
+        Return the number of elements in the abstract continuous function's
+        independent domain variable :math:`x`.
 
         Returns
         -------
         :class:`int`
-            Independent domain variable :math:`x` elements count.
+            Number of elements in the independent domain variable :math:`x`.
         """
 
         return len(self.domain)
@@ -518,19 +533,20 @@ arithmetical_operation`
     @abstractmethod
     def __eq__(self, other: object) -> bool:
         """
-        Return whether the abstract continuous function is equal to specified
-        other object, must be reimplemented by sub-classes.
+        Determine whether the abstract continuous function equals the specified
+        object.
+
+        This abstract method must be reimplemented by sub-classes.
 
         Parameters
         ----------
         other
-            Object to test whether it is equal to the abstract continuous
-            function.
+            Object to determine for equality with the abstract continuous function.
 
         Returns
         -------
         :class:`bool`
-            Whether specified object is equal to the abstract continuous
+            Whether the specified object is equal to the abstract continuous
             function.
         """
 
@@ -539,20 +555,22 @@ arithmetical_operation`
     @abstractmethod
     def __ne__(self, other: object) -> bool:
         """
-        Return whether the abstract continuous function is not equal to
-        specified other object, must be reimplemented by sub-classes.
+        Determine whether the abstract continuous function is not equal to the
+        specified object.
+
+        This method must be reimplemented by sub-classes.
 
         Parameters
         ----------
         other
-            Object to test whether it is not equal to the abstract continuous
+            Object to determine whether it is not equal to the abstract continuous
             function.
 
         Returns
         -------
         :class:`bool`
-            Whether specified object is not equal to the abstract continuous
-            function.
+            Whether the specified object is not equal to the abstract
+            continuous function.
         """
 
         ...  # pragma: no cover
@@ -564,12 +582,13 @@ arithmetical_operation`
         Parameters
         ----------
         a
-            Variable :math:`a` to add.
+            Variable :math:`a` to add to the continuous function.
 
         Returns
         -------
         :class:`colour.continuous.AbstractContinuousFunction`
-            Variable added abstract continuous function.
+            Abstract continuous function with the specified variable
+            added.
         """
 
         return self.arithmetical_operation(a, "+")
@@ -581,12 +600,13 @@ arithmetical_operation`
         Parameters
         ----------
         a
-            Variable :math:`a` to add in-place.
+            Variable :math:`a` to add in-place to the abstract continuous
+            function.
 
         Returns
         -------
         :class:`colour.continuous.AbstractContinuousFunction`
-            In-place variable added abstract continuous function.
+            Abstract continuous function with in-place addition applied.
         """
 
         return self.arithmetical_operation(a, "+", True)
@@ -598,12 +618,13 @@ arithmetical_operation`
         Parameters
         ----------
         a
-            Variable :math:`a` to subtract.
+            Variable :math:`a` to subtract from the continuous function.
 
         Returns
         -------
         :class:`colour.continuous.AbstractContinuousFunction`
-            Variable subtracted abstract continuous function.
+            Abstract continuous function with the specified variable
+            subtracted.
         """
 
         return self.arithmetical_operation(a, "-")
@@ -615,12 +636,13 @@ arithmetical_operation`
         Parameters
         ----------
         a
-            Variable :math:`a` to subtract in-place.
+            Variable :math:`a` to subtract in-place from the abstract continuous
+            function.
 
         Returns
         -------
         :class:`colour.continuous.AbstractContinuousFunction`
-            In-place variable subtracted abstract continuous function.
+            Abstract continuous function with in-place subtraction applied.
         """
 
         return self.arithmetical_operation(a, "-", True)
@@ -632,12 +654,13 @@ arithmetical_operation`
         Parameters
         ----------
         a
-            Variable :math:`a` to multiply by.
+            Variable :math:`a` to multiply the continuous function by.
 
         Returns
         -------
         :class:`colour.continuous.AbstractContinuousFunction`
-            Variable multiplied abstract continuous function.
+            Abstract continuous function with the specified variable
+            multiplied.
         """
 
         return self.arithmetical_operation(a, "*")
@@ -649,12 +672,13 @@ arithmetical_operation`
         Parameters
         ----------
         a
-            Variable :math:`a` to multiply by in-place.
+            Variable :math:`a` to multiply in-place by the abstract continuous
+            function.
 
         Returns
         -------
         :class:`colour.continuous.AbstractContinuousFunction`
-            In-place variable multiplied abstract continuous function.
+            Abstract continuous function with in-place multiplication applied.
         """
 
         return self.arithmetical_operation(a, "*", True)
@@ -666,12 +690,13 @@ arithmetical_operation`
         Parameters
         ----------
         a
-            Variable :math:`a` to divide by.
+            Variable :math:`a` to divide the continuous function by.
 
         Returns
         -------
         :class:`colour.continuous.AbstractContinuousFunction`
-            Variable divided abstract continuous function.
+            Abstract continuous function with the specified variable
+            divided.
         """
 
         return self.arithmetical_operation(a, "/")
@@ -683,12 +708,13 @@ arithmetical_operation`
         Parameters
         ----------
         a
-            Variable :math:`a` to divide by in-place.
+            Variable :math:`a` to divide in-place by the abstract continuous
+            function.
 
         Returns
         -------
         :class:`colour.continuous.AbstractContinuousFunction`
-            In-place variable divided abstract continuous function.
+            Abstract continuous function with in-place division applied.
         """
 
         return self.arithmetical_operation(a, "/", True)
@@ -703,12 +729,13 @@ arithmetical_operation`
         Parameters
         ----------
         a
-            Variable :math:`a` to exponentiate by.
+            Variable :math:`a` to raise the continuous function to the power of.
 
         Returns
         -------
         :class:`colour.continuous.AbstractContinuousFunction`
-            Variable exponentiated abstract continuous function.
+            Abstract continuous function with the specified variable
+            exponentiated.
         """
 
         return self.arithmetical_operation(a, "**")
@@ -720,12 +747,13 @@ arithmetical_operation`
         Parameters
         ----------
         a
-            Variable :math:`a` to exponentiate by in-place.
+            Variable :math:`a` to raise in-place the abstract continuous
+            function to the power of.
 
         Returns
         -------
         :class:`colour.continuous.AbstractContinuousFunction`
-            In-place variable exponentiated abstract continuous function.
+            Abstract continuous function with in-place exponentiation applied.
         """
 
         return self.arithmetical_operation(a, "**", True)
@@ -738,14 +766,16 @@ arithmetical_operation`
         in_place: bool = False,
     ) -> Self:
         """
-        Perform specified arithmetical operation with operand :math:`a`, the
-        operation can be either performed on a copy or in-place, must be
-        reimplemented by sub-classes.
+        Perform the specified arithmetical operation with operand :math:`a`,
+        either on a copy or in-place.
+
+        This method must be reimplemented by sub-classes.
 
         Parameters
         ----------
         a
-            Operand :math:`a`.
+            Operand :math:`a`. Can be a numeric value, array-like object, or
+            another continuous function instance.
         operation
             Operation to perform.
         in_place
@@ -767,8 +797,9 @@ arithmetical_operation`
     ) -> Self:
         """
         Fill NaNs in independent domain variable :math:`x` and corresponding
-        range variable :math:`y` using specified method, must be reimplemented
-        by sub-classes.
+        range variable :math:`y` using the specified method.
+
+        This abstract method must be reimplemented by sub-classes.
 
         Parameters
         ----------
@@ -788,13 +819,13 @@ arithmetical_operation`
 
     def domain_distance(self, a: ArrayLike) -> NDArrayFloat:
         """
-        Return the euclidean distance between specified array and independent
-        domain :math:`x` closest element.
+        Return the Euclidean distance between specified array and the closest
+        element of the independent domain :math:`x`.
 
         Parameters
         ----------
         a
-            Variable :math:`a` to compute the euclidean distance with
+            Variable :math:`a` to compute the Euclidean distance with the
             independent domain variable :math:`x`.
 
         Returns
@@ -810,12 +841,12 @@ arithmetical_operation`
 
     def is_uniform(self) -> bool:
         """
-        Return if independent domain variable :math:`x` is uniform.
+        Return whether the independent domain variable :math:`x` is uniform.
 
         Returns
         -------
         :class:`bool`
-            Is independent domain variable :math:`x` uniform.
+            Whether the independent domain variable :math:`x` is uniform.
         """
 
         return is_uniform(self.domain)
@@ -827,7 +858,7 @@ arithmetical_operation`
         Returns
         -------
         :class:`colour.continuous.AbstractContinuousFunction`
-            Abstract continuous function copy.
+            Copy of the abstract continuous function.
         """
 
         return deepcopy(self)

--- a/colour/continuous/multi_signals.py
+++ b/colour/continuous/multi_signals.py
@@ -1,8 +1,12 @@
 """
-Multi Signals
+Multi-Signals
 =============
 
-Define a class implementing support for multi-continuous signals:
+Define multi-continuous signal support for colour science computations.
+
+This module provides the :class:`colour.continuous.MultiSignals` class for
+representing and operating on multiple continuous signals simultaneously,
+supporting interpolation and extrapolation operations.
 
 -   :class:`colour.continuous.MultiSignals`
 """
@@ -72,25 +76,25 @@ __all__ = [
 
 class MultiSignals(AbstractContinuousFunction):
     """
-    Define the base class for multi-continuous signals, a container for
+    Define the base class for multi-signals, a container for
     multiple :class:`colour.continuous.Signal` sub-class instances.
 
     .. important::
 
-        Specific documentation about getting, setting, indexing and slicing the
-        multi-continuous signals values is available in the
+        Specific documentation about getting, setting, indexing and slicing
+        the multi-signals values is available in the
         :ref:`spectral-representation-and-continuous-signal` section.
 
     Parameters
     ----------
     data
-        Data to be stored in the multi-continuous signals.
+        Data to be stored in the multi-signals.
     domain
         Values to initialise the multiple :class:`colour.continuous.Signal`
-        sub-class instances :attr:`colour.continuous.Signal.domain` attribute
-        with. If both ``data`` and ``domain`` arguments are defined, the latter
-        will be used to initialise the :attr:`colour.continuous.Signal.domain`
-        attribute.
+        sub-class instances :attr:`colour.continuous.Signal.domain`
+        attribute with. If both ``data`` and ``domain`` arguments are
+        defined, the latter will be used to initialise the
+        :attr:`colour.continuous.Signal.domain` attribute.
     labels
         Names to use for the :class:`colour.continuous.Signal` sub-class
         instances.
@@ -103,16 +107,16 @@ class MultiSignals(AbstractContinuousFunction):
         Extrapolator class type to use as extrapolating function for the
         :class:`colour.continuous.Signal` sub-class instances.
     extrapolator_kwargs
-        Arguments to use when instantiating the extrapolating function
-        of the :class:`colour.continuous.Signal` sub-class instances.
+        Arguments to use when instantiating the extrapolating function of
+        the :class:`colour.continuous.Signal` sub-class instances.
     interpolator
         Interpolator class type to use as interpolating function for the
         :class:`colour.continuous.Signal` sub-class instances.
     interpolator_kwargs
-        Arguments to use when instantiating the interpolating function
-        of the :class:`colour.continuous.Signal` sub-class instances.
+        Arguments to use when instantiating the interpolating function of
+        the :class:`colour.continuous.Signal` sub-class instances.
     name
-        multi-continuous signals name.
+        Multi-signals name.
     signal_type
         The :class:`colour.continuous.Signal` sub-class type used for
         instances.
@@ -326,17 +330,17 @@ class MultiSignals(AbstractContinuousFunction):
     @property
     def dtype(self) -> Type[DTypeFloat]:
         """
-        Getter and setter property for the continuous signal dtype.
+        Getter and setter for the multi-signals dtype.
 
         Parameters
         ----------
         value
-            Value to set the continuous signal dtype with.
+            Value to set the multi-signals dtype with.
 
         Returns
         -------
         Type[DTypeFloat]
-            Continuous signal dtype.
+            Multi-signals dtype.
         """
 
         return first_item(self._signals.values()).dtype
@@ -351,20 +355,20 @@ class MultiSignals(AbstractContinuousFunction):
     @property
     def domain(self) -> NDArrayFloat:
         """
-        Getter and setter property for the :class:`colour.continuous.Signal`
-        sub-class instances independent domain variable :math:`x`.
+        Getter and setter for the multi-signals' independent
+        domain variable :math:`x`.
 
         Parameters
         ----------
         value
-            Value to set the :class:`colour.continuous.Signal` sub-class
-            instances independent domain variable :math:`x` with.
+            Value to set the multi-signals independent domain
+            variable :math:`x` with.
 
         Returns
         -------
         :class:`numpy.ndarray`
-            :class:`colour.continuous.Signal` sub-class instances independent
-            domain variable :math:`x`.
+            Multi-signals independent domain variable
+            :math:`x`.
         """
 
         return first_item(self._signals.values()).domain
@@ -379,20 +383,19 @@ class MultiSignals(AbstractContinuousFunction):
     @property
     def range(self) -> NDArrayFloat:
         """
-        Getter and setter property for the :class:`colour.continuous.Signal`
-        sub-class instances corresponding range variable :math:`y`.
+        Getter and setter for the multi-signals' range
+        variable :math:`y`.
 
         Parameters
         ----------
         value
-            Value to set the :class:`colour.continuous.Signal` sub-class
-            instances corresponding range variable :math:`y` with.
+            Value to set the multi-signals' range variable
+            :math:`y` with.
 
         Returns
         -------
         :class:`numpy.ndarray`
-            :class:`colour.continuous.Signal` sub-class instances corresponding
-            range variable :math:`y`.
+            Multi-signals' range variable :math:`y`.
         """
 
         return tstack([signal.range for signal in self._signals.values()])
@@ -419,20 +422,19 @@ class MultiSignals(AbstractContinuousFunction):
     @property
     def interpolator(self) -> Type[ProtocolInterpolator]:
         """
-        Getter and setter property for the :class:`colour.continuous.Signal`
-        sub-class instances interpolator type.
+        Getter and setter for the multi-signals interpolator
+        type.
 
         Parameters
         ----------
         value
-            Value to set the :class:`colour.continuous.Signal` sub-class
-            instances interpolator type with.
+            Value to set the multi-signals interpolator type
+            with.
 
         Returns
         -------
         Type[ProtocolInterpolator]
-            :class:`colour.continuous.Signal` sub-class instances interpolator
-            type.
+            Multi-signals interpolator type.
         """
 
         return first_item(self._signals.values()).interpolator
@@ -448,20 +450,19 @@ class MultiSignals(AbstractContinuousFunction):
     @property
     def interpolator_kwargs(self) -> dict:
         """
-        Getter and setter property for the :class:`colour.continuous.Signal`
-        sub-class instances interpolator instantiation time arguments.
+        Getter and setter for the interpolator instantiation time arguments.
 
         Parameters
         ----------
         value
-            Value to set the :class:`colour.continuous.Signal` sub-class
-            instances interpolator instantiation time arguments to.
+            Value to set the multi-signals interpolator
+            instantiation time arguments to.
 
         Returns
         -------
         :class:`dict`
-            :class:`colour.continuous.Signal` sub-class instances interpolator
-            instantiation time arguments.
+            Multi-signals interpolator instantiation time
+            arguments.
         """
 
         return first_item(self._signals.values()).interpolator_kwargs
@@ -476,20 +477,19 @@ class MultiSignals(AbstractContinuousFunction):
     @property
     def extrapolator(self) -> Type[ProtocolExtrapolator]:
         """
-        Getter and setter property for the :class:`colour.continuous.Signal`
-        sub-class instances extrapolator type.
+        Getter and setter for the multi-signals extrapolator
+        type.
 
         Parameters
         ----------
         value
-            Value to set the :class:`colour.continuous.Signal` sub-class
-            instances extrapolator type with.
+            Value to set the multi-signals extrapolator type
+            with.
 
         Returns
         -------
         Type[ProtocolExtrapolator]
-            :class:`colour.continuous.Signal` sub-class instances extrapolator
-            type.
+            Multi-signals extrapolator type.
         """
 
         return first_item(self._signals.values()).extrapolator
@@ -504,20 +504,20 @@ class MultiSignals(AbstractContinuousFunction):
     @property
     def extrapolator_kwargs(self) -> dict:
         """
-        Getter and setter property for the :class:`colour.continuous.Signal`
-        sub-class instances extrapolator instantiation time arguments.
+        Getter and setter for the multi-signals extrapolator
+        instantiation time arguments.
 
         Parameters
         ----------
         value
-            Value to set the :class:`colour.continuous.Signal` sub-class
-            instances extrapolator instantiation time arguments to.
+            Value to set the multi-signals extrapolator
+            instantiation time arguments to.
 
         Returns
         -------
         :class:`dict`
-            :class:`colour.continuous.Signal` sub-class instances extrapolator
-            instantiation time arguments.
+            Multi-signals extrapolator instantiation time
+            arguments.
         """
 
         return first_item(self._signals.values()).extrapolator_kwargs
@@ -532,13 +532,12 @@ class MultiSignals(AbstractContinuousFunction):
     @property
     def function(self) -> Callable:
         """
-        Getter property for the :class:`colour.continuous.Signal` sub-class
-        instances callable.
+        Getter for the multi-signals callable.
 
         Returns
         -------
         Callable
-            :class:`colour.continuous.Signal` sub-class instances callable.
+            Multi-signals callable.
         """
 
         return first_item(self._signals.values()).function
@@ -546,17 +545,19 @@ class MultiSignals(AbstractContinuousFunction):
     @property
     def signals(self) -> Dict[str, Signal]:
         """
-        Getter and setter property for the :class:`colour.continuous.Signal`
-        sub-class instances.
+        Getter and setter for the dictionary of
+        :class:`colour.continuous.Signal` sub-class instances.
 
         Parameters
         ----------
         value
-            Attribute value.
+            Dictionary of :class:`colour.continuous.Signal` sub-class
+            instances to set.
 
         Returns
         -------
         :class:`dict`
+            Dictionary mapping signal names to their corresponding
             :class:`colour.continuous.Signal` sub-class instances.
         """
 
@@ -576,8 +577,8 @@ class MultiSignals(AbstractContinuousFunction):
     @property
     def labels(self) -> List[str]:
         """
-        Getter and setter property for the :class:`colour.continuous.Signal`
-        sub-class instance names.
+        Getter and setter for the :class:`colour.continuous.Signal` sub-class
+        instance names.
 
         Parameters
         ----------
@@ -619,21 +620,21 @@ class MultiSignals(AbstractContinuousFunction):
     @property
     def signal_type(self) -> Type[Signal]:
         """
-        Getter property for the :class:`colour.continuous.Signal` sub-class
-        instances type.
+        Getter for the type of :class:`colour.continuous.Signal`
+        sub-class instances.
 
         Returns
         -------
         Type[Signal]
-            :class:`colour.continuous.Signal` sub-class instances type.
+            Type of :class:`colour.continuous.Signal` sub-class
+            instances used in this multi-signal collection.
         """
 
         return self._signal_type
 
     def __str__(self) -> str:
         """
-        Return a formatted string representation of the multi-continuous
-        signals.
+        Return a formatted string representation of the multi-signals.
 
         Returns
         -------
@@ -662,8 +663,7 @@ class MultiSignals(AbstractContinuousFunction):
 
     def __repr__(self) -> str:
         """
-        Return an evaluable string representation of the multi-continuous
-        signals.
+        Return an evaluable string representation of the multi-signals.
 
         Returns
         -------
@@ -724,7 +724,7 @@ class MultiSignals(AbstractContinuousFunction):
 
     def __hash__(self) -> int:
         """
-        Return the abstract continuous function hash.
+        Compute the hash of the multi-signals.
 
         Returns
         -------
@@ -745,8 +745,8 @@ class MultiSignals(AbstractContinuousFunction):
 
     def __getitem__(self, x: ArrayLike | slice) -> NDArrayFloat:
         """
-        Return the corresponding range variable :math:`y` for independent
-        domain variable :math:`x`.
+        Return the corresponding range variable :math:`y` for the specified
+        independent domain variable :math:`x`.
 
         Parameters
         ----------
@@ -811,8 +811,8 @@ class MultiSignals(AbstractContinuousFunction):
 
     def __setitem__(self, x: ArrayLike | slice, y: ArrayLike) -> None:
         """
-        Set the corresponding range variable :math:`y` for independent domain
-        variable :math:`x`.
+        Set the corresponding range variable :math:`y` for the specified
+        independent domain variable :math:`x`.
 
         Parameters
         ----------
@@ -942,8 +942,8 @@ class MultiSignals(AbstractContinuousFunction):
 
     def __contains__(self, x: ArrayLike | slice) -> bool:
         """
-        Return whether the multi-continuous signals contains specified
-        independent domain variable :math:`x`.
+        Determine whether the multi-signals contains the
+        specified independent domain variable :math:`x`.
 
         Parameters
         ----------
@@ -971,18 +971,18 @@ class MultiSignals(AbstractContinuousFunction):
 
     def __eq__(self, other: object) -> bool:
         """
-        Return whether the multi-continuous signals is equal to specified
-        other object.
+        Determine whether the multi-signals equals the specified
+        object.
 
         Parameters
         ----------
         other
-            Object to test whether it is equal to the multi-continuous signals.
+            Object to determine for equality with the multi-signals.
 
         Returns
         -------
         :class:`bool`
-            Whether specified object is equal to the multi-continuous signals.
+            Whether the specified object is equal to the multi-signals.
 
         Examples
         --------
@@ -1022,20 +1022,18 @@ class MultiSignals(AbstractContinuousFunction):
 
     def __ne__(self, other: object) -> bool:
         """
-        Return whether the multi-continuous signals is not equal to specified
-        other object.
+        Determine whether the multi-signals is not equal to the
+        specified object.
 
         Parameters
         ----------
         other
-            Object to test whether it is not equal to the multi-continuous
-            signals.
+            Object to test whether it is not equal to the multi-signals.
 
         Returns
         -------
         :class:`bool`
-            Whether specified object is not equal to the multi-continuous
-            signals.
+            Whether the specified object is not equal to the multi-signals.
 
         Examples
         --------
@@ -1065,13 +1063,14 @@ class MultiSignals(AbstractContinuousFunction):
         in_place: bool = False,
     ) -> MultiSignals:
         """
-        Perform specified arithmetical operation with operand :math:`a`, the
-        operation can be either performed on a copy or in-place.
+        Perform the specified arithmetical operation with operand :math:`a`,
+        either on a copy or in-place.
 
         Parameters
         ----------
         a
-            Operand :math:`a`.
+            Operand :math:`a`. Can be a numeric value, array-like object, or
+            another continuous function instance.
         operation
             Operation to perform.
         in_place
@@ -1080,7 +1079,7 @@ class MultiSignals(AbstractContinuousFunction):
         Returns
         -------
         :class:`colour.continuous.MultiSignals`
-            multi-continuous signals.
+            Multi-signals.
 
         Examples
         --------
@@ -1229,12 +1228,12 @@ class MultiSignals(AbstractContinuousFunction):
         **kwargs: Any,
     ) -> Dict[str, Signal]:
         """
-        Unpack specified data for multi-continuous signals instantiation.
+        Unpack specified data for multi-signals instantiation.
 
         Parameters
         ----------
         data
-            Data to unpack for multi-continuous signals instantiation.
+            Data to unpack for multi-signals instantiation.
         domain
             Values to initialise the multiple :class:`colour.continuous.Signal`
             sub-class instances :attr:`colour.continuous.Signal.domain`
@@ -1264,7 +1263,7 @@ class MultiSignals(AbstractContinuousFunction):
             Arguments to use when instantiating the interpolating function
             of the :class:`colour.continuous.Signal` sub-class instances.
         name
-            multi-continuous signals name.
+            Multi-signals name.
 
         Returns
         -------
@@ -1546,7 +1545,7 @@ class MultiSignals(AbstractContinuousFunction):
     ) -> MultiSignals:
         """
         Fill NaNs in independent domain variable :math:`x` and corresponding
-        range variable :math:`y` using specified method.
+        range variable :math:`y` using the specified method.
 
         Parameters
         ----------
@@ -1559,8 +1558,10 @@ class MultiSignals(AbstractContinuousFunction):
         Returns
         -------
         :class:`colour.continuous.MultiSignals`
-            NaNs filled multi-continuous signals.
+            Multi-signals with NaN values filled.
 
+        Examples
+        --------
         >>> domain = np.arange(0, 10, 1)
         >>> range_ = tstack([np.linspace(10, 100, 10)] * 3)
         >>> range_ += np.array([0, 10, 20])

--- a/colour/continuous/signal.py
+++ b/colour/continuous/signal.py
@@ -2,7 +2,11 @@
 Signal
 ======
 
-Define a class implementing support for continuous signal:
+Define support for continuous signal representation and manipulation.
+
+This module provides the :class:`colour.continuous.Signal` class for
+representing and operating on continuous signals with the specified domain and
+range values, supporting interpolation and extrapolation operations.
 
 -   :class:`colour.continuous.Signal`
 """
@@ -78,17 +82,17 @@ class Signal(AbstractContinuousFunction):
 
     The class implements the :meth:`Signal.function` method so that evaluating
     the function for any independent domain variable :math:`x \\in\\mathbb{R}`
-    returns a corresponding range variable :math:`y \\in\\mathbb{R}`.
-    It adopts an interpolating function encapsulated inside an extrapolating
-    function. The resulting function independent domain, stored as discrete
-    values in the :attr:`colour.continuous.Signal.domain` property corresponds
-    with the function dependent and already known range stored in the
+    returns a corresponding range variable :math:`y \\in\\mathbb{R}`. It adopts
+    an interpolating function encapsulated inside an extrapolating function.
+    The resulting function independent domain, stored as discrete values in
+    the :attr:`colour.continuous.Signal.domain` property corresponds with the
+    function dependent and already known range stored in the
     :attr:`colour.continuous.Signal.range` property.
 
     .. important::
 
-        Specific documentation about getting, setting, indexing and slicing the
-        continuous signal values is available in the
+        Specific documentation about getting, setting, indexing and slicing
+        the continuous signal values is available in the
         :ref:`spectral-representation-and-continuous-signal` section.
 
     Parameters
@@ -97,8 +101,8 @@ class Signal(AbstractContinuousFunction):
         Data to be stored in the continuous signal.
     domain
         Values to initialise the :attr:`colour.continuous.Signal.domain`
-        attribute with. If both ``data`` and ``domain`` arguments are defined,
-        the latter will be used to initialise the
+        attribute with. If both ``data`` and ``domain`` arguments are
+        defined, the latter will be used to initialise the
         :attr:`colour.continuous.Signal.domain` property.
 
     Other Parameters
@@ -269,7 +273,7 @@ class Signal(AbstractContinuousFunction):
     @property
     def dtype(self) -> Type[DTypeFloat]:
         """
-        Getter and setter property for the continuous signal dtype.
+        Getter and setter for the continuous signal dtype.
 
         Parameters
         ----------
@@ -278,7 +282,7 @@ class Signal(AbstractContinuousFunction):
 
         Returns
         -------
-        DTypeFloat
+        Type[DTypeFloat]
             Continuous signal dtype.
         """
 
@@ -304,7 +308,7 @@ class Signal(AbstractContinuousFunction):
     @property
     def domain(self) -> NDArrayFloat:
         """
-        Getter and setter property for the continuous signal independent
+        Getter and setter for the continuous signal's independent
         domain variable :math:`x`.
 
         Parameters
@@ -316,7 +320,8 @@ class Signal(AbstractContinuousFunction):
         Returns
         -------
         :class:`numpy.ndarray`
-            Continuous signal independent domain variable :math:`x`.
+            Continuous signal independent domain variable
+            :math:`x`.
         """
 
         return ndarray_copy(self._domain)
@@ -347,19 +352,19 @@ class Signal(AbstractContinuousFunction):
     @property
     def range(self) -> NDArrayFloat:
         """
-        Getter and setter property for the continuous signal corresponding
-        range variable :math:`y`.
+        Getter and setter for the continuous signal's range
+        variable :math:`y`.
 
         Parameters
         ----------
         value
-            Value to set the continuous signal corresponding range :math:`y`
-            variable with.
+            Value to set the continuous signal's range variable
+            :math:`y` with.
 
         Returns
         -------
         :class:`numpy.ndarray`
-            Continuous signal corresponding range variable :math:`y`.
+            Continuous signal's range variable :math:`y`.
         """
 
         return ndarray_copy(self._range)
@@ -388,7 +393,8 @@ class Signal(AbstractContinuousFunction):
     @property
     def interpolator(self) -> Type[ProtocolInterpolator]:
         """
-        Getter and setter property for the continuous signal interpolator type.
+        Getter and setter for the continuous signal interpolator
+        type.
 
         Parameters
         ----------
@@ -415,14 +421,13 @@ class Signal(AbstractContinuousFunction):
     @property
     def interpolator_kwargs(self) -> dict:
         """
-        Getter and setter property for the continuous signal interpolator
-        instantiation time arguments.
+        Getter and setter for the interpolator instantiation time arguments.
 
         Parameters
         ----------
         value
-            Value to set the continuous signal interpolator instantiation
-            time arguments to.
+            Value to set the continuous signal interpolator
+            instantiation time arguments to.
 
         Returns
         -------
@@ -448,13 +453,12 @@ class Signal(AbstractContinuousFunction):
     @property
     def extrapolator(self) -> Type[ProtocolExtrapolator]:
         """
-        Getter and setter property for the continuous signal extrapolator type.
+        Getter and setter for the continuous signal extrapolator type.
 
         Parameters
         ----------
         value
-            Value to set the continuous signal extrapolator type
-            with.
+            Value to set the continuous signal extrapolator type with.
 
         Returns
         -------
@@ -475,14 +479,14 @@ class Signal(AbstractContinuousFunction):
     @property
     def extrapolator_kwargs(self) -> dict:
         """
-        Getter and setter property for the continuous signal extrapolator
+        Getter and setter for the continuous signal extrapolator
         instantiation time arguments.
 
         Parameters
         ----------
         value
-            Value to set the continuous signal extrapolator instantiation
-            time arguments to.
+            Value to set the continuous signal extrapolator
+            instantiation time arguments to.
 
         Returns
         -------
@@ -509,7 +513,7 @@ class Signal(AbstractContinuousFunction):
     @ndarray_copy_enable(False)
     def function(self) -> Callable:
         """
-        Getter property for the continuous signal callable.
+        Getter for the continuous signal callable.
 
         Returns
         -------
@@ -645,7 +649,7 @@ class Signal(AbstractContinuousFunction):
     @ndarray_copy_enable(False)
     def __hash__(self) -> int:
         """
-        Return the abstract continuous function hash.
+        Compute the hash of the continuous signal.
 
         Returns
         -------
@@ -666,8 +670,8 @@ class Signal(AbstractContinuousFunction):
 
     def __getitem__(self, x: ArrayLike | slice) -> NDArrayFloat:
         """
-        Return the corresponding range variable :math:`y` for independent
-        domain variable :math:`x`.
+        Return the corresponding range variable :math:`y` for the specified
+        independent domain variable :math:`x`.
 
         Parameters
         ----------
@@ -712,8 +716,8 @@ class Signal(AbstractContinuousFunction):
 
     def __setitem__(self, x: ArrayLike | slice, y: ArrayLike) -> None:
         """
-        Set the corresponding range variable :math:`y` for independent domain
-        variable :math:`x`.
+        Set the corresponding range variable :math:`y` for the specified
+        independent domain variable :math:`x`.
 
         Parameters
         ----------
@@ -802,8 +806,8 @@ class Signal(AbstractContinuousFunction):
 
     def __contains__(self, x: ArrayLike | slice) -> bool:
         """
-        Return whether the continuous signal contains specified independent
-        domain variable :math:`x`.
+        Determine whether the continuous signal contains the specified
+        independent domain variable :math:`x`.
 
         Parameters
         ----------
@@ -843,18 +847,17 @@ class Signal(AbstractContinuousFunction):
     @ndarray_copy_enable(False)
     def __eq__(self, other: object) -> bool:
         """
-        Return whether the continuous signal is equal to specified other
-        object.
+        Determine whether the continuous signal equals the specified object.
 
         Parameters
         ----------
         other
-            Object to test whether it is equal to the continuous signal.
+            Object to determine for equality with the continuous signal.
 
         Returns
         -------
         :class:`bool`
-            Whether specified object is equal to the continuous signal.
+            Whether the specified object is equal to the continuous signal.
 
         Examples
         --------
@@ -893,18 +896,19 @@ class Signal(AbstractContinuousFunction):
 
     def __ne__(self, other: object) -> bool:
         """
-        Return whether the continuous signal is not equal to specified other
-        object.
+        Determine whether the continuous signal is not equal to the specified
+        other object.
 
         Parameters
         ----------
         other
-            Object to test whether it is not equal to the continuous signal.
+            Object to determine whether it is not equal to the continuous signal.
 
         Returns
         -------
         :class:`bool`
-            Whether specified object is not equal to the continuous signal.
+            Whether the specified object is not equal to the continuous
+            signal.
 
         Examples
         --------
@@ -934,22 +938,20 @@ class Signal(AbstractContinuousFunction):
         default: Real = 0,
     ) -> None:
         """
-        Fill NaNs in independent domain variable :math:`x` using specified
-        method.
+        Fill NaNs in the signal's independent domain variable :math:`x` using the
+        specified method.
+
+        This private method modifies the domain values in-place, replacing NaN
+        values according to the chosen filling strategy.
 
         Parameters
         ----------
         method
-            *Interpolation* method linearly interpolates through the NaNs,
-            *Constant* method replaces NaNs with ``default``.
+            Filling method to apply. *Interpolation* linearly interpolates
+            through the NaN values, while *Constant* replaces NaN values with
+            the specified ``default`` value.
         default
-            Value to use with the *Constant* method.
-
-        Returns
-        -------
-        :class:`colour.continuous.Signal`
-            NaNs filled continuous signal independent domain :math:`x`
-            variable.
+            Value to use when ``method`` is *Constant*.
         """
 
         self.domain = fill_nan(self._domain, method, default)
@@ -961,8 +963,8 @@ class Signal(AbstractContinuousFunction):
         default: Real = 0,
     ) -> None:
         """
-        Fill NaNs in corresponding range variable :math:`y` using specified
-        method.
+        Fill NaNs in the continuous signal's range variable :math:`y` using
+        the specified method.
 
         Parameters
         ----------
@@ -975,7 +977,7 @@ class Signal(AbstractContinuousFunction):
         Returns
         -------
         :class:`colour.continuous.Signal`
-            NaNs filled continuous signal i corresponding range :math:`y`
+            NaNs filled continuous signal in corresponding range :math:`y`
             variable.
         """
 
@@ -989,22 +991,30 @@ class Signal(AbstractContinuousFunction):
         in_place: bool = False,
     ) -> AbstractContinuousFunction:
         """
-        Perform specified arithmetical operation with operand :math:`a`, the
-        operation can be either performed on a copy or in-place.
+        Perform the specified arithmetical operation with operand :math:`a`.
+
+        The operation can be performed either on a copy of the signal or
+        in-place.
 
         Parameters
         ----------
         a
-            Operand :math:`a`.
+            Operand :math:`a`. Can be a numeric value, array-like object, or
+            another continuous function instance.
         operation
-            Operation to perform.
+            Arithmetical operation to perform. Supported operations are
+            addition (``"+"``), subtraction (``"-"``), multiplication
+            (``"*"``), division (``"/"``), and exponentiation (``"**"``).
         in_place
-            Operation happens in place.
+            Whether the operation is performed in-place on the current
+            signal instance. Default is ``False``.
 
         Returns
         -------
         :class:`colour.continuous.Signal`
-            Continuous signal.
+            Continuous signal after the arithmetical operation. If
+            ``in_place`` is ``True``, returns the modified instance;
+            otherwise returns a new instance.
 
         Examples
         --------
@@ -1106,7 +1116,7 @@ class Signal(AbstractContinuousFunction):
             defined, the latter will be used to initialise the
             :attr:`colour.continuous.Signal.domain` property.
         dtype
-            float point data type.
+            Floating point data type.
 
         Returns
         -------
@@ -1221,7 +1231,7 @@ class Signal(AbstractContinuousFunction):
     ) -> Signal:
         """
         Fill NaNs in independent domain variable :math:`x` and corresponding
-        range variable :math:`y` using specified method.
+        range variable :math:`y` using the specified method.
 
         Parameters
         ----------
@@ -1234,7 +1244,7 @@ class Signal(AbstractContinuousFunction):
         Returns
         -------
         :class:`colour.continuous.Signal`
-            NaNs filled continuous signal.
+            Continuous signal with NaN values filled.
 
         Examples
         --------
@@ -1293,7 +1303,7 @@ class Signal(AbstractContinuousFunction):
         Returns
         -------
         :class:`pandas.Series`
-            Continuous signal as a *Pandas*:class:`pandas.Series` class
+            Continuous signal as a *Pandas* :class:`pandas.Series` class
             instance.
 
         Examples

--- a/colour/continuous/signal.py
+++ b/colour/continuous/signal.py
@@ -289,8 +289,8 @@ class Signal(AbstractContinuousFunction):
         """Setter for the **self.dtype** property."""
 
         attest(
-            value in DTypeFloat.__args__,  # pyright: ignore
-            f'"dtype" must be one of the following types: {DTypeFloat.__args__}',  # pyright: ignore
+            value in DTypeFloat.__args__,
+            f'"dtype" must be one of the following types: {DTypeFloat.__args__}',
         )
 
         self._dtype = value
@@ -785,7 +785,7 @@ class Signal(AbstractContinuousFunction):
             y = np.resize(y, x.shape)
 
             # Matching domain, updating existing `self._range` values.
-            mask = np.isin(x, self._domain)  # pyright: ignore
+            mask = np.isin(x, self._domain)
             x_m = x[mask]
             indexes = np.searchsorted(self._domain, x_m)
             self._range[indexes] = y[mask]
@@ -1173,7 +1173,7 @@ class Signal(AbstractContinuousFunction):
         if isinstance(data, Signal):
             domain_unpacked = data.domain
             range_unpacked = data.range
-        elif issubclass(type(data), Sequence) or isinstance(  # pyright: ignore
+        elif issubclass(type(data), Sequence) or isinstance(
             data, (tuple, list, np.ndarray, Iterator, ValuesView)
         ):
             data_array = (
@@ -1188,7 +1188,7 @@ class Signal(AbstractContinuousFunction):
                 np.arange(0, data_array.size, dtype=dtype),
                 data_array,
             )
-        elif issubclass(type(data), Mapping) or isinstance(data, dict):  # pyright: ignore
+        elif issubclass(type(data), Mapping) or isinstance(data, dict):
             domain_unpacked, range_unpacked = tsplit(
                 sorted(cast("Mapping", data).items())
             )

--- a/colour/contrast/__init__.py
+++ b/colour/contrast/__init__.py
@@ -55,7 +55,7 @@ CONTRAST_SENSITIVITY_METHODS: CanonicalMapping = CanonicalMapping(
     }
 )
 CONTRAST_SENSITIVITY_METHODS.__doc__ = """
-Supported contrast sensitivity methods.
+Supported contrast sensitivity function computation methods.
 
 References
 ----------
@@ -68,8 +68,7 @@ def contrast_sensitivity_function(
     method: Literal["Barten 1999"] | str = "Barten 1999", **kwargs: Any
 ) -> NDArrayFloat:
     """
-    Return the contrast sensitivity :math:`S` of the human eye according to
-    the contrast sensitivity function (CSF) described by specified method.
+    Compute the contrast sensitivity :math:`S` of the human eye.
 
     Parameters
     ----------

--- a/colour/contrast/barten1999.py
+++ b/colour/contrast/barten1999.py
@@ -2,7 +2,8 @@
 Barten (1999) Contrast Sensitivity Function
 ===========================================
 
-Define the *Barten (1999)* contrast sensitivity function:
+Define the *Barten (1999)* contrast sensitivity function model for predicting
+human visual contrast perception thresholds.
 
 -   :func:`colour.contrast.contrast_sensitivity_function_Barten1999`
 
@@ -58,7 +59,7 @@ __all__ = [
 
 def optical_MTF_Barten1999(u: ArrayLike, sigma: ArrayLike = 0.01) -> NDArrayFloat:
     """
-    Return the optical modulation transfer function (MTF) :math:`M_{opt}` of
+    Compute the optical modulation transfer function (MTF) :math:`M_{opt}` of
     the eye using *Barten (1999)* method.
 
     Parameters
@@ -98,8 +99,8 @@ def pupil_diameter_Barten1999(
     Y_0: ArrayLike | None = None,
 ) -> NDArrayFloat:
     """
-    Return the pupil diameter for specified luminance and object or stimulus
-    angular size using *Barten (1999)* method.
+    Compute the pupil diameter for the specified luminance and object or
+    stimulus angular size using the *Barten (1999)* method.
 
     Parameters
     ----------
@@ -108,7 +109,7 @@ def pupil_diameter_Barten1999(
     X_0
         Angular size of the object :math:`X_0` in degrees in the x direction.
     Y_0
-        Angular size of the object :math:`X_0` in degrees in the y direction.
+        Angular size of the object :math:`Y_0` in degrees in the y direction.
 
     Returns
     -------
@@ -143,15 +144,15 @@ def sigma_Barten1999(
     d: ArrayLike = 2.1,
 ) -> NDArrayFloat:
     """
-    Return the standard deviation :math:`\\sigma` of the line-spread function
-    resulting from the convolution of the different elements of the convolution
-    process using *Barten (1999)* method.
+    Compute the standard deviation :math:`\\sigma` of the line-spread
+    function resulting from the convolution of the different elements of
+    the convolution process using *Barten (1999)* method.
 
-    The :math:`\\sigma` quantity depends on the pupil diameter :math:`d` of the
-    eye lens. For very small pupil diameters, :math:`\\sigma` increases
-    inversely proportionally with pupil size because of diffraction, and for
-    large pupil diameters, :math:`\\sigma` increases about linearly with pupil
-    size because of chromatic aberration and others aberrations.
+    The :math:`\\sigma` quantity depends on the pupil diameter :math:`d` of
+    the eye lens. For very small pupil diameters, :math:`\\sigma` increases
+    inversely proportionally with pupil size because of diffraction, and
+    for large pupil diameters, :math:`\\sigma` increases about linearly
+    with pupil size because of chromatic aberration and other aberrations.
 
     Parameters
     ----------
@@ -173,9 +174,9 @@ def sigma_Barten1999(
     Warnings
     --------
     This definition expects :math:`\\sigma_{0}` and :math:`C_{ab}` to be
-    specified in degrees and :math:`degrees\\div mm` respectively. However, in
-    the literature, the values for :math:`\\sigma_{0}` and :math:`C_{ab}` are
-    usually specified in :math:`arc min` and :math:`arc min\\div mm`
+    specified in degrees and :math:`degrees\\div mm` respectively. However,
+    in the literature, the values for :math:`\\sigma_{0}` and :math:`C_{ab}`
+    are usually specified in :math:`arc min` and :math:`arc min\\div mm`
     respectively, thus they need to be divided by 60.
 
     References
@@ -202,8 +203,8 @@ def retinal_illuminance_Barten1999(
     apply_stiles_crawford_effect_correction: bool = True,
 ) -> NDArrayFloat:
     """
-    Return the retinal illuminance :math:`E` in Trolands for specified
-    average luminance :math:`L` and pupil diameter :math:`d` using
+    Compute the retinal illuminance :math:`E` in Trolands for the specified
+    average luminance :math:`L` and pupil diameter :math:`d` using the
     *Barten (1999)* method.
 
     Parameters
@@ -213,7 +214,7 @@ def retinal_illuminance_Barten1999(
     d
         Pupil diameter :math:`d` in millimeters.
     apply_stiles_crawford_effect_correction
-        Whether to apply the correction for *Stiles-Crawford* effect.
+        Whether to apply the correction for the *Stiles-Crawford* effect.
 
     Returns
     -------
@@ -222,10 +223,11 @@ def retinal_illuminance_Barten1999(
 
     Notes
     -----
-    -   This definition is for use with photopic viewing conditions and thus
-        corrects for the Stiles-Crawford effect by default, i.e., directional
-        sensitivity of the cone cells with lower response of cone cells
-        receiving light from the edge of the pupil.
+    -   This definition is designed for photopic viewing conditions and
+        applies the *Stiles-Crawford* effect correction by default. This
+        effect accounts for the directional sensitivity of cone cells,
+        which exhibit reduced response to light entering from the edge
+        of the pupil.
 
     References
     ----------
@@ -258,7 +260,7 @@ def maximum_angular_size_Barten1999(
     N_max: ArrayLike = 15,
 ) -> NDArrayFloat:
     """
-    Return the maximum angular size :math:`X` of the object considered using
+    Compute the maximum angular size :math:`X` of the object considered using
     *Barten (1999)* method.
 
     Parameters
@@ -326,17 +328,17 @@ def contrast_sensitivity_function_Barten1999(
     u_0: ArrayLike = 7,
 ) -> NDArrayFloat:
     """
-    Return the contrast sensitivity :math:`S` of the human eye according to
-    the contrast sensitivity function (CSF) described by *Barten (1999)*.
+    Compute the contrast sensitivity :math:`S` of the human eye according
+    to the contrast sensitivity function (CSF) described by *Barten (1999)*.
 
-    Contrast sensitivity is defined as the inverse of the modulation threshold
-    of a sinusoidal luminance pattern. The modulation threshold of this pattern
-    is generally defined by 50% probability of detection. The contrast
-    sensitivity function or CSF gives the contrast sensitivity as a function of
-    spatial frequency. In the CSF, the spatial frequency is expressed in
-    angular units with respect to the eye. It reaches a maximum between 1 and
-    10 cycles per degree with a fall off at higher and lower spatial
-    frequencies.
+    Contrast sensitivity is defined as the inverse of the modulation
+    threshold of a sinusoidal luminance pattern. The modulation threshold
+    of this pattern is generally defined by 50% probability of detection.
+    The contrast sensitivity function or CSF gives the contrast sensitivity
+    as a function of spatial frequency. In the CSF, the spatial frequency
+    is expressed in angular units with respect to the eye. It reaches a
+    maximum between 1 and 10 cycles per degree with a fall-off at higher
+    and lower spatial frequencies.
 
     Parameters
     ----------
@@ -351,9 +353,11 @@ def contrast_sensitivity_function_Barten1999(
     T
         Integration time :math:`T` in seconds of the eye.
     X_0
-        Angular size :math:`X_0` in degrees of the object in the x direction.
+        Angular size :math:`X_0` in degrees of the object in the x
+        direction.
     Y_0
-        Angular size :math:`Y_0` in degrees of the object in the y direction.
+        Angular size :math:`Y_0` in degrees of the object in the y
+        direction.
     X_max
         Maximum angular size :math:`X_{max}` in degrees of the integration
         area in the x direction.
@@ -372,8 +376,8 @@ def contrast_sensitivity_function_Barten1999(
     E
         Retinal illuminance :math:`E` in Trolands.
     phi_0
-        Spectral density :math:`\\phi_0` in :math:`seconds degrees^2` of the
-        neural noise.
+        Spectral density :math:`\\phi_0` in :math:`seconds degrees^2` of
+        the neural noise.
     u_0
         Spatial frequency :math:`u_0` in :math:`cycles\\div degrees` above
         which the lateral inhibition ceases.
@@ -385,12 +389,12 @@ def contrast_sensitivity_function_Barten1999(
 
     Warnings
     --------
-    This definition expects :math:`\\sigma_{0}` and :math:`C_{ab}` used in the
-    computation of :math:`\\sigma` to be specified in degrees and
+    This definition expects :math:`\\sigma_{0}` and :math:`C_{ab}` used in
+    the computation of :math:`\\sigma` to be specified in degrees and
     :math:`degrees\\div mm` respectively. However, in the literature, the
-    values for :math:`\\sigma_{0}` and :math:`C_{ab}` are usually specified in
-    :math:`arc min` and :math:`arc min\\div mm` respectively, thus they need to
-    be divided by 60.
+    values for :math:`\\sigma_{0}` and :math:`C_{ab}` are usually specified
+    in :math:`arc min` and :math:`arc min\\div mm` respectively, thus they
+    need to be divided by 60.
 
     Notes
     -----
@@ -399,9 +403,9 @@ def contrast_sensitivity_function_Barten1999(
         sensitivity is a factor :math:`\\sqrt{2}` smaller.
     -   *Barten (1999)* CSF default values for the :math:`k`,
         :math:`\\sigma_{0}`, :math:`C_{ab}`, :math:`T`, :math:`X_{max}`,
-        :math:`N_{max}`, :math:`n`, :math:`\\phi_{0}` and :math:`u_0` constants
-        are valid for a standard observer with good vision and with an age
-        between 20 and 30 years.
+        :math:`N_{max}`, :math:`n`, :math:`\\phi_{0}` and :math:`u_0`
+        constants are valid for a standard observer with good vision and
+        with an age between 20 and 30 years.
     -   The other constants have been filled using reference data from
         *Figure 31* in :cite:`InternationalTelecommunicationUnion2015` but
         must be adapted to the current use case.

--- a/colour/corresponding/prediction.py
+++ b/colour/corresponding/prediction.py
@@ -2,7 +2,8 @@
 Corresponding Chromaticities Prediction
 =======================================
 
-Define the objects to compute corresponding chromaticities prediction.
+Define objects for computing corresponding chromaticities prediction under
+different chromatic adaptation conditions.
 
 References
 ----------
@@ -108,7 +109,7 @@ __all__ = [
 @dataclass(frozen=True)
 class CorrespondingColourDataset(MixinDataclassIterable):
     """
-    Define a corresponding colour dataset.
+    Define a corresponding colour dataset for chromatic adaptation studies.
 
     Parameters
     ----------
@@ -128,11 +129,11 @@ class CorrespondingColourDataset(MixinDataclassIterable):
     Y_t
         Test white luminance :math:`Y_t` in :math:`cd/m^2`.
     B_r
-         Luminance factor :math:`B_r` of reference achromatic background as
-         percentage.
+        Luminance factor :math:`B_r` of reference achromatic background as
+        percentage.
     B_t
-         Luminance factor :math:`B_t` of test achromatic background as
-         percentage.
+        Luminance factor :math:`B_t` of test achromatic background as
+        percentage.
     metadata
         Dataset metadata.
 
@@ -169,18 +170,22 @@ class CorrespondingColourDataset(MixinDataclassIterable):
 @dataclass(frozen=True)
 class CorrespondingChromaticitiesPrediction(MixinDataclassIterable):
     """
-    Define a chromatic adaptation model prediction.
+    Define a chromatic adaptation model prediction for corresponding
+    chromaticities.
 
     Parameters
     ----------
     name
-        Test colour name.
+        Test colour name used to identify the prediction instance.
     uv_t
-        Chromaticity coordinates :math:`uv_t^p` of test colour.
+        Chromaticity coordinates :math:`uv_t^p` of the test colour under
+        the test illuminant.
     uv_m
-        Chromaticity coordinates :math:`uv_m^p` of matching colour.
+        Chromaticity coordinates :math:`uv_m^p` of the matching colour
+        under the reference illuminant.
     uv_p
-        Chromaticity coordinates :math:`uv_p^p` of predicted colour.
+        Chromaticity coordinates :math:`uv_p^p` of the predicted colour
+        as computed by the chromatic adaptation model.
     """
 
     name: int
@@ -324,7 +329,7 @@ def corresponding_chromaticities_prediction_Fairchild1990(
     experiment: (Literal[1, 2, 3, 4, 6, 8, 9, 11, 12] | CorrespondingColourDataset) = 1,
 ) -> Tuple[CorrespondingChromaticitiesPrediction, ...]:
     """
-    Return the corresponding chromaticities prediction for *Fairchild (1990)*
+    Predict corresponding chromaticities using the *Fairchild (1990)*
     chromatic adaptation model.
 
     Parameters
@@ -393,7 +398,7 @@ def corresponding_chromaticities_prediction_CIE1994(
     experiment: (Literal[1, 2, 3, 4, 6, 8, 9, 11, 12] | CorrespondingColourDataset) = 1,
 ) -> Tuple[CorrespondingChromaticitiesPrediction, ...]:
     """
-    Return the corresponding chromaticities prediction for *CIE 1994*
+    Predict corresponding chromaticities using the *CIE 1994*
     chromatic adaptation model.
 
     Parameters
@@ -463,7 +468,7 @@ def corresponding_chromaticities_prediction_CMCCAT2000(
     experiment: (Literal[1, 2, 3, 4, 6, 8, 9, 11, 12] | CorrespondingColourDataset) = 1,
 ) -> Tuple[CorrespondingChromaticitiesPrediction, ...]:
     """
-    Return the corresponding chromaticities prediction for *CMCCAT2000*
+    Predict corresponding chromaticities using the *CMCCAT2000*
     chromatic adaptation model.
 
     Parameters
@@ -534,8 +539,8 @@ def corresponding_chromaticities_prediction_VonKries(
     transform: LiteralChromaticAdaptationTransform | str = "CAT02",
 ) -> Tuple[CorrespondingChromaticitiesPrediction, ...]:
     """
-    Return the corresponding chromaticities prediction for *Von Kries*
-    chromatic adaptation model using specified transform.
+    Predict corresponding chromaticities using the *Von Kries*
+    chromatic adaptation model.
 
     Parameters
     ----------
@@ -566,7 +571,7 @@ def corresponding_chromaticities_prediction_VonKries(
      (array([ 0.322,  0.545]), array([ 0.3348730...,  0.5471220...])),
      (array([ 0.316,  0.537]), array([ 0.3248758...,  0.5390589...])),
      (array([ 0.265,  0.553]), array([ 0.2733105...,  0.5555028...])),
-     (array([ 0.221,  0.538]), array([ 0.227148 ...,  0.5331318...)),
+     (array([ 0.221,  0.538]), array([ 0.227148 ...,  0.5331318...])),
      (array([ 0.135,  0.532]), array([ 0.1442730...,  0.5226804...])),
      (array([ 0.145,  0.472]), array([ 0.1498745...,  0.4550785...])),
      (array([ 0.163,  0.331]), array([ 0.1564975...,  0.3148796...])),
@@ -607,8 +612,8 @@ def corresponding_chromaticities_prediction_Zhai2018(
     transform: Literal["CAT02", "CAT16"] | str = "CAT02",
 ) -> Tuple[CorrespondingChromaticitiesPrediction, ...]:
     """
-    Return the corresponding chromaticities prediction for
-    *Zhai and Luo (2018)* chromatic adaptation model using specified transform.
+    Predict corresponding chromaticities using the *Zhai and Luo (2018)*
+    chromatic adaptation model.
 
     Parameters
     ----------
@@ -692,7 +697,7 @@ CORRESPONDING_CHROMATICITIES_PREDICTION_MODELS = CanonicalMapping(
     }
 )
 CORRESPONDING_CHROMATICITIES_PREDICTION_MODELS.__doc__ = """
-Aggregated corresponding chromaticities prediction models.
+Supported corresponding chromaticities prediction models.
 
 References
 ----------
@@ -724,8 +729,7 @@ def corresponding_chromaticities_prediction(
     **kwargs: Any,
 ) -> Tuple[CorrespondingChromaticitiesPrediction, ...]:
     """
-    Return the corresponding chromaticities prediction for specified chromatic
-    adaptation model.
+    Predict corresponding chromaticities.
 
     Parameters
     ----------

--- a/colour/difference/__init__.py
+++ b/colour/difference/__init__.py
@@ -117,7 +117,7 @@ DELTA_E_METHODS: CanonicalMapping = CanonicalMapping(
     }
 )
 DELTA_E_METHODS.__doc__ = """
-Supported :math:`\\Delta E_{ab}` computation methods.
+Supported :math:`\\Delta E_{ab}` colour difference computation methods.
 
 References
 ----------
@@ -143,9 +143,9 @@ def delta_E(
     **kwargs: Any,
 ) -> NDArrayFloat:
     """
-    Return the difference :math:`\\Delta E_{ab}` between two specified
-    *CIE L\\*a\\*b\\**, :math:`IC_TC_P`, or :math:`J'a'b'` colourspace arrays
-    using specified method.
+    Compute the colour difference :math:`\\Delta E_{ab}` between two
+    specified *CIE L\\*a\\*b\\**, :math:`IC_TC_P`, or :math:`J'a'b'`
+    colourspace arrays.
 
     Parameters
     ----------
@@ -161,22 +161,22 @@ def delta_E(
     Other Parameters
     ----------------
     c
-        {:func:`colour.difference.delta_E_CIE2000`},
-        Chroma weighting factor.
+        {:func:`colour.difference.delta_E_CMC`},
+        *Chroma* weighting factor.
     l
-        {:func:`colour.difference.delta_E_CIE2000`},
-        lightness weighting factor.
+        {:func:`colour.difference.delta_E_CMC`},
+        *Lightness* weighting factor.
     textiles
         {:func:`colour.difference.delta_E_CIE1994`,
         :func:`colour.difference.delta_E_CIE2000`,
         :func:`colour.difference.delta_E_DIN99`},
         Textiles application specific parametric factors
-        :math:`k_L=2,\\ k_C=k_H=1,\\ k_1=0.048,\\ k_2=0.014,\\ k_E=2,\
-\\ k_CH=0.5` weights are used instead of
-        :math:`k_L=k_C=k_H=1,\\ k_1=0.045,\\ k_2=0.015,\\ k_E=k_CH=1.0`.
+        :math:`k_L=2,\\ k_C=k_H=1,\\ k_1=0.048,\\ k_2=0.014,\\ k_E=2,\\ k_{CH}=0.5`
+        weights are used instead of
+        :math:`k_L=k_C=k_H=1,\\ k_1=0.045,\\ k_2=0.015,\\ k_E=k_{CH}=1.0`.
 
-    Return
-    ------
+    Returns
+    -------
     :class:`numpy.ndarray`
         Colour difference :math:`\\Delta E_{ab}`.
 

--- a/colour/difference/cam02_ucs.py
+++ b/colour/difference/cam02_ucs.py
@@ -47,15 +47,15 @@ def delta_E_Luo2006(
     Jpapbp_1: ArrayLike, Jpapbp_2: ArrayLike, coefficients: Coefficients_UCS_Luo2006
 ) -> NDArrayFloat:
     """
-    Return the difference :math:`\\Delta E'` between two specified
-    *Luo et al. (2006)* *CAM02-LCD*, *CAM02-SCD*, or *CAM02-UCS* colourspaces
-    :math:`J'a'b'` arrays.
+    Compute the colour difference :math:`\\Delta E'` between two specified
+    *Luo et al. (2006)* *CAM02-LCD*, *CAM02-SCD*, or *CAM02-UCS*
+    colourspaces :math:`J'a'b'` arrays.
 
     Parameters
     ----------
     Jpapbp_1
-        Standard / reference *Luo et al. (2006)* *CAM02-LCD*, *CAM02-SCD*, or
-        *CAM02-UCS* colourspaces :math:`J'a'b'` array.
+        Standard / reference *Luo et al. (2006)* *CAM02-LCD*, *CAM02-SCD*,
+        or *CAM02-UCS* colourspaces :math:`J'a'b'` array.
     Jpapbp_2
         Sample / test *Luo et al. (2006)* *CAM02-LCD*, *CAM02-SCD*, or
         *CAM02-UCS* colourspaces :math:`J'a'b'` array.
@@ -71,8 +71,8 @@ def delta_E_Luo2006(
     Warnings
     --------
     The :math:`J'a'b'` array should have been computed with a
-    *Luo et al. (2006)* *CAM02-LCD*, *CAM02-SCD*, or *CAM02-UCS* colourspace
-    and not with the *CIE L\\*a\\*b\\** colourspace.
+    *Luo et al. (2006)* *CAM02-LCD*, *CAM02-SCD*, or *CAM02-UCS*
+    colourspace and not with the *CIE L\\*a\\*b\\** colourspace.
 
     Notes
     -----
@@ -114,17 +114,18 @@ def delta_E_Luo2006(
 
 def delta_E_CAM02LCD(Jpapbp_1: ArrayLike, Jpapbp_2: ArrayLike) -> NDArrayFloat:
     """
-    Return the difference :math:`\\Delta E'` between two specified
-    *Luo et al. (2006)* *CAM02-LCD* colourspaces :math:`J'a'b'` arrays.
+    Compute the colour difference :math:`\\Delta E'` between two specified
+    *CAM02-LCD* colourspace :math:`J'a'b'` arrays using the
+    *Luo et al. (2006)* formula.
 
     Parameters
     ----------
     Jpapbp_1
-        Standard / reference *Luo et al. (2006)* *CAM02-LCD* colourspaces
-        :math:`J'a'b'` array.
+        Standard / reference *CAM02-LCD* colourspace :math:`J'a'b'` array as
+        computed by the *Luo et al. (2006)* uniform colour space model.
     Jpapbp_2
-        Sample / test *Luo et al. (2006)* *CAM02-LCD* colourspaces
-        :math:`J'a'b'` array.
+        Sample / test *CAM02-LCD* colourspace :math:`J'a'b'` array as computed
+        by the *Luo et al. (2006)* uniform colour space model.
 
     Returns
     -------
@@ -133,9 +134,9 @@ def delta_E_CAM02LCD(Jpapbp_1: ArrayLike, Jpapbp_2: ArrayLike) -> NDArrayFloat:
 
     Warnings
     --------
-    The :math:`J'a'b'` array should have been computed with a
-    *Luo et al. (2006)* *CAM02-LCD*, *CAM02-SCD*, or *CAM02-UCS* colourspace
-    and not with the *CIE L\\*a\\*b\\** colourspace.
+    The :math:`J'a'b'` arrays should have been computed with the
+    *Luo et al. (2006)* *CAM02-LCD* colourspace and not with the
+    *CIE L\\*a\\*b\\** colourspace.
 
     Notes
     -----
@@ -172,17 +173,18 @@ def delta_E_CAM02LCD(Jpapbp_1: ArrayLike, Jpapbp_2: ArrayLike) -> NDArrayFloat:
 
 def delta_E_CAM02SCD(Jpapbp_1: ArrayLike, Jpapbp_2: ArrayLike) -> NDArrayFloat:
     """
-    Return the difference :math:`\\Delta E'` between two specified
-    *Luo et al. (2006)* *CAM02-SCD* colourspaces :math:`J'a'b'` arrays.
+    Compute the colour difference :math:`\\Delta E'` between two specified
+    *CAM02-SCD* colourspace :math:`J'a'b'` arrays using the
+    *Luo et al. (2006)* formula.
 
     Parameters
     ----------
     Jpapbp_1
-        Standard / reference *Luo et al. (2006)* *CAM02-SCD* colourspaces
-        :math:`J'a'b'` array.
+        Standard / reference *CAM02-SCD* colourspace :math:`J'a'b'` array as
+        computed by the *Luo et al. (2006)* uniform colour space model.
     Jpapbp_2
-        Sample / test *Luo et al. (2006)* *CAM02-SCD* colourspaces
-        :math:`J'a'b'` array.
+        Sample / test *CAM02-SCD* colourspace :math:`J'a'b'` array as computed
+        by the *Luo et al. (2006)* uniform colour space model.
 
     Returns
     -------
@@ -191,9 +193,9 @@ def delta_E_CAM02SCD(Jpapbp_1: ArrayLike, Jpapbp_2: ArrayLike) -> NDArrayFloat:
 
     Warnings
     --------
-    The :math:`J'a'b'` array should have been computed with a
-    *Luo et al. (2006)* *CAM02-LCD*, *CAM02-SCD*, or *CAM02-UCS* colourspace
-    and not with the *CIE L\\*a\\*b\\** colourspace.
+    The :math:`J'a'b'` arrays should have been computed with the
+    *Luo et al. (2006)* *CAM02-SCD* colourspace and not with the
+    *CIE L\\*a\\*b\\** colourspace.
 
     Notes
     -----
@@ -230,17 +232,18 @@ def delta_E_CAM02SCD(Jpapbp_1: ArrayLike, Jpapbp_2: ArrayLike) -> NDArrayFloat:
 
 def delta_E_CAM02UCS(Jpapbp_1: ArrayLike, Jpapbp_2: ArrayLike) -> NDArrayFloat:
     """
-    Return the difference :math:`\\Delta E'` between two specified
-    *Luo et al. (2006)* *CAM02-UCS* colourspaces :math:`J'a'b'` arrays.
+    Compute the colour difference :math:`\\Delta E'` between two specified
+    *CAM02-UCS* colourspace :math:`J'a'b'` arrays using the
+    *Luo et al. (2006)* formula.
 
     Parameters
     ----------
     Jpapbp_1
-        Standard / reference *Luo et al. (2006)* *CAM02-UCS* colourspaces
-        :math:`J'a'b'` array.
+        Standard / reference *CAM02-UCS* colourspace :math:`J'a'b'` array as
+        computed by the *Luo et al. (2006)* uniform colour space model.
     Jpapbp_2
-        Sample / test *Luo et al. (2006)* *CAM02-UCS* colourspaces
-        :math:`J'a'b'` array.
+        Sample / test *CAM02-UCS* colourspace :math:`J'a'b'` array as computed
+        by the *Luo et al. (2006)* uniform colour space model.
 
     Returns
     -------
@@ -249,9 +252,9 @@ def delta_E_CAM02UCS(Jpapbp_1: ArrayLike, Jpapbp_2: ArrayLike) -> NDArrayFloat:
 
     Warnings
     --------
-    The :math:`J'a'b'` array should have been computed with a
-    *Luo et al. (2006)* *CAM02-LCD*, *CAM02-SCD*, or *CAM02-UCS* colourspace
-    and not with the *CIE L\\*a\\*b\\** colourspace.
+    The :math:`J'a'b'` arrays should have been computed with the
+    *Luo et al. (2006)* *CAM02-UCS* colourspace and not with the
+    *CIE L\\*a\\*b\\** colourspace.
 
     Notes
     -----

--- a/colour/difference/delta_e.py
+++ b/colour/difference/delta_e.py
@@ -2,9 +2,7 @@
 :math:`\\Delta E^*_{ab}` - Delta E Colour Difference
 ====================================================
 
-Define the :math:`\\Delta E^*_{ab}` colour difference computation objects:
-
-The following attributes and methods are available:
+Define the :math:`\\Delta E^*_{ab}` colour difference computation objects.
 
 -   :attr:`colour.difference.JND_CIE1976`
 -   :func:`colour.difference.delta_E_CIE1976`
@@ -111,8 +109,9 @@ References
 
 def delta_E_CIE1976(Lab_1: ArrayLike, Lab_2: ArrayLike) -> NDArrayFloat:
     """
-    Return the difference :math:`\\Delta E_{76}` between two specified
-    *CIE L\\*a\\*b\\** colourspace arrays using *CIE 1976* recommendation.
+    Compute the colour difference :math:`\\Delta E_{76}` between two
+    specified *CIE L\\*a\\*b\\** colourspace arrays using the *CIE 1976*
+    recommendation.
 
     Parameters
     ----------
@@ -163,8 +162,8 @@ def delta_E_CIE1994(
     Lab_1: ArrayLike, Lab_2: ArrayLike, textiles: bool = False
 ) -> NDArrayFloat:
     """
-    Return the difference :math:`\\Delta E_{94}` between two specified
-    *CIE L\\*a\\*b\\** colourspace arrays using *CIE 1994* recommendation.
+    Compute the colour difference :math:`\\Delta E_{94}` between two specified
+    *CIE L\\*a\\*b\\** colourspace arrays using the *CIE 1994* recommendation.
 
     Parameters
     ----------
@@ -256,7 +255,7 @@ def delta_E_CIE1994(
 @dataclass
 class Attributes_Specification_CIE2000(MixinDataclassArithmetic):
     """
-    Define the *CAM16* colour appearance model specification.
+    Define the *CIE 2000* colour-difference formula attribute specification.
 
     Parameters
     ----------
@@ -291,9 +290,13 @@ def intermediate_attributes_CIE2000(
     Lab_1: ArrayLike, Lab_2: ArrayLike
 ) -> Attributes_Specification_CIE2000:
     """
-    Return the intermediate attributes to compute the difference
-    :math:`\\Delta E_{00}` between two specified *CIE L\\*a\\*b\\** colourspace
-    arrays using *CIE 2000* recommendation.
+    Compute intermediate attributes for CIE 2000 colour difference calculation
+    between two specified *CIE L\\*a\\*b\\** colourspace arrays.
+
+    The intermediate attributes include the lightness, chroma, and hue
+    weighting functions (S_L, S_C, S_H), as well as the adjusted colour
+    differences (delta_L_p, delta_C_p, delta_H_p) and the rotation term (R_T)
+    required for computing :math:`\\Delta E_{00}`.
 
     Parameters
     ----------
@@ -430,8 +433,8 @@ def delta_E_CIE2000(
     Lab_1: ArrayLike, Lab_2: ArrayLike, textiles: bool = False
 ) -> NDArrayFloat:
     """
-    Return the difference :math:`\\Delta E_{00}` between two specified
-    *CIE L\\*a\\*b\\** colourspace arrays using *CIE 2000* recommendation.
+    Compute the colour difference :math:`\\Delta E_{00}` between two specified
+    *CIE L\\*a\\*b\\** colourspace arrays using the *CIE 2000* recommendation.
 
     Parameters
     ----------
@@ -444,7 +447,7 @@ def delta_E_CIE2000(
         :math:`k_L=2,\\ k_C=k_H=1` weights are used instead of
         :math:`k_L=k_C=k_H=1`.
 
-    Return
+    Returns
     -------
     :class:`numpy.ndarray`
         Colour difference :math:`\\Delta E_{00}`.
@@ -520,14 +523,14 @@ def delta_E_CMC(
     c: float = 1,
 ) -> NDArrayFloat:
     """
-    Return the difference :math:`\\Delta E_{CMC}` between two specified
-    *CIE L\\*a\\*b\\** colourspace arrays using *Colour Measurement Committee*
-    recommendation.
+    Compute the colour difference :math:`\\Delta E_{CMC}` between two
+    specified *CIE L\\*a\\*b\\** colourspace arrays using the *Colour
+    Measurement Committee* recommendation.
 
     The quasimetric has two parameters: *lightness* (l) and *chroma* (c),
-    allowing the users to weight the difference based on the ratio of l:c.
-    Commonly used values are 2:1 for acceptability and 1:1 for the threshold of
-    imperceptibility.
+    allowing users to weight the difference based on the ratio of l:c.
+    Commonly used values are 2:1 for acceptability and 1:1 for the
+    threshold of imperceptibility.
 
     Parameters
     ----------
@@ -536,9 +539,9 @@ def delta_E_CMC(
     Lab_2
         *CIE L\\*a\\*b\\** colourspace array 2.
     l
-        Lightness weighting factor.
+        *Lightness* weighting factor.
     c
-        Chroma weighting factor.
+        *Chroma* weighting factor.
 
     Returns
     -------
@@ -611,8 +614,8 @@ def delta_E_CMC(
 
 def delta_E_ITP(ICtCp_1: ArrayLike, ICtCp_2: ArrayLike) -> NDArrayFloat:
     """
-    Return the difference :math:`\\Delta E_{ITP}` between two specified
-    :math:`IC_TC_P` colour encoding arrays using
+    Compute the colour difference :math:`\\Delta E_{ITP}` between two specified
+    :math:`IC_TC_P` colour encoding arrays using the
     *Recommendation ITU-R BT.2124*.
 
     Parameters
@@ -659,12 +662,12 @@ def delta_E_ITP(ICtCp_1: ArrayLike, ICtCp_2: ArrayLike) -> NDArrayFloat:
 
 def delta_E_HyAB(Lab_1: ArrayLike, Lab_2: ArrayLike) -> NDArrayFloat:
     """
-    Return the difference between two *CIE L\\*a\\*b\\** colourspace arrays
+    Compute the colour difference between two *CIE L\\*a\\*b\\** colourspace arrays
     using a combination of a Euclidean metric in hue and chroma with a
     city-block metric to incorporate lightness differences.
 
     This metric is intended for large colour differences, on the order of 10
-    CIE L\\*a\\*b\\** units or greater.
+    *CIE L\\*a\\*b\\** units or greater.
 
     Parameters
     ----------
@@ -676,7 +679,7 @@ def delta_E_HyAB(Lab_1: ArrayLike, Lab_2: ArrayLike) -> NDArrayFloat:
     Returns
     -------
     :class:`numpy.ndarray`
-        Colour difference HyAB.
+        Colour difference :math:`\\Delta E_{HyAB}`.
 
     Notes
     -----
@@ -719,14 +722,13 @@ def delta_E_HyCH(
     Lab_1: ArrayLike, Lab_2: ArrayLike, textiles: bool = False
 ) -> NDArrayFloat:
     """
-    Return the difference between two *CIE L\\*a\\*b\\** colourspace arrays
-    using a combination of a Euclidean metric in hue and chroma with a
+    Compute the colour difference between two *CIE L\\*a\\*b\\** colourspace
+    arrays using a combination of Euclidean metric in hue and chroma with a
     city-block metric to incorporate lightness differences based on
     *CIE 2000* recommendation attributes.
 
     This metric is intended for large colour differences, on the order of 10
-    CIE L\\*a\\*b\\** units or greater.
-
+    *CIE L\\*a\\*b\\** units or greater.
 
     Parameters
     ----------
@@ -734,11 +736,13 @@ def delta_E_HyCH(
         *CIE L\\*a\\*b\\** colourspace array 1.
     Lab_2
         *CIE L\\*a\\*b\\** colourspace array 2.
+    textiles
+        Whether to use the textile-specific parametrization.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Colour difference HyCH.
+        Colour difference :math:`\\Delta E_{HyCH}`.
 
     Notes
     -----

--- a/colour/difference/din99.py
+++ b/colour/difference/din99.py
@@ -2,7 +2,7 @@
 :math:`\\Delta E_{99}` DIN99 - Colour Difference Formula
 ========================================================
 
-Define the :math:`\\Delta E_{99}` *DIN99* colour difference formula:
+Define the :math:`\\Delta E_{99}` *DIN99* colour difference formula.
 
 -   :func:`colour.difference.delta_E_DIN99`
 
@@ -42,8 +42,8 @@ def delta_E_DIN99(
     Lab_1: ArrayLike, Lab_2: ArrayLike, textiles: bool = False
 ) -> NDArrayFloat:
     """
-    Return the difference :math:`\\Delta E_{DIN99}` between two specified
-    *CIE L\\*a\\*b\\** colourspace arrays using *DIN99* formula.
+    Compute the colour difference :math:`\\Delta E_{DIN99}` between two
+    specified *CIE L\\*a\\*b\\** colourspace arrays using the *DIN99* formula.
 
     Parameters
     ----------

--- a/colour/difference/huang2015.py
+++ b/colour/difference/huang2015.py
@@ -3,7 +3,7 @@ Huang et al. (2015) Power-Functions
 ===================================
 
 Define the *Huang, Cui, Melgosa, Sanchez-Maranon, Li, Luo and Liu (2015)*
-power-functions improving the performance of colour-difference formulas:
+power-functions for improving the performance of colour-difference formulas.
 
 -   :func:`colour.difference.power_function_Huang2015`
 
@@ -67,8 +67,8 @@ References
 Notes
 -----
 -   :cite:`Li2017` does not give the coefficients for the *CAM16-LCD* and
-    *CAM16-SCD* colourspaces. *Ronnie Luo* has been contacted to know if they
-    have been computed.
+    *CAM16-SCD* colourspaces. *Ronnie Luo* has been contacted to know if
+    they have been computed.
 
 Aliases:
 
@@ -101,10 +101,9 @@ def power_function_Huang2015(
     ) = "CIE 2000",
 ) -> NDArrayFloat:
     """
-    Improve the performance of the :math:`\\Delta E` value for specified
-    coefficients using
-    *Huang, Cui, Melgosa, Sanchez-Maranon, Li, Luo and Liu (2015)*
-    power-function: :math:`d_E^{\\prime}=a*d_{E^b}`.
+    Apply the *Huang, Cui, Melgosa, Sanchez-Maranon, Li, Luo and Liu
+    (2015)* power-function to improve colour difference values for
+    specified coefficients: :math:`d_E^{\\prime}=a \\cdot d_{E}^{b}`.
 
     Parameters
     ----------
@@ -116,7 +115,7 @@ def power_function_Huang2015(
     Returns
     -------
     :class:`numpy.ndarray`
-        Improved math:`\\Delta E` value.
+        Improved :math:`\\Delta E` value.
 
     References
     ----------

--- a/colour/difference/stress.py
+++ b/colour/difference/stress.py
@@ -6,9 +6,9 @@ Define the *Kruskal's Standardized Residual Sum of Squares (:math:`STRESS`)*
 index:
 
 -   :func:`colour.index_stress_Garcia2007`: :math:`STRESS` index computation
-    according to *García, Huertas, Melgosa and Cui (2007)* method.
+    according to *García, Huertas, Melgosa and Cui (2007)* method.
 -   :func:`colour.index_stress`: *lightness* :math:`STRESS` index computation
-    according to specified method.
+    using the specified method.
 
 References
 ----------
@@ -47,9 +47,9 @@ __all__ = [
 
 def index_stress_Garcia2007(d_E: ArrayLike, d_V: ArrayLike) -> NDArrayFloat:
     """
-    Compute the
-    *Kruskal's Standardized Residual Sum of Squares (:math:`STRESS`)*
-    index according to *García, Huertas, Melgosa and Cui (2007)* method.
+    Compute the *Kruskal's Standardized Residual Sum of Squares
+    (:math:`STRESS`)* index according to the *García, Huertas, Melgosa and
+    Cui (2007)* method.
 
     Parameters
     ----------
@@ -92,7 +92,8 @@ INDEX_STRESS_METHODS: CanonicalMapping = CanonicalMapping(
     }
 )
 INDEX_STRESS_METHODS.__doc__ = """
-Supported :math:`STRESS` index computation methods.
+Supported *Standardized Residual Sum of Squares* (*STRESS*) index
+computation methods.
 
 References
 ----------
@@ -106,9 +107,8 @@ def index_stress(
     method: Literal["Garcia 2007"] | str = "Garcia 2007",
 ) -> NDArrayFloat:
     """
-    Compute the
-    *Kruskal's Standardized Residual Sum of Squares (:math:`STRESS`)*
-    index according to specified method.
+    Compute *Kruskal's Standardized Residual Sum of Squares*
+    (:math:`STRESS`) index using the specified method
 
     Parameters
     ----------

--- a/colour/examples/io/examples_fichet2021.py
+++ b/colour/examples/io/examples_fichet2021.py
@@ -32,6 +32,6 @@ if is_imageio_installed():
 
     message_box("Writing a spectral image.")
     _descriptor, path = tempfile.mkstemp(suffix=".exr")
-    colour.write_spectral_image_Fichet2021(components, path)  # pyright: ignore
+    colour.write_spectral_image_Fichet2021(components, path)
     components = colour.read_spectral_image_Fichet2021(path)
     print(components)

--- a/colour/geometry/ellipse.py
+++ b/colour/geometry/ellipse.py
@@ -2,7 +2,7 @@
 Ellipse
 =======
 
-Define the objects related to ellipse computations:
+Define objects for ellipse computations and fitting operations.
 
 -   :func:`colour.algebra.ellipse_coefficients_general_form`
 -   :func:`colour.algebra.ellipse_coefficients_canonical_form`
@@ -29,7 +29,13 @@ if typing.TYPE_CHECKING:
     from colour.hints import ArrayLike, Literal
 
 from colour.hints import NDArrayFloat, cast
-from colour.utilities import CanonicalMapping, ones, tsplit, tstack, validate_method
+from colour.utilities import (
+    CanonicalMapping,
+    ones,
+    tsplit,
+    tstack,
+    validate_method,
+)
 
 __author__ = "Colour Developers"
 __copyright__ = "Copyright 2013 Colour Developers"
@@ -50,23 +56,28 @@ __all__ = [
 
 def ellipse_coefficients_general_form(coefficients: ArrayLike) -> NDArrayFloat:
     """
-    Generate the general form ellipse coefficients from specified canonical
+    Compute general form ellipse coefficients from the specified canonical
     form ellipse coefficients.
 
-    The canonical form ellipse coefficients are as follows: the center
-    coordinates :math:`x_c` and :math:`y_c`, semi-major axis length
-    :math:`a_a`, semi-minor axis length :math:`a_b` and rotation angle
-    :math:`\\theta` in degrees of its semi-major axis :math:`a_a`.
+    Transform ellipse coefficients from canonical representation (center,
+    semi-axes, rotation) to general quadratic form
+    :math:`Ax^2 + Bxy + Cy^2 + Dx + Ey + F = 0`.
+
+    The canonical form ellipse coefficients are: center coordinates
+    :math:`(x_c, y_c)`, semi-major axis length :math:`a`, semi-minor axis
+    length :math:`b`, and rotation angle :math:`\\theta` (degrees) of the
+    semi-major axis from the positive x-axis.
 
     Parameters
     ----------
     coefficients
-        Canonical form ellipse coefficients.
+        Canonical form ellipse coefficients as
+        :math:`[x_c, y_c, a, b, \\theta]`.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        General form ellipse coefficients.
+        General form coefficients :math:`[A, B, C, D, E, F]`.
 
     References
     ----------
@@ -103,17 +114,18 @@ def ellipse_coefficients_canonical_form(
     coefficients: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Generate the canonical form ellipse coefficients from specified general
+    Compute canonical form ellipse coefficients from the specified general
     form ellipse coefficients.
 
-    The general form ellipse coefficients are the coefficients of the implicit
-    second-order polynomial/quadratic curve expressed as follows:
+    The general form ellipse coefficients are the coefficients of the
+    implicit second-order polynomial/quadratic curve expressed as follows:
 
-    :math:`F\\left(x, y\\right)` = ax^2 + bxy + cy^2 + dx + ey + f = 0`
+    :math:`F\\left(x, y\\right) = ax^2 + bxy + cy^2 + dx + ey + f = 0`
 
-    with an ellipse-specific constraint such as :math:`b^2 -4ac < 0` and where
-    :math:`a, b, c, d, e, f` are coefficients of the ellipse and
-    :math:`F\\left(x, y\\right)` are coordinates of points lying on it.
+    with an ellipse-specific constraint such as :math:`b^2 - 4ac < 0` and
+    where :math:`a, b, c, d, e, f` are the ellipse coefficients and
+    :math:`F\\left(x, y\\right)` are coordinates of points lying on the
+    ellipse.
 
     Parameters
     ----------
@@ -166,8 +178,8 @@ def ellipse_coefficients_canonical_form(
 
 def point_at_angle_on_ellipse(phi: ArrayLike, coefficients: ArrayLike) -> NDArrayFloat:
     """
-    Generate the coordinates of the point at angle :math:`\\phi` in degrees
-    on the ellipse with specified canonical form coefficients.
+    Compute the coordinates of the point at angle :math:`\\phi` in degrees on
+    the ellipse with the specified canonical form coefficients.
 
     Parameters
     ----------
@@ -183,7 +195,7 @@ def point_at_angle_on_ellipse(phi: ArrayLike, coefficients: ArrayLike) -> NDArra
     Returns
     -------
     :class:`numpy.ndarray`
-        Coordinates of the point at angle :math:`\\phi`
+        Coordinates of the point at angle :math:`\\phi`.
 
     Examples
     --------
@@ -209,16 +221,16 @@ def point_at_angle_on_ellipse(phi: ArrayLike, coefficients: ArrayLike) -> NDArra
 
 def ellipse_fitting_Halir1998(a: ArrayLike) -> NDArrayFloat:
     """
-    Generate the coefficients of the implicit second-order
-    polynomial/quadratic curve that fits specified point array :math:`a`
-    using *Halir and Flusser (1998)* method.
+    Compute the coefficients of the implicit second-order
+    polynomial/quadratic curve that fits the specified point array
+    :math:`a` using the *Halir and Flusser (1998)* method.
 
     The implicit second-order polynomial is expressed as follows:
 
-    :math:`F\\left(x, y\\right)` = ax^2 + bxy + cy^2 + dx + ey + f = 0`
+    :math:`F\\left(x, y\\right) = ax^2 + bxy + cy^2 + dx + ey + f = 0`
 
-    with an ellipse-specific constraint such as :math:`b^2 -4ac < 0` and where
-    :math:`a, b, c, d, e, f` are coefficients of the ellipse and
+    with an ellipse-specific constraint such as :math:`b^2 - 4ac < 0` and
+    where :math:`a, b, c, d, e, f` are coefficients of the ellipse and
     :math:`F\\left(x, y\\right)` are coordinates of points lying on it.
 
     Parameters
@@ -229,8 +241,8 @@ def ellipse_fitting_Halir1998(a: ArrayLike) -> NDArrayFloat:
     Returns
     -------
     :class:`numpy.ndarray`
-        Coefficients of the implicit second-order polynomial/quadratic
-        curve that fits specified point array :math:`a`.
+        Coefficients of the implicit second-order polynomial/quadratic curve
+        that fits the specified point array :math:`a`.
 
     References
     ----------
@@ -293,16 +305,15 @@ def ellipse_fitting(
     a: ArrayLike, method: Literal["Halir 1998"] | str = "Halir 1998"
 ) -> NDArrayFloat:
     """
-    Generate the coefficients of the implicit second-order
-    polynomial/quadratic curve that fits specified point array :math:`a`
-    using specified method.
+    Compute the coefficients of the implicit second-order
+    polynomial/quadratic curve that fits the specified point array :math:`a`.
 
     The implicit second-order polynomial is expressed as follows:
 
-    :math:`F\\left(x, y\\right)` = ax^2 + bxy + cy^2 + dx + ey + f = 0`
+    :math:`F\\left(x, y\\right) = ax^2 + bxy + cy^2 + dx + ey + f = 0`
 
-    with an ellipse-specific constraint such as :math:`b^2 -4ac < 0` and where
-    :math:`a, b, c, d, e, f` are coefficients of the ellipse and
+    with an ellipse-specific constraint such as :math:`b^2 - 4ac < 0` and
+    where :math:`a, b, c, d, e, f` are coefficients of the ellipse and
     :math:`F\\left(x, y\\right)` are coordinates of points lying on it.
 
     Parameters
@@ -315,8 +326,8 @@ def ellipse_fitting(
     Returns
     -------
     :class:`numpy.ndarray`
-        Coefficients of the implicit second-order polynomial/quadratic
-        curve that fits specified point array :math:`a`.
+        Coefficients of the implicit second-order polynomial/quadratic curve
+        that fits the specified point array :math:`a`.
 
     References
     ----------

--- a/colour/geometry/intersection.py
+++ b/colour/geometry/intersection.py
@@ -2,7 +2,8 @@
 Intersection Utilities
 ======================
 
-Define the geometry intersection utilities objects.
+Define utilities for computing geometric intersections and line segment
+operations in two-dimensional space.
 
 References
 ----------
@@ -52,7 +53,7 @@ def extend_line_segment(
 ) -> NDArrayFloat:
     """
     Extend the line segment defined by point arrays :math:`a` and :math:`b` by
-    specified distance and generate the new end point.
+    the specified distance and generate the new end point.
 
     Parameters
     ----------
@@ -100,18 +101,18 @@ def extend_line_segment(
 class LineSegmentsIntersections_Specification:
     """
     Define the specification for intersection of line segments :math:`l_1` and
-    :math:`l_2` returned by :func:`colour.algebra.intersect_line_segments`
-    definition.
+    :math:`l_2` returned by the
+    :func:`colour.algebra.intersect_line_segments` definition.
 
     Parameters
     ----------
     xy
         Array of :math:`l_1` and :math:`l_2` line segments intersections
-        coordinates. Non existing segments intersections coordinates are set
+        coordinates. Non-existing segments intersections coordinates are set
         with `np.nan`.
     intersect
-        Array of *bool* indicating if line segments :math:`l_1` and :math:`l_2`
-        intersect.
+        Array of *bool* indicating if line segments :math:`l_1` and
+        :math:`l_2` intersect.
     parallel
         Array of :class:`bool` indicating if line segments :math:`l_1` and
         :math:`l_2` are parallel.

--- a/colour/geometry/primitives.py
+++ b/colour/geometry/primitives.py
@@ -2,7 +2,8 @@
 Geometry Primitives
 ===================
 
-Define various geometry primitives and their generation methods:
+Define various geometry primitives and their generation methods for
+colour science visualizations and computations.
 
 -   :attr:`colour.geometry.MAPPING_PLANE_TO_AXIS`
 -   :func:`colour.geometry.primitive_grid`
@@ -72,7 +73,13 @@ MAPPING_PLANE_TO_AXIS: CanonicalMapping = CanonicalMapping(
         "yx": "-z",
     }
 )
-MAPPING_PLANE_TO_AXIS.__doc__ = """Plane to axis mapping."""
+MAPPING_PLANE_TO_AXIS.__doc__ = """
+Mapping from coordinate planes to their perpendicular axes.
+
+Maps two-letter plane identifiers (e.g., 'xy', 'yz') to their
+corresponding perpendicular axis with sign indicating the direction
+following the right-hand rule convention.
+"""
 
 
 def primitive_grid(
@@ -87,35 +94,37 @@ def primitive_grid(
     dtype_indexes: Type[DTypeInt] | None = None,
 ) -> Tuple[NDArray, NDArray, NDArray]:
     """
-    Generate vertices and indexes for a filled and outlined grid primitive.
+    Generate vertices and indexes for a filled and outlined grid
+    primitive.
 
     Parameters
     ----------
     width
-        Grid width.
+        Width of the primitive.
     height
-        Grid height.
+        Height of the primitive.
     width_segments
-        Grid segments count along the width.
+        Number of segments along the width.
     height_segments
-        Grid segments count along the height.
+        Number of segments along the height.
     axis
-        Axis the primitive will be normal to, or plane the primitive will be
-        co-planar with.
+        Axis to which the primitive will be normal, or plane with
+        which the primitive will be co-planar.
     dtype_vertices
-        :class:`numpy.dtype` to use for the grid vertices, default to
-        the :class:`numpy.dtype` defined by the
+        :class:`numpy.dtype` to use for the grid vertices. Defaults
+        to the :class:`numpy.dtype` defined by the
         :attr:`colour.constant.DTYPE_FLOAT_DEFAULT` attribute.
     dtype_indexes
-        :class:`numpy.dtype` to use for the grid indexes, default to
-        the :class:`numpy.dtype` defined by the
+        :class:`numpy.dtype` to use for the grid indexes. Defaults
+        to the :class:`numpy.dtype` defined by the
         :attr:`colour.constant.DTYPE_INT_DEFAULT` attribute.
 
     Returns
     -------
     :class:`tuple`
-        Tuple of grid vertices, face indexes to produce a filled grid and
-        outline indexes to produce an outline of the faces of the grid.
+        Tuple of grid vertices, face indexes to produce a filled
+        grid, and outline indexes to produce an outline of the grid
+        faces.
 
     References
     ----------
@@ -278,11 +287,11 @@ def primitive_cube(
     planes
         Grid primitives to include in the cube construction.
     dtype_vertices
-        :class:`numpy.dtype` to use for the grid vertices, default to
+        :class:`numpy.dtype` to use for the grid vertices. Defaults to
         the :class:`numpy.dtype` defined by the
         :attr:`colour.constant.DTYPE_FLOAT_DEFAULT` attribute.
     dtype_indexes
-        :class:`numpy.dtype` to use for the grid indexes, default to
+        :class:`numpy.dtype` to use for the grid indexes. Defaults to
         the :class:`numpy.dtype` defined by the
         :attr:`colour.constant.DTYPE_INT_DEFAULT` attribute.
 
@@ -461,65 +470,74 @@ def primitive(
     method: Literal["Cube", "Grid"] | str = "Cube", **kwargs: Any
 ) -> Tuple[NDArray, NDArray, NDArray]:
     """
-    Generate a geometry primitive using specified method.
+    Generate a geometry primitive.
+
+    This function creates geometric primitives such as cubes or grids with
+    configurable dimensions and segmentation. The generated primitive includes
+    vertices with position, texture coordinates, normal vectors, and colour
+    data, along with face and outline indexes for rendering.
 
     Parameters
     ----------
     method
-        Generation method.
+        Generation method for the primitive. Supported methods are:
+
+        - ``'Cube'``: Generate a 3D cube primitive
+        - ``'Grid'``: Generate a 2D grid primitive
 
     Other Parameters
     ----------------
     axis
         {:func:`colour.geometry.primitive_grid`},
-        Axis the primitive will be normal to, or plane the primitive will be
-        co-planar with.
+        Axis to which the primitive will be normal, or plane with which the
+        primitive will be co-planar.
     depth
-        {:func:`colour.geometry.primitive_grid`,
-        :func:`colour.geometry.primitive_cube`},
-        Primitive depth.
+        {:func:`colour.geometry.primitive_cube`},
+        Cube depth.
     depth_segments
-        {:func:`colour.geometry.primitive_grid`,
-        :func:`colour.geometry.primitive_cube`},
-        Primitive segments count along the depth.
+        {:func:`colour.geometry.primitive_cube`},
+        Cube segments count along the depth.
     dtype_indexes
         {:func:`colour.geometry.primitive_grid`,
         :func:`colour.geometry.primitive_cube`},
-        :class:`numpy.dtype` to use for the grid indexes, default to
-        the :class:`numpy.dtype` defined by the
+        :class:`numpy.dtype` to use for the grid indexes. Defaults to the
+        :class:`numpy.dtype` defined by the
         :attr:`colour.constant.DTYPE_INT_DEFAULT` attribute.
     dtype_vertices
         {:func:`colour.geometry.primitive_grid`,
         :func:`colour.geometry.primitive_cube`},
-        :class:`numpy.dtype` to use for the grid vertices, default to
-        the :class:`numpy.dtype` defined by the
+        :class:`numpy.dtype` to use for the grid vertices. Defaults to the
+        :class:`numpy.dtype` defined by the
         :attr:`colour.constant.DTYPE_FLOAT_DEFAULT` attribute.
     height
         {:func:`colour.geometry.primitive_grid`,
         :func:`colour.geometry.primitive_cube`},
-        Primitive height.
+        Height of the primitive.
     planes
         {:func:`colour.geometry.primitive_cube`},
-        Included grid primitives in the cube construction.
+        Grid primitives to include in the cube construction.
     width
         {:func:`colour.geometry.primitive_grid`,
         :func:`colour.geometry.primitive_cube`},
-        Primitive width.
+        Width of the primitive.
     width_segments
         {:func:`colour.geometry.primitive_grid`,
         :func:`colour.geometry.primitive_cube`},
-        Primitive segments count along the width.
+        Number of segments along the width.
     height_segments
         {:func:`colour.geometry.primitive_grid`,
         :func:`colour.geometry.primitive_cube`},
-        Primitive segments count along the height.
+        Number of segments along the height.
 
     Returns
     -------
     :class:`tuple`
-        Tuple of primitive vertices, face indexes to produce a filled primitive
-        and outline indexes to produce an outline of the faces of the
-        primitive.
+        Tuple containing three arrays:
+
+        - **vertices**: Structured array of vertex data including position,
+          texture coordinates, normal vectors, and colour values
+        - **faces**: Face indexes for rendering a filled primitive
+        - **outline**: Outline indexes for rendering the edges of the primitive
 
     References
     ----------

--- a/colour/geometry/primitives.py
+++ b/colour/geometry/primitives.py
@@ -139,7 +139,7 @@ def primitive_grid(
      [1 0]]
     """
 
-    axis = MAPPING_PLANE_TO_AXIS.get(axis, axis).lower()  # pyright: ignore
+    axis = MAPPING_PLANE_TO_AXIS.get(axis, axis).lower()
 
     dtype_vertices = optional(dtype_vertices, DTYPE_FLOAT_DEFAULT)
     dtype_indexes = optional(dtype_indexes, DTYPE_INT_DEFAULT)

--- a/colour/geometry/section.py
+++ b/colour/geometry/section.py
@@ -2,9 +2,17 @@
 Geometry / Hull Section
 =======================
 
-Define various objects to compute hull sections:
+Define objects for computing hull sections in colour spaces.
 
--   :func:`colour.geometry.hull_section`
+This module provides functionality to compute and analyze hull sections,
+which represent the boundary surfaces of colour gamuts when intersected
+with the specified planes in various colour spaces.
+
+Key Components
+--------------
+
+-   :func:`colour.geometry.hull_section`: Compute hull sections for colour
+    space analysis.
 """
 
 from __future__ import annotations
@@ -40,6 +48,10 @@ __all__ = [
 def edges_to_chord(edges: ArrayLike, index: int = 0) -> NDArrayFloat:
     """
     Convert specified edges to a chord, starting at specified index.
+
+    Transforms a collection of edges into a continuous chord by
+    connecting them sequentially, beginning from the specified index
+    position.
 
     Parameters
     ----------
@@ -109,7 +121,7 @@ def edges_to_chord(edges: ArrayLike, index: int = 0) -> NDArrayFloat:
 
 def close_chord(vertices: ArrayLike) -> NDArrayFloat:
     """
-    Close the chord.
+    Close a chord by appending its first vertex to the end.
 
     Parameters
     ----------
@@ -119,7 +131,8 @@ def close_chord(vertices: ArrayLike) -> NDArrayFloat:
     Returns
     -------
     :class:`numpy.ndarray`
-        Closed chord.
+        Closed chord with the first vertex appended to create a closed
+        path.
 
     Examples
     --------
@@ -139,23 +152,26 @@ def unique_vertices(
     decimals: int = np.finfo(DTYPE_FLOAT_DEFAULT).precision - 1,  # pyright: ignore
 ) -> NDArrayFloat:
     """
-    Generate the unique vertices from specified vertices.
+    Return the unique vertices from the specified vertices after rounding.
 
     Parameters
     ----------
     vertices
         Vertices to return the unique vertices from.
     decimals
-        Decimals used when rounding the vertices prior to comparison.
+        Number of decimal places for rounding the vertices prior to
+        uniqueness comparison.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Unique vertices.
+        Unique vertices with duplicates removed.
 
     Notes
     -----
-    -   The vertices are rounded at specified ``decimals``.
+    -   The vertices are rounded to the specified number of decimal places
+        before uniqueness comparison to handle floating-point precision
+        issues.
 
     Examples
     --------
@@ -181,28 +197,41 @@ def hull_section(
     normalise: bool = False,
 ) -> NDArrayFloat:
     """
-    Compute the hull section for specified axis at specified origin.
+    Compute the hull section for the specified axis at the specified origin.
+
+    Generate a cross-sectional contour of a 3D hull by intersecting it with
+    a plane perpendicular to the specified axis at the specified origin
+    coordinate. This operation produces vertices that define the boundary of
+    the hull's intersection with the cutting plane.
 
     Parameters
     ----------
     hull
-        *Trimesh* hull.
+        *Trimesh* hull object representing the 3D geometry to section.
     axis
-        Axis the hull section will be normal to.
+        Axis perpendicular to which the hull section will be computed.
+        Options are "+x", "+y", or "+z".
     origin
-        Coordinate along ``axis`` at which to plot the hull section.
+        Coordinate along ``axis`` at which to compute the hull section.
+        The value represents either an absolute position or a normalised
+        position depending on the ``normalise`` parameter.
     normalise
-        Whether to normalise ``axis`` to the extent of the hull along it.
+        Whether to normalise the ``origin`` coordinate to the extent of the
+        hull along the specified ``axis``. When ``True``, ``origin`` is
+        interpreted as a value in [0, 1] where 0 represents the minimum
+        extent and 1 represents the maximum extent along ``axis``.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Hull section vertices.
+        Hull section vertices forming a closed contour. The vertices are
+        ordered to form a continuous path around the section boundary.
 
     Raises
     ------
     ValueError
-        If no section exists on the specified axis at the given origin.
+        If no section exists on the specified axis at the specified origin,
+        typically when the cutting plane does not intersect the hull.
 
     Examples
     --------

--- a/colour/geometry/vertices.py
+++ b/colour/geometry/vertices.py
@@ -2,7 +2,8 @@
 Geometry Primitive Vertices
 ===========================
 
-Define various geometry primitive vertices generation methods:
+Define methods for generating vertices of fundamental geometric primitives
+used in colour science visualisations and computations.
 
 -   :func:`colour.geometry.primitive_vertices_quad_mpl`
 -   :func:`colour.geometry.primitive_vertices_grid_mpl`
@@ -61,22 +62,22 @@ def primitive_vertices_quad_mpl(
     axis: Literal["+z", "+x", "+y", "yz", "xz", "xy"] | str = "+z",
 ) -> NDArrayFloat:
     """
-    Generate the vertices of a quad primitive for use with *Matplotlib*
+    Generate vertices of a quad primitive for use with *Matplotlib*
     :class:`mpl_toolkits.mplot3d.art3d.Poly3DCollection` class.
 
     Parameters
     ----------
     width
-        Quad width.
+        Width of the primitive.
     height
-        Quad height.
+        Height of the primitive.
     depth
-        Quad depth.
+        Depth of the primitive.
     origin
-        Quad origin on the construction plane.
+        Origin of the primitive on the construction plane.
     axis
-        Axis the quad will be normal to, or plane the quad will be co-planar
-        with.
+        Axis to which the primitive will be normal, or plane with which the
+        primitive will be co-planar.
 
     Returns
     -------
@@ -134,27 +135,29 @@ def primitive_vertices_grid_mpl(
     axis: Literal["+z", "+x", "+y", "yz", "xz", "xy"] | str = "+z",
 ) -> NDArrayFloat:
     """
-    Generate the vertices of a grid primitive made of quad primitives for
-    use with *Matplotlib* :class:`mpl_toolkits.mplot3d.art3d.Poly3DCollection`
-    class.
+    Generate vertices for a grid primitive composed of quadrilateral
+    primitives for use with *Matplotlib*
+    :class:`mpl_toolkits.mplot3d.art3d.Poly3DCollection` class.
 
     Parameters
     ----------
     width
-        Grid width.
+        Width of the primitive.
     height
-        Grid height.
+        Height of the primitive.
     depth
-        Grid depth.
+        Depth of the primitive.
     width_segments:
-        Grid width segments, quad primitive counts along the width.
+        Number of width segments defining quad primitive counts along
+        the width axis.
     height_segments:
-        Grid height segments, quad primitive counts along the height.
+        Number of height segments defining quad primitive counts along
+        the height axis.
     origin
-        Grid origin on the construction plane.
+        Origin of the primitive on the construction plane.
     axis
-        Axis the grid will be normal to, or plane the grid will be co-planar
-        with.
+        Axis to which the primitive will be normal, or plane with which the
+        primitive will be co-planar.
 
     Returns
     -------
@@ -230,26 +233,29 @@ def primitive_vertices_cube_mpl(
     ) = None,
 ) -> NDArrayFloat:
     """
-    Generate the vertices of a cube primitive made of grid primitives for
+    Generate vertices of a cube primitive made of grid primitives for
     use with *Matplotlib* :class:`mpl_toolkits.mplot3d.art3d.Poly3DCollection`
     class.
 
     Parameters
     ----------
     width
-        Cube width.
+        Width of the primitive.
     height
-        Cube height.
+        Height of the primitive.
     depth
-        Cube depth.
+        Depth of the primitive.
     width_segments
-        Cube segments count along the width.
+        Number of width segments defining quad primitive counts along
+        the width axis.
     height_segments
-        Cube segments count along the height.
+        Number of height segments defining quad primitive counts along
+        the height axis.
     depth_segments
-        Cube segments count along the depth.
+        Number of depth segments defining quad primitive counts along
+        the depth axis.
     origin
-        Cube origin.
+        Origin of the primitive.
     planes
         Grid primitives to include in the cube construction.
 
@@ -347,25 +353,27 @@ def primitive_vertices_sphere(
     axis: Literal["+z", "+x", "+y", "yz", "xz", "xy"] | str = "+z",
 ) -> NDArrayFloat:
     """
-    Generate the vertices of a latitude-longitude sphere primitive.
+    Generate vertices of a latitude-longitude sphere primitive.
 
     Parameters
     ----------
     radius
-        Sphere radius.
+        Radius of the sphere.
     segments
-        Latitude-longitude segments, if the ``intermediate`` argument is
-        *True*, then the sphere will have one less segment along its longitude.
+        Number of latitude-longitude segments. If the ``intermediate``
+        argument is *True*, the sphere will have one fewer segment
+        along its longitude.
     intermediate
-        Whether to generate the sphere vertices at the center of the faces
+        Whether to generate sphere vertices at the centres of the faces
         outlined by the segments of a regular sphere generated without
-        the ``intermediate`` argument set to *True*. The resulting sphere is
-        inscribed on the regular sphere faces but possesses the same poles.
+        the ``intermediate`` argument set to *True*. The resulting
+        sphere is inscribed within the regular sphere faces while
+        maintaining identical poles.
     origin
-        Sphere origin on the construction plane.
+        Origin of the primitive on the construction plane.
     axis
-        Axis (or normal of the plane) the poles of the sphere will be aligned
-        with.
+        Axis to which the primitive will be normal, or plane with which the
+        primitive will be co-planar.
 
     Returns
     -------
@@ -471,7 +479,7 @@ PRIMITIVE_VERTICES_METHODS: CanonicalMapping = CanonicalMapping(
     }
 )
 PRIMITIVE_VERTICES_METHODS.__doc__ = """
-Supported geometry primitive vertices generation methods.
+Supported methods for generating vertices of geometry primitives.
 """
 
 
@@ -480,12 +488,12 @@ def primitive_vertices(
     **kwargs: Any,
 ) -> NDArrayFloat:
     """
-    Generate the vertices of a geometry primitive using specified method.
+    Generate vertices of a geometry primitive.
 
     Parameters
     ----------
     method
-        Vertices generation method.
+        Method for generating primitive vertices.
 
     Other Parameters
     ----------------
@@ -494,64 +502,68 @@ def primitive_vertices(
         :func:`colour.geometry.primitive_vertices_grid_mpl`,
         :func:`colour.geometry.primitive_vertices_sphere`},
         **{'+z', '+x', '+y', 'yz', 'xz', 'xy'}**,
-        Axis the primitive will be normal to, or plane the primitive will be
-        co-planar with.
+        Axis to which the primitive will be normal, or plane with which
+        the primitive will be co-planar.
     depth
         {:func:`colour.geometry.primitive_vertices_quad_mpl`,
         :func:`colour.geometry.primitive_vertices_grid_mpl`,
         :func:`colour.geometry.primitive_vertices_cube_mpl`},
-        Primitive depth.
+        Depth of the primitive.
     depth_segments
-        {:func:`colour.geometry.primitive_vertices_grid_mpl`,
-        :func:`colour.geometry.primitive_vertices_cube_mpl`},
-        Primitive depth segments, quad primitive counts along the depth.
+        {:func:`colour.geometry.primitive_vertices_cube_mpl`},
+        Number of depth segments defining quad primitive counts along
+        the depth axis.
     height
         {:func:`colour.geometry.primitive_vertices_quad_mpl`,
         :func:`colour.geometry.primitive_vertices_grid_mpl`,
         :func:`colour.geometry.primitive_vertices_cube_mpl`},
-        Primitive height.
+        Height of the primitive.
     height_segments
         {:func:`colour.geometry.primitive_vertices_grid_mpl`,
         :func:`colour.geometry.primitive_vertices_cube_mpl`},
-        Primitive height segments, quad primitive counts along the height.
+        Number of height segments defining quad primitive counts along
+        the height axis.
     intermediate
         {:func:`colour.geometry.primitive_vertices_sphere`},
-        Whether to generate the sphere vertices at the center of the faces
+        Whether to generate sphere vertices at the centres of the faces
         outlined by the segments of a regular sphere generated without
-        the ``intermediate`` argument set to *True*. The resulting sphere is
-        inscribed on the regular sphere faces but possesses the same poles.
+        the ``intermediate`` argument set to *True*. The resulting
+        sphere is inscribed within the regular sphere faces while
+        maintaining identical poles.
     origin
         {:func:`colour.geometry.primitive_vertices_quad_mpl`,
         :func:`colour.geometry.primitive_vertices_grid_mpl`,
         :func:`colour.geometry.primitive_vertices_cube_mpl`,
         :func:`colour.geometry.primitive_vertices_sphere`},
-        Primitive origin on the construction plane.
+        Origin of the primitive on the construction plane.
     planes
         {:func:`colour.geometry.primitive_vertices_cube_mpl`},
         **{'-x', '+x', '-y', '+y', '-z', '+z',
         'xy', 'xz', 'yz', 'yx', 'zx', 'zy'}**,
-        Included grid primitives in the cube construction.
+        Grid primitives to include in the cube construction.
     radius
         {:func:`colour.geometry.primitive_vertices_sphere`},
-        Sphere radius.
+        Radius of the sphere.
     segments
         {:func:`colour.geometry.primitive_vertices_sphere`},
-        Latitude-longitude segments, if the ``intermediate`` argument is
-        *True*, then the sphere will have one less segment along its longitude.
+        Number of latitude-longitude segments. If the ``intermediate``
+        argument is *True*, the sphere will have one fewer segment
+        along its longitude.
     width
         {:func:`colour.geometry.primitive_vertices_quad_mpl`,
         :func:`colour.geometry.primitive_vertices_grid_mpl`,
         :func:`colour.geometry.primitive_vertices_cube_mpl`},
-        Primitive width.
+        Width of the primitive.
     width_segments
         {:func:`colour.geometry.primitive_vertices_grid_mpl`,
         :func:`colour.geometry.primitive_vertices_cube_mpl`},
-        Primitive width segments, quad primitive counts along the width.
+        Number of width segments defining quad primitive counts along
+        the width axis.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Primitive vertices.
+        Vertices of the primitive.
 
     Examples
     --------

--- a/colour/graph/conversion.py
+++ b/colour/graph/conversion.py
@@ -2,7 +2,7 @@
 Automatic Colour Conversion Graph
 =================================
 
-Define the automatic colour conversion graph objects:
+Define the automatic colour conversion graph objects.
 
 -   :func:`colour.describe_conversion_path`
 -   :func:`colour.convert`
@@ -239,8 +239,12 @@ __all__ = [
 @dataclass(frozen=True)
 class Conversion_Specification:
     """
-    Conversion specification for *Colour* graph for automatic colour
-    conversion describing two nodes and the edge in the graph.
+    Define a conversion specification for the *Colour* graph used in automatic
+    colour space conversions.
+
+    The specification describes the relationship between two nodes (colour
+    spaces or representations) and the transformation function that connects
+    them within the conversion graph.
 
     Parameters
     ----------
@@ -257,7 +261,12 @@ class Conversion_Specification:
     conversion_function: Callable
 
     def __post_init__(self) -> None:
-        """Post-initialise the class."""
+        """
+        Post-initialise the class.
+
+        Convert the source and target attribute values to lowercase for
+        consistent case-insensitive comparisons.
+        """
 
         object.__setattr__(self, "source", self.source.lower())
         object.__setattr__(self, "target", self.target.lower())
@@ -306,7 +315,7 @@ def JMh_CIECAM02_to_CIECAM02(JMh: ArrayLike) -> CAM_Specification_CIECAM02:
     Parameters
     ----------
     JMh
-         *CIECAM02* :math:`JMh` correlates.
+        *CIECAM02* :math:`JMh` correlates.
 
     Returns
     -------
@@ -360,7 +369,7 @@ def JMh_CAM16_to_CAM16(JMh: ArrayLike) -> CAM_Specification_CAM16:
     Parameters
     ----------
     JMh
-         *CAM16* :math:`JMh` correlates.
+        *CAM16* :math:`JMh` correlates.
 
     Returns
     -------
@@ -383,7 +392,8 @@ Q=None, M=0.1074367..., H=None, HC=None)
 
 def CIECAM16_to_JMh_CIECAM16(specification: CAM_Specification_CIECAM16) -> NDArrayFloat:
     """
-    Convert from *CIECAM16* specification to *CIECAM16* :math:`JMh` correlates.
+    Convert from *CIECAM16* specification to *CIECAM16* :math:`JMh`
+    correlates.
 
     Parameters
     ----------
@@ -409,12 +419,13 @@ def CIECAM16_to_JMh_CIECAM16(specification: CAM_Specification_CIECAM16) -> NDArr
 
 def JMh_CIECAM16_to_CIECAM16(JMh: ArrayLike) -> CAM_Specification_CIECAM16:
     """
-    Convert from *CIECAM16* :math:`JMh` correlates to *CIECAM16* specification.
+    Convert from *CIECAM16* :math:`JMh` correlates to *CIECAM16*
+    specification.
 
     Parameters
     ----------
     JMh
-         *CIECAM16* :math:`JMh` correlates.
+        *CIECAM16* :math:`JMh` correlates.
 
     Returns
     -------
@@ -445,7 +456,8 @@ def Hellwig2022_to_JMh_Hellwig2022(
     Parameters
     ----------
     specification
-        *Hellwig and Fairchild (2022)* colour appearance model specification.
+        *Hellwig and Fairchild (2022)* colour appearance model
+        specification.
 
     Returns
     -------
@@ -474,7 +486,7 @@ def JMh_Hellwig2022_to_Hellwig2022(
     Parameters
     ----------
     JMh
-         *Hellwig and Fairchild (2022)* :math:`JMh` correlates.
+        *Hellwig and Fairchild (2022)* :math:`JMh` correlates.
 
     Returns
     -------
@@ -528,7 +540,7 @@ def JMh_sCAM_to_sCAM(JMh: ArrayLike) -> CAM_Specification_sCAM:
     Parameters
     ----------
     JMh
-         *sCAM* :math:`JMh` correlates.
+        *sCAM* :math:`JMh` correlates.
 
     Returns
     -------
@@ -551,7 +563,10 @@ M=0.1074367..., H=None, HC=None, V=None, K=None, W=None, D=None)
 
 def XYZ_to_luminance(XYZ: ArrayLike) -> NDArrayFloat:
     """
-    Convert from *CIE XYZ* tristimulus values to *luminance* :math:`Y`.
+    Convert specified *CIE XYZ* tristimulus values to *luminance* :math:`Y`.
+
+    Extract the Y component from *CIE XYZ* tristimulus values, which
+    represents the *luminance* of the colour stimulus.
 
     Parameters
     ----------
@@ -603,7 +618,7 @@ def RGB_luminance_to_RGB(Y: ArrayLike) -> NDArrayFloat:
 
 def CCT_D_uv_to_mired(CCT_D_uv: ArrayLike) -> NDArrayFloat:
     """
-    Convert specified correlated colour temperature :math:`T_{cp}` and
+    Convert correlated colour temperature :math:`T_{cp}` and
     :math:`\\Delta_{uv}` to micro reciprocal degree (mired).
 
     Parameters
@@ -1056,7 +1071,23 @@ the edge in the graph.
 
 
 def _format_node_name(name: str) -> str:
-    """Format specified name by applying a series of substitutions."""
+    """
+    Format the specified name by applying a series of substitutions.
+
+    This function transforms node names according to predefined patterns,
+    typically converting underscores to hyphens and applying other naming
+    conventions used in the colourspace models polar conversions system.
+
+    Parameters
+    ----------
+    name
+        The node name to format.
+
+    Returns
+    -------
+    :class:`str`
+        The formatted node name with substitutions applied.
+    """
 
     for pattern, substitution in [
         ("hdr_", "hdr-"),
@@ -1117,7 +1148,7 @@ def _build_graph() -> networkx.DiGraph:  # pyright: ignore  # noqa: F821
     Returns
     -------
     :class:`networkx.DiGraph`
-         Automatic colour conversion graph.
+        Automatic colour conversion graph.
     """
 
     import networkx as nx  # noqa: PLC0415
@@ -1154,8 +1185,8 @@ def _conversion_path(source: str, target: str) -> List[Callable]:
     Returns
     -------
     :class:`list`
-        Conversion path from the source node to the target node, i.e., a list of
-        conversion function callables.
+        Conversion path from the source node to the target node, i.e., a
+        list of conversion function callables.
 
     Examples
     --------
@@ -1183,19 +1214,19 @@ def _conversion_path(source: str, target: str) -> List[Callable]:
 
 def _lower_order_function(callable_: Callable) -> Callable:
     """
-    Generate the lower order function associated with specified callable,
-    i.e., the function wrapped by a partial object.
+    Extract the lower-order function from the specified callable, such as the
+    underlying function wrapped by a partial object.
 
     Parameters
     ----------
     callable_
-        Callable to generate the lower order function.
+        Callable from which to extract the lower-order function.
 
     Returns
     -------
     Callable
-        Lower order function or specified callable if no lower order function
-        exists.
+        Lower-order function if the callable is a partial object, otherwise
+        the original callable.
     """
 
     return callable_.func if isinstance(callable_, partial) else callable_
@@ -1211,8 +1242,9 @@ def describe_conversion_path(
     **kwargs: Any,
 ) -> None:
     """
-    Describe the conversion path from source colour representation to target
-    colour representation using the automatic colour conversion graph.
+    Describe the conversion path from the specified source colour
+    representation to the specified target colour representation using the
+    automatic colour conversion graph.
 
     Parameters
     ----------
@@ -1224,8 +1256,8 @@ def describe_conversion_path(
         colour conversion graph.
     mode
         Verbose mode: *Short* describes the conversion path, *Long* provides
-        details about the arguments, definitions signatures and output values,
-        *Extended* appends the definitions' documentation.
+        details about the arguments, definitions signatures and output
+        values, *Extended* appends the definitions' documentation.
     width
         Message box width.
     padding
@@ -1330,17 +1362,19 @@ def describe_conversion_path(
 def convert(a: Any, source: str, target: str, **kwargs: Any) -> Any:
     """
     Convert specified object :math:`a` from source colour representation to
-    target colour representation using the automatic colour conversion graph.
+    target colour representation using the automatic colour conversion
+    graph.
 
     The conversion is performed by finding the shortest path in a
-    `NetworkX <https://networkx.github.io>`__ :class:`DiGraph` class instance.
+    `NetworkX <https://networkx.github.io>`__ :class:`DiGraph` class
+    instance.
 
-    The conversion path adopts the **'1'** domain-range scale and the object
-    :math:`a` is expected to be *soft* normalised accordingly. For example,
-    *CIE XYZ* tristimulus values arguments for use with the *CAM16* colour
-    appearance model should be in domain `[0, 1]` instead of the domain
-    `[0, 100]` used with the **'Reference'** domain-range scale. The arguments
-    are typically converted as follows:
+    The conversion path adopts the **'1'** domain-range scale and the
+    object :math:`a` is expected to be *soft* normalised accordingly. For
+    example, *CIE XYZ* tristimulus values arguments for use with the
+    *CAM16* colour appearance model should be in domain `[0, 1]` instead
+    of the domain `[0, 100]` used with the **'Reference'** domain-range
+    scale. The arguments are typically converted as follows:
 
     -   *Scalars* in domain-range `[0, 10]`, e.g *Munsell Value* are
         scaled by *10*.
@@ -1349,40 +1383,44 @@ def convert(a: Any, source: str, target: str, **kwargs: Any) -> Any:
     -   *Integers* in domain-range `[0, 2**n -1]` where `n` is the bit
         depth are scaled by *2**n -1*.
 
-    See the `Domain-Range Scales <../basics.html#domain-range-scales>`__ page
-    for more information.
+    See the `Domain-Range Scales <../basics.html#domain-range-scales>`__
+    page for more information.
 
     Parameters
     ----------
     a
-        Object :math:`a` to convert. If :math:`a` represents a reflectance,
-        transmittance or absorptance value, the expectation is that it is
-        viewed under *CIE Standard Illuminant D Series* *D65*. The illuminant
-        can be changed on a per-definition basis along the conversion path.
+        Object :math:`a` to convert. If :math:`a` represents a
+        reflectance, transmittance or absorptance value, the expectation
+        is that it is viewed under *CIE Standard Illuminant D Series*
+        *D65*. The illuminant can be changed on a per-definition basis
+        along the conversion path.
     source
-        Source colour representation, i.e., the source node in the automatic
-        colour conversion graph.
+        Source colour representation, i.e., the source node in the
+        automatic colour conversion graph.
     target
-        Target colour representation, i.e., the target node in the automatic
-        colour conversion graph.
+        Target colour representation, i.e., the target node in the
+        automatic colour conversion graph.
 
     Other Parameters
     ----------------
     kwargs
-        See the documentation of the supported conversion
-        definitions.
+        See the documentation of the supported conversion definitions.
 
         Arguments for the conversion definitions are passed as keyword
-        arguments whose names is those of the conversion definitions and values
-        set as dictionaries. For example, in the conversion from spectral
-        distribution to *sRGB* colourspace, passing arguments to the
-        :func:`colour.sd_to_XYZ` definition is done as follows::
+        arguments whose names are those of the conversion definitions and
+        values set as dictionaries. For example, in the conversion from
+        spectral distribution to *sRGB* colourspace, passing arguments to
+        the :func:`colour.sd_to_XYZ` definition is done as follows::
 
-            convert(sd, "Spectral Distribution", "sRGB", sd_to_XYZ={\
-"illuminant": SDS_ILLUMINANTS["FL2"]})
+            convert(
+                sd,
+                "Spectral Distribution",
+                "sRGB",
+                sd_to_XYZ={"illuminant": SDS_ILLUMINANTS["FL2"]},
+            )
 
-        It is also possible to pass keyword arguments directly to the various
-        conversion definitions irrespective of their name. This is
+        It is also possible to pass keyword arguments directly to the
+        various conversion definitions irrespective of their name. This is
         ``dangerous`` and could cause unexpected behaviour, consider the
         following conversion::
 
@@ -1390,47 +1428,49 @@ def convert(a: Any, source: str, target: str, **kwargs: Any) -> Any:
 SDS_ILLUMINANTS["FL2"])
 
         Because both the :func:`colour.sd_to_XYZ` and
-        :func:`colour.XYZ_to_sRGB` definitions have an *illuminant* argument,
-        `SDS_ILLUMINANTS["FL2"]` will be passed to both of them and will raise
-        an exception in the :func:`colour.XYZ_to_sRGB` definition. This will
-        be addressed in the future by either catching the exception and trying
-        a new time without the keyword argument or more elegantly via type
-        checking.
+        :func:`colour.XYZ_to_sRGB` definitions have an *illuminant*
+        argument, `SDS_ILLUMINANTS["FL2"]` will be passed to both of them
+        and will raise an exception in the :func:`colour.XYZ_to_sRGB`
+        definition. This will be addressed in the future by either
+        catching the exception and trying a new time without the keyword
+        argument or more elegantly via type checking.
 
         With that in mind, this mechanism offers some good benefits: For
-        example, it allows defining a conversion from *CIE XYZ* colourspace to
-        *n* different colour models while passing an illuminant argument but
-        without having to explicitly define all the explicit conversion
-        definition arguments::
+        example, it allows defining a conversion from *CIE XYZ*
+        colourspace to *n* different colour models while passing an
+        illuminant argument but without having to explicitly define all
+        the explicit conversion definition arguments::
 
             a = np.array([0.20654008, 0.12197225, 0.05136952])
-            illuminant = CCS_ILLUMINANTS[\
-"CIE 1931 2 Degree Standard Observer"]["D65"]
+            illuminant = CCS_ILLUMINANTS["CIE 1931 2 Degree Standard Observer"]["D65"]
             for model in ("CIE xyY", "CIE Lab"):
                 convert(a, "CIE XYZ", model, illuminant=illuminant)
 
         Instead of::
 
             for model in ("CIE xyY", "CIE Lab"):
-                convert(a, "CIE XYZ", model, XYZ_to_xyY={"illuminant": \
-illuminant}, XYZ_to_Lab={"illuminant": illuminant})
+                convert(
+                    a,
+                    "CIE XYZ",
+                    model,
+                    XYZ_to_xyY={"illuminant": illuminant},
+                    XYZ_to_Lab={"illuminant": illuminant},
+                )
 
-        Mixing both approaches is possible for the brevity benefits. It is made
-        possible because the keyword arguments directly passed are filtered
-        first and then the resulting dict is updated with the explicit
-        conversion definition arguments::
+        Mixing both approaches is possible for the brevity benefits. It is
+        made possible because the keyword arguments directly passed are
+        filtered first and then the resulting dict is updated with the
+        explicit conversion definition arguments::
 
-            illuminant = CCS_ILLUMINANTS[\
-"CIE 1931 2 Degree Standard Observer"]["D65"]
+            illuminant = CCS_ILLUMINANTS["CIE 1931 2 Degree Standard Observer"]["D65"]
              convert(sd, "Spectral Distribution", "sRGB", "illuminant": \
 SDS_ILLUMINANTS["FL2"], XYZ_to_sRGB={"illuminant": illuminant})
 
-        For inspection purposes, verbose is enabled by passing arguments to the
-        :func:`colour.describe_conversion_path` definition via the ``verbose``
-        keyword argument as follows::
+        For inspection purposes, verbose is enabled by passing arguments
+        to the :func:`colour.describe_conversion_path` definition via the
+        ``verbose`` keyword argument as follows::
 
-            convert(sd, "Spectral Distribution", "sRGB", \
-verbose={"mode": "Long"})
+            convert(sd, "Spectral Distribution", "sRGB", verbose={"mode": "Long"})
 
     Returns
     -------
@@ -1450,39 +1490,41 @@ verbose={"mode": "Long"})
     Notes
     -----
     -   The **RGB** colour representation is assumed to be linear and
-        representing *scene-referred* imagery, i.e., **Scene-Referred RGB**
-        representation. To encode such *RGB* values as *output-referred*
-        (*display-referred*) imagery, i.e., encode the *RGB* values using an
-        encoding colour component transfer function (Encoding CCTF) /
-        opto-electronic transfer function (OETF), the
+        representing *scene-referred* imagery, i.e., **Scene-Referred
+        RGB** representation. To encode such *RGB* values as
+        *output-referred* (*display-referred*) imagery, i.e., encode the
+        *RGB* values using an encoding colour component transfer function
+        (Encoding CCTF) / opto-electronic transfer function (OETF), the
         **Output-Referred RGB** representation must be used::
 
              convert(RGB, "Scene-Referred RGB", "Output-Referred RGB")
 
-        Likewise, encoded *output-referred* *RGB* values can be decoded with
-        the **Scene-Referred RGB** representation::
+        Likewise, encoded *output-referred* *RGB* values can be decoded
+        with the **Scene-Referred RGB** representation::
 
             convert(RGB, "Output-Referred RGB", "Scene-Referred RGB")
 
     -   The following defaults have been adopted:
 
-        -   The default illuminant for the computation is
-            *CIE Standard Illuminant D Series* *D65*. It can be changed on a
+        -   The default illuminant for the computation is *CIE Standard
+            Illuminant D Series* *D65*. It can be changed on a
             per-definition basis along the conversion path. Note that the
-            conversion from spectral to *CIE XYZ* tristimulus values remains
-            unchanged.
-        -   The default *RGB* colourspace primaries and whitepoint are that of
-            the *BT.709*/*sRGB* colourspace. They can be changed on a
-            per-definition basis along the conversion path.
-        -   When using **sRGB** as a source or target colour representation,
-            the convenient :func:`colour.sRGB_to_XYZ` and
-            :func:`colour.XYZ_to_sRGB` definitions are used, respectively.
-            Thus, decoding and encoding using the sRGB electro-optical transfer
-            function (EOTF) and its inverse will be applied by default.
-        -   Most of the colour appearance models have defaults set according to
-            *IEC 61966-2-1:1999* viewing conditions, i.e., *sRGB* 64 Lux ambient
-            illumination, 80 :math:`cd/m^2`, adapting field luminance about
-            20% of a white object in the scene.
+            conversion from spectral to *CIE XYZ* tristimulus values
+            remains unchanged.
+        -   The default *RGB* colourspace primaries and whitepoint are
+            that of the *BT.709*/*sRGB* colourspace. They can be changed
+            on a per-definition basis along the conversion path.
+        -   When using **sRGB** as a source or target colour
+            representation, the convenient :func:`colour.sRGB_to_XYZ` and
+            :func:`colour.XYZ_to_sRGB` definitions are used,
+            respectively. Thus, decoding and encoding using the sRGB
+            electro-optical transfer function (EOTF) and its inverse will
+            be applied by default.
+        -   Most of the colour appearance models have defaults set
+            according to *IEC 61966-2-1:1999* viewing conditions, i.e.,
+            *sRGB* 64 Lux ambient illumination, 80 :math:`cd/m^2`,
+            adapting field luminance about 20% of a white object in the
+            scene.
 
     Examples
     --------

--- a/colour/io/__init__.py
+++ b/colour/io/__init__.py
@@ -116,7 +116,7 @@ class io(ModuleAPI):
     """Define a class acting like the *io* module."""
 
     def __getattr__(self, attribute: str) -> Any:
-        """Return the value from the attribute with specified name."""
+        """Return the value from the attribute with the specified name."""
 
         return super().__getattr__(attribute)
 

--- a/colour/io/ctl.py
+++ b/colour/io/ctl.py
@@ -2,7 +2,9 @@
 CTL Processing
 ==============
 
-Define the object for the *Color Transformation Language* (CTL) processing:
+Define objects and functions for *Color Transformation Language* (CTL)
+processing, enabling programmatic colour transformations through the Academy
+Color Encoding System (ACES) CTL interpreter.
 
 -   :func:`colour.io.ctl_render`
 -   :func:`colour.io.process_image_ctl`
@@ -85,8 +87,8 @@ def ctl_render(
     ctl_transforms
         Sequence of *CTL* transforms to apply on the image, either paths to
         existing *CTL* transforms, multi-line *CTL* code transforms or a mix
-        of both or dictionary of sequence of *CTL* transforms to apply on the
-        image and their sequence of parameters.
+        of both, or dictionary of sequence of *CTL* transforms to apply on
+        the image and their sequence of parameters.
 
     Other Parameters
     ----------------
@@ -221,10 +223,10 @@ def process_image_ctl(
     a
         Image data to process with *ctlrender*.
     ctl_transforms
-        Sequence of *CTL* transforms to apply on the image, either paths to
-        existing *CTL* transforms, multi-line *CTL* code transforms or a mix
-        of both or dictionary of sequence of *CTL* transforms to apply on the
-        image and their sequence of parameters.
+        Sequence of *CTL* transforms to apply to the image, either paths to
+        existing *CTL* transform files, multi-line *CTL* code transforms, or
+        a combination of both. Alternatively, a dictionary mapping sequences
+        of *CTL* transforms to their corresponding parameter sequences.
 
     Other Parameters
     ----------------

--- a/colour/io/fichet2021.py
+++ b/colour/io/fichet2021.py
@@ -2,7 +2,8 @@
 OpenEXR Layout for Spectral Images - Fichet, Pacanowski and Wilkie (2021)
 =========================================================================
 
-Define the *Fichet et al. (2021)* spectral image input / output objects.
+Define spectral image input/output functionality based on the
+*Fichet et al. (2021)* OpenEXR layout specification.
 
 References
 ----------
@@ -144,7 +145,7 @@ def match_groups_to_nm(
     units: Literal["m", "Hz"] | str,
 ) -> float:
     """
-    Convert wavelength or frequency match groups to nanometer values.
+    Convert wavelength or frequency match groups to nanometre values.
 
     Parameters
     ----------
@@ -158,7 +159,7 @@ def match_groups_to_nm(
     Returns
     -------
     :class:`float`
-        Nanometer value.
+        Nanometre value.
 
     Raises
     ------
@@ -203,6 +204,10 @@ def sd_to_spectrum_attribute_Fichet2021(
     """
     Convert the specified spectral distribution to a spectrum attribute value
     according to *Fichet et al. (2021)*.
+
+    The conversion produces a string representation of the spectral
+    distribution suitable for use in rendering systems, with wavelength-value
+    pairs formatted as a semicolon-delimited list.
 
     Parameters
     ----------
@@ -291,15 +296,15 @@ class Specification_Fichet2021:
     path
         Path of the spectral image.
     components
-        Components of the spectral image, e.g., *S0*, *S1*, *S2*, *S3*, *T*, or
-        any wavelength number for bi-spectral images.
+        Components of the spectral image, e.g., *S0*, *S1*, *S2*, *S3*, *T*,
+        or any wavelength number for bi-spectral images.
     is_emissive
-        Whether the image is emissive, i.e, using the *S0* component.
+        Whether the image is emissive, i.e., using the *S0* component.
     is_polarised
-        Whether the image is polarised, i.e, using the *S0*, *S1*, *S2*, and
-        *S3* components.
+        Whether the image is polarised, i.e., using the *S0*, *S1*, *S2*,
+        and *S3* components.
     is_bispectral
-        Whether the image is bi-spectral, i.e, using the *T*, and any
+        Whether the image is bi-spectral, i.e., using the *T*, and any
         wavelength number.
     attributes
         An array of :class:`colour.io.Image_Specification_Attribute` class
@@ -331,7 +336,7 @@ class Specification_Fichet2021:
         Parameters
         ----------
         path
-            Image path
+            Image path.
 
         Returns
         -------
@@ -464,8 +469,8 @@ def read_spectral_image_Fichet2021(
     additional_data: bool = False,
 ) -> ComponentsFichet2021 | Tuple[ComponentsFichet2021, Specification_Fichet2021]:
     """
-    Read the *Fichet et al. (2021)* spectral image at the specified path using
-    *OpenImageIO*.
+    Read the *Fichet et al. (2021)* spectral image at the specified path
+    using *OpenImageIO*.
 
     Parameters
     ----------
@@ -480,13 +485,13 @@ def read_spectral_image_Fichet2021(
     -------
     :class:`dict` or :class:`tuple`
         Dictionary of component names and their corresponding tuple of
-        wavelengths and values or tuple of the aforementioned dictionary and
-        :class:`colour.Specification_Fichet2021` class instance.
+        wavelengths and values or tuple of the aforementioned dictionary
+        and :class:`colour.Specification_Fichet2021` class instance.
 
     Notes
     -----
-    -   Spectrum attributes are not parsed but can be converted to spectral
-        distribution using the
+    -   Spectrum attributes are not parsed but can be converted to
+        spectral distribution using the
         :func:`colour.io.spectrum_attribute_to_sd_Fichet2021` definition.
 
     References
@@ -555,11 +560,11 @@ def sds_and_msds_to_components_Fichet2021(
     **kwargs: Any,
 ) -> ComponentsFichet2021:
     """
-    Convert the specified spectral and multi-spectral distributions to
+    Convert specified spectral and multi-spectral distributions to
     *Fichet et al. (2021)* components.
 
-    The spectral and multi-spectral distributions will be aligned to the
-    intersection of their spectral shapes.
+    Align the spectral and multi-spectral distributions to the intersection
+    of their spectral shapes before conversion.
 
     Parameters
     ----------
@@ -568,12 +573,12 @@ def sds_and_msds_to_components_Fichet2021(
         *Fichet et al. (2021)* components.
     specification
         *Fichet et al. (2021)* spectral image specification, used to
-        generate the proper component type, i.e., emissive or other.
+        determine the proper component type, i.e., emissive or other.
 
     Other Parameters
     ----------------
     shape
-        Optional shape the *Fichet et al. (2021)* components should take:
+        Optional shape the *Fichet et al. (2021)* components should take.
         Used when converting spectral distributions of a colour rendition
         chart to create a rectangular image rather than a single line of
         values.

--- a/colour/io/image.py
+++ b/colour/io/image.py
@@ -2,7 +2,8 @@
 Image Input / Output Utilities
 ==============================
 
-Define the image related input / output utilities objects.
+Define image-related input/output utility objects for colour science
+applications.
 """
 
 from __future__ import annotations
@@ -71,16 +72,16 @@ __all__ = [
 @dataclass(frozen=True)
 class Image_Specification_BitDepth:
     """
-    Define a bit-depth specification.
+    Define a bit-depth specification for image processing operations.
 
     Parameters
     ----------
     name
-        Attribute name.
+        Attribute name identifying the bit-depth specification.
     numpy
-        Object representing the *Numpy* bit-depth.
+        Object representing the *NumPy* bit-depth data type.
     openimageio
-        Object representing the *OpenImageIO* bit-depth.
+        Object representing the *OpenImageIO* bit-depth specification.
     """
 
     name: str
@@ -91,16 +92,17 @@ class Image_Specification_BitDepth:
 @dataclass
 class Image_Specification_Attribute:
     """
-    Define an image specification attribute.
+    Define an image specification attribute for OpenImageIO operations.
 
     Parameters
     ----------
     name
-        Attribute name.
+        Attribute name identifying the metadata field.
     value
-        Attribute value.
+        Attribute value containing the metadata content.
     type_
-        Attribute type as an *OpenImageIO* :class:`TypeDesc` class instance.
+        Attribute type as an *OpenImageIO* :class:`TypeDesc` class instance
+        specifying the data type of the value.
     """
 
     name: str
@@ -155,20 +157,27 @@ def add_attributes_to_image_specification_OpenImageIO(
     image_specification: ImageSpec, attributes: Sequence
 ) -> ImageSpec:
     """
-    Add the specified attributes to the specified *OpenImageIO* image specification.
+    Add the specified attributes to the specified *OpenImageIO* image
+    specification.
+
+    Apply metadata attributes to an existing image specification object,
+    enabling customization of image properties such as compression,
+    colour space information, or other format-specific metadata.
 
     Parameters
     ----------
     image_specification
-        *OpenImageIO* image specification.
+        *OpenImageIO* image specification to modify.
     attributes
-        An array of :class:`colour.io.Image_Specification_Attribute` class
-        instances used to set attributes of the image.
+        Sequence of :class:`colour.io.Image_Specification_Attribute`
+        instances containing metadata to apply to the image
+        specification.
 
     Returns
     -------
     :class:`ImageSpec`
-        *OpenImageIO* image specification.
+        Modified *OpenImageIO* image specification with applied
+        attributes.
 
     Examples
     --------
@@ -220,11 +229,11 @@ def image_specification_OpenImageIO(
     channels
         Image channel count.
     bit_depth
-        Bit-depth to create the image with, the bit-depth conversion behaviour is
-        ruled directly by *OpenImageIO*.
+        Bit-depth to create the image with. The bit-depth conversion
+        behaviour is ruled directly by *OpenImageIO*.
     attributes
-        An array of :class:`colour.io.Image_Specification_Attribute` class
-        instances used to set attributes of the image.
+        An array of :class:`colour.io.Image_Specification_Attribute`
+        class instances used to set attributes of the image.
 
     Returns
     -------
@@ -264,25 +273,31 @@ def convert_bit_depth(
     ] = "float32",
 ) -> NDArrayReal:
     """
-    Convert the specified array to the specified bit-depth, using the current
-    bit-depth of the array to determine the appropriate conversion path.
+    Convert the specified array to the specified bit-depth.
+
+    The conversion path is determined by the current bit-depth of the input
+    array and the target bit-depth. Supports conversions between unsigned
+    integers, floating-point types, and mixed type conversions with
+    appropriate scaling.
 
     Parameters
     ----------
     a
-        Array to convert to specified bit-depth.
+        Array to convert to the specified bit-depth.
     bit_depth
-        Bit-depth.
+        Target bit-depth. Supported types include unsigned integers
+        ("uint8", "uint16") and floating-point ("float16", "float32",
+        "float64", "float128").
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Converted array.
+        Array converted to the specified bit-depth.
 
     Raises
     ------
     AssertionError
-        If the bit-depth or image bit-depth is not supported.
+        If the source or target bit-depth is not supported.
 
     Examples
     --------
@@ -383,24 +398,32 @@ def read_image_OpenImageIO(
     **kwargs: Any,
 ) -> NDArrayReal | Tuple[NDArrayReal, Tuple[Image_Specification_Attribute, ...]]:
     """
-    Read the image data at the specified path using *OpenImageIO*.
+    Read image data from the specified path using *OpenImageIO*.
+
+    Load image data from the file system with support for various bit-depth
+    formats. The bit-depth conversion behaviour is controlled by
+    *OpenImageIO*, with this function performing only the final type
+    conversion after reading.
 
     Parameters
     ----------
     path
-        Image path.
+        Path to the image file.
     bit_depth
-        Returned image bit-depth, the bit-depth conversion behaviour is driven
-        directly by *OpenImageIO*, this definition only converts to the
-        relevant data type after reading.
+        Target bit-depth for the returned image data. The bit-depth
+        conversion is handled by *OpenImageIO* during the read operation,
+        with this function converting to the appropriate *NumPy* data type
+        afterwards.
     additional_data
-        Whether to return additional data.
+        Whether to return additional metadata from the image file.
 
     Returns
     -------
     :class:`numpy.ndarray` or :class:`tuple`
-        Image data or tuple of image data and list of
-        :class:`colour.io.Image_Specification_Attribute` class instances.
+        Image data as an array when ``additional_data`` is ``False``, or a
+        tuple containing the image data and a tuple of
+        :class:`colour.io.Image_Specification_Attribute` instances when
+        ``additional_data`` is ``True``.
 
     Notes
     -----
@@ -472,16 +495,16 @@ def read_image_Imageio(
     **kwargs: Any,
 ) -> NDArrayReal:
     """
-    Read the image data at the specified path using *Imageio*.
+    Read image data from the specified path using *Imageio*.
 
     Parameters
     ----------
     path
-        Image path.
+        Path to the image file.
     bit_depth
-        Returned image bit-depth, the image data is converted with
-        :func:`colour.io.convert_bit_depth` definition after reading the
-        image.
+        Target bit-depth for the returned image data. The image data is
+        converted with :func:`colour.io.convert_bit_depth` definition after
+        reading the image.
 
     Other Parameters
     ----------------
@@ -531,7 +554,7 @@ READ_IMAGE_METHODS: CanonicalMapping = CanonicalMapping(
     }
 )
 READ_IMAGE_METHODS.__doc__ = """
-Supported image read methods.
+Supported image reading methods.
 """
 
 
@@ -544,38 +567,43 @@ def read_image(
     **kwargs: Any,
 ) -> NDArrayReal:
     """
-    Read the image data at the specified path using the specified method.
+    Read image data from the specified path.
+
+    Load and optionally convert image data from various formats,
+    supporting multiple bit-depth conversions and backend libraries for
+    flexible image I/O operations in colour science workflows.
 
     Parameters
     ----------
     path
-        Image path.
+        Path to the image file.
     bit_depth
-        Returned image bit-depth, for the *Imageio* method, the image data is
-        converted with :func:`colour.io.convert_bit_depth` definition after
-        reading the image, for the *OpenImageIO* method, the bit-depth
-        conversion behaviour is driven directly by the library, this definition
-        only converts to the relevant data type after reading.
+        Target bit-depth for the returned image data. For the *Imageio*
+        method, image data is converted using
+        :func:`colour.io.convert_bit_depth` after reading. For the
+        *OpenImageIO* method, bit-depth conversion is handled by the
+        library with this parameter controlling only the final data type.
     method
-        Read method, i.e., the image library used for reading images.
+        Image reading backend library. Defaults to *OpenImageIO* with
+        automatic fallback to *Imageio* if unavailable.
 
     Other Parameters
     ----------------
     additional_data
         {:func:`colour.io.read_image_OpenImageIO`},
-        Whether to return additional data.
+        Whether to return additional metadata with the image data.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Image data.
+        Image data as a NumPy array with the specified bit-depth.
 
     Notes
     -----
-    -   If the specified method is *OpenImageIO* but the library is not available
-        writing will be performed by *Imageio*.
-    -   If the specified method is *Imageio*, ``kwargs`` is passed directly to the
-        wrapped definition.
+    -   If the specified method is *OpenImageIO* but the library is not
+        available, reading will be performed by *Imageio*.
+    -   If the specified method is *Imageio*, ``kwargs`` is passed
+        directly to the wrapped definition.
     -   For convenience, single channel images are squeezed to 2D arrays.
 
     Examples
@@ -623,17 +651,17 @@ def write_image_OpenImageIO(
     attributes: Sequence | None = None,
 ) -> bool:
     """
-    Write the specified image data at the specified path using *OpenImageIO*.
+    Write image data to the specified path using *OpenImageIO*.
 
     Parameters
     ----------
     image
-        Image data.
+        Image data to write.
     path
-        Image path.
+        Path to the image file.
     bit_depth
-        Bit-depth to write the image at, the bit-depth conversion behaviour is
-        ruled directly by *OpenImageIO*.
+        Bit-depth to write the image at. The bit-depth conversion behaviour
+        is ruled directly by *OpenImageIO*.
     attributes
         An array of :class:`colour.io.Image_Specification_Attribute` class
         instances used to set attributes of the image.
@@ -749,36 +777,36 @@ def write_image_Imageio(
     **kwargs: Any,
 ) -> bytes | None:
     """
-    Write the specified image data at the specified path using *Imageio*.
+    Write image data to the specified path using *Imageio*.
 
     Parameters
     ----------
     image
-        Image data.
+        Image data to write.
     path
-        Image path.
+        Path to the image file.
     bit_depth
-        Bit-depth to write the image at, the image data is converted with
-        :func:`colour.io.convert_bit_depth` definition prior to writing the
-        image.
+        Bit-depth to write the image at. The image data is converted with
+        :func:`colour.io.convert_bit_depth` definition prior to writing.
 
     Other Parameters
     ----------------
     kwargs
-        Keywords arguments.
+        Keywords arguments passed to the underlying *Imageio* ``imwrite``
+        function.
 
     Returns
     -------
-    :class:`bool`
-        Definition success.
+    :class:`bytes` or :py:data:`None`
+        Image data written as bytes if successful, :py:data:`None`
+        otherwise.
 
     Notes
     -----
-    -   It is possible to control how the images are saved by the *Freeimage*
-        backend by using the ``flags`` keyword argument and passing a desired
-        value. See the *Load / Save flag constants* section in
-        https://sourceforge.net/p/freeimage/svn/HEAD/tree/FreeImage/trunk/\
-Source/FreeImage.h
+    -   Control how images are saved by the *Freeimage* backend using the
+        ``flags`` keyword argument with desired values. See the *Load /
+        Save flag constants* section in
+        https://sourceforge.net/p/freeimage/svn/HEAD/tree/FreeImage/trunk/Source/FreeImage.h
 
     Examples
     --------
@@ -829,7 +857,7 @@ WRITE_IMAGE_METHODS: CanonicalMapping = CanonicalMapping(
     }
 )
 WRITE_IMAGE_METHODS.__doc__ = """
-Supported image write methods.
+Supported image writing methods.
 """
 
 
@@ -843,20 +871,20 @@ def write_image(
     **kwargs: Any,
 ) -> bool:
     """
-    Write the specified image data at the specified path using the specified method.
+    Write image data to the specified path.
 
     Parameters
     ----------
     image
-        Image data.
+        Image data to write.
     path
-        Image path.
+        Path to the image file.
     bit_depth
-        Bit-depth to write the image at, for the *Imageio* method, the image
-        data is converted with :func:`colour.io.convert_bit_depth` definition
-        prior to writing the image.
+        Bit-depth to write the image at. For the *Imageio* method, the
+        image data is converted with :func:`colour.io.convert_bit_depth`
+        definition prior to writing the image.
     method
-        Write method, i.e., the image library used for writing images.
+        Image writing backend library.
 
     Other Parameters
     ----------------
@@ -872,15 +900,15 @@ def write_image(
 
     Notes
     -----
-    -   If the specified method is *OpenImageIO* but the library is not available
-        writing will be performed by *Imageio*.
-    -   If the specified method is *Imageio*, ``kwargs`` is passed directly to the
-        wrapped definition.
-    -   It is possible to control how the images are saved by the *Freeimage*
-        backend by using the ``flags`` keyword argument and passing a desired
-        value. See the *Load / Save flag constants* section in
-        https://sourceforge.net/p/freeimage/svn/HEAD/tree/FreeImage/trunk/\
-Source/FreeImage.h
+    -   If the specified method is *OpenImageIO* but the library is not
+        available writing will be performed by *Imageio*.
+    -   If the specified method is *Imageio*, ``kwargs`` is passed directly
+        to the wrapped definition.
+    -   It is possible to control how the images are saved by the
+        *Freeimage* backend by using the ``flags`` keyword argument and
+        passing a desired value. See the *Load / Save flag constants*
+        section in
+        https://sourceforge.net/p/freeimage/svn/HEAD/tree/FreeImage/trunk/Source/FreeImage.h
 
     Examples
     --------
@@ -916,7 +944,8 @@ Source/FreeImage.h
 
     if method.lower() == "imageio" and not is_imageio_installed():  # pragma: no cover
         usage_warning(
-            '"Imageio" related API features are not available, switching to "Imageio"!'
+            '"Imageio" related API features are not available, '
+            'switching to "OpenImageIO"!'
         )
         method = "openimageio"
 
@@ -932,25 +961,23 @@ Source/FreeImage.h
 
 def as_3_channels_image(a: ArrayLike) -> NDArrayFloat:
     """
-    Convert the specified array :math:`a` to a 3-channels image-like
+    Convert the specified array :math:`a` to a 3-channel image-like
     representation.
 
     Parameters
     ----------
     a
-         Array :math:`a` to convert to a 3-channels image-like
-         representation.
+        Array :math:`a` to convert to a 3-channel image-like representation.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        3-channels image-like representation of array :math:`a`.
+        3-channel image-like representation of array :math:`a`.
 
     Raises
     ------
     ValueError
-        If the array has more than 3 dimensions or more than 1 or 3
-        channels.
+        If the array has more than 3 dimensions or more than 1 or 3 channels.
 
     Examples
     --------

--- a/colour/io/luts/__init__.py
+++ b/colour/io/luts/__init__.py
@@ -1,4 +1,18 @@
 """
+Look-Up Table (LUT) I/O
+=======================
+
+Implement support for reading and writing industry-standard Look-Up Table
+(LUT) formats used in colour pipelines and digital intermediate workflows.
+
+-   :class:`colour.LUT1D`: 1D LUT for single-channel transformations
+-   :class:`colour.LUT3x1D`: Three separate 1D LUTs for per-channel operations
+-   :class:`colour.LUT3D`: 3D LUT for complex colour transformations
+-   :class:`colour.LUTSequence`: Sequential LUT operations
+-   :class:`colour.LUTOperatorMatrix`: Matrix-based LUT operations
+-   :func:`colour.io.read_LUT`: Auto-detect and read LUT files
+-   :func:`colour.io.write_LUT`: Write LUT files in specified formats
+
 References
 ----------
 -   :cite:`AdobeSystems2013b` : Adobe Systems. (2013). Cube LUT Specification.
@@ -112,7 +126,7 @@ def read_LUT(
     **kwargs: Any,
 ) -> LUT1D | LUT3x1D | LUT3D | LUTSequence | LUTOperatorMatrix:
     """
-    Read the specified *LUT* file using the specified method.
+    Read the specified *LUT* file.
 
     Parameters
     ----------
@@ -252,7 +266,7 @@ LUT_WRITE_METHODS = CanonicalMapping(
     }
 )
 LUT_WRITE_METHODS.__doc__ = """
-Supported *LUT* reading methods.
+Supported *LUT* writing methods.
 
 References
 ----------
@@ -268,22 +282,22 @@ def write_LUT(
     **kwargs: Any,
 ) -> bool:
     """
-    Write the specified *LUT* to the specified file using the specified method.
+    Write the specified *LUT* to the specified file.
 
     Parameters
     ----------
     LUT
         :class:`colour.LUT1D` or :class:`colour.LUT3x1D` or
         :class:`colour.LUT3D` or :class:`colour.LUTSequence` or
-        :class:`colour.LUTOperatorMatrix` class instance to write at specified
-        path.
+        :class:`colour.LUTOperatorMatrix` class instance to write at the
+        specified path.
     path
-        *LUT* path.
+        *LUT* file path.
     decimals
-        Formatting decimals.
+        Number of decimal places for formatting numeric values.
     method
         Writing method, if *None*, the method will be auto-detected
-        according to extension.
+        according to the file extension.
 
     Returns
     -------

--- a/colour/io/luts/cinespace_csp.py
+++ b/colour/io/luts/cinespace_csp.py
@@ -54,14 +54,14 @@ def read_LUT_Cinespace(path: str | PathLike) -> LUT3x1D | LUT3D | LUTSequence:
     Parameters
     ----------
     path
-        *LUT* path.
+        *LUT* file path.
 
     Returns
     -------
     :class:`colour.LUT3x1D` or :class:`colour.LUT3D` or \
-:class:`colour.LUTSequence`
-        :class:`LUT3x1D` or :class:`LUT3D` or :class:`LUTSequence` class
-        instance.
+    :class:`colour.LUTSequence`
+        :class:`LUT3x1D`, :class:`LUT3D`, or :class:`LUTSequence`
+        class instance.
 
     References
     ----------
@@ -253,11 +253,11 @@ def write_LUT_Cinespace(
     ----------
     LUT
         :class:`LUT1D`, :class:`LUT3x1D` or :class:`LUT3D` or
-        :class:`LUTSequence` class instance to write at specified path.
+        :class:`LUTSequence` class instance to write at the specified path.
     path
-        *LUT* path.
+        *LUT* file path.
     decimals
-        Formatting decimals.
+        Number of decimal places for formatting numeric values.
 
     Returns
     -------
@@ -339,7 +339,7 @@ def write_LUT_Cinespace(
         attest(2 <= LUT[1].size <= 256, "Cube size must be in domain [2, 256]!")
 
     def _ragged_size(table: ArrayLike) -> list:
-        """Return the ragged size of specified table."""
+        """Return the ragged size of the specified table."""
 
         R, G, B = tsplit(table)
 

--- a/colour/io/luts/common.py
+++ b/colour/io/luts/common.py
@@ -2,7 +2,7 @@
 LUT Processing Common Utilities
 ===============================
 
-Define the *LUT* processing common utilities objects that don't fall in any
+Define *LUT* processing common utilities objects that do not fall within any
 specific category.
 """
 
@@ -29,7 +29,11 @@ __all__ = [
 
 def path_to_title(path: str | PathLike) -> str:
     """
-    Convert the specified file path to a title.
+    Convert the specified file path to a human-readable title.
+
+    Extract the base filename from the specified path, remove the file
+    extension, and replace underscores, hyphens, and dots with spaces to
+    create a readable title format.
 
     Parameters
     ----------

--- a/colour/io/luts/iridas_cube.py
+++ b/colour/io/luts/iridas_cube.py
@@ -50,10 +50,15 @@ def read_LUT_IridasCube(path: str | PathLike) -> LUT3x1D | LUT3D:
     """
     Read the specified *Iridas* *.cube* *LUT* file.
 
+    Parse an *Iridas* *.cube* Look-Up Table file and return the
+    corresponding *LUT* object. The function automatically detects
+    whether the file contains a 3x1D or 3D *LUT* based on the
+    presence of *LUT_1D_SIZE* or *LUT_3D_SIZE* declarations.
+
     Parameters
     ----------
     path
-        *LUT* path.
+        *LUT* file path.
 
     Returns
     -------
@@ -195,12 +200,12 @@ def write_LUT_IridasCube(
     Parameters
     ----------
     LUT
-        :class:`LUT1D`, :class:`LUT3x1D`, :class:`LUT3D` or :class:`LUTSequence`
-        class instance to write at specified path.
+        :class:`LUT1D`, :class:`LUT3x1D`, :class:`LUT3D` or
+        :class:`LUTSequence` class instance to write at the specified path.
     path
-        *LUT* path.
+        *LUT* file path.
     decimals
-        Formatting decimals.
+        Number of decimal places for formatting numeric values.
 
     Returns
     -------
@@ -228,7 +233,7 @@ def write_LUT_IridasCube(
     ...     domain,
     ...     comments=["A first comment.", "A second comment."],
     ... )
-    >>> write_LUT_IridasCube(LUTxD, "My_LUT.cube")  # doctest: +SKIP
+    >>> write_LUT_IridasCube(LUT, "My_LUT.cube")  # doctest: +SKIP
 
     Writing a 3D *Iridas* *.cube* *LUT*:
 
@@ -239,7 +244,7 @@ def write_LUT_IridasCube(
     ...     np.array([[-0.1, -0.2, -0.4], [1.5, 3.0, 6.0]]),
     ...     comments=["A first comment.", "A second comment."],
     ... )
-    >>> write_LUT_IridasCube(LUTxD, "My_LUT.cube")  # doctest: +SKIP
+    >>> write_LUT_IridasCube(LUT, "My_LUT.cube")  # doctest: +SKIP
     """
 
     path = str(path)

--- a/colour/io/luts/lut.py
+++ b/colour/io/luts/lut.py
@@ -2,12 +2,17 @@
 LUT Processing
 ==============
 
-Define the classes and definitions handling *LUT* processing:
+Define the classes and definitions for *Look-Up Table* (*LUT*) processing
+operations.
 
--   :class:`colour.LUT1D`
--   :class:`colour.LUT3x1D`
--   :class:`colour.LUT3D`
--   :class:`colour.io.LUT_to_LUT`
+-   :class:`colour.LUT1D`: One-dimensional lookup table for single-channel
+    transformations
+-   :class:`colour.LUT3x1D`: Three parallel one-dimensional lookup tables
+    for independent RGB channel processing
+-   :class:`colour.LUT3D`: Three-dimensional lookup table for complex colour
+    space transformations
+-   :class:`colour.io.LUT_to_LUT`: Utility for converting between different
+    LUT formats and types
 """
 
 from __future__ import annotations
@@ -78,28 +83,29 @@ __all__ = [
 
 class AbstractLUT(ABC):
     """
-    Define the base class for *LUT*.
+    Define the base class for *LUT* (Look-Up Table).
 
-    This is an :class:`ABCMeta` abstract class that must be inherited by
-    sub-classes.
+    This is an abstract base class (:class:`ABCMeta`) that must be inherited
+    by concrete *LUT* implementations to provide common functionality and
+    interface specifications.
 
     Parameters
     ----------
     table
-        Underlying *LUT* table.
+        Underlying *LUT* table array containing the lookup values.
     name
-        *LUT* name.
+        *LUT* identifying name.
     dimensions
-        *LUT* dimensions, typically, 1 for a 1D *LUT*, 2 for a 3x1D *LUT* and 3
-        for a 3D *LUT*.
+        *LUT* dimensionality: typically 1 for a 1D *LUT*, 2 for a 3x1D *LUT*,
+        and 3 for a 3D *LUT*.
     domain
-        *LUT* domain, also used to define the instantiation time default table
-        domain.
+        *LUT* input domain boundaries, also used to define the instantiation
+        time default table domain.
     size
-        *LUT* size, also used to define the instantiation time default table
-        size.
+        *LUT* resolution or sampling density, also used to define the
+        instantiation time default table size.
     comments
-        Comments to add to the *LUT*.
+        Additional comments or metadata to associate with the *LUT*.
 
     Attributes
     ----------
@@ -160,7 +166,10 @@ class AbstractLUT(ABC):
     @property
     def table(self) -> NDArrayFloat:
         """
-        Getter and setter property for the underlying *LUT* table.
+        Getter and setter for the underlying *LUT* table.
+
+        Access or modify the lookup table data structure that defines the
+        transformation mapping for this LUT instance.
 
         Parameters
         ----------
@@ -184,7 +193,7 @@ class AbstractLUT(ABC):
     @property
     def name(self) -> str:
         """
-        Getter and setter property for the *LUT* name.
+        Getter and setter for the *LUT* name.
 
         Parameters
         ----------
@@ -213,7 +222,10 @@ class AbstractLUT(ABC):
     @property
     def domain(self) -> NDArrayFloat:
         """
-        Getter and setter property for the *LUT* domain.
+        Getter and setter for the *LUT* domain.
+
+        The domain defines the input coordinate space for the lookup table,
+        specifying the valid range of input values that can be interpolated.
 
         Parameters
         ----------
@@ -237,7 +249,7 @@ class AbstractLUT(ABC):
     @property
     def dimensions(self) -> int:
         """
-        Getter property for the *LUT* dimensions.
+        Getter for the *LUT* dimensions.
 
         Returns
         -------
@@ -250,7 +262,7 @@ class AbstractLUT(ABC):
     @property
     def size(self) -> int:
         """
-        Getter property for the *LUT* size.
+        Getter for the *LUT* size.
 
         Returns
         -------
@@ -263,7 +275,7 @@ class AbstractLUT(ABC):
     @property
     def comments(self) -> list:
         """
-        Getter and setter property for the *LUT* comments.
+        Getter and setter for the *LUT* comments.
 
         Parameters
         ----------
@@ -333,6 +345,9 @@ class AbstractLUT(ABC):
         """
         Return an evaluable string representation of the *LUT*.
 
+        This method provides a string that, when evaluated, recreates the
+        *LUT* object with its current state and configuration.
+
         Returns
         -------
         :class:`str`
@@ -355,7 +370,7 @@ class AbstractLUT(ABC):
 
     def __eq__(self, other: object) -> bool:
         """
-        Return whether the *LUT* is equal to specified other object.
+        Return whether the *LUT* is equal to the specified other object.
 
         Parameters
         ----------
@@ -365,7 +380,7 @@ class AbstractLUT(ABC):
         Returns
         -------
         :class:`bool`
-            Whether specified object is equal to the *LUT*.
+            Whether the specified object is equal to the *LUT*.
         """
 
         return isinstance(other, AbstractLUT) and all(
@@ -377,17 +392,18 @@ class AbstractLUT(ABC):
 
     def __ne__(self, other: object) -> bool:
         """
-        Return whether the *LUT* is not equal to specified other object.
+        Determine whether the *LUT* is not equal to the specified other
+        object.
 
         Parameters
         ----------
         other
-            Object to test whether it is not equal to the *LUT*.
+            Object to test for inequality with the *LUT*.
 
         Returns
         -------
         :class:`bool`
-            Whether specified object is not equal to the *LUT*.
+            Whether the specified object is not equal to the *LUT*.
         """
 
         return not (self == other)
@@ -399,7 +415,7 @@ class AbstractLUT(ABC):
         Parameters
         ----------
         a
-            :math:`a` variable to add.
+            *a* variable to add.
 
         Returns
         -------
@@ -413,15 +429,19 @@ class AbstractLUT(ABC):
         """
         Implement support for in-place addition.
 
+        Add the specified operand to this *LUT* in-place, modifying the
+        current instance rather than creating a new one.
+
         Parameters
         ----------
         a
-            :math:`a` variable to add in-place.
+            Operand to add in-place. Can be a numeric array or another
+            *LUT* instance with compatible dimensions.
 
         Returns
         -------
         :class:`colour.io.luts.lut.AbstractLUT`
-            In-place variable added *LUT*.
+            Current *LUT* instance with the addition applied in-place.
         """
 
         return self.arithmetical_operation(a, "+", True)
@@ -433,7 +453,7 @@ class AbstractLUT(ABC):
         Parameters
         ----------
         a
-            :math:`a` variable to subtract.
+            Variable, array or *LUT* to subtract from the current *LUT*.
 
         Returns
         -------
@@ -467,7 +487,8 @@ class AbstractLUT(ABC):
         Parameters
         ----------
         a
-            :math:`a` variable to multiply by.
+            Variable to multiply with the *LUT*. Can be a numeric array or
+            another *LUT* instance.
 
         Returns
         -------
@@ -513,17 +534,17 @@ class AbstractLUT(ABC):
 
     def __idiv__(self, a: ArrayLike | AbstractLUT) -> Self:
         """
-        Implement support for in-place division.
+        Perform in-place division of the *LUT* by the specified operand.
 
         Parameters
         ----------
         a
-            :math:`a` variable to divide by in-place.
+            Operand to divide the *LUT* by in-place.
 
         Returns
         -------
         :class:`colour.io.luts.lut.AbstractLUT`
-            In-place variable divided *LUT*.
+            Current *LUT* instance with the division applied in-place.
         """
 
         return self.arithmetical_operation(a, "/", True)
@@ -572,23 +593,34 @@ class AbstractLUT(ABC):
         in_place: bool = False,
     ) -> Self:
         """
-        Perform specified arithmetical operation with :math:`a` operand, the
-        operation can be either performed on a copy or in-place, must be
-        reimplemented by sub-classes.
+        Perform the specified arithmetical operation with the :math:`a`
+        operand.
+
+        Execute the requested mathematical operation between this *LUT*
+        instance and the specified operand. The operation can be performed
+        either on a copy of the *LUT* or in-place on the current instance.
+        This method must be reimplemented by sub-classes to handle their
+        specific table structures.
 
         Parameters
         ----------
         a
-            Operand.
+            Operand for the arithmetical operation. Can be either a numeric
+            array or another *LUT* instance with compatible dimensions.
         operation
-            Operation to perform.
+            Arithmetical operation to perform. Supported operations are
+            addition (``+``), subtraction (``-``), multiplication (``*``),
+            division (``/``), and exponentiation (``**``).
         in_place
-            Operation happens in place.
+            Whether to perform the operation in-place on the current *LUT*
+            instance (``True``) or on a copy (``False``).
 
         Returns
         -------
         :class:`colour.io.luts.lut.AbstractLUT`
-            *LUT*.
+            Modified *LUT* instance. If ``in_place`` is ``True``, returns
+            the current instance after modification. If ``False``, returns
+            a new modified copy.
         """
 
         operator, ioperator = {
@@ -611,7 +643,7 @@ class AbstractLUT(ABC):
     @abstractmethod
     def _validate_table(self, table: ArrayLike) -> NDArrayFloat:
         """
-        Validate specified table according to *LUT* dimensions.
+        Validate the specified table according to *LUT* dimensions.
 
         Parameters
         ----------
@@ -651,7 +683,7 @@ class AbstractLUT(ABC):
              [0 1]
              [0 1]]
 
-        While an explicit domain defines every single discrete samples::
+        While an explicit domain defines every single discrete sample::
 
             [[0.0 0.0 0.0]
              [0.1 0.1 0.1]
@@ -674,7 +706,7 @@ class AbstractLUT(ABC):
         domain: ArrayLike | None = None,
     ) -> NDArrayFloat:
         """
-        Return a linear table of specified size according to *LUT* dimensions.
+        Generate a linear table of the specified size according to LUT dimensions.
 
         Parameters
         ----------
@@ -700,7 +732,7 @@ class AbstractLUT(ABC):
         Returns
         -------
         :class:`colour.io.luts.lut.AbstractLUT`
-            *LUT* copy.
+            Copy of the LUT instance.
         """
 
         return deepcopy(self)
@@ -724,7 +756,8 @@ class AbstractLUT(ABC):
     @abstractmethod
     def apply(self, RGB: ArrayLike, **kwargs: Any) -> NDArrayFloat:
         """
-        Apply the *LUT* to specified *RGB* colourspace array using specified method.
+        Apply the *LUT* to the specified *RGB* colourspace array using the
+        specified method.
 
         Parameters
         ----------
@@ -737,12 +770,14 @@ class AbstractLUT(ABC):
             Whether the *LUT* should be applied in the forward or inverse
             direction.
         extrapolator
-            Extrapolator class type or object to use as extrapolating function.
+            Extrapolator class type or object to use as extrapolating
+            function.
         extrapolator_kwargs
             Arguments to use when instantiating or calling the extrapolating
             function.
         interpolator
-            Interpolator class type or object to use as interpolating function.
+            Interpolator class type or object to use as interpolating
+            function.
         interpolator_kwargs
             Arguments to use when instantiating or calling the interpolating
             function.
@@ -760,7 +795,7 @@ class AbstractLUT(ABC):
         **kwargs: Any,
     ) -> AbstractLUT:
         """
-        Convert the *LUT* to specified ``cls`` class instance.
+        Convert the *LUT* to the specified ``cls`` class instance.
 
         Parameters
         ----------
@@ -801,6 +836,12 @@ class AbstractLUT(ABC):
 class LUT1D(AbstractLUT):
     """
     Define the base class for a 1D *LUT*.
+
+    A 1D (one-dimensional) lookup table provides a mapping function from
+    input values to output values through interpolation of discrete table
+    entries. This class is commonly used for tone mapping, gamma correction,
+    and other single-channel transformations where the output depends solely
+    on the input value.
 
     Parameters
     ----------
@@ -884,7 +925,7 @@ class LUT1D(AbstractLUT):
 
     def _validate_table(self, table: ArrayLike) -> NDArrayFloat:
         """
-        Validate specified table is a 1D array.
+        Validate that the specified table is a 1D array.
 
         Parameters
         ----------
@@ -894,7 +935,7 @@ class LUT1D(AbstractLUT):
         Returns
         -------
         :class:`numpy.ndarray`
-            Validated table as a :class:`ndarray` instance.
+            Validated table as a :class:`numpy.ndarray` instance.
         """
 
         table = as_float_array(table)
@@ -963,20 +1004,26 @@ class LUT1D(AbstractLUT):
         domain: ArrayLike | None = None,
     ) -> NDArrayFloat:
         """
-        Return a linear table, the number of output samples :math:`n` is equal
-        to ``size``.
+        Generate a linear table with the specified number of output samples
+        :math:`n`.
+
+        The table contains linearly spaced values across the specified domain.
+        If no domain is provided, the default domain [0, 1] is used.
 
         Parameters
         ----------
         size
-            Expected table size, default to 10.
+            Number of samples in the output table. Default is 10.
         domain
-            Domain of the table.
+            Domain boundaries of the table as a 2-element array [min, max]
+            or an array of values whose minimum and maximum define the
+            domain. Default is [0, 1].
 
         Returns
         -------
         :class:`numpy.ndarray`
-            Linear table with ``size`` samples.
+            Linear table containing ``size`` evenly spaced samples across
+            the specified domain.
 
         Examples
         --------
@@ -1003,8 +1050,8 @@ class LUT1D(AbstractLUT):
         Other Parameters
         ----------------
         kwargs
-            Keywords arguments, only specified for signature compatibility with
-            the :meth:`AbstractLUT.invert` method.
+            Keywords arguments, only specified for signature compatibility
+            with the :meth:`AbstractLUT.invert` method.
 
         Returns
         -------
@@ -1047,7 +1094,8 @@ class LUT1D(AbstractLUT):
 
     def apply(self, RGB: ArrayLike, **kwargs: Any) -> NDArrayFloat:
         """
-        Apply the *LUT* to specified *RGB* colourspace array using specified method.
+        Apply the *LUT* to the specified *RGB* colourspace array using the
+        specified method.
 
         Parameters
         ----------
@@ -1060,7 +1108,8 @@ class LUT1D(AbstractLUT):
             Whether the *LUT* should be applied in the forward or inverse
             direction.
         extrapolator
-            Extrapolator class type or object to use as extrapolating function.
+            Extrapolator class type or object to use as extrapolating
+            function.
         extrapolator_kwargs
             Arguments to use when instantiating or calling the extrapolating
             function.
@@ -1079,7 +1128,8 @@ class LUT1D(AbstractLUT):
         >>> LUT = LUT1D(LUT1D.linear_table() ** (1 / 2.2))
         >>> RGB = np.array([0.18, 0.18, 0.18])
 
-        *LUT* applied to the specified *RGB* colourspace in the forward direction:
+        *LUT* applied to the specified *RGB* colourspace in the forward
+        direction:
 
         >>> LUT.apply(RGB)  # doctest: +ELLIPSIS
         array([ 0.4529220...,  0.4529220...,  0.4529220...])
@@ -1121,6 +1171,11 @@ class LUT3x1D(AbstractLUT):
     """
     Define the base class for a 3x1D *LUT*.
 
+    A 3x1D (three-by-one-dimensional) lookup table applies independent
+    transformations to each channel of a three-channel input. Each channel
+    has its own 1D lookup table, enabling per-channel colour corrections
+    and tone mapping operations.
+
     Parameters
     ----------
     table
@@ -1128,8 +1183,8 @@ class LUT3x1D(AbstractLUT):
     name
         *LUT* name.
     domain
-        *LUT* domain, also used to define the instantiation time default table
-        domain.
+        *LUT* domain, also used to define the instantiation time default
+        table domain.
     size
         Size of the instantiation time default table, default to 10.
     comments
@@ -1168,8 +1223,8 @@ class LUT3x1D(AbstractLUT):
                   [ 1.  1.  1.]]
     Size       : (16, 3)
 
-    Instantiating a LUT using a custom table with 16x3 elements, custom name,
-    custom domain and comments:
+    Instantiating a LUT using a custom table with 16x3 elements, custom
+    name, custom domain and comments:
 
     >>> from colour.algebra import spow
     >>> domain = np.array([[-0.1, -0.2, -0.4], [1.5, 3.0, 6.0]])
@@ -1228,7 +1283,7 @@ class LUT3x1D(AbstractLUT):
 
     def _validate_domain(self, domain: ArrayLike) -> NDArrayFloat:
         """
-        Validate specified domain.
+        Validate the specified domain for the lookup table.
 
         Parameters
         ----------
@@ -1297,8 +1352,10 @@ class LUT3x1D(AbstractLUT):
         domain: ArrayLike | None = None,
     ) -> NDArrayFloat:
         """
-        Return a linear table, the number of output samples :math:`n` is equal
-        to ``size * 3`` or ``size[0] + size[1] + size[2]``.
+        Generate a linear table with the specified size and domain.
+
+        The number of output samples :math:`n` is equal to ``size * 3`` or
+        ``size[0] + size[1] + size[2]``.
 
         Parameters
         ----------
@@ -1310,8 +1367,8 @@ class LUT3x1D(AbstractLUT):
         Returns
         -------
         :class:`numpy.ndarray`
-            Linear table with ``size * 3`` or ``size[0] + size[1] + size[2]``
-            samples.
+            Linear table with ``size * 3`` or ``size[0] + size[1] +
+            size[2]`` samples.
 
         Warnings
         --------
@@ -1459,7 +1516,8 @@ class LUT3x1D(AbstractLUT):
 
     def apply(self, RGB: ArrayLike, **kwargs: Any) -> NDArrayFloat:
         """
-        Apply the *LUT* to specified *RGB* colourspace array using specified method.
+        Apply the *LUT* to the specified *RGB* colourspace array using the
+        specified method.
 
         Parameters
         ----------
@@ -1472,7 +1530,8 @@ class LUT3x1D(AbstractLUT):
             Whether the *LUT* should be applied in the forward or inverse
             direction.
         extrapolator
-            Extrapolator class type or object to use as extrapolating function.
+            Extrapolator class type or object to use as extrapolating
+            function.
         extrapolator_kwargs
             Arguments to use when instantiating or calling the extrapolating
             function.
@@ -1563,7 +1622,13 @@ class LUT3x1D(AbstractLUT):
 
 class LUT3D(AbstractLUT):
     """
-    Define the base class for a 3D *LUT*.
+    Define the base class for a 3-dimensional lookup table (3D *LUT*).
+
+    This class provides a foundation for working with 3D lookup tables,
+    which map input colour values through a discretized 3D grid to output
+    colour values. The table operates on three input channels
+    simultaneously, making it suitable for RGB-to-RGB colour
+    transformations and other tristimulus colour space operations.
 
     Parameters
     ----------
@@ -1572,8 +1637,8 @@ class LUT3D(AbstractLUT):
     name
         *LUT* name.
     domain
-        *LUT* domain, also used to define the instantiation time default table
-        domain.
+        *LUT* domain, also used to define the instantiation time default
+        table domain.
     size
         Size of the instantiation time default table, default to 33.
     comments
@@ -1611,8 +1676,8 @@ class LUT3D(AbstractLUT):
                   [ 1.  1.  1.]]
     Size       : (16, 16, 16, 3)
 
-    Instantiating a LUT using a custom table with 16x16x16x3 elements, custom
-    name, custom domain and comments:
+    Instantiating a LUT using a custom table with 16x16x16x3 elements,
+    custom name, custom domain and comments:
 
     >>> from colour.algebra import spow
     >>> domain = np.array([[-0.1, -0.2, -0.4], [1.5, 3.0, 6.0]])
@@ -1650,7 +1715,8 @@ class LUT3D(AbstractLUT):
 
     def _validate_table(self, table: ArrayLike) -> NDArrayFloat:
         """
-        Validate specified table is a 4D array and that its dimensions are equal.
+        Validate that the specified table is a 4D array with equal
+        dimensions.
 
         Parameters
         ----------
@@ -1660,7 +1726,7 @@ class LUT3D(AbstractLUT):
         Returns
         -------
         :class:`numpy.ndarray`
-            Validated table as a :class:`ndarray` instance.
+            Validated table as a :class:`numpy.ndarray` instance.
         """
 
         table = as_float_array(table)
@@ -1671,17 +1737,18 @@ class LUT3D(AbstractLUT):
 
     def _validate_domain(self, domain: ArrayLike) -> NDArrayFloat:
         """
-        Validate specified domain.
+        Validate the specified domain for the 3D lookup table.
 
         Parameters
         ----------
         domain
-            Domain to validate.
+            Domain array to validate. Must be a 2D array with at least 2
+            rows and exactly 3 columns.
 
         Returns
         -------
         :class:`numpy.ndarray`
-            Validated domain as a :class:`ndarray` instance.
+            Validated domain as a :class:`numpy.ndarray` instance.
 
         Notes
         -----
@@ -1710,7 +1777,7 @@ class LUT3D(AbstractLUT):
             [[0 0 0]
              [1 1 1]]
 
-        While an explicit domain defines every single discrete samples::
+        While an explicit domain defines every single discrete sample::
 
             [[0.0 0.0 0.0]
              [0.1 0.1 0.1]
@@ -1742,8 +1809,10 @@ class LUT3D(AbstractLUT):
         domain: ArrayLike | None = None,
     ) -> NDArrayFloat:
         """
-        Return a linear table, the number of output samples :math:`n` is equal
-        to ``size**3 * 3`` or ``size[0] * size[1] * size[2] * 3``.
+        Generate a linear table with the specified size and domain.
+
+        The number of output samples :math:`n` is equal to ``size**3 * 3`` or
+        ``size[0] * size[1] * size[2] * 3``.
 
         Parameters
         ----------
@@ -1907,18 +1976,19 @@ class LUT3D(AbstractLUT):
         ----------------
         extrapolate
             Whether to extrapolate the *LUT* when computing its inverse.
-            Extrapolation is performed by reflecting the *LUT* cube along its 8
-            faces. Note that the domain is extended beyond [0, 1], thus the
-            *LUT* might not be handled properly in other software.
+            Extrapolation is performed by reflecting the *LUT* cube along
+            its 8 faces. Note that the domain is extended beyond [0, 1],
+            thus the *LUT* might not be handled properly in other software.
         interpolator
-            Interpolator class type or object to use as interpolating function.
+            Interpolator class type or object to use as interpolating
+            function.
         query_size
-            Number of points to query in the KDTree, their mean is computed,
-            resulting in a smoother result.
+            Number of points to query in the KDTree, their mean is
+            computed, resulting in a smoother result.
         size
-            Size of the inverse *LUT*. With the specified implementation, it is
-            good practise to double the size of the inverse *LUT* to provide a
-            smoother result. If ``size`` is not specified,
+            Size of the inverse *LUT*. With the specified implementation,
+            it is good practise to double the size of the inverse *LUT* to
+            provide a smoother result. If ``size`` is not specified,
             :math:`2^{\\sqrt{size_{LUT}} + 1} + 1` will be used instead.
 
         Returns
@@ -2004,7 +2074,8 @@ class LUT3D(AbstractLUT):
 
     def apply(self, RGB: ArrayLike, **kwargs: Any) -> NDArrayFloat:
         """
-        Apply the *LUT* to specified *RGB* colourspace array using specified method.
+        Apply the *LUT* to the specified *RGB* colourspace array using the
+        specified interpolation method.
 
         Parameters
         ----------
@@ -2018,19 +2089,19 @@ class LUT3D(AbstractLUT):
             direction.
         extrapolate
             Whether to extrapolate the *LUT* when computing its inverse.
-            Extrapolation is performed by reflecting the *LUT* cube along its 8
-            faces.
+            Extrapolation is performed by reflecting the *LUT* cube along
+            its 8 faces.
         interpolator
-            Interpolator object to use as interpolating function.
+            Interpolator object to use as the interpolating function.
         interpolator_kwargs
             Arguments to use when calling the interpolating function.
         query_size
-            Number of points to query in the KDTree, their mean is computed,
-            resulting in a smoother result.
+            Number of points to query in the KDTree, with their mean
+            computed to produce a smoother result.
         size
-            Size of the inverse *LUT*. With the specified implementation, it is
-            good practise to double the size of the inverse *LUT* to provide a
-            smoother result. If ``size`` is not specified,
+            Size of the inverse *LUT*. With the specified implementation,
+            it is recommended to double the size of the inverse *LUT* to
+            provide a smoother result. If ``size`` is not specified,
             :math:`2^{\\sqrt{size_{LUT}} + 1} + 1` will be used instead.
 
         Returns
@@ -2106,16 +2177,20 @@ def LUT_to_LUT(
     **kwargs: Any,
 ) -> AbstractLUT:
     """
-    Convert specified *LUT* to specified ``cls`` class instance.
+    Convert a specified *LUT* to the specified ``cls`` class instance.
+
+    This function facilitates conversion between different LUT class types,
+    including LUT1D, LUT3x1D, and LUT3D instances. Some conversions may be
+    destructive and require explicit force conversion.
 
     Parameters
     ----------
     LUT
         *LUT* to convert.
     cls
-        *LUT* class instance.
+        Target *LUT* class type for conversion.
     force_conversion
-        Whether to force the conversion if destructive.
+        Whether to force the conversion if it would be destructive.
 
     Other Parameters
     ----------------

--- a/colour/io/luts/lut.py
+++ b/colour/io/luts/lut.py
@@ -795,12 +795,7 @@ class AbstractLUT(ABC):
             If the conversion is destructive.
         """
 
-        return LUT_to_LUT(
-            self,
-            cls,
-            force_conversion,
-            **kwargs,  # pyright: ignore
-        )
+        return LUT_to_LUT(self, cls, force_conversion, **kwargs)
 
 
 class LUT1D(AbstractLUT):
@@ -2177,7 +2172,7 @@ def LUT_to_LUT(
     """
 
     ranks = {LUT1D: 1, LUT3x1D: 2, LUT3D: 3}
-    path = (ranks[LUT.__class__], ranks[cls])  # pyright: ignore
+    path = (ranks[LUT.__class__], ranks[cls])
     path_verbose = [f"{element}D" if element != 2 else "3x1D" for element in path]
     if path in ((1, 3), (2, 1), (2, 3), (3, 1), (3, 2)) and not force_conversion:
         error = (
@@ -2235,6 +2230,6 @@ def LUT_to_LUT(
             domain=domain,
             size=table.shape[0],
             comments=LUT.comments,
-        )  # pyright: ignore
+        )
 
     return LUT

--- a/colour/io/luts/operator.py
+++ b/colour/io/luts/operator.py
@@ -2,7 +2,8 @@
 LUT Operator
 ============
 
-Define the *LUT* operator classes:
+Define operator classes for Look-Up Table (LUT) transformations within the
+colour processing pipeline.
 
 -   :class:`colour.io.AbstractLUTSequenceOperator`
 -   :class:`colour.LUTOperatorMatrix`
@@ -45,8 +46,10 @@ class AbstractLUTSequenceOperator(ABC):
     """
     Define the base class for *LUT* sequence operators.
 
-    This is an :class:`ABCMeta` abstract class that must be inherited by
-    sub-classes.
+    Provide an abstract base class that establishes the interface for all
+    *LUT* sequence operator implementations. This :class:`ABCMeta` abstract
+    class must be inherited by concrete sub-classes that implement specific
+    operator functionality within *LUT* processing pipelines.
 
     Parameters
     ----------
@@ -78,7 +81,7 @@ class AbstractLUTSequenceOperator(ABC):
     @property
     def name(self) -> str:
         """
-        Getter and setter property for the *LUT* name.
+        Getter and setter for the *LUT* name.
 
         Parameters
         ----------
@@ -107,7 +110,7 @@ class AbstractLUTSequenceOperator(ABC):
     @property
     def comments(self) -> List[str]:
         """
-        Getter and setter property for the *LUT* comments.
+        Getter and setter for the *LUT* comments.
 
         Parameters
         ----------
@@ -136,7 +139,8 @@ class AbstractLUTSequenceOperator(ABC):
     @abstractmethod
     def apply(self, RGB: ArrayLike, *args: Any, **kwargs: Any) -> NDArrayFloat:
         """
-        Apply the *LUT* sequence operator to the specified *RGB* colourspace array.
+        Apply the *LUT* sequence operator to the specified *RGB* colourspace
+        array.
 
         Parameters
         ----------
@@ -159,8 +163,13 @@ class AbstractLUTSequenceOperator(ABC):
 
 class LUTOperatorMatrix(AbstractLUTSequenceOperator):
     """
-    Define the *LUT* operator supporting a 3x3 or 4x4 matrix and an offset
-    vector.
+    Define the *LUT* operator that applies matrix transformations and offset
+    vectors for colour space conversions.
+
+    Support 3x3 or 4x4 matrix operations with optional offset vectors to
+    perform affine transformations on *RGB* colourspace data. The operator
+    internally reshapes matrices to 4x4 and offsets to 4-element vectors to
+    maintain computational consistency.
 
     Parameters
     ----------
@@ -252,7 +261,7 @@ class LUTOperatorMatrix(AbstractLUTSequenceOperator):
     @property
     def matrix(self) -> NDArrayFloat:
         """
-        Getter and setter property for the *LUT* operator matrix.
+        Getter and setter for the *LUT* operator matrix.
 
         Parameters
         ----------
@@ -290,7 +299,10 @@ class LUTOperatorMatrix(AbstractLUTSequenceOperator):
     @property
     def offset(self) -> NDArrayFloat:
         """
-        Getter and setter property for the *LUT* operator offset.
+        Getter and setter for the *LUT* operator offset vector.
+
+        The offset vector is applied after the matrix transformation in the LUT
+        operator, enabling translation operations in the colour space.
 
         Parameters
         ----------
@@ -300,7 +312,7 @@ class LUTOperatorMatrix(AbstractLUTSequenceOperator):
         Returns
         -------
         :class:`numpy.ndarray`
-            Operator offset.
+            Operator offset vector.
         """
 
         return self._offset
@@ -412,7 +424,8 @@ class LUTOperatorMatrix(AbstractLUTSequenceOperator):
 
     def __eq__(self, other: object) -> bool:
         """
-        Return whether the *LUT* operator is equal to specified other object.
+        Determine whether the *LUT* operator is equal to the specified other
+        object.
 
         Parameters
         ----------
@@ -439,7 +452,8 @@ class LUTOperatorMatrix(AbstractLUTSequenceOperator):
 
     def __ne__(self, other: object) -> bool:
         """
-        Return whether the *LUT* operator is not equal to specified other object.
+        Determine whether the *LUT* operator is not equal to the specified other
+        object.
 
         Parameters
         ----------
@@ -449,7 +463,7 @@ class LUTOperatorMatrix(AbstractLUTSequenceOperator):
         Returns
         -------
         :class:`bool`
-            Whether specified object is not equal to the *LUT* operator.
+            Whether the specified object is not equal to the *LUT* operator.
 
         Examples
         --------
@@ -468,7 +482,7 @@ class LUTOperatorMatrix(AbstractLUTSequenceOperator):
         **kwargs: Any,
     ) -> NDArrayFloat:
         """
-        Apply the *LUT* operator to specified *RGB* array.
+        Apply the *LUT* operator to the specified *RGB* array.
 
         Parameters
         ----------

--- a/colour/io/luts/resolve_cube.py
+++ b/colour/io/luts/resolve_cube.py
@@ -51,17 +51,22 @@ def read_LUT_ResolveCube(path: str | PathLike) -> LUT3x1D | LUT3D | LUTSequence:
     """
     Read the specified *Resolve* *.cube* *LUT* file.
 
+    Read and parse a *DaVinci Resolve* *.cube* lookup table file, which may
+    contain a 1D LUT, a 3D LUT, or a sequence of both. The *.cube* format
+    supports configurable precision and domain ranges, making it suitable for
+    colour grading and colour space transformations.
+
     Parameters
     ----------
     path
-        *LUT* path.
+        Path to the *.cube* *LUT* file to read.
 
     Returns
     -------
-    :class:`colour.LUT3x1D` or :class:`colour.LUT3D` or \
-:class:`colour.LUTSequence`
-        :class:`LUT3x1D` or :class:`LUT3D` or :class:`LUTSequence` class
-        instance.
+    :class:`colour.LUT3x1D` or :class:`colour.LUT3D` or :class:`colour.LUTSequence`
+        :class:`LUT3x1D` instance for 1D shaper LUTs, :class:`LUT3D` instance
+        for 3D colour transformation LUTs, or :class:`LUTSequence` instance
+        when the file contains both shaper and 3D LUT data.
 
     References
     ----------
@@ -245,17 +250,17 @@ def write_LUT_ResolveCube(
     decimals: int = 7,
 ) -> bool:
     """
-    Write the specified *LUT* to specified the *Resolve* *.cube* *LUT* file.
+    Write the specified *LUT* to the specified *Resolve* *.cube* *LUT* file.
 
     Parameters
     ----------
     LUT
         :class:`LUT1D`, :class:`LUT3x1D` or :class:`LUT3D` or
-        :class:`LUTSequence` class instance to write at specified path.
+        :class:`LUTSequence` class instance to write at the specified path.
     path
-        *LUT* path.
+        *LUT* file path.
     decimals
-        Formatting decimals.
+        Number of decimal places for formatting numeric values.
 
     Returns
     -------

--- a/colour/io/luts/sequence.py
+++ b/colour/io/luts/sequence.py
@@ -1,8 +1,9 @@
 """
-LUT Operator
+LUT Sequence
 ============
 
-Define the *LUT* sequence class:
+Define the *LUT* sequence container for Look-Up Table (LUT) processing
+pipelines:
 
 -   :class:`colour.LUTSequence`
 """
@@ -42,11 +43,12 @@ class LUTSequence(MutableSequence):
     """
     Define the base class for a *LUT* sequence.
 
-    A *LUT* sequence is a series of *LUTs*, *LUT* operators or objects
-    implementing the :class:`colour.hints.ProtocolLUTSequenceItem` protocol.
+    A *LUT* sequence represents a series of *LUTs*, *LUT* operators or
+    objects implementing the :class:`colour.hints.ProtocolLUTSequenceItem`
+    protocol.
 
-    The :class:`colour.LUTSequence` class can be used to model series of *LUTs*
-    such as when a shaper *LUT* is combined with a 3D *LUT*.
+    The :class:`colour.LUTSequence` class can be used to model series of
+    *LUTs* such as when a shaper *LUT* is combined with a 3D *LUT*.
 
     Other Parameters
     ----------------
@@ -120,7 +122,10 @@ class LUTSequence(MutableSequence):
     @property
     def sequence(self) -> List[ProtocolLUTSequenceItem]:
         """
-        Getter and setter property for the underlying *LUT* sequence.
+        Getter and setter for the underlying *LUT* sequence.
+
+        Access and modify the sequence of lookup table operations that
+        define the transformation pipeline.
 
         Parameters
         ----------
@@ -149,29 +154,30 @@ class LUTSequence(MutableSequence):
 
     def __getitem__(self, index: int | slice) -> Any:
         """
-        Return the *LUT* sequence item(s) at specified index (or slice).
+        Return *LUT* sequence item(s) at specified index or slice.
 
         Parameters
         ----------
         index
-            Index (or slice) to return the *LUT* sequence item(s) at.
+            Index or slice to return *LUT* sequence item(s) at.
 
         Returns
         -------
         ProtocolLUTSequenceItem
-            *LUT* sequence item(s) at specified index (or slice).
+            *LUT* sequence item(s) at specified index or slice.
         """
 
         return self._sequence[index]
 
     def __setitem__(self, index: int | slice, value: Any) -> None:
         """
-        Set the *LUT* sequence at specified index (or slice) with specified value.
+        Set the *LUT* sequence at the specified index or slice with the
+        specified value.
 
         Parameters
         ----------
         index
-            Index (or slice) to set the *LUT* sequence value at.
+            Index or slice to set the *LUT* sequence value at.
         value
             Value to set the *LUT* sequence with.
         """
@@ -186,7 +192,7 @@ class LUTSequence(MutableSequence):
 
     def __delitem__(self, index: int | slice) -> None:
         """
-        Delete the *LUT* sequence item(s) at specified index (or slice).
+        Delete the *LUT* sequence item(s) at the specified index (or slice).
 
         Parameters
         ----------
@@ -247,6 +253,9 @@ class LUTSequence(MutableSequence):
         """
         Return an evaluable string representation of the *LUT* sequence.
 
+        Generate a string representation that can be evaluated to recreate
+        the *LUT* sequence with its current state.
+
         Returns
         -------
         :class:`str`
@@ -267,7 +276,10 @@ class LUTSequence(MutableSequence):
 
     def __eq__(self, other: object) -> bool:
         """
-        Return whether the *LUT* sequence is equal to specified other object.
+        Test whether the *LUT* sequence is equal to the specified other object.
+
+        Compare this *LUT* sequence with another object for equality. The
+        comparison evaluates structural and content equivalence.
 
         Parameters
         ----------
@@ -290,7 +302,8 @@ class LUTSequence(MutableSequence):
 
     def __ne__(self, other: object) -> bool:
         """
-        Return whether the *LUT* sequence is not equal to specified other object.
+        Return whether the *LUT* sequence is not equal to the specified other
+        object.
 
         Parameters
         ----------
@@ -300,19 +313,20 @@ class LUTSequence(MutableSequence):
         Returns
         -------
         :class:`bool`
-            Whether specified object is not equal to the *LUT* sequence.
+            Whether the specified object is not equal to the *LUT* sequence.
         """
 
         return not (self == other)
 
     def insert(self, index: int, value: ProtocolLUTSequenceItem) -> None:
         """
-        Insert specified *LUT* at specified index into the *LUT* sequence.
+        Insert the specified *LUT* at the specified index in the *LUT*
+        sequence.
 
         Parameters
         ----------
         index
-            Index to insert the item at into the *LUT* sequence.
+            Index at which to insert the item in the *LUT* sequence.
         value
             *LUT* to insert into the *LUT* sequence.
         """
@@ -326,13 +340,14 @@ class LUTSequence(MutableSequence):
 
     def apply(self, RGB: ArrayLike, **kwargs: Any) -> NDArrayFloat:
         """
-        Apply the *LUT* sequence sequentially to specified *RGB* colourspace array.
+        Apply the *LUT* sequence sequentially to the specified *RGB* colourspace
+        array.
 
         Parameters
         ----------
         RGB
-            *RGB* colourspace array to apply the *LUT* sequence
-            sequentially onto.
+            *RGB* colourspace array to apply the *LUT* sequence sequentially
+            onto.
 
         Other Parameters
         ----------------

--- a/colour/io/luts/sony_spi1d.py
+++ b/colour/io/luts/sony_spi1d.py
@@ -48,7 +48,7 @@ def read_LUT_SonySPI1D(path: str | PathLike) -> LUT1D | LUT3x1D:
     Parameters
     ----------
     path
-        *LUT* path.
+        *LUT* file path.
 
     Returns
     -------
@@ -167,22 +167,22 @@ def write_LUT_SonySPI1D(
     Parameters
     ----------
     LUT
-        :class:`LUT1D`, :class:`LUT3x1D` or :class:`LUTSequence` class instance
-        to write at specified path.
+        :class:`LUT1D`, :class:`LUT3x1D` or :class:`LUTSequence` class
+        instance to write at the specified path.
     path
-        *LUT* path.
+        *LUT* file path.
     decimals
-        Formatting decimals.
+        Number of decimal places for formatting numeric values.
 
     Returns
     -------
     :class:`bool`
-        Definition success.
+        Whether the write operation was successful.
 
     Warnings
     --------
-    -   If a :class:`LUTSequence` class instance is passed as ``LUT``, the
-        first *LUT* in the *LUT* sequence will be used.
+    -   If a :class:`LUTSequence` class instance is passed as ``LUT``,
+        the first *LUT* in the *LUT* sequence will be used.
 
     Examples
     --------
@@ -196,7 +196,7 @@ def write_LUT_SonySPI1D(
     ...     domain,
     ...     comments=["A first comment.", "A second comment."],
     ... )
-    >>> write_LUT_SonySPI1D(LUT, "My_LUT.cube")  # doctest: +SKIP
+    >>> write_LUT_SonySPI1D(LUT, "My_LUT.spi1d")  # doctest: +SKIP
 
     Writing a 3x1D *Sony* *.spi1d* *LUT*:
 
@@ -207,7 +207,7 @@ def write_LUT_SonySPI1D(
     ...     domain,
     ...     comments=["A first comment.", "A second comment."],
     ... )
-    >>> write_LUT_SonySPI1D(LUT, "My_LUT.cube")  # doctest: +SKIP
+    >>> write_LUT_SonySPI1D(LUT, "My_LUT.spi1d")  # doctest: +SKIP
     """
 
     path = str(path)

--- a/colour/io/luts/sony_spi3d.py
+++ b/colour/io/luts/sony_spi3d.py
@@ -44,12 +44,12 @@ __all__ = [
 
 def read_LUT_SonySPI3D(path: str | PathLike) -> LUT3D:
     """
-    Read specified *Sony* *.spi3d* *LUT* file.
+    Read the specified *Sony* *.spi3d* *LUT* file.
 
     Parameters
     ----------
     path
-        *LUT* path.
+        *LUT* file path.
 
     Returns
     -------
@@ -147,17 +147,17 @@ def write_LUT_SonySPI3D(
     LUT: LUT3D | LUTSequence, path: str | PathLike, decimals: int = 7
 ) -> bool:
     """
-    Write specified *LUT* to specified *Sony* *.spi3d* *LUT* file.
+    Write the specified *LUT* to the specified *Sony* *.spi3d* *LUT* file.
 
     Parameters
     ----------
     LUT
-        :class:`LUT3D` or :class:`LUTSequence` class instance to write at specified
-        path.
+        :class:`LUT3D` or :class:`LUTSequence` class instance to write at
+        the specified path.
     path
-        *LUT* path.
+        *LUT* file path.
     decimals
-        Formatting decimals.
+        Number of decimal places for formatting numeric values.
 
     Returns
     -------
@@ -166,8 +166,8 @@ def write_LUT_SonySPI3D(
 
     Warnings
     --------
-    -   If a :class:`LUTSequence` class instance is passed as ``LUT``, the
-        first *LUT* in the *LUT* sequence will be used.
+    -   If a :class:`LUTSequence` class instance is passed as ``LUT``,
+        the first *LUT* in the *LUT* sequence will be used.
 
     Examples
     --------

--- a/colour/io/luts/sony_spimtx.py
+++ b/colour/io/luts/sony_spimtx.py
@@ -2,7 +2,8 @@
 Sony .spimtx LUT Format Input / Output Utilities
 ================================================
 
-Define *Sony* *.spimtx* *LUT* format related input / output utilities objects.
+Define the *Sony* *.spimtx* *LUT* format related input / output utilities
+objects:
 
 -   :func:`colour.io.read_LUT_SonySPImtx`
 -   :func:`colour.io.write_LUT_SonySPImtx`
@@ -35,19 +36,25 @@ __all__ = [
 ]
 
 
-def read_LUT_SonySPImtx(path: str | PathLike[str]) -> LUTOperatorMatrix:
+def read_LUT_SonySPImtx(path: str | PathLike) -> LUTOperatorMatrix:
     """
-    Read specified *Sony* *.spimtx* *LUT* file.
+    Read the specified *Sony* *.spimtx* *LUT* file.
+
+    Parse the *.spimtx* format which contains a 3x4 matrix stored as 12
+    values. Extract the 3x3 transformation matrix and offset vector from
+    the fourth column (scaled by 65535) to create a
+    :class:`colour.LUTOperatorMatrix` instance.
 
     Parameters
     ----------
     path
-        *LUT* path.
+        *LUT* file path.
 
     Returns
     -------
     :class:`colour.LUTOperatorMatrix`
-        :class:`colour.io.Matrix` class instance.
+        *LUT* operator matrix instance containing the extracted 3x3 matrix
+        and offset vector.
 
     Examples
     --------
@@ -84,21 +91,21 @@ def read_LUT_SonySPImtx(path: str | PathLike[str]) -> LUTOperatorMatrix:
 
 def write_LUT_SonySPImtx(
     LUT: LUTOperatorMatrix,
-    path: str | PathLike[str] | typing.IO[typing.Any],
+    path: str | PathLike | typing.IO[typing.Any],
     decimals: int = 7,
 ) -> bool:
     """
-    Write specified *LUT* to specified *Sony* *.spimtx* *LUT* file.
+    Write the specified *LUT* to the specified *Sony* *.spimtx* *LUT* file.
 
     Parameters
     ----------
     LUT
-        :class:`colour.LUTOperatorMatrix` class instance to write at specified
-        path.
+        :class:`LUTOperatorMatrix` class instance to write at the
+        specified path.
     path
-        *LUT* path.
+        *LUT* file path.
     decimals
-        Formatting decimals.
+        Number of decimal places for formatting numeric values.
 
     Returns
     -------
@@ -115,7 +122,7 @@ def write_LUT_SonySPImtx(
     ...     ]
     ... )
     >>> M = LUTOperatorMatrix(matrix)
-    >>> write_LUT_SonySPI1D(M, "My_LUT.spimtx")  # doctest: +SKIP
+    >>> write_LUT_SonySPImtx(M, "My_LUT.spimtx")  # doctest: +SKIP
     """
 
     matrix, offset = LUT.matrix, LUT.offset

--- a/colour/io/luts/tests/test_lut.py
+++ b/colour/io/luts/tests/test_lut.py
@@ -1249,7 +1249,7 @@ class TestLUT3D:
             Size       : (33, 33, 33, 3)
             """
         ).strip()
-        self._repr = None  # pyright: ignore
+        self._repr = None
         self._inverted_apply_1 = np.array(
             [
                 [

--- a/colour/io/luts/tests/test_sequence.py
+++ b/colour/io/luts/tests/test_sequence.py
@@ -420,7 +420,7 @@ LUTSequence(
                 **kwargs: Any,
             ) -> NDArrayFloat:
                 """
-                Apply the *LUT* sequence operator to specified *RGB* colourspace
+                Apply the *LUT* sequence operator to the specified *RGB* colourspace
                 array.
 
                 Parameters

--- a/colour/io/ocio.py
+++ b/colour/io/ocio.py
@@ -2,7 +2,7 @@
 OpenColorIO Processing
 ======================
 
-Define the object for *OpenColorIO* processing:
+Define the object for *OpenColorIO* processing.
 
 -   :func:`colour.io.process_image_OpenColorIO`
 """
@@ -44,11 +44,11 @@ def process_image_OpenColorIO(a: ArrayLike, *args: Any, **kwargs: Any) -> NDArra
     Other Parameters
     ----------------
     config
-        *OpenColorIO* config to use for processing. If not defined, the
-        *OpenColorIO* set defined by the ``$OCIO`` environment variable is
-        used.
+        *OpenColorIO* configuration to use for processing. If not specified,
+        the *OpenColorIO* configuration defined by the ``$OCIO`` environment
+        variable is used.
     args
-        Arguments for `Config.getProcessor` method. See
+        Arguments for the ``Config.getProcessor`` method. See
         https://opencolorio.readthedocs.io/en/latest/api/config.html for
         more information.
 

--- a/colour/io/tabular.py
+++ b/colour/io/tabular.py
@@ -2,7 +2,8 @@
 CSV Tabular Data Input / Output
 ===============================
 
-Define various input / output objects for *CSV* tabular data files:
+Define input / output utilities for reading and writing spectral data and
+spectral distributions from/to *CSV* tabular data files.
 
 -   :func:`colour.read_spectral_data_from_csv_file`
 -   :func:`colour.read_sds_from_csv_file`
@@ -85,8 +86,8 @@ def read_spectral_data_from_csv_file(
 
     Notes
     -----
-    -   A *CSV* spectral data file should define at least define two fields:
-        one for the wavelengths and one for the associated values of one
+    -   A *CSV* spectral data file should at least define two fields: one
+        for the wavelengths and one for the associated values of one
         spectral distribution.
 
     Examples
@@ -167,8 +168,8 @@ def read_sds_from_csv_file(
     path: str | PathLike, **kwargs: Any
 ) -> Dict[str, SpectralDistribution]:
     """
-    Read spectral data from the specified *CSV* file and convert its content to a
-    *dict* of :class:`colour.SpectralDistribution` class instances.
+    Read spectral data from the specified *CSV* file and convert its content
+    to a *dict* of :class:`colour.SpectralDistribution` class instances.
 
     Parameters
     ----------
@@ -178,7 +179,7 @@ def read_sds_from_csv_file(
     Other Parameters
     ----------------
     kwargs
-        Keywords arguments passed to :func:`numpy.recfromcsv` definition.
+        Keywords arguments passed to :func:`numpy.genfromtxt` definition.
 
     Returns
     -------
@@ -313,14 +314,14 @@ def write_sds_to_csv_file(
     sds: Dict[str, SpectralDistribution], path: str | PathLike
 ) -> bool:
     """
-    Write the specified spectral distributions to the specified *CSV* file.
+    Write spectral distributions to a CSV file.
 
     Parameters
     ----------
     sds
-        Spectral distributions to write to specified *CSV* file.
+        Spectral distributions to write to the specified CSV file.
     path
-        *CSV* file path.
+        CSV file path.
 
     Returns
     -------

--- a/colour/io/tm2714.py
+++ b/colour/io/tm2714.py
@@ -2,8 +2,12 @@
 IES TM-27-14 Data Input / Output
 ================================
 
-Define the :class:`colour.SpectralDistribution_IESTM2714` class handling *IES
-TM-27-14* spectral data *XML* files.
+Define classes and utilities for handling *IES TM-27-14* spectral data *XML*
+files.
+
+This module provides the :class:`colour.SpectralDistribution_IESTM2714` class
+for reading and writing spectral distribution data according to the *IES
+TM-27-14* standard format for electronic transfer of spectral data.
 
 References
 ----------
@@ -63,7 +67,7 @@ NAMESPACE_IESTM2714: str = "http://www.ies.org/iestm2714"
 @dataclass
 class Element_Specification_IESTM2714:
     """
-    *IES TM-27-14* spectral data *XML* file element specification.
+    Define *IES TM-27-14* spectral data *XML* file element specification.
 
     Parameters
     ----------
@@ -93,7 +97,7 @@ class Element_Specification_IESTM2714:
 
 class Header_IESTM2714:
     """
-    Define the header object for a *IES TM-27-14* spectral distribution.
+    Define the header object for an *IES TM-27-14* spectral distribution.
 
     Parameters
     ----------
@@ -104,15 +108,16 @@ class Header_IESTM2714:
     description
         Description of the spectral data in the spectral data *XML* file.
     document_creator
-        Creator of the spectral data *XML* file, which may be a test lab, a
-        research group, a standard body, a company or an individual.
+        Creator of the spectral data *XML* file, which may be a test lab,
+        a research group, a standard body, a company or an individual.
     unique_identifier
-        Unique identifier to the product under test or the spectral data in the
-        document.
+        Unique identifier to the product under test or the spectral data
+        in the document.
     measurement_equipment
         Description of the equipment used to measure the spectral data.
     laboratory
-        Testing laboratory name that performed the spectral data measurements.
+        Testing laboratory name that performed the spectral data
+        measurements.
     report_number
         Testing laboratory report number.
     report_date
@@ -235,7 +240,7 @@ class Header_IESTM2714:
     @property
     def mapping(self) -> Structure:
         """
-        Getter property for the mapping structure.
+        Getter for the mapping structure.
 
         Returns
         -------
@@ -248,7 +253,7 @@ class Header_IESTM2714:
     @property
     def manufacturer(self) -> str | None:
         """
-        Getter and setter property for the manufacturer.
+        Getter and setter for the manufacturer name.
 
         Parameters
         ----------
@@ -258,7 +263,7 @@ class Header_IESTM2714:
         Returns
         -------
         :class:`str` or :py:data:`None`
-            Manufacturer.
+            Manufacturer name.
         """
 
         return self._manufacturer
@@ -278,7 +283,7 @@ class Header_IESTM2714:
     @property
     def catalog_number(self) -> str | None:
         """
-        Getter and setter property for the catalog number.
+        Getter and setter for the catalog number.
 
         Parameters
         ----------
@@ -308,7 +313,7 @@ class Header_IESTM2714:
     @property
     def description(self) -> str | None:
         """
-        Getter and setter property for the description.
+        Getter and setter for the description.
 
         Parameters
         ----------
@@ -338,7 +343,7 @@ class Header_IESTM2714:
     @property
     def document_creator(self) -> str | None:
         """
-        Getter and setter property for the document creator.
+        Getter and setter for the document creator.
 
         Parameters
         ----------
@@ -368,7 +373,7 @@ class Header_IESTM2714:
     @property
     def unique_identifier(self) -> str | None:
         """
-        Getter and setter property for the unique identifier.
+        Getter and setter for the unique identifier.
 
         Parameters
         ----------
@@ -398,7 +403,7 @@ class Header_IESTM2714:
     @property
     def measurement_equipment(self) -> str | None:
         """
-        Getter and setter property for the measurement equipment.
+        Getter and setter for the measurement equipment.
 
         Parameters
         ----------
@@ -428,7 +433,7 @@ class Header_IESTM2714:
     @property
     def laboratory(self) -> str | None:
         """
-        Getter and setter property for the laboratory.
+        Getter and setter for the laboratory information.
 
         Parameters
         ----------
@@ -445,7 +450,7 @@ class Header_IESTM2714:
 
     @laboratory.setter
     def laboratory(self, value: str | None) -> None:
-        """Setter for the **self.measurement_equipment** property."""
+        """Setter for the **self.laboratory** property."""
 
         if value is not None:
             attest(
@@ -458,7 +463,7 @@ class Header_IESTM2714:
     @property
     def report_number(self) -> str | None:
         """
-        Getter and setter property for the report number.
+        Getter and setter for the report number.
 
         Parameters
         ----------
@@ -488,7 +493,7 @@ class Header_IESTM2714:
     @property
     def report_date(self) -> str | None:
         """
-        Getter and setter property for the report date.
+        Getter and setter for the report date.
 
         Parameters
         ----------
@@ -518,7 +523,7 @@ class Header_IESTM2714:
     @property
     def document_creation_date(self) -> str | None:
         """
-        Getter and setter property for the document creation date.
+        Getter and setter for the document creation date.
 
         Parameters
         ----------
@@ -548,7 +553,7 @@ class Header_IESTM2714:
     @property
     def comments(self) -> str | None:
         """
-        Getter and setter property for the comments.
+        Getter and setter for the comments associated with the object.
 
         Parameters
         ----------
@@ -577,12 +582,12 @@ class Header_IESTM2714:
 
     def __str__(self) -> str:
         """
-        Return a formatted string representation of the header.
+        Return a formatted string representation of the *IES TM-27-14* header.
 
         Returns
         -------
         :class:`str`
-            Formatted string representation.
+            Formatted string representation displaying the header attributes.
 
         Examples
         --------
@@ -625,7 +630,7 @@ class Header_IESTM2714:
 
     def __repr__(self) -> str:
         """
-        Generate an evaluable string representation of the header.
+        Return an evaluable string representation of the header.
 
         Returns
         -------
@@ -667,7 +672,7 @@ class Header_IESTM2714:
 
     def __hash__(self) -> int:
         """
-        Generate the header hash.
+        Return the header hash.
 
         Returns
         -------
@@ -693,7 +698,11 @@ class Header_IESTM2714:
 
     def __eq__(self, other: object) -> bool:
         """
-        Determine whether the header is equal to specified other object.
+        Determine whether the header is equal to the specified other object.
+
+        Compare all header attributes to determine equality between this header
+        and the specified object. Two headers are considered equal when all
+        their attributes match exactly.
 
         Parameters
         ----------
@@ -703,7 +712,7 @@ class Header_IESTM2714:
         Returns
         -------
         :class:`bool`
-            Whether specified object is equal to the header.
+            Whether the specified object is equal to the header.
 
         Examples
         --------
@@ -734,7 +743,7 @@ class Header_IESTM2714:
 
     def __ne__(self, other: object) -> bool:
         """
-        Determine whether the header is not equal to specified other object.
+        Determine whether the header is not equal to the specified other object.
 
         Parameters
         ----------
@@ -759,18 +768,24 @@ class Header_IESTM2714:
 
 class SpectralDistribution_IESTM2714(SpectralDistribution):
     """
-    Define a *IES TM-27-14* spectral distribution.
+    Define an *IES TM-27-14* spectral distribution for electronic transfer of
+    spectral data.
 
-    This class can read and write *IES TM-27-14* spectral data *XML* files.
+    This class provides functionality to read and write spectral distribution
+    data using the *IES TM-27-14* standard format. The standard defines
+    an *XML* schema for exchanging spectral measurement data between systems,
+    ensuring consistent representation of wavelength-dependent measurements
+    across different applications and instruments.
 
     Parameters
     ----------
     path
         Spectral data *XML* file path.
     header
-        *IES TM-27-14* spectral distribution header.
+        *IES TM-27-14* spectral distribution header containing metadata.
     spectral_quantity
-        Quantity of measurement for each element of the spectral data.
+        Quantity of measurement for each element of the spectral data (e.g.,
+        "reflectance", "transmittance", "radiance").
     reflection_geometry
         Spectral reflectance factors geometric conditions.
     transmission_geometry
@@ -1003,7 +1018,7 @@ class SpectralDistribution_IESTM2714(SpectralDistribution):
     @property
     def mapping(self) -> Structure:
         """
-        Getter property for the mapping structure.
+        Getter for the structure containing file mappings.
 
         Returns
         -------
@@ -1016,7 +1031,7 @@ class SpectralDistribution_IESTM2714(SpectralDistribution):
     @property
     def path(self) -> str | None:
         """
-        Getter and setter property for the path.
+        Getter and setter for the resource path.
 
         Parameters
         ----------
@@ -1026,7 +1041,7 @@ class SpectralDistribution_IESTM2714(SpectralDistribution):
         Returns
         -------
         :class:`str` or :py:data:`None`
-            Path.
+            Path to the resource.
         """
 
         return self._path
@@ -1048,7 +1063,7 @@ class SpectralDistribution_IESTM2714(SpectralDistribution):
     @property
     def header(self) -> Header_IESTM2714:
         """
-        Getter and setter property for the header.
+        Getter and setter for the *IES TM-27-14* spectral distribution header.
 
         Parameters
         ----------
@@ -1058,7 +1073,7 @@ class SpectralDistribution_IESTM2714(SpectralDistribution):
         Returns
         -------
         :class:`colour.io.tm2714.Header_IESTM2714`
-            Header.
+            Header object containing spectral distribution metadata.
         """
 
         return self._header
@@ -1095,7 +1110,7 @@ class SpectralDistribution_IESTM2714(SpectralDistribution):
         | None
     ):
         """
-        Getter and setter property for the spectral quantity.
+        Getter and setter for the spectral quantity.
 
         Parameters
         ----------
@@ -1162,7 +1177,7 @@ class SpectralDistribution_IESTM2714(SpectralDistribution):
         | None
     ):
         """
-        Getter and setter property for the reflection geometry.
+        Getter and setter for the reflection geometry.
 
         Parameters
         ----------
@@ -1213,7 +1228,7 @@ class SpectralDistribution_IESTM2714(SpectralDistribution):
         self,
     ) -> Literal["0:0", "di:0", "de:0", "0:di", "0:de", "d:d", "other"] | None:
         """
-        Getter and setter property for the transmission geometry.
+        Getter and setter for the transmission geometry.
 
         Parameters
         ----------
@@ -1246,7 +1261,8 @@ class SpectralDistribution_IESTM2714(SpectralDistribution):
     @property
     def bandwidth_FWHM(self) -> float | None:
         """
-        Getter and setter property for the full-width half-maximum bandwidth.
+        Getter and setter for the full-width half-maximum (FWHM) bandwidth of
+        the spectral measurement.
 
         Parameters
         ----------
@@ -1278,18 +1294,20 @@ class SpectralDistribution_IESTM2714(SpectralDistribution):
     @property
     def bandwidth_corrected(self) -> bool | None:
         """
-        Getter and setter property for whether bandwidth correction has been
-        applied to the measured data.
+        Getter and setter for whether bandwidth correction has been applied to
+        the measured data.
 
         Parameters
         ----------
         value
-            Whether bandwidth correction has been applied to the measured data.
+            Whether bandwidth correction has been applied to the measured
+            data.
 
         Returns
         -------
         :class:`bool` or :py:data:`None`
-            Whether bandwidth correction has been applied to the measured data.
+            Whether bandwidth correction has been applied to the measured
+            data.
         """
 
         return self._bandwidth_corrected
@@ -1308,13 +1326,14 @@ class SpectralDistribution_IESTM2714(SpectralDistribution):
 
     def __str__(self) -> str:
         """
-        Return a formatted string representation of the *IES TM-27-14*
+        Generate a formatted string representation of the *IES TM-27-14*
         spectral distribution.
 
         Returns
         -------
         :class:`str`
-            Formatted string representation.
+            Formatted string representation containing path, spectral
+            metadata, header details, and spectral data values.
 
         Examples
         --------
@@ -1481,7 +1500,7 @@ class SpectralDistribution_IESTM2714(SpectralDistribution):
 
     def __repr__(self) -> str:
         """
-        Generate an evaluable string representation of the *IES TM-27-14*
+        Return an evaluable string representation of the *IES TM-27-14*
         spectral distribution.
 
         Returns
@@ -1640,7 +1659,7 @@ class SpectralDistribution_IESTM2714(SpectralDistribution):
 
     def read(self) -> SpectralDistribution_IESTM2714:
         """
-        Read and parse the spectral data from the *XML* file path.
+        Read and parse the spectral data from the specified *XML* file path.
 
         Returns
         -------
@@ -1731,7 +1750,8 @@ class SpectralDistribution_IESTM2714(SpectralDistribution):
 
     def write(self) -> bool:
         """
-        Write the spectral distribution spectral data to the *XML* file path.
+        Write the spectral distribution spectral data to the specified *XML*
+        file path.
 
         Returns
         -------

--- a/colour/io/uprtek_sekonic.py
+++ b/colour/io/uprtek_sekonic.py
@@ -2,8 +2,9 @@
 UPRTek and Sekonic Spectral Data
 ================================
 
-Define the input and output objects for *UPRTek* and *Sekonic*
-*Pseudo-XLS*/*CSV* spectral data files.
+Define input and output objects for parsing and handling *UPRTek* and
+*Sekonic* spectral measurement data stored in *Pseudo-XLS* and *CSV* file
+formats.
 
 -   :class:`colour.SpectralDistribution_UPRTek`
 -   :class:`colour.SpectralDistribution_Sekonic`
@@ -40,13 +41,18 @@ __all__ = [
 
 class SpectralDistribution_UPRTek(SpectralDistribution_IESTM2714):
     """
-    Implement support to read and write *IES TM-27-14* spectral data XML file
-    from a *UPRTek* *Pseudo-XLS* file.
+    Implement support to read and write *IES TM-27-14* spectral data XML
+    files from *UPRTek* *Pseudo-XLS* files.
+
+    This class extends :class:`SpectralDistribution_IESTM2714` to handle
+    the specific *Pseudo-XLS* format used by *UPRTek* spectral measurement
+    devices. The implementation parses metadata embedded in the file and
+    converts it to the standard *IES TM-27-14* XML format.
 
     Parameters
     ----------
     path
-        Path for *UPRTek* *Pseudo-XLS* file.
+        Absolute or relative path to the *UPRTek* *Pseudo-XLS* file.
 
     Attributes
     ----------
@@ -172,19 +178,20 @@ class SpectralDistribution_UPRTek(SpectralDistribution_IESTM2714):
     @property
     def metadata(self) -> dict:
         """
-        Getter property for the metadata.
+        Getter for the dataset metadata.
 
         Returns
         -------
         :class:`dict`
-            Metadata.
+            Dataset metadata containing information about the data source,
+            structure, and properties.
         """
 
         return self._metadata
 
     def __str__(self) -> str:
         """
-        Generate formatted string representation of the *UPRTek* spectral
+        Return a formatted string representation of the *UPRTek* spectral
         distribution.
 
         Returns
@@ -282,7 +289,8 @@ class SpectralDistribution_UPRTek(SpectralDistribution_IESTM2714):
 
     def read(self) -> SpectralDistribution_UPRTek:
         """
-        Read and parse the spectral data from a specified *UPRTek* *CSV* file.
+        Read and parse the spectral data from the specified *UPRTek* *CSV*
+        file.
 
         Returns
         -------
@@ -437,8 +445,12 @@ class SpectralDistribution_UPRTek(SpectralDistribution_IESTM2714):
 
 class SpectralDistribution_Sekonic(SpectralDistribution_UPRTek):
     """
-    Implement support to read and write *IES TM-27-14* spectral data XML file
-    from a *Sekonic* *CSV* file.
+    Provide support for reading and writing *IES TM-27-14* spectral data XML
+    files from *Sekonic* *CSV* files.
+
+    This class extends the *UPRTek* spectral distribution functionality to
+    handle *Sekonic* spectrometer data files. It enables conversion between
+    *Sekonic* *CSV* format and the standardized *IES TM-27-14* XML format.
 
     Parameters
     ----------
@@ -547,7 +559,7 @@ class SpectralDistribution_Sekonic(SpectralDistribution_UPRTek):
 
     def __str__(self) -> str:
         """
-        Generate formatted string representation of the *Sekonic* spectral
+        Return a formatted string representation of the *Sekonic* spectral
         distribution.
 
         Returns
@@ -645,8 +657,8 @@ class SpectralDistribution_Sekonic(SpectralDistribution_UPRTek):
 
     def read(self) -> SpectralDistribution_Sekonic:
         """
-        Read and parse the spectral data from a specified *Sekonic* *Pseudo-XLS*
-        file.
+        Read and parse the spectral data from the specified *Sekonic*
+        *Pseudo-XLS* file.
 
         Returns
         -------

--- a/colour/io/xrite.py
+++ b/colour/io/xrite.py
@@ -2,7 +2,7 @@
 X-Rite Data Input
 =================
 
-Define the input object for *X-Rite* spectral data files:
+Define input functionality for X-Rite spectral data files.
 
 -   :func:`colour.read_sds_from_xrite_file`
 """

--- a/colour/models/cam02_ucs.py
+++ b/colour/models/cam02_ucs.py
@@ -3,7 +3,7 @@ CAM02-LCD, CAM02-SCD, and CAM02-UCS Colourspaces - Luo, Cui and Li (2006)
 =========================================================================
 
 Define the *Luo et al. (2006)* *CAM02-LCD*, *CAM02-SCD*, and *CAM02-UCS*
-colourspaces transformations:
+colourspaces transformations.
 
 -   :func:`colour.JMh_CIECAM02_to_CAM02LCD`
 -   :func:`colour.CAM02LCD_to_JMh_CIECAM02`
@@ -83,8 +83,17 @@ __all__ = [
 @dataclass(frozen=True)
 class Coefficients_UCS_Luo2006(MixinDataclassIterable):
     """
-    Define the class storing *Luo et al. (2006)* fitting coefficients for
-    the *CAM02-LCD*, *CAM02-SCD*, and *CAM02-UCS* colourspaces.
+    Store *Luo et al. (2006)* fitting coefficients for the *CAM02-LCD*,
+    *CAM02-SCD*, and *CAM02-UCS* colourspaces.
+
+    Attributes
+    ----------
+    K_L
+        Lightness coefficient.
+    c_1
+        First chroma coefficient.
+    c_2
+        Second chroma coefficient.
     """
 
     K_L: float
@@ -110,13 +119,13 @@ def JMh_CIECAM02_to_UCS_Luo2006(
 ) -> NDArrayFloat:
     """
     Convert from *CIECAM02* :math:`JMh` correlates array to one of the
-    *Luo et al. (2006)* *CAM02-LCD*, *CAM02-SCD*, or *CAM02-UCS* colourspaces
-    :math:`J'a'b'` array.
+    *Luo et al. (2006)* *CAM02-LCD*, *CAM02-SCD*, or *CAM02-UCS*
+    colourspaces :math:`J'a'b'` array.
 
-    The :math:`JMh` correlates array is constructed using the CIECAM02
+    The :math:`JMh` correlates array is constructed using the *CIECAM02*
     correlate of *Lightness* :math:`J`, the *CIECAM02* correlate of
-    *colourfulness* :math:`M` and the *CIECAM02* *Hue* angle :math:`h` in
-    degrees.
+    *colourfulness* :math:`M` and the *CIECAM02* *Hue* angle :math:`h`
+    in degrees.
 
     Parameters
     ----------
@@ -193,9 +202,9 @@ def UCS_Luo2006_to_JMh_CIECAM02(
     Jpapbp: ArrayLike, coefficients: Coefficients_UCS_Luo2006
 ) -> NDArrayFloat:
     """
-    Convert from one of the *Luo et al. (2006)* *CAM02-LCD*, *CAM02-SCD*, or
-    *CAM02-UCS* colourspaces :math:`J'a'b'` array to *CIECAM02* :math:`JMh`
-    correlates array.
+    Convert from one of the *Luo et al. (2006)* *CAM02-LCD*, *CAM02-SCD*,
+    or *CAM02-UCS* colourspaces :math:`J'a'b'` array to *CIECAM02*
+    :math:`JMh` correlates array.
 
     Parameters
     ----------
@@ -261,8 +270,8 @@ def UCS_Luo2006_to_JMh_CIECAM02(
 
 def JMh_CIECAM02_to_CAM02LCD(JMh: ArrayLike) -> NDArrayFloat:
     """
-    Convert from *CIECAM02* :math:`JMh` correlates array to
-    *Luo et al. (2006)* *CAM02-LCD* colourspace :math:`J'a'b'` array.
+    Convert from *CIECAM02* :math:`JMh` correlates array to *Luo et al.
+    (2006)* *CAM02-LCD* colourspace :math:`J'a'b'` array.
 
     Parameters
     ----------
@@ -326,8 +335,8 @@ def JMh_CIECAM02_to_CAM02LCD(JMh: ArrayLike) -> NDArrayFloat:
 
 def CAM02LCD_to_JMh_CIECAM02(Jpapbp: ArrayLike) -> NDArrayFloat:
     """
-    Convert from *Luo et al. (2006)* *CAM02-LCD* colourspace :math:`J'a'b'`
-    array to *CIECAM02* :math:`JMh` correlates array.
+    Convert from *Luo et al. (2006)* *CAM02-LCD* colourspace
+    :math:`J'a'b'` array to *CIECAM02* :math:`JMh` correlates array.
 
     Parameters
     ----------
@@ -381,8 +390,8 @@ def CAM02LCD_to_JMh_CIECAM02(Jpapbp: ArrayLike) -> NDArrayFloat:
 
 def JMh_CIECAM02_to_CAM02SCD(JMh: ArrayLike) -> NDArrayFloat:
     """
-    Convert from *CIECAM02* :math:`JMh` correlates array to
-    *Luo et al. (2006)* *CAM02-SCD* colourspace :math:`J'a'b'` array.
+    Convert from *CIECAM02* :math:`JMh` correlates array to *Luo et al.
+    (2006)* *CAM02-SCD* colourspace :math:`J'a'b'` array.
 
     Parameters
     ----------
@@ -446,13 +455,14 @@ def JMh_CIECAM02_to_CAM02SCD(JMh: ArrayLike) -> NDArrayFloat:
 
 def CAM02SCD_to_JMh_CIECAM02(Jpapbp: ArrayLike) -> NDArrayFloat:
     """
-    Convert from *Luo et al. (2006)* *CAM02-SCD* colourspace :math:`J'a'b'`
-    array to *CIECAM02* :math:`JMh` correlates array.
+    Convert from *Luo et al. (2006)* *CAM02-SCD* colourspace
+    :math:`J'a'b'` array to *CIECAM02* :math:`JMh` correlates array.
 
     Parameters
     ----------
     Jpapbp
-        *Luo et al. (2006)* *CAM02-SCD* colourspace :math:`J'a'b'` array.
+        *Luo et al. (2006)* *CAM02-SCD* colourspace :math:`J'a'b'`
+        array.
 
     Returns
     -------
@@ -501,8 +511,8 @@ def CAM02SCD_to_JMh_CIECAM02(Jpapbp: ArrayLike) -> NDArrayFloat:
 
 def JMh_CIECAM02_to_CAM02UCS(JMh: ArrayLike) -> NDArrayFloat:
     """
-    Convert from *CIECAM02* :math:`JMh` correlates array to
-    *Luo et al. (2006)* *CAM02-UCS* colourspace :math:`J'a'b'` array.
+    Convert from *CIECAM02* :math:`JMh` correlates array to *Luo et al.
+    (2006)* *CAM02-UCS* colourspace :math:`J'a'b'` array.
 
     Parameters
     ----------
@@ -516,7 +526,7 @@ def JMh_CIECAM02_to_CAM02UCS(JMh: ArrayLike) -> NDArrayFloat:
 
     Notes
     -----
-    -   *UCS* in *CAM02-UCS* stands for *Uniform Colour Colourspace*.
+    -   *UCS* in *CAM02-UCS* stands for *Uniform Colour Space*.
 
     +------------+------------------------+------------------+
     | **Domain** |  **Scale - Reference** | **Scale - 1**    |
@@ -581,7 +591,7 @@ def CAM02UCS_to_JMh_CIECAM02(Jpapbp: ArrayLike) -> NDArrayFloat:
 
     Notes
     -----
-    -   *UCS* in *CAM02-UCS* stands for *Uniform Colour Colourspace*.
+    -   *UCS* in *CAM02-UCS* stands for *Uniform Colour Space*.
 
     +------------+------------------------+------------------+
     | **Domain** |  **Scale - Reference** | **Scale - 1**    |
@@ -624,8 +634,8 @@ def XYZ_to_UCS_Luo2006(
 ) -> NDArrayFloat:
     """
     Convert from *CIE XYZ* tristimulus values to one of the
-    *Luo et al. (2006)* *CAM02-LCD*, *CAM02-SCD*, or *CAM02-UCS* colourspaces
-    :math:`J'a'b'` array.
+    *Luo et al. (2006)* *CAM02-LCD*, *CAM02-SCD*, or *CAM02-UCS*
+    colourspaces :math:`J'a'b'` array.
 
     Parameters
     ----------
@@ -639,10 +649,11 @@ def XYZ_to_UCS_Luo2006(
     ----------------
     kwargs
         {:func:`colour.XYZ_to_CIECAM02`},
-        See the documentation of the previously listed definition. The default
-        viewing conditions are that of *IEC 61966-2-1:1999*, i.e., *sRGB* 64 Lux
-        ambient illumination, 80 :math:`cd/m^2`, adapting field luminance about
-        20% of a white object in the scene.
+        See the documentation of the previously listed definition. The
+        default viewing conditions are those of *IEC 61966-2-1:1999*,
+        i.e., *sRGB* 64 Lux ambient illumination, 80 :math:`cd/m^2`,
+        adapting field luminance about 20% of a white object in the
+        scene.
 
     Returns
     -------
@@ -652,8 +663,8 @@ def XYZ_to_UCS_Luo2006(
 
     Warnings
     --------
-    The ``XYZ_w`` parameter for :func:`colour.XYZ_to_CAM16` definition must be
-    specified in the same domain-range scale than the ``XYZ`` parameter.
+    The ``XYZ_w`` parameter for :func:`colour.XYZ_to_CAM16` definition must
+    be specified in the same domain-range scale than the ``XYZ`` parameter.
 
     Notes
     -----
@@ -731,10 +742,11 @@ def UCS_Luo2006_to_XYZ(
     ----------------
     kwargs
         {:func:`colour.CIECAM02_to_XYZ`},
-        See the documentation of the previously listed definition. The default
-        viewing conditions are that of *IEC 61966-2-1:1999*, i.e., *sRGB* 64 Lux
-        ambient illumination, 80 :math:`cd/m^2`, adapting field luminance about
-        20% of a white object in the scene.
+        See the documentation of the previously listed definition. The
+        default viewing conditions are those of *IEC 61966-2-1:1999*,
+        i.e., *sRGB* 64 Lux ambient illumination, 80 :math:`cd/m^2`,
+        adapting field luminance about 20% of a white object in the
+        scene.
 
     Returns
     -------
@@ -743,8 +755,8 @@ def UCS_Luo2006_to_XYZ(
 
     Warnings
     --------
-    The ``XYZ_w`` parameter for :func:`colour.XYZ_to_CAM16` definition must be
-    specified in the same domain-range scale than the ``XYZ`` parameter.
+    The ``XYZ_w`` parameter for :func:`colour.XYZ_to_CAM16` definition must
+    be specified in the same domain-range scale as the ``XYZ`` parameter.
 
     Notes
     -----
@@ -813,20 +825,23 @@ def XYZ_to_CAM02LCD(XYZ: ArrayLike, **kwargs: Any) -> NDArrayFloat:
     ----------------
     kwargs
         {:func:`colour.XYZ_to_CIECAM02`},
-        See the documentation of the previously listed definition. The default
-        viewing conditions are that of *IEC 61966-2-1:1999*, i.e., *sRGB* 64 Lux
-        ambient illumination, 80 :math:`cd/m^2`, adapting field luminance about
-        20% of a white object in the scene.
+        See the documentation of the previously listed definition. The
+        default viewing conditions are those of *IEC 61966-2-1:1999*,
+        i.e., *sRGB* 64 Lux ambient illumination, 80 :math:`cd/m^2`,
+        adapting field luminance about 20% of a white object in the
+        scene.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        *Luo et al. (2006)* *CAM02-LCD* colourspace :math:`J'a'b'` array.
+        *Luo et al. (2006)* *CAM02-LCD* colourspace :math:`J'a'b'`
+        array.
 
     Warnings
     --------
-    The ``XYZ_w`` parameter for :func:`colour.XYZ_to_CAM16` definition must be
-    specified in the same domain-range scale than the ``XYZ`` parameter.
+    The ``XYZ_w`` parameter for :func:`colour.XYZ_to_CAM16` definition
+    must be specified in the same domain-range scale as the ``XYZ``
+    parameter.
 
     Notes
     -----
@@ -878,10 +893,11 @@ def CAM02LCD_to_XYZ(Jpapbp: ArrayLike, **kwargs: Any) -> NDArrayFloat:
     ----------------
     kwargs
         {:func:`colour.CIECAM02_to_XYZ`},
-        See the documentation of the previously listed definition. The default
-        viewing conditions are that of *IEC 61966-2-1:1999*, i.e., *sRGB* 64 Lux
-        ambient illumination, 80 :math:`cd/m^2`, adapting field luminance about
-        20% of a white object in the scene.
+        See the documentation of the previously listed definition. The
+        default viewing conditions are those of *IEC 61966-2-1:1999*,
+        i.e., *sRGB* 64 Lux ambient illumination, 80 :math:`cd/m^2`,
+        adapting field luminance about 20% of a white object in the
+        scene.
 
     Returns
     -------
@@ -890,8 +906,8 @@ def CAM02LCD_to_XYZ(Jpapbp: ArrayLike, **kwargs: Any) -> NDArrayFloat:
 
     Warnings
     --------
-    The ``XYZ_w`` parameter for :func:`colour.XYZ_to_CAM16` definition must be
-    specified in the same domain-range scale than the ``XYZ`` parameter.
+    The ``XYZ_w`` parameter for :func:`colour.XYZ_to_CAM16` definition must
+    be specified in the same domain-range scale as the ``XYZ`` parameter.
 
     Notes
     -----
@@ -943,20 +959,23 @@ def XYZ_to_CAM02SCD(XYZ: ArrayLike, **kwargs: Any) -> NDArrayFloat:
     ----------------
     kwargs
         {:func:`colour.XYZ_to_CIECAM02`},
-        See the documentation of the previously listed definition. The default
-        viewing conditions are that of *IEC 61966-2-1:1999*, i.e., *sRGB* 64 Lux
-        ambient illumination, 80 :math:`cd/m^2`, adapting field luminance about
-        20% of a white object in the scene.
+        See the documentation of the previously listed definition. The
+        default viewing conditions are those of *IEC 61966-2-1:1999*,
+        i.e., *sRGB* 64 Lux ambient illumination, 80 :math:`cd/m^2`,
+        adapting field luminance about 20% of a white object in the
+        scene.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        *Luo et al. (2006)* *CAM02-SCD* colourspace :math:`J'a'b'` array.
+        *Luo et al. (2006)* *CAM02-SCD* colourspace :math:`J'a'b'`
+        array.
 
     Warnings
     --------
-    The ``XYZ_w`` parameter for :func:`colour.XYZ_to_CAM16` definition must be
-    specified in the same domain-range scale than the ``XYZ`` parameter.
+    The ``XYZ_w`` parameter for :func:`colour.XYZ_to_CAM16` definition
+    must be specified in the same domain-range scale as the ``XYZ``
+    parameter.
 
     Notes
     -----
@@ -1008,10 +1027,11 @@ def CAM02SCD_to_XYZ(Jpapbp: ArrayLike, **kwargs: Any) -> NDArrayFloat:
     ----------------
     kwargs
         {:func:`colour.CIECAM02_to_XYZ`},
-        See the documentation of the previously listed definition. The default
-        viewing conditions are that of *IEC 61966-2-1:1999*, i.e., *sRGB* 64 Lux
-        ambient illumination, 80 :math:`cd/m^2`, adapting field luminance about
-        20% of a white object in the scene.
+        See the documentation of the previously listed definition. The
+        default viewing conditions are those of *IEC 61966-2-1:1999*,
+        i.e., *sRGB* 64 Lux ambient illumination, 80 :math:`cd/m^2`,
+        adapting field luminance about 20% of a white object in the
+        scene.
 
     Returns
     -------
@@ -1021,7 +1041,7 @@ def CAM02SCD_to_XYZ(Jpapbp: ArrayLike, **kwargs: Any) -> NDArrayFloat:
     Warnings
     --------
     The ``XYZ_w`` parameter for :func:`colour.XYZ_to_CAM16` definition must be
-    specified in the same domain-range scale than the ``XYZ`` parameter.
+    specified in the same domain-range scale as the ``XYZ`` parameter.
 
     Notes
     -----
@@ -1073,20 +1093,23 @@ def XYZ_to_CAM02UCS(XYZ: ArrayLike, **kwargs: Any) -> NDArrayFloat:
     ----------------
     kwargs
         {:func:`colour.XYZ_to_CIECAM02`},
-        See the documentation of the previously listed definition. The default
-        viewing conditions are that of *IEC 61966-2-1:1999*, i.e., *sRGB* 64 Lux
-        ambient illumination, 80 :math:`cd/m^2`, adapting field luminance about
-        20% of a white object in the scene.
+        See the documentation of the previously listed definition. The
+        default viewing conditions are those of *IEC 61966-2-1:1999*,
+        i.e., *sRGB* 64 Lux ambient illumination, 80 :math:`cd/m^2`,
+        adapting field luminance about 20% of a white object in the
+        scene.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        *Luo et al. (2006)* *CAM02-UCS* colourspace :math:`J'a'b'` array.
+        *Luo et al. (2006)* *CAM02-UCS* colourspace :math:`J'a'b'`
+        array.
 
     Warnings
     --------
-    The ``XYZ_w`` parameter for :func:`colour.XYZ_to_CAM16` definition must be
-    specified in the same domain-range scale than the ``XYZ`` parameter.
+    The ``XYZ_w`` parameter for :func:`colour.XYZ_to_CAM16` definition
+    must be specified in the same domain-range scale as the ``XYZ``
+    parameter.
 
     Notes
     -----
@@ -1138,10 +1161,11 @@ def CAM02UCS_to_XYZ(Jpapbp: ArrayLike, **kwargs: Any) -> NDArrayFloat:
     ----------------
     kwargs
         {:func:`colour.CIECAM02_to_XYZ`},
-        See the documentation of the previously listed definition. The default
-        viewing conditions are that of *IEC 61966-2-1:1999*, i.e., *sRGB* 64 Lux
-        ambient illumination, 80 :math:`cd/m^2`, adapting field luminance about
-        20% of a white object in the scene.
+        See the documentation of the previously listed definition. The
+        default viewing conditions are those of *IEC 61966-2-1:1999*,
+        i.e., *sRGB* 64 Lux ambient illumination, 80 :math:`cd/m^2`,
+        adapting field luminance about 20% of a white object in the
+        scene.
 
     Returns
     -------
@@ -1150,8 +1174,8 @@ def CAM02UCS_to_XYZ(Jpapbp: ArrayLike, **kwargs: Any) -> NDArrayFloat:
 
     Warnings
     --------
-    The ``XYZ_w`` parameter for :func:`colour.XYZ_to_CAM16` definition must be
-    specified in the same domain-range scale than the ``XYZ`` parameter.
+    The ``XYZ_w`` parameter for :func:`colour.XYZ_to_CAM16` definition must
+    be specified in the same domain-range scale as the ``XYZ`` parameter.
 
     Notes
     -----

--- a/colour/models/cam16_ucs.py
+++ b/colour/models/cam16_ucs.py
@@ -3,7 +3,7 @@ CAM16-LCD, CAM16-SCD, and CAM16-UCS Colourspaces - Li et al. (2017)
 ===================================================================
 
 Define the *Li, Li, Wang, Zu, Luo, Cui, Melgosa, Brill and Pointer (2017)*
-*CAM16-LCD*, *CAM16-SCD*, and *CAM16-UCS* colourspaces transformations:
+*CAM16-LCD*, *CAM16-SCD*, and *CAM16-UCS* colourspaces transformations.
 
 -   :func:`colour.JMh_CAM16_to_CAM16LCD`
 -   :func:`colour.CAM16LCD_to_JMh_CAM16`
@@ -91,18 +91,18 @@ __all__ = [
 
 def _UCS_Luo2006_callable_to_UCS_Li2017_docstring(callable_: Callable) -> str:
     """
-    Convert specified *Luo et al. (2006)* callable docstring to
-    *Li et al. (2017)* docstring.
+    Convert the docstring of the specified *Luo et al. (2006)* callable to
+    conform to *Li et al. (2017)* conventions.
 
     Parameters
     ----------
     callable_
-        Callable to use the docstring from.
+        Callable whose docstring will be adapted.
 
     Returns
     -------
     :class:`str`
-        Docstring.
+        Converted docstring following *Li et al. (2017)* conventions.
     """
 
     docstring = callable_.__doc__
@@ -182,25 +182,27 @@ def XYZ_to_UCS_Li2017(
     XYZ: ArrayLike, coefficients: ArrayLike, **kwargs: Any
 ) -> NDArrayFloat:
     """
-    Convert from *CIE XYZ* tristimulus values to one of the *Li et al. (2017)*
-    *CAM16-LCD*, *CAM16-SCD*, or *CAM16-UCS* colourspaces :math:`J'a'b'` array.
+    Convert from *CIE XYZ* tristimulus values to one of the *Li et al.
+    (2017)* *CAM16-LCD*, *CAM16-SCD*, or *CAM16-UCS* colourspaces
+    :math:`J'a'b'` array.
 
     Parameters
     ----------
     XYZ
         *CIE XYZ* tristimulus values.
     coefficients
-        Coefficients of one of the *Li et al. (2017)* *CAM16-LCD*, *CAM16-SCD*,
-        or *CAM16-UCS* colourspaces.
+        Coefficients of one of the *Li et al. (2017)* *CAM16-LCD*,
+        *CAM16-SCD*, or *CAM16-UCS* colourspaces.
 
     Other Parameters
     ----------------
     kwargs
         {:func:`colour.XYZ_to_CAM16`},
-        See the documentation of the previously listed definition. The default
-        viewing conditions are that of *IEC 61966-2-1:1999*, i.e., *sRGB* 64 Lux
-        ambient illumination, 80 :math:`cd/m^2`, adapting field luminance about
-        20% of a white object in the scene.
+        See the documentation of the previously listed definition. The
+        default viewing conditions are those of *IEC 61966-2-1:1999*,
+        i.e., *sRGB* 64 Lux ambient illumination, 80 :math:`cd/m^2`,
+        adapting field luminance about 20% of a white object in the
+        scene.
 
     Returns
     -------
@@ -210,8 +212,8 @@ def XYZ_to_UCS_Li2017(
 
     Warnings
     --------
-    The ``XYZ_w`` parameter for :func:`colour.XYZ_to_CAM16` definition must be
-    specified in the same domain-range scale than the ``XYZ`` parameter.
+    The ``XYZ_w`` parameter for :func:`colour.XYZ_to_CAM16` definition must
+    be specified in the same domain-range scale as the ``XYZ`` parameter.
 
     Notes
     -----
@@ -288,17 +290,18 @@ def UCS_Li2017_to_XYZ(
         *Li et al. (2017)* *CAM16-LCD*, *CAM16-SCD*, or *CAM16-UCS*
         colourspaces :math:`J'a'b'` array.
     coefficients
-        Coefficients of one of the *Li et al. (2017)* *CAM16-LCD*, *CAM16-SCD*,
-        or *CAM16-UCS* colourspaces.
+        Coefficients of one of the *Li et al. (2017)* *CAM16-LCD*,
+        *CAM16-SCD*, or *CAM16-UCS* colourspaces.
 
     Other Parameters
     ----------------
     kwargs
         {:func:`colour.CAM16_to_XYZ`},
-        See the documentation of the previously listed definition. The default
-        viewing conditions are that of *IEC 61966-2-1:1999*, i.e., *sRGB* 64 Lux
-        ambient illumination, 80 :math:`cd/m^2`, adapting field luminance about
-        20% of a white object in the scene.
+        See the documentation of the previously listed definition. The
+        default viewing conditions are those of *IEC 61966-2-1:1999*,
+        i.e., *sRGB* 64 Lux ambient illumination, 80 :math:`cd/m^2`,
+        adapting field luminance about 20% of a white object in the
+        scene.
 
     Returns
     -------
@@ -307,8 +310,8 @@ def UCS_Li2017_to_XYZ(
 
     Warnings
     --------
-    The ``XYZ_w`` parameter for :func:`colour.XYZ_to_CAM16` definition must be
-    specified in the same domain-range scale than the ``XYZ`` parameter.
+    The ``XYZ_w`` parameter for :func:`colour.XYZ_to_CAM16` definition must
+    be specified in the same domain-range scale as the ``XYZ`` parameter.
 
     Notes
     -----

--- a/colour/models/cie_lab.py
+++ b/colour/models/cie_lab.py
@@ -2,7 +2,7 @@
 CIE L*a*b* Colourspace
 ======================
 
-Define the *CIE L\\*a\\*b\\** colourspace transformations:
+Define the *CIE L\\*a\\*b\\** colourspace transformations.
 
 -   :func:`colour.XYZ_to_Lab`
 -   :func:`colour.Lab_to_XYZ`

--- a/colour/models/cie_luv.py
+++ b/colour/models/cie_luv.py
@@ -2,7 +2,7 @@
 CIE L*u*v* Colourspace
 ======================
 
-Define the *CIE L\\*u\\*v\\** colourspace transformations:
+Define the *CIE L\\*u\\*v\\** colourspace transformations.
 
 -   :func:`colour.XYZ_to_Luv`
 -   :func:`colour.Luv_to_XYZ`
@@ -233,8 +233,8 @@ def Luv_to_uv(
     ],
 ) -> NDArrayFloat:
     """
-    Return the :math:`uv^p` chromaticity coordinates from specified
-    *CIE L\\*u\\*v\\** colourspace array.
+    Convert from *CIE L\\*u\\*v\\** colourspace to :math:`uv^p` chromaticity
+    coordinates.
 
     Parameters
     ----------
@@ -293,9 +293,9 @@ def uv_to_Luv(
     L: ArrayLike = 100,
 ) -> NDArrayFloat:
     """
-    Return the *CIE L\\*u\\*v\\** colourspace array from specified :math:`uv^p`
-    chromaticity coordinates by extending the array last dimension with specified
-    :math:`L` *Lightness*.
+    Convert from :math:`uv^p` chromaticity coordinates to *CIE L\\*u\\*v\\**
+    colourspace by extending the array's last dimension with the specified
+    :math:`L^*` *Lightness*.
 
     Parameters
     ----------
@@ -305,9 +305,9 @@ def uv_to_Luv(
         Reference *illuminant* *CIE xy* chromaticity coordinates or *CIE xyY*
         colourspace array.
     L
-        Optional :math:`L^*` *Lightness* value used to construct the intermediate
-        *CIE XYZ* colourspace array, the default :math:`L^*` *Lightness* value is
-        100.
+        Optional :math:`L^*` *Lightness* value used to construct the
+        intermediate *CIE XYZ* colourspace array, the default :math:`L^*`
+        *Lightness* value is 100.
 
     Returns
     -------
@@ -359,8 +359,8 @@ def uv_to_Luv(
 
 def Luv_uv_to_xy(uv: ArrayLike) -> NDArrayFloat:
     """
-    Return the *CIE xy* chromaticity coordinates from specified *CIE L\\*u\\*v\\**
-    colourspace :math:`uv^p` chromaticity coordinates.
+    Convert from *CIE L\\*u\\*v\\** colourspace :math:`u'v'` chromaticity
+    coordinates to *CIE xy* chromaticity coordinates.
 
     Parameters
     ----------
@@ -394,8 +394,8 @@ def Luv_uv_to_xy(uv: ArrayLike) -> NDArrayFloat:
 
 def xy_to_Luv_uv(xy: ArrayLike) -> NDArrayFloat:
     """
-    Return the *CIE L\\*u\\*v\\** colourspace :math:`uv^p` chromaticity
-    coordinates from specified *CIE xy* chromaticity coordinates.
+    Convert from *CIE xy* chromaticity coordinates to *CIE L\\*u\\*v\\**
+    colourspace :math:`u'v'` chromaticity coordinates.
 
     Parameters
     ----------
@@ -434,10 +434,11 @@ def XYZ_to_CIE1976UCS(
     ],
 ) -> NDArrayFloat:
     """
-    Convert from *CIE XYZ* tristimulus values to :math:`uv^pL\\*` colourspace.
+    Convert from *CIE XYZ* tristimulus values to :math:`uv^pL^*` colourspace.
 
-    This colourspace combines the :math:`uv^p` chromaticity coordinates with
-    the *Lightness* :math:`L\\*` from the *CIE L\\*u\\*v\\** colourspace.
+    This colourspace combines the :math:`uv^p` chromaticity
+    coordinates with the *Lightness* :math:`L^{*}` from the
+    *CIE L*u*v** colourspace.
 
     It is a convenient definition for use with the
     *CIE 1976 UCS Chromaticity Diagram*.
@@ -453,7 +454,7 @@ def XYZ_to_CIE1976UCS(
     Returns
     -------
     :class:`numpy.ndarray`
-        :math:`uv^pL\\*` colourspace array.
+        :math:`uv^pL^*` colourspace array.
 
     Notes
     -----
@@ -499,10 +500,11 @@ def CIE1976UCS_to_XYZ(
     ],
 ) -> NDArrayFloat:
     """
-    Convert from *CIE XYZ* tristimulus values to :math:`uv^pL\\*` colourspace.
+    Convert from :math:`uv^pL^*` colourspace to *CIE XYZ* tristimulus values.
 
-    This colourspace combines the :math:`uv^p` chromaticity coordinates with
-    the *Lightness* :math:`L\\*` from the *CIE L\\*u\\*v\\** colourspace.
+    This colourspace combines the :math:`uv^p` chromaticity
+    coordinates with the *Lightness* :math:`L^{*}` from the
+    *CIE L*u*v** colourspace.
 
     It is a convenient definition for use with the
     *CIE 1976 UCS Chromaticity Diagram*.
@@ -510,7 +512,7 @@ def CIE1976UCS_to_XYZ(
     Parameters
     ----------
     uvL
-        :math:`uv^pL\\*` colourspace array.
+        :math:`uv^pL^*` colourspace array.
     illuminant
         Reference *illuminant* *CIE xy* chromaticity coordinates or *CIE xyY*
         colourspace array.
@@ -518,7 +520,7 @@ def CIE1976UCS_to_XYZ(
     Returns
     -------
     :class:`numpy.ndarray`
-        :math:`uv^pL\\*` colourspace array.
+        *CIE XYZ* tristimulus values.
 
     Notes
     -----

--- a/colour/models/cie_ucs.py
+++ b/colour/models/cie_ucs.py
@@ -2,7 +2,7 @@
 CIE 1960 UCS Colourspace
 ========================
 
-Define the *CIE 1960 UCS* colourspace transformations:
+Define the *CIE 1960 UCS* colourspace transformations.
 
 -   :func:`colour.XYZ_to_UCS`
 -   :func:`colour.UCS_to_XYZ`
@@ -104,8 +104,8 @@ def XYZ_to_UCS(XYZ: ArrayLike) -> NDArrayFloat:
 
 def UCS_to_XYZ(UVW: ArrayLike) -> NDArrayFloat:
     """
-    Convert from *CIE 1960 UCS* :math:`UVW` colourspace to *CIE XYZ* tristimulus
-    values.
+    Convert from *CIE 1960 UCS* :math:`UVW` colourspace to *CIE XYZ*
+    tristimulus values.
 
     Parameters
     ----------
@@ -152,8 +152,8 @@ def UCS_to_XYZ(UVW: ArrayLike) -> NDArrayFloat:
 
 def UCS_to_uv(UVW: ArrayLike) -> NDArrayFloat:
     """
-    Return the *uv* chromaticity coordinates from specified *CIE 1960 UCS*
-    :math:`UVW` colourspace array.
+    Convert from *CIE 1960 UCS* colourspace to *uv* chromaticity
+    coordinates.
 
     Parameters
     ----------
@@ -163,7 +163,7 @@ def UCS_to_uv(UVW: ArrayLike) -> NDArrayFloat:
     Returns
     -------
     :class:`numpy.ndarray`
-        *uv* chromaticity coordinates.
+        *CIE UCS uv* chromaticity coordinates.
 
     Notes
     -----
@@ -195,13 +195,13 @@ def UCS_to_uv(UVW: ArrayLike) -> NDArrayFloat:
 
 def uv_to_UCS(uv: ArrayLike, V: ArrayLike = 1) -> NDArrayFloat:
     """
-    Return the *CIE 1960 UCS* :math:`UVW` colourspace array from specified *uv*
-    chromaticity coordinates.
+    Convert from *uv* chromaticity coordinates to *CIE 1960 UCS*
+    colourspace.
 
     Parameters
     ----------
     uv
-        *uv* chromaticity coordinates.
+        *CIE UCS uv* chromaticity coordinates.
     V
         Optional :math:`V` *luminance* value used to construct the
         *CIE 1960 UCS* :math:`UVW` colourspace array, the default :math:`V`
@@ -235,8 +235,8 @@ def uv_to_UCS(uv: ArrayLike, V: ArrayLike = 1) -> NDArrayFloat:
 
 def UCS_uv_to_xy(uv: ArrayLike) -> NDArrayFloat:
     """
-    Return the *CIE xy* chromaticity coordinates from specified *CIE 1960 UCS*
-    :math:`UVW` colourspace *uv* chromaticity coordinates.
+    Convert from *CIE 1960 UCS* :math:`UVW` colourspace *uv* chromaticity
+    coordinates to *CIE xy* chromaticity coordinates.
 
     Parameters
     ----------
@@ -270,8 +270,8 @@ def UCS_uv_to_xy(uv: ArrayLike) -> NDArrayFloat:
 
 def xy_to_UCS_uv(xy: ArrayLike) -> NDArrayFloat:
     """
-    Return the *CIE 1960 UCS* :math:`UVW` colourspace *uv* chromaticity
-    coordinates from specified *CIE xy* chromaticity coordinates.
+    Convert from *CIE xy* chromaticity coordinates to *CIE 1960 UCS*
+    :math:`UVW` colourspace *uv* chromaticity coordinates.
 
     Parameters
     ----------
@@ -307,11 +307,12 @@ def XYZ_to_CIE1960UCS(
     XYZ: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Convert from *CIE XYZ* tristimulus values to :math:`uvV` colourspace.
+    Convert from *CIE XYZ* tristimulus values to *CIE 1960 UCS* :math:`uvV`
+    colourspace.
 
-    This colourspace combines the *CIE 1960 UCS* :math:`UVW` colourspace *uv*
-    chromaticity coordinates with the luminance :math:`V` from the
-    *CIE 1960 UCS* :math:`UVW` colourspace.
+    This colourspace combines the *CIE 1960 UCS* :math:`UVW` colourspace
+    :math:`uv` chromaticity coordinates with the luminance :math:`V` from
+    the *CIE 1960 UCS* :math:`UVW` colourspace.
 
     It is a convenient definition for use with the
     *CIE 1960 UCS Chromaticity Diagram*.
@@ -332,8 +333,6 @@ def XYZ_to_CIE1960UCS(
     | **Domain**     | **Scale - Reference** | **Scale - 1**   |
     +================+=======================+=================+
     | ``XYZ``        | [0, 1]                | [0, 1]          |
-    +----------------+-----------------------+-----------------+
-    | ``illuminant`` | [0, 1]                | [0, 1]          |
     +----------------+-----------------------+-----------------+
 
     +----------------+-----------------------+-----------------+
@@ -363,11 +362,12 @@ def CIE1960UCS_to_XYZ(
     uvV: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Convert from *CIE XYZ* tristimulus values to :math:`uvV` colourspace.
+    Convert from *CIE 1960 UCS* :math:`uvV` colourspace to *CIE XYZ*
+    tristimulus values.
 
-    This colourspace combines the *CIE 1960 UCS* :math:`UVW` colourspace *uv*
-    chromaticity coordinates with the luminance :math:`V` from the
-    *CIE 1960 UCS* :math:`UVW` colourspace.
+    This colourspace combines the *CIE 1960 UCS* :math:`UVW` colourspace
+    :math:`uv` chromaticity coordinates with the luminance :math:`V` from
+    the *CIE 1960 UCS* :math:`UVW` colourspace.
 
     It is a convenient definition for use with the
     *CIE 1960 UCS Chromaticity Diagram*.
@@ -380,7 +380,7 @@ def CIE1960UCS_to_XYZ(
     Returns
     -------
     :class:`numpy.ndarray`
-        :math:`uvV` colourspace array.
+        *CIE XYZ* tristimulus values.
 
     Notes
     -----
@@ -388,8 +388,6 @@ def CIE1960UCS_to_XYZ(
     | **Domain**     | **Scale - Reference** | **Scale - 1**   |
     +================+=======================+=================+
     | ``uvV``        | [0, 1]                | [0, 1]          |
-    +----------------+-----------------------+-----------------+
-    | ``illuminant`` | [0, 1]                | [0, 1]          |
     +----------------+-----------------------+-----------------+
 
     +----------------+-----------------------+-----------------+

--- a/colour/models/cie_uvw.py
+++ b/colour/models/cie_uvw.py
@@ -2,7 +2,7 @@
 CIE 1964 U*V*W* Colourspace
 ===========================
 
-Define the *CIE 1964 U\\*V\\*W\\** colourspace transformations:
+Define the *CIE 1964 U\\*V\\*W\\** colourspace transformations.
 
 -   :func:`colour.XYZ_to_UVW`
 -   :func:`colour.UVW_to_XYZ`
@@ -119,7 +119,7 @@ def UVW_to_XYZ(
     ],
 ) -> NDArrayFloat:
     """
-    Convert *CIE 1964 U\\*V\\*W\\** colourspace to *CIE XYZ* tristimulus
+    Convert from *CIE 1964 U\\*V\\*W\\** colourspace to *CIE XYZ* tristimulus
     values.
 
     Parameters

--- a/colour/models/cie_xyy.py
+++ b/colour/models/cie_xyy.py
@@ -2,7 +2,7 @@
 Tristimulus Values, CIE xyY Colourspace and Chromaticity Coordinates
 ====================================================================
 
-Define the *CIE xyY* colourspace transformations:
+Define the *CIE xyY* colourspace transformations.
 
 -   :func:`colour.XYZ_to_xyY`
 -   :func:`colour.xyY_to_XYZ`
@@ -62,7 +62,8 @@ def XYZ_to_xyY(XYZ: ArrayLike) -> NDArrayFloat:
     Returns
     -------
     :class:`numpy.ndarray`
-        *CIE xyY* colourspace array.
+        *CIE xyY* colourspace array with chromaticity coordinates
+        :math:`x, y` and luminance :math:`Y`.
 
     Notes
     -----
@@ -109,7 +110,8 @@ def xyY_to_XYZ(xyY: ArrayLike) -> NDArrayFloat:
     Parameters
     ----------
     xyY
-        *CIE xyY* colourspace array.
+        *CIE xyY* colourspace array with chromaticity coordinates
+        :math:`x, y` and luminance :math:`Y`.
 
     Returns
     -------
@@ -156,16 +158,18 @@ def xyY_to_XYZ(xyY: ArrayLike) -> NDArrayFloat:
 
 def xyY_to_xy(xyY: ArrayLike) -> NDArrayFloat:
     """
-    Convert from *CIE xyY* colourspace to *CIE xy* chromaticity coordinates.
+    Convert from *CIE xyY* colourspace to *CIE xy* chromaticity
+    coordinates.
 
-    ``xyY`` argument with last dimension being equal to 2 will be assumed to be
-    a *CIE xy* chromaticity coordinates argument and will be returned directly
-    by the definition.
+    ``xyY`` argument with last dimension being equal to 2 will be
+    assumed to be a *CIE xy* chromaticity coordinates argument and will
+    be returned directly by the definition.
 
     Parameters
     ----------
     xyY
-        *CIE xyY* colourspace array or *CIE xy* chromaticity coordinates.
+        *CIE xyY* colourspace array or *CIE xy* chromaticity
+        coordinates.
 
     Returns
     -------
@@ -206,20 +210,23 @@ def xyY_to_xy(xyY: ArrayLike) -> NDArrayFloat:
 
 def xy_to_xyY(xy: ArrayLike, Y: ArrayLike = 1) -> NDArrayFloat:
     """
-    Convert from *CIE xy* chromaticity coordinates to *CIE xyY* colourspace by
-    extending the array last dimension with specified :math:`Y` *luminance*.
+    Convert from *CIE xy* chromaticity coordinates to *CIE xyY*
+    colourspace by extending the array's last dimension with the
+    specified :math:`Y` *luminance*.
 
-    ``xy`` argument with last dimension being equal to 3 will be assumed to be
-    a *CIE xyY* colourspace array argument and will be returned directly by the
-    definition.
+    ``xy`` argument with last dimension equal to 3 will be assumed
+    to be a *CIE xyY* colourspace array and will be returned
+    directly by the definition.
 
     Parameters
     ----------
     xy
-        *CIE xy* chromaticity coordinates or *CIE xyY* colourspace array.
+        *CIE xy* chromaticity coordinates or *CIE xyY* colourspace
+        array.
     Y
-        Optional :math:`Y` *luminance* value used to construct the *CIE xyY*
-        colourspace array, the default :math:`Y` *luminance* value is 1.
+        Optional :math:`Y` *luminance* value used to construct the
+        *CIE xyY* colourspace array. The default :math:`Y`
+        *luminance* value is 1.
 
     Returns
     -------
@@ -240,10 +247,10 @@ def xy_to_xyY(xy: ArrayLike, Y: ArrayLike = 1) -> NDArrayFloat:
     | ``xyY``    | [0, 1]                | [0, 1]        |
     +------------+-----------------------+---------------+
 
-    -   This definition is a convenient object provided to implement support of
-        illuminant argument luminance value in various :mod:`colour.models`
-        package objects such as :func:`colour.Lab_to_XYZ` or
-        :func:`colour.Luv_to_XYZ`.
+    -   This definition is a convenient object provided to
+        implement support of illuminant argument luminance value
+        in various :mod:`colour.models` package objects such as
+        :func:`colour.Lab_to_XYZ` or :func:`colour.Luv_to_XYZ`.
 
     References
     ----------
@@ -279,8 +286,8 @@ def xy_to_xyY(xy: ArrayLike, Y: ArrayLike = 1) -> NDArrayFloat:
 
 def XYZ_to_xy(XYZ: ArrayLike) -> NDArrayFloat:
     """
-    Return the *CIE xy* chromaticity coordinates from specified *CIE XYZ*
-    tristimulus values.
+    Convert from *CIE XYZ* tristimulus values to *CIE xy* chromaticity
+    coordinates.
 
     Parameters
     ----------
@@ -316,8 +323,7 @@ def XYZ_to_xy(XYZ: ArrayLike) -> NDArrayFloat:
 
 def xy_to_XYZ(xy: ArrayLike) -> NDArrayFloat:
     """
-    Return the *CIE XYZ* tristimulus values from specified *CIE xy* chromaticity
-    coordinates.
+    Convert from *CIE xy* chromaticity coordinates to *CIE XYZ* tristimulus values.
 
     Parameters
     ----------

--- a/colour/models/common.py
+++ b/colour/models/common.py
@@ -2,7 +2,7 @@
 Common Colour Models Utilities
 ==============================
 
-Define various colour models common utilities:
+Define utilities for common colour models and transformations.
 
 -   :attr:`colour.COLOURSPACE_MODELS`
 -   :func:`colour.models.Jab_to_JCh`
@@ -198,12 +198,11 @@ def Jab_to_JCh(Jab: ArrayLike) -> NDArrayFloat:
     """
     Convert from *Jab* colour representation to *JCh* colour representation.
 
-    This definition is used to perform conversion from *CIE L\\*a\\*b\\**
-    colourspace to *CIE L\\*C\\*Hab* colourspace and for other similar
-    conversions. It implements a generic transformation from *lightness*
-    :math:`J`, :math:`a` and :math:`b` opponent colour dimensions to the
-    correlates of *lightness* :math:`J`, chroma :math:`C` and hue angle
-    :math:`h`.
+    This definition performs conversion from *CIE L\\*a\\*b\\** colourspace to
+    *CIE L\\*C\\*Hab* colourspace and other similar conversions. It implements
+    a generic transformation from *lightness* :math:`J`, :math:`a` and
+    :math:`b` opponent colour dimensions to the correlates of *lightness*
+    :math:`J`, chroma :math:`C` and hue angle :math:`h`.
 
     Parameters
     ----------
@@ -259,11 +258,11 @@ def JCh_to_Jab(JCh: ArrayLike) -> NDArrayFloat:
     """
     Convert from *JCh* colour representation to *Jab* colour representation.
 
-    This definition is used to perform conversion from *CIE L\\*C\\*Hab*
-    colourspace to *CIE L\\*a\\*b\\** colourspace and for other similar
-    conversions. It implements a generic transformation from the correlates of
-    *lightness* :math:`J`, chroma :math:`C` and hue angle :math:`h` to
-    *lightness* :math:`J`, :math:`a` and :math:`b` opponent colour dimensions.
+    This definition performs conversion from *CIE L\\*C\\*Hab* colourspace to
+    *CIE L\\*a\\*b\\**  colourspace and other similar conversions. It implements
+    a generic transformation from the correlates of *lightness* :math:`J`,
+    chroma :math:`C` and hue angle :math:`h` to *lightness* :math:`J`,
+    :math:`a` and :math:`b` opponent colour dimensions
 
     Parameters
     ----------
@@ -322,16 +321,15 @@ def XYZ_to_Iab(
     matrix_LMS_p_to_Iab: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Convert from *CIE XYZ* tristimulus values to *IPT*-like :math:`Iab` colour
-    representation.
+    Convert from *CIE XYZ* tristimulus values to *IPT*-like :math:`Iab`
+    colour representation.
 
-    This definition is used to perform conversion from *CIE XYZ* tristimulus
-    values to *IPT* colourspace and for other similar conversions. It
-    implements a generic transformation from *CIE XYZ* tristimulus values to
-    *lightness* :math:`I`, :math:`a` and :math:`b` representing
-    red-green dimension, i.e., the dimension lost by protanopes and
-    the yellow-blue dimension, i.e., the dimension lost by tritanopes,
-    respectively.
+    Perform conversion from *CIE XYZ* tristimulus values to *IPT*
+    colourspace and other similar conversions. It implements a generic
+    transformation from *CIE XYZ* tristimulus values to *lightness*
+    :math:`I`, :math:`a` representing the red-green dimension (the
+    dimension lost by protanopes), and :math:`b` representing the
+    yellow-blue dimension (the dimension lost by tritanopes).
 
     Parameters
     ----------
@@ -341,8 +339,8 @@ def XYZ_to_Iab(
         Callable applying the forward non-linearity to the :math:`LMS`
         colourspace array.
     matrix_XYZ_to_LMS
-        Matrix converting from *CIE XYZ* tristimulus values to :math:`LMS`
-        colourspace.
+        Matrix converting from *CIE XYZ* tristimulus values to
+        :math:`LMS` colourspace.
     matrix_LMS_p_to_Iab
         Matrix converting from non-linear :math:`LMS_p` colourspace to
         *IPT*-like :math:`Iab` colour representation.
@@ -412,12 +410,12 @@ def Iab_to_XYZ(
     Convert from *IPT*-like :math:`Iab` colour representation to *CIE XYZ*
     tristimulus values.
 
-    This definition is used to perform conversion from *IPT* colourspace to
-    *CIE XYZ* tristimulus values and for other similar conversions. It
-    implements a generic transformation from *lightness* :math:`I`, :math:`a`
-    and :math:`b` representing red-green dimension, i.e., the dimension lost by
-    protanopes and the yellow-blue dimension, i.e., the dimension lost by
-    tritanopes, respectively to *CIE XYZ* tristimulus values.
+    Perform conversion from *IPT* colourspace to *CIE XYZ* tristimulus
+    values and other similar conversions. It implements a generic
+    transformation from *lightness* :math:`I`, :math:`a` representing the
+    red-green dimension (the dimension lost by protanopes), and :math:`b`
+    representing the yellow-blue dimension (the dimension lost by tritanopes)
+    to *CIE XYZ* tristimulus values.
 
     Parameters
     ----------
@@ -427,11 +425,11 @@ def Iab_to_XYZ(
         Callable applying the reverse non-linearity to the :math:`LMS_p`
         colourspace array.
     matrix_Iab_to_LMS_p
-        Matrix converting from *IPT*-like :math:`Iab` colour representation to
-        non-linear :math:`LMS_p` colourspace.
+        Matrix converting from *IPT*-like :math:`Iab` colour
+        representation to non-linear :math:`LMS_p` colourspace.
     matrix_LMS_to_XYZ
-        Matrix converting from :math:`LMS` colourspace to *CIE XYZ* tristimulus
-        values.
+        Matrix converting from :math:`LMS` colourspace to *CIE XYZ*
+        tristimulus values.
 
     Returns
     -------

--- a/colour/models/datasets/macadam_ellipses.py
+++ b/colour/models/datasets/macadam_ellipses.py
@@ -2,7 +2,8 @@
 MacAdam (1942) Ellipses (Observer PGN)
 ======================================
 
-Define the *MacAdam (1942) Ellipses (Observer PGN)* ellipses data.
+Define the *MacAdam (1942) Ellipses (Observer PGN)* ellipses data for colour
+discrimination threshold analysis.
 
 References
 ----------

--- a/colour/models/datasets/pointer_gamut.py
+++ b/colour/models/datasets/pointer_gamut.py
@@ -2,7 +2,11 @@
 Pointer's Gamut
 ===============
 
-Define the *Pointer's Gamut* data.
+Define the *Pointer's Gamut* data for real surface colours.
+
+This module provides the data representing the gamut of real surface colours
+as measured by Pointer (1980). The data includes the gamut volume in
+*CIE L\\*C\\*Hab* colourspace and boundary chromaticity coordinates.
 
 References
 ----------

--- a/colour/models/din99.py
+++ b/colour/models/din99.py
@@ -3,7 +3,7 @@ DIN99 Colourspace and DIN99b, DIN99c, DIN99d Refined Formulas
 =============================================================
 
 Define the *DIN99* colourspace and *DIN99b*, *DIN99c*, *DIN99d* refined
-formulas transformations:
+formulas transformations.
 
 -   :func:`colour.Lab_to_DIN99`
 -   :func:`colour.DIN99_to_Lab`
@@ -70,8 +70,8 @@ DIN99_METHODS: CanonicalMapping = CanonicalMapping(
     }
 )
 """
-*DIN99* colourspace methods, i.e., the coefficients for the *DIN99b*, *DIN99c*,
-and *DIN99d* refined formulas according to *Cui et al. (2002)*.
+Supported *DIN99* colourspace methods, i.e., the coefficients for the *DIN99b*,
+*DIN99c*, and *DIN99d* refined formulas according to *Cui et al. (2002)*.
 
 References
 ----------
@@ -88,23 +88,22 @@ def Lab_to_DIN99(
     ) = "DIN99",
 ) -> NDArrayFloat:
     """
-    Convert from *CIE L\\*a\\*b\\** colourspace to *DIN99* colourspace or
-    one of the *DIN99b*, *DIN99c*, *DIN99d* refined formulas according
-    to *Cui et al. (2002)*.
+    Convert from *CIE L\\*a\\*b\\** colourspace to *DIN99* colourspace or one
+    of the *DIN99b*, *DIN99c*, *DIN99d* refined formulas according to
+    *Cui et al. (2002)*.
 
     Parameters
     ----------
     Lab
         *CIE L\\*a\\*b\\** colourspace array.
     k_E
-        Parametric factor :math:`K_E` used to compensate for texture and other
-        specimen presentation effects.
-    k_CH
-        Parametric factor :math:`K_{CH}` used to compensate for texture and
+        Parametric factor :math:`K_E` used to compensate for texture and
         other specimen presentation effects.
+    k_CH
+        Parametric factor :math:`K_{CH}` used to compensate for texture
+        and other specimen presentation effects.
     method
-        Computation method to choose between the :cite:`ASTMInternational2007`
-        formula and the refined formulas according to *Cui et al. (2002)*.
+        Computation method.
 
     Returns
     -------
@@ -180,23 +179,22 @@ def DIN99_to_Lab(
     ) = "DIN99",
 ) -> NDArrayFloat:
     """
-    Convert from *DIN99* colourspace or one of the *DIN99b*, *DIN99c*,
-    *DIN99d* refined formulas according to *Cui et al. (2002)* to
-    *CIE L\\*a\\*b\\** colourspace.
+    Convert from *DIN99* colourspace or one of the *DIN99b*, *DIN99c*, *DIN99d*
+    refined formulas according to *Cui et al. (2002)* to *CIE L\\*a\\*b\\**
+    colourspace.
 
     Parameters
     ----------
     Lab_99
         *DIN99* colourspace array.
     k_E
-        Parametric factor :math:`K_E` used to compensate for texture and other
-        specimen presentation effects.
+        Parametric factor :math:`K_E` used to compensate for texture
+        and other specimen presentation effects.
     k_CH
-        Parametric factor :math:`K_{CH}` used to compensate for texture and
-        other specimen presentation effects.
+        Parametric factor :math:`K_{CH}` used to compensate for texture
+        and other specimen presentation effects.
     method
-        Computation method to choose between the :cite:`ASTMInternational2007`
-        formula and the refined formulas according to *Cui et al. (2002)*.
+        Computation method.
 
     Returns
     -------
@@ -275,9 +273,9 @@ def XYZ_to_DIN99(
     ) = "DIN99",
 ) -> NDArrayFloat:
     """
-    Convert from *CIE XYZ* tristimulus values to *DIN99* colourspace or
-    one of the *DIN99b*, *DIN99c*, *DIN99d* refined formulas according
-    to *Cui et al. (2002)*.
+    Convert from *CIE XYZ* tristimulus values to *DIN99* colourspace or one
+    of the *DIN99b*, *DIN99c*, *DIN99d* refined formulas according to
+    *Cui et al. (2002)*.
 
     Parameters
     ----------
@@ -287,14 +285,13 @@ def XYZ_to_DIN99(
         Reference *illuminant* *CIE xy* chromaticity coordinates or *CIE xyY*
         colourspace array.
     k_E
-        Parametric factor :math:`K_E` used to compensate for texture and other
-        specimen presentation effects.
+        Parametric factor :math:`K_E` used to compensate for texture and
+        other specimen presentation effects.
     k_CH
         Parametric factor :math:`K_{CH}` used to compensate for texture and
         other specimen presentation effects.
     method
-        Computation method to choose between the :cite:`ASTMInternational2007`
-        formula and the refined formulas according to *Cui et al. (2002)*.
+        Computation method.
 
     Returns
     -------
@@ -351,8 +348,8 @@ def DIN99_to_XYZ(
 ) -> NDArrayFloat:
     """
     Convert from *DIN99* colourspace or one of the *DIN99b*, *DIN99c*,
-    *DIN99d* refined formulas according to *Cui et al. (2002)* to *CIE XYZ*
-    tristimulus values.
+    *DIN99d* refined formulas according to *Cui et al. (2002)* to
+    *CIE XYZ* tristimulus values.
 
     Parameters
     ----------
@@ -362,14 +359,13 @@ def DIN99_to_XYZ(
         Reference *illuminant* *CIE xy* chromaticity coordinates or *CIE xyY*
         colourspace array.
     k_E
-        Parametric factor :math:`K_E` used to compensate for texture and other
-        specimen presentation effects.
+        Parametric factor :math:`K_E` used to compensate for texture
+        and other specimen presentation effects.
     k_CH
-        Parametric factor :math:`K_{CH}` used to compensate for texture and
-        other specimen presentation effects.
+        Parametric factor :math:`K_{CH}` used to compensate for texture
+        and other specimen presentation effects.
     method
-        Computation method to choose between the :cite:`ASTMInternational2007`
-        formula and the refined formulas according to *Cui et al. (2002)*.
+        Computation method.
 
     Returns
     -------

--- a/colour/models/hdr_cie_lab.py
+++ b/colour/models/hdr_cie_lab.py
@@ -1,24 +1,23 @@
 """
-Hdr-CIELAB Colourspace
+hdr-CIELAB Colourspace
 ======================
 
-Define the *hdr-CIELAB* colourspace transformations:
+Define the *hdr-CIELAB* colourspace transformations.
 
--   :attr:`colour.HDR_CIELAB_METHODS`: Supported *hdr-CIELAB* colourspace
-    computation methods.
+-   :attr:`colour.HDR_CIELAB_METHODS`
 -   :func:`colour.XYZ_to_hdr_CIELab`
 -   :func:`colour.hdr_CIELab_to_XYZ`
 
 References
 ----------
--   :cite:`Fairchild2010` : Fairchild, M. D., & Wyble, D. R. (2010). hdr-CIELAB
-    and hdr-IPT: Simple Models for Describing the Color of High-Dynamic-Range
-    and Wide-Color-Gamut Images. Proc. of Color and Imaging Conference,
-    322-326. ISBN:978-1-62993-215-6
--   :cite:`Fairchild2011` : Fairchild, M. D., & Chen, P. (2011). Brightness,
-    lightness, and specifying color in high-dynamic-range scenes and images. In
-    S. P. Farnand & F. Gaykema (Eds.), Proc. SPIE 7867, Image Quality and
-    System Performance VIII (p. 78670O). doi:10.1117/12.872075
+-   :cite:`Fairchild2010` : Fairchild, M. D., & Wyble, D. R. (2010).
+    hdr-CIELAB and hdr-IPT: Simple Models for Describing the Color of
+    High-Dynamic-Range and Wide-Color-Gamut Images. Proc. of Color and
+    Imaging Conference, 322-326. ISBN:978-1-62993-215-6
+-   :cite:`Fairchild2011` : Fairchild, M. D., & Chen, P. (2011).
+    Brightness, lightness, and specifying color in high-dynamic-range scenes
+    and images. In S. P. Farnand & F. Gaykema (Eds.), Proc. SPIE 7867, Image
+    Quality and System Performance VIII (p. 78670O). doi:10.1117/12.872075
 """
 
 from __future__ import annotations
@@ -84,8 +83,9 @@ def exponent_hdr_CIELab(
     method: (Literal["Fairchild 2011", "Fairchild 2010"] | str) = "Fairchild 2011",
 ) -> NDArrayFloat:
     """
-    Compute *hdr-CIELAB* colourspace *Lightness* :math:`\\epsilon` exponent
-    using *Fairchild and Wyble (2010)* or *Fairchild and Chen (2011)* method.
+    Compute the *hdr-CIELAB* colourspace *Lightness* :math:`\\epsilon`
+    exponent using the *Fairchild and Wyble (2010)* or *Fairchild and Chen
+    (2011)* methods.
 
     Parameters
     ----------
@@ -189,13 +189,13 @@ def XYZ_to_hdr_CIELab(
     |                | ``b_hdr`` : [-100, 100] | ``b_hdr`` : [-1, 1] |
     +----------------+-------------------------+---------------------+
 
-    -   Conversion to polar coordinates to compute the *chroma* :math:`C_{hdr}`
-        and *hue* :math:`h_{hdr}` correlates can be safely performed with
-        :func:`colour.Lab_to_LCHab` definition.
+    -   Conversion to polar coordinates to compute the *chroma*
+        :math:`C_{hdr}` and *hue* :math:`h_{hdr}` correlates can be
+        safely performed with :func:`colour.Lab_to_LCHab` definition.
     -   Conversion to cartesian coordinates from the *Lightness*
-        :math:`L_{hdr}`, *chroma* :math:`C_{hdr}` and *hue* :math:`h_{hdr}`
-        correlates can be safely performed with :func:`colour.LCHab_to_Lab`
-        definition.
+        :math:`L_{hdr}`, *chroma* :math:`C_{hdr}` and *hue*
+        :math:`h_{hdr}` correlates can be safely performed with
+        :func:`colour.LCHab_to_Lab` definition.
 
     References
     ----------

--- a/colour/models/hdr_ipt.py
+++ b/colour/models/hdr_ipt.py
@@ -1,11 +1,10 @@
 """
-Hdr-IPT Colourspace
+hdr-IPT Colourspace
 ===================
 
-Define the *hdr-IPT* colourspace transformations:
+Define the *hdr-IPT* colourspace transformations.
 
--   :attr:`colour.HDR_IPT_METHODS`: Supported *hdr-IPT* colourspace computation
-    methods.
+-   :attr:`colour.HDR_IPT_METHODS`
 -   :func:`colour.XYZ_to_hdr_IPT`
 -   :func:`colour.hdr_IPT_to_XYZ`
 
@@ -87,8 +86,9 @@ def exponent_hdr_IPT(
     method: (Literal["Fairchild 2011", "Fairchild 2010"] | str) = "Fairchild 2011",
 ) -> NDArrayFloat:
     """
-    Compute *hdr-IPT* colourspace *Lightness* :math:`\\epsilon` exponent using
-    *Fairchild and Wyble (2010)* or *Fairchild and Chen (2011)* method.
+    Compute the *hdr-IPT* colourspace *Lightness* :math:`\\epsilon` exponent
+    using the *Fairchild and Wyble (2010)* or *Fairchild and Chen (2011)*
+    methods.
 
     Parameters
     ----------

--- a/colour/models/hunter_lab.py
+++ b/colour/models/hunter_lab.py
@@ -2,7 +2,7 @@
 Hunter L,a,b Colour Scale
 =========================
 
-Define the *Hunter L,a,b* colour scale transformations:
+Define the *Hunter L,a,b* colour scale transformations.
 
 -   :func:`colour.XYZ_to_K_ab_HunterLab1966`
 -   :func:`colour.XYZ_to_Hunter_Lab`
@@ -91,7 +91,8 @@ def XYZ_to_Hunter_Lab(
     ]["D65"].K_ab,
 ) -> NDArrayFloat:
     """
-    Convert from *CIE XYZ* tristimulus values to *Hunter L,a,b* colour scale.
+    Convert from *CIE XYZ* tristimulus values to *Hunter L,a,b* colour
+    scale.
 
     Parameters
     ----------
@@ -100,8 +101,8 @@ def XYZ_to_Hunter_Lab(
     XYZ_n
         Reference *illuminant* tristimulus values.
     K_ab
-        Reference *illuminant* chromaticity coefficients, if ``K_ab`` is set to
-        *None* it will be computed using
+        Reference *illuminant* chromaticity coefficients. If ``K_ab`` is
+        set to *None*, it will be computed using
         :func:`colour.XYZ_to_K_ab_HunterLab1966`.
 
     Returns
@@ -169,7 +170,8 @@ def Hunter_Lab_to_XYZ(
     ]["D65"].K_ab,
 ) -> NDArrayFloat:
     """
-    Convert from *Hunter L,a,b* colour scale to *CIE XYZ* tristimulus values.
+    Convert from *Hunter L,a,b* colour scale to *CIE XYZ* tristimulus
+    values.
 
     Parameters
     ----------
@@ -178,8 +180,8 @@ def Hunter_Lab_to_XYZ(
     XYZ_n
         Reference *illuminant* tristimulus values.
     K_ab
-        Reference *illuminant* chromaticity coefficients, if ``K_ab`` is set to
-        *None* it will be computed using
+        Reference *illuminant* chromaticity coefficients. If ``K_ab`` is
+        set to *None*, it will be computed using
         :func:`colour.XYZ_to_K_ab_HunterLab1966`.
 
     Returns

--- a/colour/models/hunter_rdab.py
+++ b/colour/models/hunter_rdab.py
@@ -2,7 +2,7 @@
 Hunter Rd,a,b Colour Scale
 ==========================
 
-Define the *Hunter Rd,a,b* colour scale transformations:
+Define the *Hunter Rd,a,b* colour scale transformations.
 
 -   :func:`colour.XYZ_to_Hunter_Rdab`
 -   :func:`colour.Hunter_Rdab_to_XYZ`
@@ -50,7 +50,8 @@ def XYZ_to_Hunter_Rdab(
     ]["D65"].K_ab,
 ) -> NDArrayFloat:
     """
-    Convert from *CIE XYZ* tristimulus values to *Hunter Rd,a,b* colour scale.
+    Convert from *CIE XYZ* tristimulus values to *Hunter Rd,a,b* colour
+    scale.
 
     Parameters
     ----------
@@ -59,8 +60,8 @@ def XYZ_to_Hunter_Rdab(
     XYZ_n
         Reference *illuminant* tristimulus values.
     K_ab
-        Reference *illuminant* chromaticity coefficients, if ``K_ab`` is set to
-        *None* it will be computed using
+        Reference *illuminant* chromaticity coefficients. If ``K_ab`` is
+        set to *None*, it will be computed using
         :func:`colour.XYZ_to_K_ab_HunterLab1966`.
 
     Returns
@@ -130,7 +131,8 @@ def Hunter_Rdab_to_XYZ(
     ]["D65"].K_ab,
 ) -> NDArrayFloat:
     """
-    Convert from *Hunter Rd,a,b* colour scale to *CIE XYZ* tristimulus values.
+    Convert from *Hunter Rd,a,b* colour scale to *CIE XYZ* tristimulus
+    values.
 
     Parameters
     ----------
@@ -139,8 +141,8 @@ def Hunter_Rdab_to_XYZ(
     XYZ_n
         Reference *illuminant* tristimulus values.
     K_ab
-        Reference *illuminant* chromaticity coefficients, if ``K_ab`` is set to
-        *None* it will be computed using
+        Reference *illuminant* chromaticity coefficients. If ``K_ab`` is
+        set to *None*, it will be computed using
         :func:`colour.XYZ_to_K_ab_HunterLab1966`.
 
     Returns

--- a/colour/models/icacb.py
+++ b/colour/models/icacb.py
@@ -2,7 +2,7 @@
 :math:`IC_AC_B` Colourspace
 ===========================
 
-Define the :math:`IC_AC_B` colourspace transformations:
+Define the :math:`IC_AC_B` colourspace transformations.
 
 -   :func:`colour.XYZ_to_ICaCb`
 -   :func:`colour.ICaCb_to_XYZ`
@@ -109,8 +109,8 @@ def XYZ_to_ICaCb(XYZ: ArrayLike) -> NDArrayFloat:
     Examples
     --------
     >>> XYZ = np.array([0.20654008, 0.12197225, 0.05136952])
-    >>> XYZ_to_ICaCb(XYZ)
-    array([ 0.06875297,  0.05753352,  0.02081548])
+    >>> XYZ_to_ICaCb(XYZ)  # doctest: +ELLIPSIS
+    array([ 0.0687529...,  0.0575335...,  0.0208154...])
     """
 
     def LMS_to_LMS_p_callable(LMS: ArrayLike) -> NDArrayFloat:
@@ -132,17 +132,17 @@ def XYZ_to_ICaCb(XYZ: ArrayLike) -> NDArrayFloat:
 
 def ICaCb_to_XYZ(ICaCb: ArrayLike) -> NDArrayFloat:
     """
-    Convert from :math:`IC_AC_B` tristimulus values to *CIE XYZ* colourspace.
+    Convert from :math:`IC_AC_B` colourspace to *CIE XYZ* tristimulus values.
 
     Parameters
     ----------
     ICaCb
-        :math:`IC_AC_B` tristimulus values.
+        :math:`IC_AC_B` colourspace array.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        *CIE XYZ* colourspace array.
+        *CIE XYZ* tristimulus values.
 
     Notes
     -----
@@ -162,15 +162,18 @@ def ICaCb_to_XYZ(ICaCb: ArrayLike) -> NDArrayFloat:
     | ``XYZ``    | [0, 1]                | [0, 1]          |
     +------------+-----------------------+-----------------+
 
+    -   Output *CIE XYZ* tristimulus values are adapted to
+        *CIE Standard Illuminant D Series* *D65*.
+
     References
     ----------
     :cite:`Frohlich2017`
 
     Examples
     --------
-    >>> XYZ = np.array([0.06875297, 0.05753352, 0.02081548])
-    >>> ICaCb_to_XYZ(XYZ)
-    array([ 0.20654008,  0.12197225,  0.05136951])
+    >>> ICaCb = np.array([0.06875297, 0.05753352, 0.02081548])
+    >>> ICaCb_to_XYZ(ICaCb)  # doctest: +ELLIPSIS
+    array([ 0.2065400...,  0.1219722...,  0.0513695...])
     """
 
     def LMS_p_to_LMS_callable(LMS_p: ArrayLike) -> NDArrayFloat:

--- a/colour/models/igpgtg.py
+++ b/colour/models/igpgtg.py
@@ -2,7 +2,7 @@
 :math:`I_GP_GT_G` Colourspace
 =============================
 
-Define the :math:`I_GP_GT_G` colourspace transformations:
+Define the :math:`I_GP_GT_G` colourspace transformations.
 
 -   :func:`colour.XYZ_to_IgPgTg`
 -   :func:`colour.IgPgTg_to_XYZ`
@@ -165,6 +165,9 @@ def IgPgTg_to_XYZ(IgPgTg: ArrayLike) -> NDArrayFloat:
     +============+=======================+=================+
     | ``XYZ``    | [0, 1]                | [0, 1]          |
     +------------+-----------------------+-----------------+
+
+    -   Output *CIE XYZ* tristimulus values are adapted to
+        *CIE Standard Illuminant D Series* *D65*.
 
     References
     ----------

--- a/colour/models/ipt.py
+++ b/colour/models/ipt.py
@@ -2,13 +2,10 @@
 IPT Colourspace
 ===============
 
-Define the *IPT* colourspace transformations:
+Define the *IPT* colourspace transformations and correlate computations.
 
 -   :func:`colour.XYZ_to_IPT`
 -   :func:`colour.IPT_to_XYZ`
-
-And computation of correlates:
-
 -   :func:`colour.IPT_hue_angle`
 
 References
@@ -160,6 +157,9 @@ def IPT_to_XYZ(IPT: ArrayLike) -> NDArrayFloat:
     | ``XYZ``    | [0, 1]                | [0, 1]          |
     +------------+-----------------------+-----------------+
 
+    -   Output *CIE XYZ* tristimulus values are adapted to
+        *CIE Standard Illuminant D Series* *D65*.
+
     References
     ----------
     :cite:`Fairchild2013y`
@@ -181,7 +181,7 @@ def IPT_to_XYZ(IPT: ArrayLike) -> NDArrayFloat:
 
 def IPT_hue_angle(IPT: ArrayLike) -> NDArrayFloat:
     """
-    Compute the hue angle in degrees from *IPT* colourspace.
+    Compute the hue angle in degrees from the *IPT* colourspace array.
 
     Parameters
     ----------

--- a/colour/models/jzazbz.py
+++ b/colour/models/jzazbz.py
@@ -2,7 +2,7 @@
 :math:`J_za_zb_z` Colourspace
 =============================
 
-Define the :math:`J_za_zb_z` colourspace:
+Define the :math:`J_za_zb_z` colourspace transformations.
 
 -   :func:`colour.models.IZAZBZ_METHODS`
 -   :func:`colour.models.XYZ_to_Izazbz`
@@ -187,9 +187,9 @@ def XYZ_to_Izazbz(
     Returns
     -------
     :class:`numpy.ndarray`
-        :math:`I_za_zb_z` colourspace array where :math:`I_z` is the achromatic
-        response, :math:`a_z` is redness-greenness and :math:`b_z` is
-        yellowness-blueness.
+        :math:`I_za_zb_z` colourspace array where :math:`I_z` is the
+        achromatic response, :math:`a_z` is redness-greenness and
+        :math:`b_z` is yellowness-blueness.
 
     Warnings
     --------
@@ -198,12 +198,12 @@ def XYZ_to_Izazbz(
 
     Notes
     -----
-    -   The underlying *SMPTE ST 2084:2014* transfer function is an absolute
-        transfer function, thus the domain and range values for the *Reference*
-        and *1* scales are only indicative that the data is not affected by
-        scale transformations. The effective domain of *SMPTE ST 2084:2014*
-        inverse electro-optical transfer function (EOTF) is
-        [0.0001, 10000].
+    -   The underlying *SMPTE ST 2084:2014* transfer function is an
+        absolute transfer function, thus the domain and range values for
+        the *Reference* and *1* scales are only indicative that the data
+        is not affected by scale transformations. The effective domain of
+        *SMPTE ST 2084:2014* inverse electro-optical transfer function
+        (EOTF) is [0.0001, 10000].
 
     +------------+-----------------------+------------------+
     | **Domain** | **Scale - Reference** | **Scale - 1**    |
@@ -297,10 +297,12 @@ def Izazbz_to_XYZ(
 
     Notes
     -----
-    -   The underlying *SMPTE ST 2084:2014* transfer function is an absolute
-        transfer function, thus the domain and range values for the *Reference*
-        and *1* scales are only indicative that the data is not affected by
-        scale transformations.
+    -   The underlying *SMPTE ST 2084:2014* transfer function is an
+        absolute transfer function, thus the domain and range values for
+        the *Reference* and *1* scales are only indicative that the data
+        is not affected by scale transformations. The effective domain of
+        *SMPTE ST 2084:2014* inverse electro-optical transfer function
+        (EOTF) is [0.0001, 10000].
 
     +------------+-----------------------+------------------+
     | **Domain** | **Scale - Reference** | **Scale - 1**    |
@@ -363,63 +365,65 @@ def XYZ_to_Jzazbz(
     XYZ_D65: ArrayLike, constants: Structure = CONSTANTS_JZAZBZ_SAFDAR2017
 ) -> NDArrayFloat:
     """
-    Convert from *CIE XYZ* tristimulus values to :math:`J_za_zb_z`
-    colourspace.
+        Convert from *CIE XYZ* tristimulus values to :math:`J_za_zb_z`
+        colourspace.
 
     Parameters
     ----------
-    XYZ_D65
-        *CIE XYZ* tristimulus values under
-        *CIE Standard Illuminant D Series D65*.
-    constants
-        :math:`J_za_zb_z` colourspace constants.
+        XYZ_D65
+            *CIE XYZ* tristimulus values under
+            *CIE Standard Illuminant D Series D65*.
+        constants
+            :math:`J_za_zb_z` colourspace constants.
 
     Returns
     -------
-    :class:`numpy.ndarray`
-        :math:`J_za_zb_z` colourspace array where :math:`J_z` is Lightness,
-        :math:`a_z` is redness-greenness and :math:`b_z` is
-        yellowness-blueness.
+        :class:`numpy.ndarray`
+            :math:`J_za_zb_z` colourspace array where :math:`J_z` is
+            Lightness, :math:`a_z` is redness-greenness and :math:`b_z` is
+            yellowness-blueness.
 
-    Warnings
-    --------
-    The underlying *SMPTE ST 2084:2014* transfer function is an absolute
-    transfer function.
+        Warnings
+        --------
+        The underlying *SMPTE ST 2084:2014* transfer function is an absolute
+        transfer function.
 
     Notes
     -----
-    -   The underlying *SMPTE ST 2084:2014* transfer function is an absolute
-        transfer function, thus the domain and range values for the *Reference*
-        and *1* scales are only indicative that the data is not affected by
-        scale transformations. The effective domain of *SMPTE ST 2084:2014*
-        inverse electro-optical transfer function (EOTF) is
-        [0.0001, 10000].
+        -   The underlying *SMPTE ST 2084:2014* transfer function is an
+            absolute transfer function, thus the domain and range values for
+            the *Reference* and *1* scales are only indicative that the data
+            is not affected by scale transformations. The effective domain of
+            *SMPTE ST 2084:2014* inverse electro-optical transfer function
+            (EOTF) is [0.0001, 10000].
+    domain of *SMPTE ST 2084:2014* inverse electro-optical transfer
+            function (EOTF) is [0.0001, 10000].
 
-    +------------+-----------------------+------------------+
-    | **Domain** | **Scale - Reference** | **Scale - 1**    |
-    +============+=======================+==================+
-    | ``XYZ``    | ``UN``                | ``UN``           |
-    +------------+-----------------------+------------------+
+        +------------+-----------------------+------------------+
+        | **Domain** | **Scale - Reference** | **Scale - 1**    |
+        +============+=======================+==================+
+        | ``XYZ``    | ``UN``                | ``UN``           |
+        +------------+-----------------------+------------------+
 
-    +------------+-----------------------+------------------+
-    | **Range**  | **Scale - Reference** | **Scale - 1**    |
-    +============+=======================+==================+
-    | ``Jzazbz`` | ``Jz`` : [0, 1]       | ``Jz`` : [0, 1]  |
-    |            |                       |                  |
-    |            | ``az`` : [-1, 1]      | ``az`` : [-1, 1] |
-    |            |                       |                  |
-    |            | ``bz`` : [-1, 1]      | ``bz`` : [-1, 1] |
-    +------------+-----------------------+------------------+
+        +------------+-----------------------+------------------+
+        | **Range**  | **Scale - Reference** | **Scale - 1**    |
+        +============+=======================+==================+
+        | ``Jzazbz`` | ``Jz`` : [0, 1]       | ``Jz`` : [0, 1]  |
+        |            |                       |                  |
+        |            | ``az`` : [-1, 1]      | ``az`` : [-1, 1] |
+        |            |                       |                  |
+        |            | ``bz`` : [-1, 1]      | ``bz`` : [-1, 1] |
+        +------------+-----------------------+------------------+
 
     References
     ----------
-    :cite:`Safdar2017`
+        :cite:`Safdar2017`
 
     Examples
     --------
-    >>> XYZ = np.array([0.20654008, 0.12197225, 0.05136952])
-    >>> XYZ_to_Jzazbz(XYZ)  # doctest: +ELLIPSIS
-    array([ 0.0053504...,  0.0092430...,  0.0052600...])
+        >>> XYZ = np.array([0.20654008, 0.12197225, 0.05136952])
+        >>> XYZ_to_Jzazbz(XYZ)  # doctest: +ELLIPSIS
+        array([ 0.0053504...,  0.0092430...,  0.0052600...])
     """
 
     XYZ_D65 = as_float_array(XYZ_D65)
@@ -444,7 +448,7 @@ def Jzazbz_to_XYZ(
     Parameters
     ----------
     Jzazbz
-        :math:`J_za_zb_z` colourspace array  where :math:`J_z` is Lightness,
+        :math:`J_za_zb_z` colourspace array where :math:`J_z` is Lightness,
         :math:`a_z` is redness-greenness and :math:`b_z` is
         yellowness-blueness.
     constants
@@ -463,10 +467,12 @@ def Jzazbz_to_XYZ(
 
     Notes
     -----
-    -   The underlying *SMPTE ST 2084:2014* transfer function is an absolute
-        transfer function, thus the domain and range values for the *Reference*
-        and *1* scales are only indicative that the data is not affected by
-        scale transformations.
+    -   The underlying *SMPTE ST 2084:2014* transfer function is an
+        absolute transfer function, thus the domain and range values for
+        the *Reference* and *1* scales are only indicative that the data
+        is not affected by scale transformations. The effective domain of
+        *SMPTE ST 2084:2014* inverse electro-optical transfer function
+        (EOTF) is [0.0001, 10000].
 
     +------------+-----------------------+------------------+
     | **Domain** | **Scale - Reference** | **Scale - 1**    |

--- a/colour/models/oklab.py
+++ b/colour/models/oklab.py
@@ -2,7 +2,7 @@
 Oklab Colourspace
 =================
 
-Define the *Oklab* colourspace transformations:
+Define the *Oklab* colourspace transformations.
 
 -   :func:`colour.XYZ_to_Oklab`
 -   :func:`colour.Oklab_to_XYZ`

--- a/colour/models/osa_ucs.py
+++ b/colour/models/osa_ucs.py
@@ -2,7 +2,7 @@
 Optical Society of America Uniform Colour Scales (OSA UCS)
 ==========================================================
 
-Define the *OSA UCS* colourspace:
+Define the *OSA UCS* colourspace transformations.
 
 -   :func:`colour.XYZ_to_OSA_UCS`
 -   :func:`colour.OSA_UCS_to_XYZ`
@@ -71,9 +71,10 @@ def XYZ_to_OSA_UCS(XYZ: ArrayLike) -> NDArrayFloat:
     Convert from *CIE XYZ* tristimulus values under the
     *CIE 1964 10 Degree Standard Observer* to *OSA UCS* colourspace.
 
-    The lightness axis, *L* is usually in range [-9, 5] and centered around
-    middle gray (Munsell N/6). The yellow-blue axis, *j* is usually in range
-    [-15, 15]. The red-green axis, *g* is usually in range [-20, 15].
+    The lightness axis, *L*, is typically in range [-9, 5] and centered
+    around middle gray (Munsell N/6). The yellow-blue axis, *j*, is
+    typically in range [-15, 15]. The red-green axis, *g*, is typically in
+    range [-20, 15].
 
     Parameters
     ----------
@@ -153,6 +154,11 @@ def OSA_UCS_to_XYZ(
     Convert from *OSA UCS* colourspace to *CIE XYZ* tristimulus values under
     the *CIE 1964 10 Degree Standard Observer*.
 
+    The lightness axis, *L*, is typically in range [-9, 5] and centered
+    around middle gray (Munsell N/6). The yellow-blue axis, *j*, is
+    typically in range [-15, 15]. The red-green axis, *g*, is typically in
+    range [-20, 15].
+
     Parameters
     ----------
     Ljg
@@ -168,11 +174,11 @@ def OSA_UCS_to_XYZ(
 
     Warnings
     --------
-    There is no analytical inverse transformation from *OSA UCS* to :math:`Ljg`
+    There is no analytical inverse transformation from *OSA UCS* :math:`Ljg`
     lightness, jaune (yellowness), and greenness to *CIE XYZ* tristimulus
-    values, the current implementation relies on optimisation using
-    :func:`scipy.optimize.fmin` definition and thus has reduced precision and
-    poor performance.
+    values. The current implementation relies on optimisation using
+    :func:`scipy.optimize.fmin` definition and thus exhibits reduced
+    precision and poor performance.
 
     Notes
     -----

--- a/colour/models/prolab.py
+++ b/colour/models/prolab.py
@@ -2,7 +2,7 @@
 ProLab Colourspace
 ==================
 
-Define the *ProLab* colourspace transformations:
+Define the *ProLab* colourspace transformations.
 
 -   :func:`colour.XYZ_to_ProLab`
 -   :func:`colour.ProLab_to_XYZ`
@@ -58,8 +58,8 @@ MATRIX_INVERSE_Q: NDArrayFloat = np.linalg.inv(MATRIX_Q)
 
 def projective_transformation(a: ArrayLike, Q: ArrayLike) -> NDArrayFloat:
     """
-    Transform specified array :math:`a` with the projective transformation matrix
-    :math:`Q`.
+    Apply the specified projective transformation matrix :math:`Q` to the
+    array :math:`a`.
 
     Parameters
     ----------

--- a/colour/models/ragoo2021.py
+++ b/colour/models/ragoo2021.py
@@ -3,7 +3,7 @@ Ragoo and Farup (2021) Optimised IPT Colourspace
 ================================================
 
 Define the *Ragoo and Farup (2021)* *Optimised IPT* colourspace
-transformations:
+transformations.
 
 -   :func:`colour.XYZ_to_IPT_Ragoo2021`
 -   :func:`colour.IPT_Ragoo2021_to_XYZ`
@@ -79,8 +79,8 @@ non-linear cone responses matrix.
 
 def XYZ_to_IPT_Ragoo2021(XYZ: ArrayLike) -> NDArrayFloat:
     """
-    Convert from *CIE XYZ* tristimulus values to
-    *Ragoo and Farup (2021)* *Optimised IPT* colourspace.
+    Convert from *CIE XYZ* tristimulus values to *Ragoo and Farup (2021)*
+    *Optimised IPT* colourspace.
 
     Parameters
     ----------

--- a/colour/models/rgb/cmyk.py
+++ b/colour/models/rgb/cmyk.py
@@ -93,7 +93,7 @@ def RGB_to_CMY(RGB: ArrayLike) -> NDArrayFloat:
 
 def CMY_to_RGB(CMY: ArrayLike) -> NDArrayFloat:
     """
-    Convert from *CMY* colourspace to *CMY* colourspace.
+    Convert from *CMY* colourspace to *RGB* colourspace.
 
     Parameters
     ----------

--- a/colour/models/rgb/common.py
+++ b/colour/models/rgb/common.py
@@ -2,7 +2,8 @@
 Common RGB Colour Models Utilities
 ==================================
 
-Define various RGB colour models common utilities.
+Define utilities for RGB colour models including transformations,
+chromaticity coordinates, and primaries matrices.
 """
 
 from __future__ import annotations
@@ -55,8 +56,8 @@ def XYZ_to_sRGB(
     chromatic_adaptation_transform
         *Chromatic adaptation* transform.
     apply_cctf_encoding
-        Whether to apply the *sRGB* encoding colour component transfer function
-        / inverse electro-optical transfer function.
+        Whether to apply the *sRGB* encoding colour component transfer
+        function / inverse electro-optical transfer function.
 
     Returns
     -------
@@ -116,8 +117,8 @@ def sRGB_to_XYZ(
     chromatic_adaptation_transform
         *Chromatic adaptation* transform.
     apply_cctf_decoding
-        Whether to apply the *sRGB* decoding colour component transfer function
-        / electro-optical transfer function.
+        Whether to apply the *sRGB* decoding colour component transfer
+        function / electro-optical transfer function.
 
     Returns
     -------

--- a/colour/models/rgb/cylindrical.py
+++ b/colour/models/rgb/cylindrical.py
@@ -11,11 +11,13 @@ Define various cylindrical and spherical colour models:
 -   :func:`colour.RGB_to_HCL`
 -   :func:`colour.HCL_to_RGB`
 
-These colour models trade off perceptual relevance for computation speed.
-They should not be used in the colour science domain, although they are useful
-for image analysis and provide end user software colour selection tools.
+These colour models prioritise computational efficiency over perceptual
+uniformity. While unsuitable for rigorous colour science applications, they
+serve effectively in image analysis workflows and provide intuitive colour
+selection interfaces for end-user applications.
 
-They are provided for convenience and completeness.
+These transformations are included for practical utility and comprehensive
+coverage of colour space conversions.
 
 References
 ----------
@@ -88,7 +90,7 @@ def RGB_to_HSV(RGB: ArrayLike) -> NDArrayFloat:
     Returns
     -------
     :class:`numpy.ndarray`
-        *HSV* array.
+        *HSV* colourspace array.
 
     Notes
     -----
@@ -393,8 +395,8 @@ def RGB_to_HCL(RGB: ArrayLike, gamma: float = 3, Y_0: float = 100) -> NDArrayFlo
     | ``HCL``    | [0, 1]                | [0, 1]        |
     +------------+-----------------------+---------------+
 
-    -   This implementation used the equations specified in
-        :cite:`Sarifuddin2005a` and the corrections from
+    -   This implementation uses the equations specified in
+        :cite:`Sarifuddin2005a` with the corrections from
         :cite:`Sarifuddin2021`.
 
     References
@@ -485,8 +487,8 @@ def HCL_to_RGB(HCL: ArrayLike, gamma: float = 3, Y_0: float = 100) -> NDArrayFlo
     | ``RGB``    | [0, 1]                | [0, 1]        |
     +------------+-----------------------+---------------+
 
-    -   This implementation used the equations specified in
-        :cite:`Sarifuddin2005a` and the corrections from
+    -   This implementation uses the equations specified in
+        :cite:`Sarifuddin2005a` with the corrections from
         :cite:`Sarifuddin2021`.
 
     References

--- a/colour/models/rgb/datasets/eci_rgb_v2.py
+++ b/colour/models/rgb/datasets/eci_rgb_v2.py
@@ -76,7 +76,7 @@ MATRIX_XYZ_TO_ECI_RGB_V2: NDArrayFloat = np.linalg.inv(MATRIX_ECI_RGB_V2_TO_XYZ)
 
 def _scale_domain_0_100_range_0_1(a: ArrayLike, callable_: Callable) -> NDArrayFloat:
     """
-    Scale the input domain of specified *luminance* :math:`Y` or *Lightness*
+    Scale the input domain of the specified *luminance* :math:`Y` or *Lightness*
     :math:`L^*` array to [0, 100], call the specified callable, and
     scales the output range to [0, 1].
 

--- a/colour/models/rgb/derivation.py
+++ b/colour/models/rgb/derivation.py
@@ -2,9 +2,9 @@
 RGB Colourspace Derivation
 ==========================
 
-Define the objects related to *RGB* colourspace derivation, essentially
-calculating the normalised primary matrix for specified *RGB* colourspace primaries
-and whitepoint:
+Define objects for *RGB* colourspace derivation, primarily focused on
+calculating the normalised primary matrix from the specified *RGB* colourspace
+primaries and whitepoint.
 
 -   :func:`colour.normalised_primary_matrix`
 -   :func:`colour.chromatically_adapted_primaries`
@@ -61,7 +61,8 @@ __all__ = [
 
 def xy_to_z(xy: ArrayLike) -> float:
     """
-    Return the *z* coordinate using specified :math:`xy` chromaticity coordinates.
+    Return the *z* coordinate using the specified :math:`xy` chromaticity
+    coordinates.
 
     Parameters
     ----------
@@ -89,8 +90,8 @@ def normalised_primary_matrix(
 ) -> NDArrayFloat:
     """
     Compute the *Normalised Primary Matrix* (NPM) converting a *RGB*
-    colourspace array to *CIE XYZ* tristimulus values using specified *primaries*
-    and *whitepoint* :math:`xy` chromaticity coordinates.
+    colourspace array to *CIE XYZ* tristimulus values using the specified
+    *primaries* and *whitepoint* :math:`xy` chromaticity coordinates.
 
     Parameters
     ----------
@@ -140,8 +141,8 @@ def chromatically_adapted_primaries(
     ) = "CAT02",
 ) -> NDArrayFloat:
     """
-    Chromatically adapt specified *primaries* :math:`xy` chromaticity coordinates
-    from test ``whitepoint_t`` to reference ``whitepoint_r``.
+    Chromatically adapt specified *primaries* :math:`xy` chromaticity
+    coordinates from test ``whitepoint_t`` to reference ``whitepoint_r``.
 
     Parameters
     ----------
@@ -150,14 +151,16 @@ def chromatically_adapted_primaries(
     whitepoint_t
         Test illuminant / whitepoint :math:`xy` chromaticity coordinates.
     whitepoint_r
-        Reference illuminant / whitepoint :math:`xy` chromaticity coordinates.
+        Reference illuminant / whitepoint :math:`xy` chromaticity
+        coordinates.
     chromatic_adaptation_transform
         *Chromatic adaptation* transform.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Chromatically adapted primaries :math:`xy` chromaticity coordinates.
+        Chromatically adapted primaries :math:`xy` chromaticity
+        coordinates.
 
     Examples
     --------
@@ -187,7 +190,7 @@ def chromatically_adapted_primaries(
 def primaries_whitepoint(npm: ArrayLike) -> Tuple[NDArrayFloat, NDArrayFloat]:
     """
     Compute the *primaries* and *whitepoint* :math:`xy` chromaticity
-    coordinates using specified *Normalised Primary Matrix* (NPM).
+    coordinates using the specified *Normalised Primary Matrix* (NPM).
 
     Parameters
     ----------
@@ -233,7 +236,8 @@ def primaries_whitepoint(npm: ArrayLike) -> Tuple[NDArrayFloat, NDArrayFloat]:
 
 def RGB_luminance_equation(primaries: ArrayLike, whitepoint: ArrayLike) -> str:
     """
-    Return the *luminance equation* from specified *primaries* and *whitepoint*.
+    Return the *luminance equation* from the specified *primaries* and
+    *whitepoint*.
 
     Parameters
     ----------
@@ -264,17 +268,17 @@ def RGB_luminance(
     RGB: ArrayLike, primaries: ArrayLike, whitepoint: ArrayLike
 ) -> NDArrayFloat:
     """
-    Return the *luminance* :math:`Y` of specified *RGB* components from specified
-    *primaries* and *whitepoint*.
+    Calculate the *luminance* :math:`Y` of the specified *RGB* components using
+    the specified *primaries* and *whitepoint* chromaticity coordinates.
 
     Parameters
     ----------
     RGB
-        *RGB* chromaticity coordinate matrix.
+        *RGB* colour components array.
     primaries
-        Primaries chromaticity coordinate matrix.
+        Primaries :math:`xy` chromaticity coordinates array.
     whitepoint
-        Illuminant / whitepoint chromaticity coordinates.
+        Illuminant / whitepoint :math:`xy` chromaticity coordinates.
 
     Returns
     -------

--- a/colour/models/rgb/hanbury2003.py
+++ b/colour/models/rgb/hanbury2003.py
@@ -2,7 +2,10 @@
 IHLS Colour Encoding
 ====================
 
-Define the :math:`IHLS` (Improved HLS) colourspace related transformations:
+Define the :math:`IHLS` (Improved HLS) colourspace encoding and decoding
+transformations. The :math:`IHLS` colourspace provides a 3D-polar coordinate
+colour representation that improves upon the standard HLS model for image
+analysis applications.
 
 -   :func:`colour.RGB_to_IHLS`
 -   :func:`colour.IHLS_to_RGB`

--- a/colour/models/rgb/ictcp.py
+++ b/colour/models/rgb/ictcp.py
@@ -167,8 +167,8 @@ def RGB_to_ICtCp(
                 :cite:`Dolby2016a`: *Dolby 2016*, *ITU-R BT.2100-1 PQ*,
                 *ITU-R BT.2100-2 PQ* methods.
             -   *Recommendation ITU-R BT.2100* *Reference HLG* opto-electrical
-                transfer function (OETF) and the :math:`IC_TC_P` matrix
-                from :cite:`Dolby2016a`: *ITU-R BT.2100-1 HLG* method.
+                transfer function (OETF) and the :math:`IC_TC_P` matrix from
+                :cite:`Dolby2016a`: *ITU-R BT.2100-1 HLG* method.
 
         -   *ITU-R BT.2100-2*
 
@@ -177,15 +177,15 @@ def RGB_to_ICtCp(
                 :cite:`Dolby2016a`: *Dolby 2016*, *ITU-R BT.2100-1 PQ*,
                 *ITU-R BT.2100-2 PQ* methods.
             -   *Recommendation ITU-R BT.2100* *Reference HLG* opto-electrical
-                transfer function (OETF) and a custom :math:`IC_TC_P`
-                matrix from :cite:`InternationalTelecommunicationUnion2018`:
+                transfer function (OETF) and a custom :math:`IC_TC_P` matrix
+                from :cite:`InternationalTelecommunicationUnion2018`:
                 *ITU-R BT.2100-2 HLG* method.
 
     L_p
         Display peak luminance :math:`cd/m^2` for *SMPTE ST 2084:2014*
-        non-linear encoding. This parameter should stay at its default
-        :math:`10000 cd/m^2` value for practical applications. It is exposed so
-        that the definition can be used as a fitting function.
+        non-linear encoding. This parameter should remain at its default
+        :math:`10000 cd/m^2` value for practical applications. It is exposed
+        to enable the definition to be used as a fitting function.
 
     Returns
     -------
@@ -199,14 +199,14 @@ def RGB_to_ICtCp(
 
     Notes
     -----
-    -   The *ITU-R BT.2100-1 PQ* and *ITU-R BT.2100-2 PQ* methods are aliases
-        for the *Dolby 2016* method.
+    -   The *ITU-R BT.2100-1 PQ* and *ITU-R BT.2100-2 PQ* methods are
+        aliases for the *Dolby 2016* method.
     -   The underlying *SMPTE ST 2084:2014* transfer function is an absolute
-        transfer function, thus the domain and range values for the *Reference*
-        and *1* scales are only indicative that the data is not affected by
-        scale transformations. The effective domain of *SMPTE ST 2084:2014*
-        inverse electro-optical transfer function (EOTF) is
-        [0.0001, 10000].
+        transfer function, thus the domain and range values for the
+        *Reference* and *1* scales are only indicative that the data is not
+        affected by scale transformations. The effective domain of
+        *SMPTE ST 2084:2014* inverse electro-optical transfer function (EOTF)
+        is [0.0001, 10000].
 
     +------------+-----------------------+------------------+
     | **Domain** | **Scale - Reference** | **Scale - 1**    |
@@ -296,9 +296,10 @@ def ICtCp_to_RGB(
                 function (EOTF) and the :math:`IC_TC_P` matrix from
                 :cite:`Dolby2016a`: *Dolby 2016*, *ITU-R BT.2100-1 PQ*,
                 *ITU-R BT.2100-2 PQ* methods.
-            -   *Recommendation ITU-R BT.2100* *Reference HLG* opto-electrical
-                transfer function (OETF) and the :math:`IC_TC_P` matrix
-                from :cite:`Dolby2016a`: *ITU-R BT.2100-1 HLG* method.
+            -   *Recommendation ITU-R BT.2100* *Reference HLG*
+                opto-electrical transfer function (OETF) and the
+                :math:`IC_TC_P` matrix from :cite:`Dolby2016a`:
+                *ITU-R BT.2100-1 HLG* method.
 
         -   *ITU-R BT.2100-2*
 
@@ -306,16 +307,17 @@ def ICtCp_to_RGB(
                 function (EOTF) and the :math:`IC_TC_P` matrix from
                 :cite:`Dolby2016a`: *Dolby 2016*, *ITU-R BT.2100-1 PQ*,
                 *ITU-R BT.2100-2 PQ* methods.
-            -   *Recommendation ITU-R BT.2100* *Reference HLG* opto-electrical
-                transfer function (OETF) and a custom :math:`IC_TC_P`
-                matrix from :cite:`InternationalTelecommunicationUnion2018`:
+            -   *Recommendation ITU-R BT.2100* *Reference HLG*
+                opto-electrical transfer function (OETF) and a custom
+                :math:`IC_TC_P` matrix from
+                :cite:`InternationalTelecommunicationUnion2018`:
                 *ITU-R BT.2100-2 HLG* method.
 
     L_p
         Display peak luminance :math:`cd/m^2` for *SMPTE ST 2084:2014*
-        non-linear encoding. This parameter should stay at its default
-        :math:`10000 cd/m^2` value for practical applications. It is exposed so
-        that the definition can be used as a fitting function.
+        non-linear encoding. This parameter should remain at its default
+        :math:`10000 cd/m^2` value for practical applications. It is exposed
+        to enable the definition to be used as a fitting function.
 
     Returns
     -------
@@ -329,12 +331,12 @@ def ICtCp_to_RGB(
 
     Notes
     -----
-    -   The *ITU-R BT.2100-1 PQ* and *ITU-R BT.2100-2 PQ* methods are aliases
-        for the *Dolby 2016* method.
-    -   The underlying *SMPTE ST 2084:2014* transfer function is an absolute
-        transfer function, thus the domain and range values for the *Reference*
-        and *1* scales are only indicative that the data is not affected by
-        scale transformations.
+    -   The *ITU-R BT.2100-1 PQ* and *ITU-R BT.2100-2 PQ* methods are
+        aliases for the *Dolby 2016* method.
+    -   The underlying *SMPTE ST 2084:2014* transfer function is an
+        absolute transfer function, thus the domain and range values for
+        the *Reference* and *1* scales are only indicative that the data is
+        not affected by scale transformations.
 
     +------------+-----------------------+------------------+
     | **Domain** | **Scale - Reference** | **Scale - 1**    |
@@ -437,9 +439,10 @@ def XYZ_to_ICtCp(
                 function (EOTF) and the :math:`IC_TC_P` matrix from
                 :cite:`Dolby2016a`: *Dolby 2016*, *ITU-R BT.2100-1 PQ*,
                 *ITU-R BT.2100-2 PQ* methods.
-            -   *Recommendation ITU-R BT.2100* *Reference HLG* opto-electrical
-                transfer function (OETF) and the :math:`IC_TC_P` matrix
-                from :cite:`Dolby2016a`: *ITU-R BT.2100-1 HLG* method.
+            -   *Recommendation ITU-R BT.2100* *Reference HLG*
+                opto-electrical transfer function (OETF) and the
+                :math:`IC_TC_P` matrix from :cite:`Dolby2016a`:
+                *ITU-R BT.2100-1 HLG* method.
 
         -   *ITU-R BT.2100-2*
 
@@ -447,16 +450,17 @@ def XYZ_to_ICtCp(
                 function (EOTF) and the :math:`IC_TC_P` matrix from
                 :cite:`Dolby2016a`: *Dolby 2016*, *ITU-R BT.2100-1 PQ*,
                 *ITU-R BT.2100-2 PQ* methods.
-            -   *Recommendation ITU-R BT.2100* *Reference HLG* opto-electrical
-                transfer function (OETF) and a custom :math:`IC_TC_P`
-                matrix from :cite:`InternationalTelecommunicationUnion2018`:
+            -   *Recommendation ITU-R BT.2100* *Reference HLG*
+                opto-electrical transfer function (OETF) and a custom
+                :math:`IC_TC_P` matrix from
+                :cite:`InternationalTelecommunicationUnion2018`:
                 *ITU-R BT.2100-2 HLG* method.
 
     L_p
         Display peak luminance :math:`cd/m^2` for *SMPTE ST 2084:2014*
-        non-linear encoding. This parameter should stay at its default
-        :math:`10000 cd/m^2` value for practical applications. It is exposed so
-        that the definition can be used as a fitting function.
+        non-linear encoding. This parameter should remain at its default
+        :math:`10000 cd/m^2` value for practical applications. It is exposed
+        to enable the definition to be used as a fitting function.
 
     Returns
     -------
@@ -470,14 +474,14 @@ def XYZ_to_ICtCp(
 
     Notes
     -----
-    -   The underlying *SMPTE ST 2084:2014* transfer function is an absolute
-        transfer function, thus the domain and range values for the *Reference*
-    -   The *ITU-R BT.2100-1 PQ* and *ITU-R BT.2100-2 PQ* methods are aliases
-        for the *Dolby 2016* method.
-        and *1* scales are only indicative that the data is not affected by
-        scale transformations. The effective domain of *SMPTE ST 2084:2014*
-        inverse electro-optical transfer function (EOTF) is
-        [0.0001, 10000].
+    -   The *ITU-R BT.2100-1 PQ* and *ITU-R BT.2100-2 PQ* methods are
+        aliases for the *Dolby 2016* method.
+    -   The underlying *SMPTE ST 2084:2014* transfer function is an
+        absolute transfer function, thus the domain and range values for
+        the *Reference* and *1* scales are only indicative that the data
+        is not affected by scale transformations. The effective domain of
+        *SMPTE ST 2084:2014* inverse electro-optical transfer function
+        (EOTF) is [0.0001, 10000].
 
     +------------+-----------------------+------------------+
     | **Domain** | **Scale - Reference** | **Scale - 1**    |
@@ -560,9 +564,10 @@ def ICtCp_to_XYZ(
                 function (EOTF) and the :math:`IC_TC_P` matrix from
                 :cite:`Dolby2016a`: *Dolby 2016*, *ITU-R BT.2100-1 PQ*,
                 *ITU-R BT.2100-2 PQ* methods.
-            -   *Recommendation ITU-R BT.2100* *Reference HLG* opto-electrical
-                transfer function (OETF) and the :math:`IC_TC_P` matrix
-                from :cite:`Dolby2016a`: *ITU-R BT.2100-1 HLG* method.
+            -   *Recommendation ITU-R BT.2100* *Reference HLG*
+                opto-electrical transfer function (OETF) and the
+                :math:`IC_TC_P` matrix from :cite:`Dolby2016a`:
+                *ITU-R BT.2100-1 HLG* method.
 
         -   *ITU-R BT.2100-2*
 
@@ -570,16 +575,17 @@ def ICtCp_to_XYZ(
                 function (EOTF) and the :math:`IC_TC_P` matrix from
                 :cite:`Dolby2016a`: *Dolby 2016*, *ITU-R BT.2100-1 PQ*,
                 *ITU-R BT.2100-2 PQ* methods.
-            -   *Recommendation ITU-R BT.2100* *Reference HLG* opto-electrical
-                transfer function (OETF) and a custom :math:`IC_TC_P`
-                matrix from :cite:`InternationalTelecommunicationUnion2018`:
+            -   *Recommendation ITU-R BT.2100* *Reference HLG*
+                opto-electrical transfer function (OETF) and a custom
+                :math:`IC_TC_P` matrix from
+                :cite:`InternationalTelecommunicationUnion2018`:
                 *ITU-R BT.2100-2 HLG* method.
 
     L_p
         Display peak luminance :math:`cd/m^2` for *SMPTE ST 2084:2014*
-        non-linear encoding. This parameter should stay at its default
-        :math:`10000 cd/m^2` value for practical applications. It is exposed so
-        that the definition can be used as a fitting function.
+        non-linear encoding. This parameter should remain at its default
+        :math:`10000 cd/m^2` value for practical applications. It is exposed
+        to enable the definition to be used as a fitting function.
 
     Returns
     -------
@@ -593,12 +599,12 @@ def ICtCp_to_XYZ(
 
     Notes
     -----
-    -   The *ITU-R BT.2100-1 PQ* and *ITU-R BT.2100-2 PQ* methods are aliases
-        for the *Dolby 2016* method.
+    -   The *ITU-R BT.2100-1 PQ* and *ITU-R BT.2100-2 PQ* methods are
+        aliases for the *Dolby 2016* method.
     -   The underlying *SMPTE ST 2084:2014* transfer function is an absolute
-        transfer function, thus the domain and range values for the *Reference*
-        and *1* scales are only indicative that the data is not affected by
-        scale transformations.
+        transfer function, thus the domain and range values for the
+        *Reference* and *1* scales are only indicative that the data is not
+        affected by scale transformations.
 
     +------------+-----------------------+------------------+
     | **Domain** | **Scale - Reference** | **Scale - 1**    |

--- a/colour/models/rgb/itut_h_273.py
+++ b/colour/models/rgb/itut_h_273.py
@@ -2,9 +2,9 @@
 Recommendation ITU-T H.273 Code points for Video Signal Type Identification
 ===========================================================================
 
-Define a set of standard video signal colour primaries, transfer functions and
-matrix coefficients used in deriving luma and chroma signals along with
-related definitions:
+Define standard video signal colour primaries, transfer functions, and matrix
+coefficients used in deriving luma and chroma signals along with related
+definitions:
 
 -   :attr:`colour.COLOUR_PRIMARIES_ITUTH273`
 -   :attr:`colour.TRANSFER_CHARACTERISTICS_ITUTH273`
@@ -14,11 +14,11 @@ related definitions:
 -   :attr:`colour.models.describe_video_signal_matrix_coefficients`
 
 These values were historically defined in
-:cite:`InternationalOrganizationforStandardization2013` then
-superseded and duplicated by other standards such as
+:cite:`InternationalOrganizationforStandardization2013` then superseded and
+duplicated by other standards such as
 :cite:`InternationalOrganizationforStandardization2020`,
 :cite:`InternationalOrganizationforStandardization2021` and
-:cite:`InternationalTelecommunicationUnion2021`. They are widely in use to
+:cite:`InternationalTelecommunicationUnion2021`. They are widely used to
 define colour-related properties in video encoding and decoding software
 libraries, including *FFmpeg*.
 
@@ -192,8 +192,8 @@ def _clipped_domain_function(
     function: Callable, domain: list | tuple = (0, 1)
 ) -> Callable:
     """
-    Wrap specified function and produce a new callable clipping the input value to
-    specified domain.
+    Wrap specified function and produce a new callable clipping the input value
+    to the specified domain.
 
     Parameters
     ----------
@@ -220,7 +220,7 @@ def _clipped_domain_function(
 
 def _reserved(*args: Any) -> NoReturn:  # noqa: ARG001
     """
-    Define a reserved function.
+    Indicate a reserved function by raising a runtime error.
 
     Examples
     --------
@@ -237,7 +237,12 @@ def _reserved(*args: Any) -> NoReturn:  # noqa: ARG001
 
 def _unspecified(*args: Any) -> NoReturn:  # noqa: ARG001
     """
-    Define an unspecified function.
+    Indicate unspecified video signal characteristics by raising a runtime
+    error.
+
+    Raise a runtime error when called to signal that image characteristics
+    are unknown or determined by the application, as defined in ITU-T H.273
+    and related video signal type identification standards.
 
     Examples
     --------
@@ -339,18 +344,20 @@ References
 
 class FFmpegConstantsColourPrimaries_ITUTH273(IntEnum):
     """
-    Define the constant names used by *FFmpeg* in the `AVColorPrimaries` enum.
+    Define the constant names used by *FFmpeg* in the `AVColorPrimaries`
+    enum.
 
     Notes
     -----
     -   *AVCOL_PRI_JEDEC_P22* is equal to `AVCOL_PRI_EBU3213` in *FFmpeg*
-        but neither *Recommendation ITU-T H.273* (2021) nor *ISO/IEC 23091-2*
-        (2021) define the same primaries as *EBU Tech 3213*, nor do they refer
-        to it. *ColourPrimaries 22* in both standards specifies the
-        informative remark *No corresponding industry specification identified*.
-        However, *ISO/IEC 23001-8* (2013) and *ISO/IEC 14497-10* (2020)
-        specify the *JEDEC P22 phosphors* and *EBU Tech. 3213-E (1975)*
-        informative remarks respectively while defining the same primaries and
+        but neither *Recommendation ITU-T H.273* (2021) nor
+        *ISO/IEC 23091-2* (2021) define the same primaries as
+        *EBU Tech 3213*, nor do they refer to it. *ColourPrimaries 22* in
+        both standards specifies the informative remark *No corresponding
+        industry specification identified*. However, *ISO/IEC 23001-8*
+        (2013) and *ISO/IEC 14497-10* (2020) specify the
+        *JEDEC P22 phosphors* and *EBU Tech. 3213-E (1975)* informative
+        remarks respectively while defining the same primaries and
         whitepoint as the 2021 standards. This is likely an error in the
         earlier standards that was discovered and corrected.
 
@@ -513,7 +520,8 @@ References
 class FFmpegConstantsTransferCharacteristics_ITUTH273(IntEnum):
     """
     Define the constant names used by *FFmpeg* in the
-    `AVColorTransferCharacteristic` enum.
+    `AVColorTransferCharacteristic` enum for transfer characteristics as
+    specified in ITU-T H.273.
 
     References
     ----------
@@ -804,8 +812,8 @@ MATRICES_ITUTH273_RGB_TO_XYZ = {
     23: np.array("Reserved"),
 }
 if is_documentation_building():  # pragma: no cover
-    WHITEPOINT_NAMES_ITUTH273 = DocstringDict(WHITEPOINT_NAMES_ITUTH273)
-    WHITEPOINT_NAMES_ITUTH273.__doc__ = """
+    MATRICES_ITUTH273_RGB_TO_XYZ = DocstringDict(MATRICES_ITUTH273_RGB_TO_XYZ)
+    MATRICES_ITUTH273_RGB_TO_XYZ.__doc__ = """
 *RGB* to *CIE XYZ* tristimulus values matrices associated with the source
 colour primaries as specified in Table 3 of
 :cite:`InternationalOrganizationforStandardization2021` and
@@ -837,8 +845,8 @@ MATRICES_XYZ_TO_ITUTH273_RGB = {
     23: np.array("Reserved"),
 }
 if is_documentation_building():  # pragma: no cover
-    WHITEPOINT_NAMES_ITUTH273 = DocstringDict(WHITEPOINT_NAMES_ITUTH273)
-    WHITEPOINT_NAMES_ITUTH273.__doc__ = """
+    MATRICES_XYZ_TO_ITUTH273_RGB = DocstringDict(MATRICES_XYZ_TO_ITUTH273_RGB)
+    MATRICES_XYZ_TO_ITUTH273_RGB.__doc__ = """
 *CIE XYZ* tristimulus values to *RGB* matrices associated with the source
 colour primaries as specified in Table 3 of
 :cite:`InternationalOrganizationforStandardization2021` and
@@ -896,7 +904,7 @@ def describe_video_signal_colour_primaries(
     code_point: int, print_description: bool = True, **kwargs: Any
 ) -> str:
     """
-    Describe specified video signal colour primaries code point.
+    Describe the specified video signal colour primaries code point.
 
     Parameters
     ----------
@@ -1052,7 +1060,7 @@ def describe_video_signal_transfer_characteristics(
     code_point: int, print_description: bool = True, **kwargs: Any
 ) -> str:
     """
-    Describe specified video signal transfer characteristics code point.
+    Describe the specified video signal transfer characteristics code point.
 
     Parameters
     ----------
@@ -1077,7 +1085,7 @@ def describe_video_signal_transfer_characteristics(
     Returns
     -------
     str
-        Video signal colour primaries code point description.
+        Video signal transfer characteristics code point description.
 
     References
     ----------
@@ -1176,12 +1184,12 @@ def describe_video_signal_matrix_coefficients(
     code_point: int, print_description: bool = True, **kwargs: Any
 ) -> str:
     """
-    Describe specified video signal matrix coefficients code point.
+    Describe the specified video signal matrix coefficients code point.
 
     Parameters
     ----------
     code_point
-        Video signal matrix coefficients code point to describe from
+        Video signal matrix coefficients code point to describe from the
         :attr:`colour.MATRIX_COEFFICIENTS_ITUTH273` attribute.
     print_description
         Whether to print the description.
@@ -1201,7 +1209,7 @@ def describe_video_signal_matrix_coefficients(
     Returns
     -------
     str
-        Video signal colour primaries code point description.
+        Video signal matrix coefficients code point description.
 
     References
     ----------

--- a/colour/models/rgb/prismatic.py
+++ b/colour/models/rgb/prismatic.py
@@ -2,7 +2,8 @@
 Prismatic Colourspace
 =====================
 
-Define the *Prismatic* colourspace transformations:
+Define transformations for the *Prismatic* colourspace, a perceptually-based
+colour representation that separates lightness from chromaticity components.
 
 -   :func:`colour.RGB_to_Prismatic`
 -   :func:`colour.Prismatic_to_RGB`
@@ -78,7 +79,7 @@ def RGB_to_Prismatic(RGB: ArrayLike) -> NDArrayFloat:
     >>> RGB_to_Prismatic(RGB)  # doctest: +ELLIPSIS
     array([ 0.75...   ,  0.1666666...,  0.3333333...,  0.5...   ])
 
-    Adjusting saturation of specified *RGB* colourspace array:
+    Adjusting saturation of the specified *RGB* colourspace array:
     >>> saturation = 0.5
     >>> Lrgb = RGB_to_Prismatic(RGB)
     >>> Lrgb[..., 1:] = 1 / 3 + saturation * (Lrgb[..., 1:] - 1 / 3)

--- a/colour/models/rgb/rgb_colourspace.py
+++ b/colour/models/rgb/rgb_colourspace.py
@@ -78,53 +78,52 @@ __all__ = [
 
 class RGB_Colourspace:
     """
-    Implement support for the *RGB* colourspaces datasets from
-    :mod:`colour.models.datasets.aces_rgb`, etc....
+    Implement support for *RGB* colourspace datasets from modules including
+    :mod:`colour.models.datasets.aces_rgb`.
 
     Colour science literature related to *RGB* colourspaces and encodings
-    defines their dataset using different degree of precision or rounding.
-    While instances where a whitepoint is being defined with a value
-    different from its canonical agreed one are rare, it is however very
-    common to have normalised primary matrices rounded at different
-    decimals. This can yield large discrepancies in computations.
+    defines datasets using different degrees of precision or rounding. While
+    instances where a whitepoint differs from its canonical agreed value are
+    rare, normalised primary matrices are commonly rounded at different
+    decimal places. This can yield large discrepancies in computations.
 
-    Such an occurrence is the *V-Gamut* colourspace white paper, that defines
-    the *V-Gamut* to *ITU-R BT.709* conversion matrix as follows::
+    Such an occurrence is the *V-Gamut* colourspace white paper, which
+    defines the *V-Gamut* to *ITU-R BT.709* conversion matrix as follows::
 
         [[ 1.806576 -0.695697 -0.110879]
          [-0.170090  1.305955 -0.135865]
          [-0.025206 -0.154468  1.179674]]
 
-    Computing this matrix using *ITU-R BT.709* colourspace derived normalised
-    primary matrix yields::
+    Computing this matrix using *ITU-R BT.709* colourspace derived
+    normalised primary matrix yields::
 
         [[ 1.8065736 -0.6956981 -0.1108786]
          [-0.1700890  1.3059548 -0.1358648]
          [-0.0252057 -0.1544678  1.1796737]]
 
-    The latter matrix is almost equals with the former, however performing the
-    same computation using *IEC 61966-2-1:1999* *sRGB* colourspace normalised
-    primary matrix introduces severe disparities::
+    The latter matrix is almost equal to the former, however performing the
+    same computation using *IEC 61966-2-1:1999* *sRGB* colourspace
+    normalised primary matrix introduces severe disparities::
 
         [[ 1.8063853 -0.6956147 -0.1109453]
          [-0.1699311  1.3058387 -0.1358616]
          [-0.0251630 -0.1544899  1.1797117]]
 
-    In order to provide support for both literature defined dataset and
-    accurate computations enabling transformations without loss of precision,
-    the :class:`colour.RGB_Colourspace` class provides two sets of
-    transformation matrices:
+    To provide support for both literature-defined datasets and accurate
+    computations enabling transformations without loss of precision, the
+    :class:`colour.RGB_Colourspace` class provides two sets of transformation
+    matrices:
 
         -   Instantiation transformation matrices
         -   Derived transformation matrices
 
     Upon instantiation, the :class:`colour.RGB_Colourspace` class stores the
-    specified ``matrix_RGB_to_XYZ`` and ``matrix_XYZ_to_RGB`` arguments and also
-    computes their derived counterpart using the ``primaries`` and
+    specified ``matrix_RGB_to_XYZ`` and ``matrix_XYZ_to_RGB`` arguments and
+    also computes their derived counterparts using the ``primaries`` and
     ``whitepoint`` arguments.
 
-    Whether the initialisation or derived matrices are used in subsequent
-    computations is dependent on the
+    Whether instantiation or derived matrices are used in subsequent
+    computations depends on the
     :attr:`colour.RGB_Colourspace.use_derived_matrix_RGB_to_XYZ` and
     :attr:`colour.RGB_Colourspace.use_derived_matrix_XYZ_to_RGB` attribute
     values.
@@ -140,14 +139,16 @@ class RGB_Colourspace:
     whitepoint_name
         *RGB* colourspace whitepoint name.
     matrix_RGB_to_XYZ
-        Transformation matrix from colourspace to *CIE XYZ* tristimulus values.
+        Transformation matrix from colourspace to *CIE XYZ* tristimulus
+        values.
     matrix_XYZ_to_RGB
-        Transformation matrix from *CIE XYZ* tristimulus values to colourspace.
+        Transformation matrix from *CIE XYZ* tristimulus values to
+        colourspace.
     cctf_encoding
         Encoding colour component transfer function (Encoding CCTF) /
         opto-electronic transfer function (OETF) that maps estimated
-        tristimulus values in a scene to :math:`R'G'B'` video component signal
-        value.
+        tristimulus values in a scene to :math:`R'G'B'` video component
+        signal value.
     cctf_decoding
         Decoding colour component transfer function (Decoding CCTF) /
         electro-optical transfer function (EOTF) that maps an
@@ -158,7 +159,8 @@ class RGB_Colourspace:
         use a computed derived normalised primary matrix.
     use_derived_matrix_XYZ_to_RGB
         Whether to use the instantiation time inverse normalised primary
-        matrix or to use a computed derived inverse normalised primary matrix.
+        matrix or to use a computed derived inverse normalised primary
+        matrix.
 
     Attributes
     ----------
@@ -187,10 +189,10 @@ class RGB_Colourspace:
     -   The normalised primary matrix defined by
         :attr:`colour.RGB_Colourspace.matrix_RGB_to_XYZ` property is treated
         as the prime matrix from which the inverse will be calculated as
-        required by the internal derivation mechanism. This behaviour has been
-        chosen in accordance with literature where commonly a *RGB* colourspace
-        is defined by its normalised primary matrix as it is directly computed
-        from the chosen primaries and whitepoint.
+        required by the internal derivation mechanism. This behaviour has
+        been chosen in accordance with literature where commonly a *RGB*
+        colourspace is defined by its normalised primary matrix as it is
+        directly computed from the chosen primaries and whitepoint.
 
     References
     ----------
@@ -280,7 +282,7 @@ class RGB_Colourspace:
     @property
     def name(self) -> str:
         """
-        Getter and setter property for the name.
+        Getter and setter for the *RGB* colourspace name.
 
         Parameters
         ----------
@@ -309,7 +311,7 @@ class RGB_Colourspace:
     @property
     def primaries(self) -> NDArrayFloat:
         """
-        Getter and setter property for the primaries.
+        Getter and setter for the *RGB* colourspace primaries.
 
         Parameters
         ----------
@@ -330,7 +332,7 @@ class RGB_Colourspace:
 
         attest(
             isinstance(value, (tuple, list, np.ndarray, np.matrix)),
-            f'"matrix_XYZ_to_RGB" property: "{value!r}" is not a "tuple", '
+            f'"primaries" property: "{value!r}" is not a "tuple", '
             f'"list", "ndarray" or "matrix" instance!',
         )
 
@@ -346,7 +348,7 @@ class RGB_Colourspace:
     @property
     def whitepoint(self) -> NDArrayFloat:
         """
-        Getter and setter property for the whitepoint.
+        Getter and setter for the *RGB* colourspace whitepoint.
 
         Parameters
         ----------
@@ -367,7 +369,7 @@ class RGB_Colourspace:
 
         attest(
             isinstance(value, (tuple, list, np.ndarray, np.matrix)),
-            f'"matrix_XYZ_to_RGB" property: "{value!r}" is not a "tuple", '
+            f'"whitepoint" property: "{value!r}" is not a "tuple", '
             f'"list", "ndarray" or "matrix" instance!',
         )
 
@@ -380,17 +382,24 @@ class RGB_Colourspace:
     @property
     def whitepoint_name(self) -> str | None:
         """
-        Getter and setter property for the whitepoint_name.
+        Getter and setter for the *RGB* colourspace whitepoint name.
+
+        Define or retrieve the name identifier for the reference illuminant
+        (whitepoint) used by this *RGB* colourspace. This property allows
+        tracking of standardized illuminant names such as 'D65', 'D50', or
+        custom whitepoint identifiers.
 
         Parameters
         ----------
         value
-            Value to set the whitepoint_name with.
+            Name identifier to set for the *RGB* colourspace whitepoint. Can
+            be a standard illuminant name or custom identifier.
 
         Returns
         -------
         :class:`str` or :py:data:`None`
-            *RGB* colourspace whitepoint name.
+            *RGB* colourspace whitepoint name identifier. Returns
+            :py:data:`None` if no name has been specified.
         """
 
         return self._whitepoint_name
@@ -410,20 +419,20 @@ class RGB_Colourspace:
     @property
     def matrix_RGB_to_XYZ(self) -> NDArrayFloat:
         """
-        Getter and setter property for the transformation matrix from
-        colourspace to *CIE XYZ* tristimulus values.
+        Getter and setter for the transformation matrix from RGB colourspace
+        to *CIE XYZ* tristimulus values.
 
         Parameters
         ----------
         value
-            Transformation matrix from colourspace to *CIE XYZ* tristimulus
-            values.
+            Transformation matrix from RGB colourspace to *CIE XYZ*
+            tristimulus values.
 
         Returns
         -------
         :class:`numpy.ndarray`
-            Transformation matrix from colourspace to *CIE XYZ* tristimulus
-            values.
+            Transformation matrix from RGB colourspace to *CIE XYZ*
+            tristimulus values.
         """
 
         if self._matrix_RGB_to_XYZ is None or self._use_derived_matrix_RGB_to_XYZ:
@@ -452,19 +461,19 @@ class RGB_Colourspace:
     @property
     def matrix_XYZ_to_RGB(self) -> NDArrayFloat:
         """
-        Getter and setter property for the transformation matrix from *CIE XYZ*
-        tristimulus values to colourspace.
+        Getter and setter for the transformation matrix from *CIE XYZ*
+        tristimulus values to RGB colourspace.
 
         Parameters
         ----------
         value
-            Transformation matrix from *CIE XYZ* tristimulus values to
+            Transformation matrix from *CIE XYZ* tristimulus values to the
             colourspace.
 
         Returns
         -------
         :class:`numpy.ndarray`
-            Transformation matrix from *CIE XYZ* tristimulus values to
+            Transformation matrix from *CIE XYZ* tristimulus values to the
             colourspace.
         """
 
@@ -494,9 +503,8 @@ class RGB_Colourspace:
     @property
     def cctf_encoding(self) -> Callable | None:
         """
-        Getter and setter property for the encoding colour component transfer
-        function (Encoding CCTF) / opto-electronic transfer function
-        (OETF).
+        Getter and setter for the encoding colour component transfer
+        function (Encoding CCTF) / opto-electronic transfer function (OETF).
 
         Parameters
         ----------
@@ -528,7 +536,7 @@ class RGB_Colourspace:
     @property
     def cctf_decoding(self) -> Callable | None:
         """
-        Getter and setter property for the decoding colour component transfer
+        Getter and setter for the decoding colour component transfer
         function (Decoding CCTF) / electro-optical transfer function
         (EOTF).
 
@@ -562,9 +570,12 @@ class RGB_Colourspace:
     @property
     def use_derived_matrix_RGB_to_XYZ(self) -> bool:
         """
-        Getter and setter property for whether to use the instantiation time
-        normalised primary matrix or to use a computed derived normalised
-        primary matrix.
+        Getter and setter for whether to use the instantiation time normalised
+        primary matrix or to use a computed derived normalised primary matrix.
+
+        Control whether the RGB to XYZ transformation uses the pre-computed
+        normalised primary matrix from instantiation or derives it dynamically
+        from the current primaries and whitepoint.
 
         Parameters
         ----------
@@ -595,23 +606,25 @@ class RGB_Colourspace:
     @property
     def use_derived_matrix_XYZ_to_RGB(self) -> bool:
         """
-        Getter and setter property for Whether to use the instantiation time
-        inverse normalised primary matrix or to use a computed derived inverse
-        normalised primary matrix.
+        Getter and setter for whether to use the instantiation time inverse
+        normalised primary matrix or to compute a derived inverse normalised
+        primary matrix.
+
+        Control whether the XYZ to RGB transformation uses the pre-computed
+        inverse matrix from instantiation or derives it dynamically from the
+        current primary matrix.
 
         Parameters
         ----------
         value
             Whether to use the instantiation time inverse normalised primary
-            matrix or to use a computed derived inverse normalised primary
-            matrix.
+            matrix or to compute a derived inverse normalised primary matrix.
 
         Returns
         -------
         :class:`bool`
             Whether to use the instantiation time inverse normalised primary
-            matrix or to use a computed derived inverse normalised primary
-            matrix.
+            matrix or to compute a derived inverse normalised primary matrix.
         """
 
         return self._use_derived_matrix_XYZ_to_RGB
@@ -629,12 +642,14 @@ class RGB_Colourspace:
 
     def __str__(self) -> str:
         """
-        Return a formatted string representation of the *RGB* colourspace.
+        Generate a formatted string representation of the *RGB* colourspace.
 
         Returns
         -------
         :class:`str`
-            Formatted string representation.
+            Formatted string representation displaying colourspace properties
+            including primaries, whitepoint, encoding/decoding CCTFs, and
+            normalised primary matrices.
 
         Examples
         --------
@@ -726,13 +741,15 @@ class RGB_Colourspace:
 
     def __repr__(self) -> str:
         """
-        Return an (almost) evaluable string representation of the *RGB*
-        colourspace.
+        Return an evaluable string representation of the *RGB* colourspace.
+
+        The representation includes all parameters needed to reconstruct the
+        colourspace instance.
 
         Returns
         -------
-        :class`str`
-            (Almost) evaluable string representation.
+        :class:`str`
+            Evaluable string representation.
 
         Examples
         --------
@@ -810,8 +827,11 @@ class RGB_Colourspace:
 
     def _derive_transformation_matrices(self) -> None:
         """
-        Compute the derived transformations matrices, the normalised primary
-        matrix and its inverse.
+        Derive transformation matrices from the RGB colourspace specification.
+
+        Compute the normalised primary matrix and its inverse matrix that are
+        used for transformations between the RGB colourspace and CIE XYZ
+        tristimulus values.
         """
 
         if self._primaries is not None and self._whitepoint is not None:
@@ -822,14 +842,14 @@ class RGB_Colourspace:
 
     def use_derived_transformation_matrices(self, usage: bool = True) -> None:
         """
-        Enable or disables usage of both derived transformations matrices,
+        Enable or disable usage of both derived transformation matrices,
         the normalised primary matrix and its inverse in subsequent
         computations.
 
         Parameters
         ----------
         usage
-            Whether to use the derived transformations matrices.
+            Whether to use the derived transformation matrices.
         """
 
         self.use_derived_matrix_RGB_to_XYZ = usage
@@ -845,8 +865,8 @@ class RGB_Colourspace:
     ) -> RGB_Colourspace:
         """
         Chromatically adapt the *RGB* colourspace *primaries* :math:`xy`
-        chromaticity coordinates from *RGB* colourspace whitepoint to reference
-        ``whitepoint``.
+        chromaticity coordinates from *RGB* colourspace whitepoint to the
+        specified reference whitepoint.
 
         Parameters
         ----------
@@ -918,12 +938,16 @@ class RGB_Colourspace:
 
     def copy(self) -> RGB_Colourspace:
         """
-        Return a copy of the *RGB* colourspace.
+        Create a deep copy of the *RGB* colourspace instance.
+
+        Generate an independent copy of this *RGB* colourspace with all
+        attributes duplicated, including primaries, whitepoint, matrices,
+        and transfer functions.
 
         Returns
         -------
         :class:`colour.RGB_Colourspace`
-            *RGB* colourspace copy.
+            Independent deep copy of the *RGB* colourspace instance.
         """
 
         return deepcopy(self)
@@ -950,11 +974,11 @@ def XYZ_to_RGB(
     colourspace
         Output *RGB* colourspace.
     illuminant
-        *CIE xy* chromaticity coordinates or *CIE xyY* colourspace array of the
-        *illuminant* for the input *CIE XYZ* tristimulus values.
+        *CIE xy* chromaticity coordinates or *CIE xyY* colourspace array of
+        the *illuminant* for the input *CIE XYZ* tristimulus values.
     chromatic_adaptation_transform
-        *Chromatic adaptation* transform, if *None* no chromatic adaptation is
-        performed.
+        *Chromatic adaptation* transform. If *None*, no chromatic adaptation
+        is performed.
     apply_cctf_encoding
         Apply the *RGB* colourspace encoding colour component transfer
         function / opto-electronic transfer function.
@@ -1084,11 +1108,11 @@ def RGB_to_XYZ(
     colourspace
         Input *RGB* colourspace.
     illuminant
-        *CIE xy* chromaticity coordinates or *CIE xyY* colourspace array of the
-        *illuminant* for the output *CIE XYZ* tristimulus values.
+        *CIE xy* chromaticity coordinates or *CIE xyY* colourspace array of
+        the *illuminant* for the output *CIE XYZ* tristimulus values.
     chromatic_adaptation_transform
-        *Chromatic adaptation* transform, if *None* no chromatic adaptation is
-        performed.
+        *Chromatic adaptation* transform, if *None* no chromatic adaptation
+        is performed.
     apply_cctf_decoding
         Apply the *RGB* colourspace decoding colour component transfer
         function / opto-electronic transfer function.
@@ -1205,9 +1229,9 @@ def matrix_RGB_to_RGB(
     ) = "CAT02",
 ) -> NDArrayFloat:
     """
-    Compute the matrix :math:`M` converting from specified input *RGB*
-    colourspace to output *RGB* colourspace using specified *chromatic
-    adaptation* method.
+    Compute the matrix :math:`M` converting from the specified input *RGB*
+    colourspace to the specified output *RGB* colourspace using the
+    specified *chromatic adaptation* method.
 
     Parameters
     ----------
@@ -1216,8 +1240,8 @@ def matrix_RGB_to_RGB(
     output_colourspace
         *RGB* output colourspace.
     chromatic_adaptation_transform
-        *Chromatic adaptation* transform, if *None* no chromatic adaptation is
-        performed.
+        *Chromatic adaptation* transform. If *None*, no chromatic
+        adaptation is performed.
 
     Returns
     -------
@@ -1288,8 +1312,9 @@ def RGB_to_RGB(
     **kwargs: Any,
 ) -> NDArrayFloat:
     """
-    Convert specified *RGB* colourspace array from specified input *RGB* colourspace
-    to output *RGB* colourspace using specified *chromatic adaptation* method.
+    Convert *RGB* colourspace array from the specified input *RGB* colourspace to
+    specified output *RGB* colourspace using the specified *chromatic adaptation*
+    method.
 
     Parameters
     ----------
@@ -1300,11 +1325,11 @@ def RGB_to_RGB(
     output_colourspace
         *RGB* output colourspace.
     chromatic_adaptation_transform
-        *Chromatic adaptation* transform, if *None* no chromatic adaptation is
-        performed.
+        *Chromatic adaptation* transform, if *None* no chromatic adaptation
+        is performed.
     apply_cctf_decoding
-        Apply the input colourspace decoding colour component transfer function
-        / electro-optical transfer function.
+        Apply the input colourspace decoding colour component transfer
+        function / electro-optical transfer function.
     apply_cctf_encoding
         Apply the output colourspace encoding colour component transfer
         function / opto-electronic transfer function.

--- a/colour/models/rgb/tests/test_rgb_colourspace.py
+++ b/colour/models/rgb/tests/test_rgb_colourspace.py
@@ -340,8 +340,8 @@ class TestXYZ_to_RGB:
         )
 
         # TODO: Remove tests when dropping deprecated signature support.
-        np.testing.assert_allclose(  # pyright: ignore
-            XYZ_to_RGB(  # pyright: ignore
+        np.testing.assert_allclose(
+            XYZ_to_RGB(
                 np.array([0.21638819, 0.12570000, 0.03847493]),
                 np.array([0.34570, 0.35850]),  # pyright: ignore
                 np.array([0.31270, 0.32900]),
@@ -359,8 +359,8 @@ class TestXYZ_to_RGB:
             atol=TOLERANCE_ABSOLUTE_TESTS,
         )
 
-        np.testing.assert_allclose(  # pyright: ignore
-            XYZ_to_RGB(  # pyright: ignore
+        np.testing.assert_allclose(
+            XYZ_to_RGB(
                 np.array([0.21638819, 0.12570000, 0.03847493]),
                 np.array([0.34570, 0.35850]),  # pyright: ignore
                 np.array([0.31270, 0.32900]),
@@ -378,8 +378,8 @@ class TestXYZ_to_RGB:
             atol=TOLERANCE_ABSOLUTE_TESTS,
         )
 
-        np.testing.assert_allclose(  # pyright: ignore
-            XYZ_to_RGB(  # pyright: ignore
+        np.testing.assert_allclose(
+            XYZ_to_RGB(
                 np.array([0.21638819, 0.12570000, 0.03847493]),
                 np.array([0.34570, 0.35850]),  # pyright: ignore
                 np.array([0.32168, 0.33767]),
@@ -395,8 +395,8 @@ class TestXYZ_to_RGB:
             atol=TOLERANCE_ABSOLUTE_TESTS,
         )
 
-        np.testing.assert_allclose(  # pyright: ignore
-            XYZ_to_RGB(  # pyright: ignore
+        np.testing.assert_allclose(
+            XYZ_to_RGB(
                 np.array([0.21638819, 0.12570000, 0.03847493]),
                 np.array([0.34570, 0.35850]),  # pyright: ignore
                 np.array([0.31270, 0.32900, 1.00000]),
@@ -540,8 +540,8 @@ class TestRGB_to_XYZ:
         )
 
         # TODO: Remove tests when dropping deprecated signature support.
-        np.testing.assert_allclose(  # pyright: ignore
-            RGB_to_XYZ(  # pyright: ignore
+        np.testing.assert_allclose(
+            RGB_to_XYZ(
                 np.array([0.70556599, 0.19109268, 0.22340812]),
                 np.array([0.31270, 0.32900]),  # pyright: ignore
                 np.array([0.34570, 0.35850]),
@@ -559,8 +559,8 @@ class TestRGB_to_XYZ:
             atol=TOLERANCE_ABSOLUTE_TESTS,
         )
 
-        np.testing.assert_allclose(  # pyright: ignore
-            RGB_to_XYZ(  # pyright: ignore
+        np.testing.assert_allclose(
+            RGB_to_XYZ(
                 np.array([0.72794579, 0.18180021, 0.17951580]),
                 np.array([0.31270, 0.32900]),  # pyright: ignore
                 np.array([0.34570, 0.35850]),
@@ -578,8 +578,8 @@ class TestRGB_to_XYZ:
             atol=TOLERANCE_ABSOLUTE_TESTS,
         )
 
-        np.testing.assert_allclose(  # pyright: ignore
-            RGB_to_XYZ(  # pyright: ignore
+        np.testing.assert_allclose(
+            RGB_to_XYZ(
                 np.array([0.21959099, 0.06985815, 0.04703704]),
                 np.array([0.32168, 0.33767]),  # pyright: ignore
                 np.array([0.34570, 0.35850]),
@@ -595,8 +595,8 @@ class TestRGB_to_XYZ:
             atol=TOLERANCE_ABSOLUTE_TESTS,
         )
 
-        np.testing.assert_allclose(  # pyright: ignore
-            RGB_to_XYZ(  # pyright: ignore
+        np.testing.assert_allclose(
+            RGB_to_XYZ(
                 np.array([0.45620801, 0.03079991, 0.04091883]),
                 np.array([0.31270, 0.32900, 1.00000]),  # pyright: ignore
                 np.array([0.34570, 0.35850]),

--- a/colour/models/rgb/transfer_functions/__init__.py
+++ b/colour/models/rgb/transfer_functions/__init__.py
@@ -431,13 +431,12 @@ def log_encoding(
     value: ArrayLike, function: LiteralLogEncoding | str = "Cineon", **kwargs: Any
 ) -> NDArrayFloat | NDArrayInt:
     """
-    Encode *scene-referred* exposure values to :math:`R'G'B'` video component
-    signal value using specified *log* encoding function.
+    Apply the specified log encoding opto-electronic transfer function (OETF).
 
     Parameters
     ----------
     value
-        *Scene-referred* exposure values.
+        Scene-linear value.
     function
         *Log* encoding function.
 
@@ -480,7 +479,7 @@ def log_encoding(
     Returns
     -------
     :class:`numpy.ndarray`
-        *Log* values.
+        Logarithmic encoded value.
 
     Examples
     --------
@@ -552,13 +551,12 @@ def log_decoding(
     **kwargs: Any,
 ) -> NDArrayFloat:
     """
-    Decode :math:`R'G'B'` video component signal value to *scene-referred*
-    exposure values using specified *log* decoding function.
+    Apply the specified log decoding inverse opto-electronic transfer function (OETF).
 
     Parameters
     ----------
     value
-        *Log* values.
+        Logarithmic encoded value.
     function
         *Log* decoding function.
 
@@ -601,7 +599,7 @@ def log_decoding(
     Returns
     -------
     :class:`numpy.ndarray`
-        *Scene-referred* exposure values.
+        Scene-linear value.
 
     Examples
     --------
@@ -663,14 +661,12 @@ def oetf(
     value: ArrayLike, function: LiteralOETF | str = "ITU-R BT.709", **kwargs: Any
 ) -> NDArrayFloat:
     """
-    Encode estimated tristimulus values in a scene to :math:`R'G'B'` video
-    component signal value using specified opto-electronic transfer function
-    (OETF).
+    Apply the specified opto-electronic transfer function (OETF).
 
     Parameters
     ----------
     value
-        Value.
+        Scene-linear value.
     function
         Opto-electronic transfer function (OETF).
 
@@ -691,7 +687,7 @@ def oetf(
     Returns
     -------
     :class:`numpy.ndarray`
-        :math:`R'G'B'` video component signal value.
+        Non-linear signal value.
 
     Examples
     --------
@@ -738,14 +734,12 @@ def oetf_inverse(
     **kwargs: Any,
 ) -> NDArrayFloat:
     """
-    Decode :math:`R'G'B'` video component signal value to tristimulus values
-    at the display using specified inverse opto-electronic transfer function
-    (OETF).
+    Apply the specified inverse opto-electronic transfer function (OETF).
 
     Parameters
     ----------
     value
-        Value.
+        Non-linear signal value.
     function
         Inverse opto-electronic transfer function (OETF).
 
@@ -762,11 +756,10 @@ def oetf_inverse(
         :func:`colour.models.oetf_inverse_BT709`},
         See the documentation of the previously listed definitions.
 
-
     Returns
     -------
     :class:`numpy.ndarray`
-        Tristimulus values at the display.
+        Scene-linear value.
 
     Examples
     --------
@@ -813,13 +806,12 @@ def eotf(
     **kwargs: Any,
 ) -> NDArrayFloat:
     """
-    Decode :math:`R'G'B'` video component signal value to tristimulus values
-    at the display using specified electro-optical transfer function (EOTF).
+    Apply the specified electro-optical transfer function (EOTF).
 
     Parameters
     ----------
     value
-        Value.
+        Non-linear signal value.
     function
         Electro-optical transfer function (EOTF).
 
@@ -839,7 +831,7 @@ def eotf(
     Returns
     -------
     :class:`numpy.ndarray`
-        Tristimulus values at the display.
+        Display-linear value.
 
     Examples
     --------
@@ -884,14 +876,12 @@ def eotf_inverse(
     **kwargs: Any,
 ) -> NDArrayFloat | NDArrayInt:
     """
-    Encode estimated tristimulus values in a scene to :math:`R'G'B'` video
-    component signal value using specified inverse electro-optical transfer
-    function (EOTF).
+    Apply the specified inverse electro-optical transfer function (EOTF).
 
     Parameters
     ----------
     value
-        Value.
+        Display-linear value.
     function
         Inverse electro-optical transfer function (EOTF).
 
@@ -910,7 +900,7 @@ def eotf_inverse(
     Returns
     -------
     :class:`numpy.ndarray`
-        :math:`R'G'B'` video component signal value.
+        Non-linear signal value.
 
     Examples
     --------
@@ -960,20 +950,19 @@ CCTF_ENCODINGS.update(LOG_ENCODINGS)
 CCTF_ENCODINGS.update(OETFS)
 CCTF_ENCODINGS.update(EOTF_INVERSES)
 CCTF_ENCODINGS.__doc__ = """
-Supported encoding colour component transfer functions (Encoding CCTFs), a
-collection of the functions defined by :attr:`colour.LOG_ENCODINGS`,
-:attr:`colour.OETFS`, :attr:`colour.EOTF_INVERSES` attributes, the
+Supported encoding colour component transfer functions (encoding CCTFs), a
+collection comprising functions from :attr:`colour.LOG_ENCODINGS`,
+:attr:`colour.OETFS`, :attr:`colour.EOTF_INVERSES`,
 :func:`colour.models.cctf_encoding_ProPhotoRGB`,
 :func:`colour.models.cctf_encoding_RIMMRGB`,
-:func:`colour.models.cctf_encoding_ROMMRGB` definitions and 3 gamma encoding
-functions (1 / 2.2, 1 / 2.4, 1 / 2.6).
+:func:`colour.models.cctf_encoding_ROMMRGB`, and three gamma encoding
+functions (1/2.2, 1/2.4, 1/2.6).
 
 Warnings
 --------
 For *ITU-R BT.2100*, only the inverse electro-optical transfer functions
-(EOTFs / EOCFs) are exposed by this attribute, See the
-:attr:`colour.OETFS` attribute for the opto-electronic transfer functions
-(OETF).
+(EOTFs) are exposed by this definition, See the :func:`colour.oetf`
+definition for the opto-electronic transfer functions (OETF).
 """
 
 
@@ -981,15 +970,14 @@ def cctf_encoding(
     value: ArrayLike, function: LiteralCCTFEncoding | str = "sRGB", **kwargs: Any
 ) -> NDArrayFloat | NDArrayInt:
     """
-    Encode linear :math:`RGB` values to non-linear :math:`R'G'B'` values using
-    specified encoding colour component transfer function (Encoding CCTF).
+    Apply the specified encoding colour component transfer function (Encoding
+    CCTF).
 
     Parameters
     ----------
     value
-        Linear :math:`RGB` values.
+        Linear RGB value.
     function
-        {:attr:`colour.CCTF_ENCODINGS`},
         Encoding colour component transfer function.
 
     Other Parameters
@@ -1001,14 +989,13 @@ def cctf_encoding(
     Warnings
     --------
     For *ITU-R BT.2100*, only the inverse electro-optical transfer functions
-    (EOTFs / EOCFs) are exposed by this definition, See the
-    :func:`colour.oetf` definition for the opto-electronic transfer functions
-    (OETF).
+    (EOTFs) are exposed by this definition, See the :func:`colour.oetf`
+    definition for the opto-electronic transfer functions (OETF).
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Non-linear :math:`R'G'B'` values.
+        Non-linear RGB value.
 
     Examples
     --------
@@ -1057,25 +1044,19 @@ CCTF_DECODINGS.update(LOG_DECODINGS)
 CCTF_DECODINGS.update(OETF_INVERSES)
 CCTF_DECODINGS.update(EOTFS)
 CCTF_DECODINGS.__doc__ = """
-Supported decoding colour component transfer functions (Decoding CCTFs), a
-collection of the functions defined by :attr:`colour.LOG_DECODINGS`,
-:attr:`colour.EOTFS`, :attr:`colour.OETF_INVERSES` attributes, the
+Supported decoding colour component transfer functions (decoding CCTFs), a
+collection comprising functions from :attr:`colour.LOG_DECODINGS`,
+:attr:`colour.OETF_INVERSES`, :attr:`colour.EOTFS`,
 :func:`colour.models.cctf_decoding_ProPhotoRGB`,
 :func:`colour.models.cctf_decoding_RIMMRGB`,
-:func:`colour.models.cctf_decoding_ROMMRGB` definitions and 3 gamma decoding
+:func:`colour.models.cctf_decoding_ROMMRGB`, and three gamma decoding
 functions (2.2, 2.4, 2.6).
 
 Warnings
 --------
 For *ITU-R BT.2100*, only the electro-optical transfer functions
-(EOTFs / EOCFs) are exposed by this attribute, See the
-:attr:`colour.OETF_INVERSES` attribute for the inverse opto-electronic
-transfer functions (OETF).
-
-Notes
------
--   The order by which this attribute is defined and updated is critically
-    important to ensure that *ITU-R BT.2100* definitions are reciprocal.
+(EOTFs) are exposed by this attribute. See :attr:`colour.OETF_INVERSES`
+for the inverse opto-electronic transfer functions (OETFs).
 """
 
 
@@ -1085,15 +1066,14 @@ def cctf_decoding(
     **kwargs: Any,
 ) -> NDArrayFloat:
     """
-    Decode non-linear :math:`R'G'B'` values to linear :math:`RGB` values using
-    specified decoding colour component transfer function (Decoding CCTF).
+    Apply the specified decoding colour component transfer function (Decoding
+    CCTF).
 
     Parameters
     ----------
     value
-        Non-linear :math:`R'G'B'` values.
+        Non-linear RGB value.
     function
-        {:attr:`colour.CCTF_DECODINGS`},
         Decoding colour component transfer function.
 
     Other Parameters
@@ -1105,14 +1085,13 @@ def cctf_decoding(
     Warnings
     --------
     For *ITU-R BT.2100*, only the electro-optical transfer functions
-    (EOTFs / EOCFs) are exposed by this definition, See the
-    :func:`colour.oetf_inverse` definition for the inverse opto-electronic
-    transfer functions (OETF).
+    (EOTFs) are exposed by this attribute. See :attr:`colour.OETF_INVERSES`
+    for the inverse opto-electronic transfer functions (OETFs).
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Linear :math:`RGB` values.
+        Linear RGB value.
 
     Examples
     --------
@@ -1173,15 +1152,14 @@ def ootf(
     **kwargs: Any,
 ) -> NDArrayFloat:
     """
-    Map relative scene linear light to display linear light using specified
-    opto-optical transfer function (OOTF / OOCF).
+    Apply the specified opto-optical transfer function (OOTF).
 
     Parameters
     ----------
     value
-        Value.
+        Scene-linear value.
     function
-        Opto-optical transfer function (OOTF / OOCF).
+        Opto-optical transfer function (OOTF).
 
     Other Parameters
     ----------------
@@ -1193,7 +1171,7 @@ def ootf(
     Returns
     -------
     :class:`numpy.ndarray`
-        Luminance of a displayed linear component.
+        Display-linear value.
 
     Examples
     --------
@@ -1231,15 +1209,14 @@ def ootf_inverse(
     **kwargs: Any,
 ) -> NDArrayFloat:
     """
-    Map relative display linear light to scene linear light using specified
-    inverse opto-optical transfer function (OOTF / OOCF).
+    Apply the specified inverse opto-optical transfer function (OOTF).
 
     Parameters
     ----------
     value
-        Value.
+        Display-linear value.
     function
-        Inverse opto-optical transfer function (OOTF / OOCF).
+        Inverse opto-optical transfer function (OOTF).
 
     Other Parameters
     ----------------
@@ -1251,7 +1228,7 @@ def ootf_inverse(
     Returns
     -------
     :class:`numpy.ndarray`
-        Luminance of scene linear light.
+        Scene-linear value.
 
     Examples
     --------

--- a/colour/models/rgb/transfer_functions/aces.py
+++ b/colour/models/rgb/transfer_functions/aces.py
@@ -56,7 +56,14 @@ import numpy as np
 if typing.TYPE_CHECKING:
     from colour.hints import ArrayLike, Literal, NDArrayFloat, NDArrayInt
 
-from colour.utilities import Structure, as_float, as_int, from_range_1, to_domain_1
+from colour.utilities import (
+    Structure,
+    as_float,
+    as_int,
+    from_range_1,
+    optional,
+    to_domain_1,
+)
 
 __author__ = "Colour Developers"
 __copyright__ = "Copyright 2013 Colour Developers"
@@ -115,7 +122,7 @@ def log_encoding_ACESproxy(
     lin_AP1: ArrayLike,
     bit_depth: Literal[10, 12] = 10,
     out_int: bool = False,
-    constants: dict = CONSTANTS_ACES_PROXY,
+    constants: dict | None = None,
 ) -> NDArrayFloat | NDArrayInt:
     """
     Define the *ACESproxy* colourspace log encoding curve / opto-electronic
@@ -171,6 +178,7 @@ def log_encoding_ACESproxy(
     """
 
     lin_AP1 = to_domain_1(lin_AP1)
+    constants = optional(constants, CONSTANTS_ACES_PROXY)
 
     CV_min = constants[bit_depth].CV_min
     CV_max = constants[bit_depth].CV_max
@@ -256,10 +264,8 @@ def log_decoding_ACESproxy(
     0.1...
     """
 
-    if constants is None:
-        constants = CONSTANTS_ACES_PROXY
-
     ACESproxy = to_domain_1(ACESproxy)
+    constants = optional(constants, CONSTANTS_ACES_PROXY)
 
     mid_CV_offset = constants[bit_depth].mid_CV_offset
     mid_log_offset = constants[bit_depth].mid_log_offset
@@ -390,7 +396,7 @@ def log_decoding_ACEScc(ACEScc: ArrayLike) -> NDArrayFloat:
 
 
 def log_encoding_ACEScct(
-    lin_AP1: ArrayLike, constants: Structure = CONSTANTS_ACES_CCT
+    lin_AP1: ArrayLike, constants: Structure | None = None
 ) -> NDArrayFloat:
     """
     Define the *ACEScct* colourspace log encoding / opto-electronic transfer
@@ -436,6 +442,7 @@ def log_encoding_ACEScct(
     """
 
     lin_AP1 = to_domain_1(lin_AP1)
+    constants = optional(constants, CONSTANTS_ACES_CCT)
 
     ACEScct = np.where(
         lin_AP1 <= constants.X_BRK,
@@ -447,7 +454,7 @@ def log_encoding_ACEScct(
 
 
 def log_decoding_ACEScct(
-    ACEScct: ArrayLike, constants: Structure = CONSTANTS_ACES_CCT
+    ACEScct: ArrayLike, constants: Structure | None = None
 ) -> NDArrayFloat:
     """
     Define the *ACEScct* colourspace log decoding / electro-optical transfer
@@ -493,6 +500,7 @@ def log_decoding_ACEScct(
     """
 
     ACEScct = to_domain_1(ACEScct)
+    constants = optional(constants, CONSTANTS_ACES_CCT)
 
     lin_AP1 = np.where(
         ACEScct > constants.Y_BRK,

--- a/colour/models/rgb/transfer_functions/aces.py
+++ b/colour/models/rgb/transfer_functions/aces.py
@@ -2,7 +2,7 @@
 Academy Color Encoding System - Log Encodings
 =============================================
 
-Define the *Academy Color Encoding System* (ACES) log encodings:
+Define the *Academy Color Encoding System* (ACES) log encodings.
 
 -   :func:`colour.models.log_encoding_ACESproxy`
 -   :func:`colour.models.log_decoding_ACESproxy`
@@ -125,16 +125,15 @@ def log_encoding_ACESproxy(
     constants: dict | None = None,
 ) -> NDArrayFloat | NDArrayInt:
     """
-    Define the *ACESproxy* colourspace log encoding curve / opto-electronic
-    transfer function.
+    Apply the *ACESproxy* log encoding opto-electronic transfer function (OETF).
 
     Parameters
     ----------
     lin_AP1
-        *lin_AP1* value.
+        Linear *AP1* colourspace value.
     bit_depth
         *ACESproxy* bit-depth.
-    out_in
+    out_int
         Whether to return value as int code value or float equivalent of a
         code value at a specified bit-depth.
     constants
@@ -143,7 +142,7 @@ def log_encoding_ACESproxy(
     Returns
     -------
     :class:`numpy.ndarray`
-        *ACESproxy* non-linear value.
+        *ACESproxy* non-linear encoded value.
 
     Notes
     -----
@@ -212,25 +211,24 @@ def log_decoding_ACESproxy(
     constants: dict | None = None,
 ) -> NDArrayFloat:
     """
-    Define the *ACESproxy* colourspace log decoding curve / electro-optical
-    transfer function.
+    Apply the *ACESproxy* log decoding inverse opto-electronic transfer function (OETF).
 
     Parameters
     ----------
     ACESproxy
-        *ACESproxy* non-linear value.
+        *ACESproxy* non-linear encoded value.
     bit_depth
         *ACESproxy* bit-depth.
     in_int
-        Whether to treat the input value as int code value or float
-        equivalent of a code value at a specified bit-depth.
+        Whether to treat the input value as integer code value or floating
+        point equivalent of a code value at specified bit-depth.
     constants
         *ACESproxy* constants.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        *lin_AP1* value.
+        Linear *AP1* colourspace value.
 
     Notes
     -----
@@ -281,18 +279,17 @@ def log_decoding_ACESproxy(
 
 def log_encoding_ACEScc(lin_AP1: ArrayLike) -> NDArrayFloat:
     """
-    Define the *ACEScc* colourspace log encoding / opto-electronic transfer
-    function.
+    Apply the *ACEScc* log encoding opto-electronic transfer function (OETF).
 
     Parameters
     ----------
     lin_AP1
-        *lin_AP1* value.
+        Linear *AP1* colourspace value.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        *ACEScc* non-linear value.
+        *ACEScc* non-linear encoded value.
 
     Notes
     -----
@@ -339,18 +336,17 @@ def log_encoding_ACEScc(lin_AP1: ArrayLike) -> NDArrayFloat:
 
 def log_decoding_ACEScc(ACEScc: ArrayLike) -> NDArrayFloat:
     """
-    Define the *ACEScc* colourspace log decoding / electro-optical transfer
-    function.
+    Apply the *ACEScc* log decoding inverse opto-electronic transfer function (OETF).
 
     Parameters
     ----------
     ACEScc
-        *ACEScc* non-linear value.
+        *ACEScc* non-linear encoded value.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        *lin_AP1* value.
+        Linear *AP1* colourspace value.
 
     Notes
     -----
@@ -399,20 +395,19 @@ def log_encoding_ACEScct(
     lin_AP1: ArrayLike, constants: Structure | None = None
 ) -> NDArrayFloat:
     """
-    Define the *ACEScct* colourspace log encoding / opto-electronic transfer
-    function.
+    Apply the *ACEScct* log encoding opto-electronic transfer function (OETF).
 
     Parameters
     ----------
     lin_AP1
-        *lin_AP1* value.
+        Linear *AP1* colourspace value.
     constants
         *ACEScct* constants.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        *ACEScct* non-linear value.
+        *ACEScct* non-linear encoded value.
 
     Notes
     -----
@@ -457,27 +452,19 @@ def log_decoding_ACEScct(
     ACEScct: ArrayLike, constants: Structure | None = None
 ) -> NDArrayFloat:
     """
-    Define the *ACEScct* colourspace log decoding / electro-optical transfer
-    function.
+    Apply the *ACEScct* log decoding inverse opto-electronic transfer function (OETF).
 
     Parameters
     ----------
     ACEScct
-        *ACEScct* non-linear value.
+        *ACEScct* non-linear encoded value.
     constants
         *ACEScct* constants.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        *lin_AP1* value.
-
-    References
-    ----------
-    :cite:`TheAcademyofMotionPictureArtsandSciences2014q`,
-    :cite:`TheAcademyofMotionPictureArtsandSciences2014r`,
-    :cite:`TheAcademyofMotionPictureArtsandSciences2016c`,
-    :cite:`TheAcademyofMotionPictureArtsandSciencese`
+        Linear *AP1* colourspace value.
 
     Notes
     -----
@@ -492,6 +479,13 @@ def log_decoding_ACEScct(
     +=============+=======================+===============+
     | ``lin_AP1`` | [0, 1]                | [0, 1]        |
     +-------------+-----------------------+---------------+
+
+    References
+    ----------
+    :cite:`TheAcademyofMotionPictureArtsandSciences2014q`,
+    :cite:`TheAcademyofMotionPictureArtsandSciences2014r`,
+    :cite:`TheAcademyofMotionPictureArtsandSciences2016c`,
+    :cite:`TheAcademyofMotionPictureArtsandSciencese`
 
     Examples
     --------

--- a/colour/models/rgb/transfer_functions/apple_log_profile.py
+++ b/colour/models/rgb/transfer_functions/apple_log_profile.py
@@ -29,7 +29,7 @@ import numpy as np
 if typing.TYPE_CHECKING:
     from colour.hints import ArrayLike, NDArrayFloat
 
-from colour.utilities import Structure, as_float, from_range_1, to_domain_1
+from colour.utilities import Structure, as_float, from_range_1, optional, to_domain_1
 
 __author__ = "Colour Developers"
 __copyright__ = "Copyright 2013 Colour Developers"
@@ -57,7 +57,7 @@ CONSTANTS_APPLE_LOG_PROFILE: Structure = Structure(
 
 def log_encoding_AppleLogProfile(
     R: ArrayLike,
-    constants: Structure = CONSTANTS_APPLE_LOG_PROFILE,
+    constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
     Define the *Apple Log Profile* log encoding curve.
@@ -104,6 +104,7 @@ def log_encoding_AppleLogProfile(
     """
 
     R = to_domain_1(R)
+    constants = optional(constants, CONSTANTS_APPLE_LOG_PROFILE)
 
     R_0 = constants.R_0
     R_t = constants.R_t
@@ -130,7 +131,7 @@ def log_encoding_AppleLogProfile(
 
 def log_decoding_AppleLogProfile(
     P: ArrayLike,
-    constants: Structure = CONSTANTS_APPLE_LOG_PROFILE,
+    constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
     Define the *Apple Log Profile* log decoding curve.
@@ -176,6 +177,7 @@ def log_decoding_AppleLogProfile(
     """
 
     P = to_domain_1(P)
+    constants = optional(constants, CONSTANTS_APPLE_LOG_PROFILE)
 
     R_0 = constants.R_0
     R_t = constants.R_t

--- a/colour/models/rgb/transfer_functions/apple_log_profile.py
+++ b/colour/models/rgb/transfer_functions/apple_log_profile.py
@@ -2,7 +2,7 @@
 Apple Log Profile Log Encoding
 ==============================
 
-Define the *Apple Log Profile* log encoding:
+Define the *Apple Log Profile* log encoding.
 
 -   :func:`colour.models.log_encoding_AppleLogProfile`
 -   :func:`colour.models.log_decoding_AppleLogProfile`
@@ -60,29 +60,30 @@ def log_encoding_AppleLogProfile(
     constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
-    Define the *Apple Log Profile* log encoding curve.
+    Apply the *Apple Log Profile* log encoding opto-electronic transfer function (OETF).
 
     Parameters
     ----------
     R
-        Linear reflection data :math`R`.
+        Linear reflection data :math:`R`.
     constants
         *Apple Log Profile* constants.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        *Apple Log Profile* captured pixel value :math:`P`
+        Logarithmically encoded value :math:`P`.
 
     References
     ----------
-    :cite:`AppleInc.2023`, :cite:`TheAcademyofMotionPictureArtsandSciences2023`
+    :cite:`AppleInc.2023`,
+    :cite:`TheAcademyofMotionPictureArtsandSciences2023`
 
     Notes
     -----
     -   The scene reflection signal :math:`R` captured by the camera is
-        represented using a floating point encoding. The :math:`R` value of
-        0.18 corresponds to the signal produced by an 18% reflectance;
+        represented using a floating point encoding. The :math:`R` value
+        of 0.18 corresponds to the signal produced by an 18% reflectance
         reference gray chart.
 
     +------------+-----------------------+---------------+
@@ -134,28 +135,29 @@ def log_decoding_AppleLogProfile(
     constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
-    Define the *Apple Log Profile* log decoding curve.
+    Apply the *Apple Log Profile* log decoding inverse opto-electronic transfer
+    function (OETF).
 
     Parameters
     ----------
     P
-        *Apple Log Profile* captured pixel value :math:`P`
+        Logarithmically encoded value :math:`P`.
     constants
         *Apple Log Profile* constants.
 
     Returns
     -------
     :class:`numpy.ndarray`
-         Linear reflection data :math`R`.
-
+        Linear reflection data :math:`R`.
 
     References
     ----------
-    :cite:`AppleInc.2023`, :cite:`TheAcademyofMotionPictureArtsandSciences2023`
+    :cite:`AppleInc.2023`,
+    :cite:`TheAcademyofMotionPictureArtsandSciences2023`
 
     Notes
     -----
-    -   The captured pixel :math:`P` value is using a floating point encoding
+    -   The captured pixel :math:`P` value uses floating point encoding
         normalized to the [0, 1] range.
 
     +------------+-----------------------+---------------+

--- a/colour/models/rgb/transfer_functions/arib_std_b67.py
+++ b/colour/models/rgb/transfer_functions/arib_std_b67.py
@@ -3,7 +3,7 @@ ARIB STD-B67 (Hybrid Log-Gamma)
 ===============================
 
 Define the *ARIB STD-B67 (Hybrid Log-Gamma)* opto-electrical transfer function
-(OETF) and its inverse:
+(OETF) and its inverse.
 
 -   :func:`colour.models.oetf_ARIBSTDB67`
 -   :func:`colour.models.oetf_inverse_ARIBSTDB67`
@@ -60,7 +60,7 @@ def oetf_ARIBSTDB67(
     constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
-    Define *ARIB STD-B67 (Hybrid Log-Gamma)* opto-electrical transfer
+    Apply the *ARIB STD-B67 (Hybrid Log-Gamma)* opto-electronic transfer
     function (OETF).
 
     Parameters
@@ -68,7 +68,7 @@ def oetf_ARIBSTDB67(
     E
         Voltage normalised by the reference white level and proportional to
         the implicit light intensity that would be detected with a reference
-        camera color channel R, G, B.
+        camera colour channel R, G, B.
     r
         Video level corresponding to reference white level.
     constants
@@ -77,7 +77,7 @@ def oetf_ARIBSTDB67(
     Returns
     -------
     :class:`numpy.ndarray`
-        Resulting non-linear signal :math:`E'`.
+        Non-linear signal :math:`E'`.
 
     Notes
     -----
@@ -94,8 +94,8 @@ def oetf_ARIBSTDB67(
     +------------+-----------------------+---------------+
 
     -   This definition uses the *mirror* negative number handling mode of
-        :func:`colour.models.gamma_function` definition to the sign of negative
-        numbers.
+        :func:`colour.models.gamma_function` definition to preserve the sign
+        of negative numbers.
 
     References
     ----------
@@ -126,8 +126,8 @@ def oetf_inverse_ARIBSTDB67(
     constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
-    Define *ARIB STD-B67 (Hybrid Log-Gamma)* inverse opto-electrical transfer
-    function (OETF).
+    Apply the *ARIB STD-B67 (Hybrid Log-Gamma)* inverse opto-electronic
+    transfer function (OETF).
 
     Parameters
     ----------
@@ -141,9 +141,9 @@ def oetf_inverse_ARIBSTDB67(
     Returns
     -------
     :class:`numpy.ndarray`
-        Voltage :math:`E` normalised by the reference white level and
-        proportional to the implicit light intensity that would be detected
-        with a reference camera color channel R, G, B.
+        Voltage normalised by the reference white level and proportional to
+        the implicit light intensity that would be detected with a reference
+        camera colour channel R, G, B.
 
     Notes
     -----
@@ -159,9 +159,9 @@ def oetf_inverse_ARIBSTDB67(
     | ``E``      | [0, 1]                | [0, 1]        |
     +------------+-----------------------+---------------+
 
-    -   This definition uses the *mirror* negative number handling mode of
-        :func:`colour.models.gamma_function` definition to the sign of negative
-        numbers.
+    -   This definition uses the *mirror* negative number handling mode
+        of :func:`colour.models.gamma_function` definition to preserve
+        the sign of negative numbers.
 
     References
     ----------

--- a/colour/models/rgb/transfer_functions/arib_std_b67.py
+++ b/colour/models/rgb/transfer_functions/arib_std_b67.py
@@ -33,6 +33,7 @@ from colour.utilities import (
     as_float_array,
     domain_range_scale,
     from_range_1,
+    optional,
     to_domain_1,
 )
 
@@ -56,7 +57,7 @@ CONSTANTS_ARIBSTDB67: Structure = Structure(a=0.17883277, b=0.28466892, c=0.5599
 def oetf_ARIBSTDB67(
     E: ArrayLike,
     r: ArrayLike = 0.5,
-    constants: Structure = CONSTANTS_ARIBSTDB67,
+    constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
     Define *ARIB STD-B67 (Hybrid Log-Gamma)* opto-electrical transfer
@@ -108,6 +109,7 @@ def oetf_ARIBSTDB67(
 
     E = to_domain_1(E)
     r = as_float_array(r)
+    constants = optional(constants, CONSTANTS_ARIBSTDB67)
 
     a = constants.a
     b = constants.b
@@ -121,7 +123,7 @@ def oetf_ARIBSTDB67(
 def oetf_inverse_ARIBSTDB67(
     E_p: ArrayLike,
     r: ArrayLike = 0.5,
-    constants: Structure = CONSTANTS_ARIBSTDB67,
+    constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
     Define *ARIB STD-B67 (Hybrid Log-Gamma)* inverse opto-electrical transfer
@@ -172,6 +174,7 @@ def oetf_inverse_ARIBSTDB67(
     """
 
     E_p = to_domain_1(E_p)
+    constants = optional(constants, CONSTANTS_ARIBSTDB67)
 
     a = constants.a
     b = constants.b

--- a/colour/models/rgb/transfer_functions/arri.py
+++ b/colour/models/rgb/transfer_functions/arri.py
@@ -2,7 +2,7 @@
 ARRI Log Encodings
 ==================
 
-Define the *ARRI LogC3* and *ARRI LogC4* log encodings:
+Define the *ARRI LogC3* and *ARRI LogC4* log encodings.
 
 -   :func:`colour.models.log_encoding_ARRILogC3`
 -   :func:`colour.models.log_decoding_ARRILogC3`
@@ -566,8 +566,7 @@ def log_encoding_ARRILogC3(
     EI: Literal[160, 200, 250, 320, 400, 500, 640, 800, 1000, 1280, 1600] = 800,
 ) -> NDArrayFloat:
     """
-    Define the *ARRI LogC3* log encoding curve / opto-electronic transfer
-    function.
+    Apply the *ARRI LogC3* log encoding opto-electronic transfer function (OETF).
 
     Parameters
     ----------
@@ -583,7 +582,7 @@ def log_encoding_ARRILogC3(
     Returns
     -------
     :class:`numpy.ndarray`
-        *ARRI LogC3* encoded data :math:`t`.
+        *ARRI LogC3* non-linear encoded data :math:`t`.
 
     References
     ----------
@@ -633,13 +632,13 @@ def log_decoding_ARRILogC3(
     EI: Literal[160, 200, 250, 320, 400, 500, 640, 800, 1000, 1280, 1600] = 800,
 ) -> NDArrayFloat:
     """
-    Define the *ARRI LogC3* log decoding curve / electro-optical transfer
-    function.
+    Apply the *ARRI LogC3* log decoding inverse opto-electronic transfer
+    function (OETF).
 
     Parameters
     ----------
     t
-        *ARRI LogC3* encoded data :math:`t`.
+        *ARRI LogC3* non-linear encoded data :math:`t`.
     firmware
         Alexa firmware version.
     method
@@ -712,8 +711,7 @@ def log_encoding_ARRILogC4(
     constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
-    Define the *ARRI LogC4* log encoding curve / opto-electronic transfer
-    function.
+    Apply the *ARRI LogC4* log encoding opto-electronic transfer function (OETF).
 
     Parameters
     ----------
@@ -725,7 +723,7 @@ def log_encoding_ARRILogC4(
     Returns
     -------
     :class:`numpy.ndarray`
-        *ARRI LogC4* encoded signal :math:`E'`.
+        *ARRI LogC4* non-linear encoded signal :math:`E'`.
 
     References
     ----------
@@ -774,20 +772,20 @@ def log_decoding_ARRILogC4(
     constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
-    Define the *ARRI LogC4* log decoding curve / electro-optical transfer
-    function.
+    Apply the *ARRI LogC4* log decoding inverse opto-electronic transfer
+    function (OETF).
 
     Parameters
     ----------
     E_p
-        *ARRI LogC4* encoded signal :math:`E'`.
+        *ARRI LogC4* non-linear encoded signal :math:`E'`.
     constants
         *ARRI LogC4* constants.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Linear data :math:`E_{scene}`.
+        Relative scene linear signal :math:`E_{scene}`.
 
     Notes
     -----

--- a/colour/models/rgb/transfer_functions/arri.py
+++ b/colour/models/rgb/transfer_functions/arri.py
@@ -33,6 +33,7 @@ from colour.utilities import (
     Structure,
     as_float,
     from_range_1,
+    optional,
     to_domain_1,
     validate_method,
 )
@@ -708,7 +709,7 @@ del _a, _b, _c
 
 def log_encoding_ARRILogC4(
     E_scene: ArrayLike,
-    constants: Structure = CONSTANTS_ARRILOGC4,
+    constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
     Define the *ARRI LogC4* log encoding curve / opto-electronic transfer
@@ -751,6 +752,7 @@ def log_encoding_ARRILogC4(
     """
 
     E_scene = to_domain_1(E_scene)
+    constants = optional(constants, CONSTANTS_ARRILOGC4)
 
     a = constants.a
     b = constants.b
@@ -769,7 +771,7 @@ def log_encoding_ARRILogC4(
 
 def log_decoding_ARRILogC4(
     E_p: ArrayLike,
-    constants: Structure = CONSTANTS_ARRILOGC4,
+    constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
     Define the *ARRI LogC4* log decoding curve / electro-optical transfer
@@ -812,6 +814,7 @@ def log_decoding_ARRILogC4(
     """
 
     E_p = to_domain_1(E_p)
+    constants = optional(constants, CONSTANTS_ARRILOGC4)
 
     a = constants.a
     b = constants.b

--- a/colour/models/rgb/transfer_functions/blackmagic_design.py
+++ b/colour/models/rgb/transfer_functions/blackmagic_design.py
@@ -23,7 +23,7 @@ import numpy as np
 if typing.TYPE_CHECKING:
     from colour.hints import ArrayLike, NDArrayFloat
 
-from colour.utilities import Structure, as_float, from_range_1, to_domain_1
+from colour.utilities import Structure, as_float, from_range_1, optional, to_domain_1
 
 __author__ = "Colour Developers"
 __copyright__ = "Copyright 2013 Colour Developers"
@@ -51,7 +51,7 @@ CONSTANTS_BLACKMAGIC_FILM_GENERATION_5: Structure = Structure(
 
 def oetf_BlackmagicFilmGeneration5(
     x: ArrayLike,
-    constants: Structure = CONSTANTS_BLACKMAGIC_FILM_GENERATION_5,
+    constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
     Define the *Blackmagic Film Generation 5* opto-electronic transfer
@@ -94,6 +94,7 @@ def oetf_BlackmagicFilmGeneration5(
     """
 
     x = to_domain_1(x)
+    constants = optional(constants, CONSTANTS_BLACKMAGIC_FILM_GENERATION_5)
 
     A = constants.A
     B = constants.B
@@ -113,7 +114,7 @@ def oetf_BlackmagicFilmGeneration5(
 
 def oetf_inverse_BlackmagicFilmGeneration5(
     y: ArrayLike,
-    constants: Structure = CONSTANTS_BLACKMAGIC_FILM_GENERATION_5,
+    constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
     Define the *Blackmagic Film Generation 5* inverse opto-electronic transfer
@@ -157,6 +158,7 @@ def oetf_inverse_BlackmagicFilmGeneration5(
     """
 
     y = to_domain_1(y)
+    constants = optional(constants, CONSTANTS_BLACKMAGIC_FILM_GENERATION_5)
 
     A = constants.A
     B = constants.B

--- a/colour/models/rgb/transfer_functions/blackmagic_design.py
+++ b/colour/models/rgb/transfer_functions/blackmagic_design.py
@@ -2,7 +2,7 @@
 Blackmagic Design Transfer Functions
 ====================================
 
-Define the *Blackmagic Design* colour component transfer functions:
+Define the *Blackmagic Design* colour component transfer functions.
 
 -   :func:`colour.models.oetf_BlackmagicFilmGeneration5`
 -   :func:`colour.models.oetf_inverse_BlackmagicFilmGeneration5`
@@ -54,13 +54,13 @@ def oetf_BlackmagicFilmGeneration5(
     constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
-    Define the *Blackmagic Film Generation 5* opto-electronic transfer
-    function (OETF).
+    Apply the *Blackmagic Film Generation 5* opto-electronic transfer function
+    (OETF).
 
     Parameters
     ----------
     x
-        Linear light value :math`x`.
+        Linear light value :math:`x`.
     constants
         *Blackmagic Film Generation 5* constants.
 
@@ -117,8 +117,8 @@ def oetf_inverse_BlackmagicFilmGeneration5(
     constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
-    Define the *Blackmagic Film Generation 5* inverse opto-electronic transfer
-    function (OETF).
+    Apply the *Blackmagic Film Generation 5* inverse opto-electronic
+    transfer function (OETF).
 
     Parameters
     ----------
@@ -130,7 +130,7 @@ def oetf_inverse_BlackmagicFilmGeneration5(
     Returns
     -------
     :class:`numpy.ndarray`
-        Linear light value :math`x`.
+        Linear light value :math:`x`.
 
     Notes
     -----

--- a/colour/models/rgb/transfer_functions/canon.py
+++ b/colour/models/rgb/transfer_functions/canon.py
@@ -2,7 +2,7 @@
 Canon Log Encodings
 ===================
 
-Define the *Canon Log* encodings:
+Define the *Canon Log* encodings.
 
 -   :attr:`colour.models.CANON_LOG_ENCODING_METHODS`
 -   :func:`colour.models.log_encoding_CanonLog`
@@ -100,8 +100,7 @@ def log_encoding_CanonLog_v1(
     in_reflection: bool = True,
 ) -> NDArrayFloat:
     """
-    Define the *Canon Log* v1 log encoding curve / opto-electronic transfer
-    function.
+    Apply the *Canon Log* v1 log encoding opto-electronic transfer function (OETF).
 
     Parameters
     ----------
@@ -110,15 +109,15 @@ def log_encoding_CanonLog_v1(
     bit_depth
         Bit-depth used for conversion.
     out_normalised_code_value
-        Whether the *Canon Log* non-linear data is encoded as normalised code
-        values.
+        Whether the *Canon Log* v1 non-linear data is encoded as normalised
+        code values.
     in_reflection
         Whether the light level :math:`x` to a camera is reflection.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        *Canon Log* non-linear data.
+        *Canon Log* v1 non-linear encoded data.
 
     References
     ----------
@@ -143,8 +142,8 @@ def log_encoding_CanonLog_v1(
     >>> log_encoding_CanonLog_v1(0.18) * 100  # doctest: +ELLIPSIS
     34.3389651...
 
-    The values of *Table 2 Canon-Log Code Values* table in :cite:`Thorpe2012a`
-    are obtained as follows:
+    The values of *Table 2 Canon-Log Code Values* table in
+    :cite:`Thorpe2012a` are obtained as follows:
 
     >>> x = np.array([0, 2, 18, 90, 720]) / 100
     >>> np.around(log_encoding_CanonLog_v1(x) * (2**10 - 1)).astype(np.int_)
@@ -177,17 +176,17 @@ def log_decoding_CanonLog_v1(
     out_reflection: bool = True,
 ) -> NDArrayFloat:
     """
-    Define the *Canon Log* v1 log decoding curve / electro-optical transfer
-    function.
+    Apply the *Canon Log* v1 log decoding inverse opto-electronic transfer
+    function (OETF).
 
     Parameters
     ----------
     clog
-        *Canon Log* non-linear data.
+        *Canon Log* v1 non-linear encoded data.
     bit_depth
         Bit-depth used for conversion.
     in_normalised_code_value
-        Whether the *Canon Log* non-linear data is encoded with normalised
+        Whether the *Canon Log* v1 non-linear data is encoded with normalised
         code values.
     out_reflection
         Whether the light level :math:`x` to a camera is reflection.
@@ -244,8 +243,7 @@ def log_encoding_CanonLog_v1_2(
     in_reflection: bool = True,
 ) -> NDArrayFloat:
     """
-    Define the *Canon Log* v1.2 log encoding curve / opto-electronic transfer
-    function.
+    Apply the *Canon Log* v1.2 log encoding opto-electronic transfer function (OETF).
 
     Parameters
     ----------
@@ -254,15 +252,15 @@ def log_encoding_CanonLog_v1_2(
     bit_depth
         Bit-depth used for conversion.
     out_normalised_code_value
-        Whether the *Canon Log* non-linear data is encoded as normalised code
-        values.
+        Whether the *Canon Log* v1.2 non-linear data is encoded as
+        normalised code values.
     in_reflection
         Whether the light level :math:`x` to a camera is reflection.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        *Canon Log* non-linear data.
+        *Canon Log* v1.2 non-linear encoded data.
 
     References
     ----------
@@ -314,17 +312,18 @@ def log_decoding_CanonLog_v1_2(
     out_reflection: bool = True,
 ) -> NDArrayFloat:
     """
-    Define the *Canon Log* v1.2 log decoding curve / electro-optical transfer
-    function.
+    Apply the *Canon Log* v1.2 log decoding inverse opto-electronic transfer
+
+    function (OETF).
 
     Parameters
     ----------
     clog
-        *Canon Log* non-linear data.
+        *Canon Log* v1.2 non-linear encoded data.
     bit_depth
         Bit-depth used for conversion.
     in_normalised_code_value
-        Whether the *Canon Log* non-linear data is encoded with normalised
+        Whether the *Canon Log* v1.2 non-linear data is encoded with normalised
         code values.
     out_reflection
         Whether the light level :math:`x` to a camera is reflection.
@@ -384,8 +383,8 @@ CANON_LOG_ENCODING_METHODS: CanonicalMapping = CanonicalMapping(
     }
 )
 CANON_LOG_ENCODING_METHODS.__doc__ = """
-Supported *CanonLog* log encoding curve / opto-electronic transfer function
-methods.
+Supported *Canon Log* log encoding curve / opto-electronic transfer function
+(OETF) methods.
 
 References
 ----------
@@ -401,8 +400,7 @@ def log_encoding_CanonLog(
     method: Literal["v1", "v1.2"] | str = "v1.2",
 ) -> NDArrayFloat:
     """
-    Define the *Canon Log* log encoding curve / opto-electronic transfer
-    function.
+    Apply the *Canon Log* log encoding opto-electronic transfer function (OETF).
 
     Parameters
     ----------
@@ -411,8 +409,8 @@ def log_encoding_CanonLog(
     bit_depth
         Bit-depth used for conversion.
     out_normalised_code_value
-        Whether the *Canon Log* non-linear data is encoded as normalised code
-        values.
+        Whether the *Canon Log* non-linear data is encoded as normalised
+        code values.
     in_reflection
         Whether the light level :math:`x` to a camera is reflection.
     method
@@ -421,7 +419,7 @@ def log_encoding_CanonLog(
     Returns
     -------
     :class:`numpy.ndarray`
-        *Canon Log* non-linear data.
+        *Canon Log* non-linear encoded data.
 
     References
     ----------
@@ -448,8 +446,8 @@ def log_encoding_CanonLog(
     >>> log_encoding_CanonLog(0.18, method="v1") * 100  # doctest: +ELLIPSIS
     34.3389651...
 
-    The values of *Table 2 Canon-Log Code Values* table in :cite:`Thorpe2012a`
-    are obtained as follows:
+    The values of *Table 2 Canon-Log Code Values* table in
+    :cite:`Thorpe2012a` are obtained as follows:
 
     >>> x = np.array([0, 2, 18, 90, 720]) / 100
     >>> np.around(log_encoding_CanonLog(x, method="v1") * (2**10 - 1)).astype(np.int_)
@@ -472,8 +470,8 @@ CANON_LOG_DECODING_METHODS: CanonicalMapping = CanonicalMapping(
     }
 )
 CANON_LOG_DECODING_METHODS.__doc__ = """
-Supported *CanonLog* log decoding curve / electro-optical transfer function
-methods.
+Supported *Canon Log* log decoding curve / electro-optical transfer function
+(EOTF) methods.
 
 References
 ----------
@@ -489,13 +487,12 @@ def log_decoding_CanonLog(
     method: Literal["v1", "v1.2"] | str = "v1.2",
 ) -> NDArrayFloat:
     """
-    Define the *Canon Log* log decoding curve / electro-optical transfer
-    function.
+    Apply the *Canon Log* log decoding inverse opto-electronic transfer function (OETF).
 
     Parameters
     ----------
     clog
-        *Canon Log* non-linear data.
+        *Canon Log* non-linear encoded data.
     bit_depth
         Bit-depth used for conversion.
     in_normalised_code_value
@@ -552,8 +549,7 @@ def log_encoding_CanonLog2_v1(
     in_reflection: bool = True,
 ) -> NDArrayFloat:
     """
-    Define the *Canon Log 2* v1 log encoding curve / opto-electronic transfer
-    function.
+    Apply the *Canon Log 2* v1 log encoding opto-electronic transfer function (OETF).
 
     Parameters
     ----------
@@ -562,7 +558,7 @@ def log_encoding_CanonLog2_v1(
     bit_depth
         Bit-depth used for conversion.
     out_normalised_code_value
-        Whether the *Canon Log 2* non-linear data is encoded as normalised
+        Whether the *Canon Log 2* v1 non-linear data is encoded as normalised
         code values.
     in_reflection
         Whether the light level :math:`x` to a camera is reflection.
@@ -570,7 +566,7 @@ def log_encoding_CanonLog2_v1(
     Returns
     -------
     :class:`numpy.ndarray`
-        *Canon Log 2* non-linear data.
+        *Canon Log 2* v1 non-linear encoded data.
 
     Notes
     -----
@@ -620,18 +616,18 @@ def log_decoding_CanonLog2_v1(
     out_reflection: bool = True,
 ) -> NDArrayFloat:
     """
-    Define the *Canon Log 2* v1 log decoding curve / electro-optical transfer
-    function.
+    Apply the *Canon Log 2* v1 log decoding inverse opto-electronic transfer
+    function (OETF).
 
     Parameters
     ----------
     clog2
-        *Canon Log 2* non-linear data.
+        *Canon Log 2* v1 non-linear encoded data.
     bit_depth
         Bit-depth used for conversion.
     in_normalised_code_value
-        Whether the *Canon Log 2* non-linear data is encoded with normalised
-        code values.
+        Whether the *Canon Log 2* v1 non-linear data is encoded with
+        normalised code values.
     out_reflection
         Whether the light level :math:`x` to a camera is reflection.
 
@@ -687,8 +683,8 @@ def log_encoding_CanonLog2_v1_2(
     in_reflection: bool = True,
 ) -> NDArrayFloat:
     """
-    Define the *Canon Log 2* v1.2 log encoding curve / opto-electronic transfer
-    function.
+    Apply the *Canon Log 2* v1.2 log encoding opto-electronic transfer function
+    (OETF).
 
     Parameters
     ----------
@@ -697,15 +693,15 @@ def log_encoding_CanonLog2_v1_2(
     bit_depth
         Bit-depth used for conversion.
     out_normalised_code_value
-        Whether the *Canon Log 2* non-linear data is encoded as normalised
-        code values.
+        Whether the *Canon Log 2* v1.2 non-linear data is encoded as
+        normalised code values.
     in_reflection
         Whether the light level :math:`x` to a camera is reflection.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        *Canon Log 2* non-linear data.
+        *Canon Log 2* v1.2 non-linear encoded data.
 
     Notes
     -----
@@ -757,17 +753,17 @@ def log_decoding_CanonLog2_v1_2(
     out_reflection: bool = True,
 ) -> NDArrayFloat:
     """
-    Define the *Canon Log 2* v1.2 log decoding curve / electro-optical transfer
-    function.
+    Apply the *Canon Log 2* v1.2 log decoding inverse opto-electronic transfer
+    function (OETF).
 
     Parameters
     ----------
     clog2
-        *Canon Log 2* non-linear data.
+        *Canon Log 2* v1.2 non-linear encoded data.
     bit_depth
         Bit-depth used for conversion.
     in_normalised_code_value
-        Whether the *Canon Log 2* non-linear data is encoded with normalised
+        Whether the *Canon Log 2* v1.2 non-linear data is encoded with normalised
         code values.
     out_reflection
         Whether the light level :math:`x` to a camera is reflection.
@@ -828,7 +824,7 @@ CANON_LOG_2_ENCODING_METHODS: CanonicalMapping = CanonicalMapping(
 )
 CANON_LOG_2_ENCODING_METHODS.__doc__ = """
 Supported *Canon Log 2* log encoding curve / opto-electronic transfer function
-methods.
+(OETF) methods.
 
 References
 ----------
@@ -844,8 +840,7 @@ def log_encoding_CanonLog2(
     method: Literal["v1", "v1.2"] | str = "v1.2",
 ) -> NDArrayFloat:
     """
-    Define the *Canon Log 2* log encoding curve / opto-electronic transfer
-    function.
+    Apply the *Canon Log 2* log encoding opto-electronic transfer function (OETF).
 
     Parameters
     ----------
@@ -864,7 +859,7 @@ def log_encoding_CanonLog2(
     Returns
     -------
     :class:`numpy.ndarray`
-        *Canon Log 2* non-linear data.
+        *Canon Log 2* non-linear encoded data.
 
     Notes
     -----
@@ -905,7 +900,7 @@ CANON_LOG_2_DECODING_METHODS: CanonicalMapping = CanonicalMapping(
 )
 CANON_LOG_2_DECODING_METHODS.__doc__ = """
 Supported *Canon Log 2* log decoding curve / electro-optical transfer function
-methods.
+(EOTF) methods.
 
 References
 ----------
@@ -921,13 +916,13 @@ def log_decoding_CanonLog2(
     method: Literal["v1", "v1.2"] | str = "v1.2",
 ) -> NDArrayFloat:
     """
-    Define the *Canon Log 2* log decoding curve / electro-optical transfer
-    function.
+    Apply the *Canon Log 2* log decoding inverse opto-electronic transfer
+    function (OETF).
 
     Parameters
     ----------
     clog2
-        *Canon Log 2* non-linear data.
+        *Canon Log 2* non-linear encoded data.
     bit_depth
         Bit-depth used for conversion.
     in_normalised_code_value
@@ -981,8 +976,8 @@ def log_encoding_CanonLog3_v1(
     in_reflection: bool = True,
 ) -> NDArrayFloat:
     """
-    Define the *Canon Log 3* v1 log encoding curve / opto-electronic transfer
-    function.
+    Apply the *Canon Log 3* v1 log encoding opto-electronic transfer function
+    (OETF).
 
     Parameters
     ----------
@@ -991,21 +986,21 @@ def log_encoding_CanonLog3_v1(
     bit_depth
         Bit-depth used for conversion.
     out_normalised_code_value
-        Whether the *Canon Log 3* non-linear data is encoded as normalised code
-        values.
+        Whether the *Canon Log 3* v1 non-linear data is encoded as
+        normalised code values.
     in_reflection
         Whether the light level :math:`x` to a camera is reflection.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        *Canon Log 3* non-linear data.
+        *Canon Log 3* v1 non-linear encoded data.
 
     Notes
     -----
-    -   Introspection of the grafting points by Shaw, N. (2018) shows that the
-        *Canon Log 3* v1 IDT was likely derived from its encoding curve as the
-        latter is grafted at *+/-0.014*::
+    -   Introspection of the grafting points by Shaw, N. (2018) shows
+        that the *Canon Log 3* v1 IDT was likely derived from its
+        encoding curve as the latter is grafted at *+/-0.014*::
 
             >>> clog3 = 0.04076162
             >>> (clog3 - 0.073059361) / 2.3069815
@@ -1067,18 +1062,18 @@ def log_decoding_CanonLog3_v1(
     out_reflection: bool = True,
 ) -> NDArrayFloat:
     """
-    Define the *Canon Log 3* v1 log decoding curve / electro-optical transfer
-    function.
+    Apply the *Canon Log 3* v1 log decoding inverse opto-electronic transfer
+    function (OETF).
 
     Parameters
     ----------
     clog3
-        *Canon Log 3* non-linear data.
+        *Canon Log 3* v1 non-linear encoded data.
     bit_depth
         Bit-depth used for conversion.
     in_normalised_code_value
-        Whether the *Canon Log 3* non-linear data is encoded with normalised
-        code values.
+        Whether the *Canon Log 3* v1 non-linear data is encoded with
+        normalised code values.
     out_reflection
         Whether the light level :math:`x` to a camera is reflection.
 
@@ -1137,8 +1132,8 @@ def log_encoding_CanonLog3_v1_2(
     in_reflection: bool = True,
 ) -> NDArrayFloat:
     """
-    Define the *Canon Log 3* v1.2 log encoding curve / opto-electronic transfer
-    function.
+    Apply the *Canon Log 3* v1.2 log encoding opto-electronic transfer function
+    (OETF).
 
     Parameters
     ----------
@@ -1147,15 +1142,15 @@ def log_encoding_CanonLog3_v1_2(
     bit_depth
         Bit-depth used for conversion.
     out_normalised_code_value
-        Whether the *Canon Log 3* non-linear data is encoded as normalised code
-        values.
+        Whether the *Canon Log 3* v1.2 non-linear data is encoded as normalised
+        code values.
     in_reflection
         Whether the light level :math:`x` to a camera is reflection.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        *Canon Log 3* non-linear data.
+        *Canon Log 3* v1.2 non-linear encoded data.
 
     Notes
     -----
@@ -1214,18 +1209,18 @@ def log_decoding_CanonLog3_v1_2(
     out_reflection: bool = True,
 ) -> NDArrayFloat:
     """
-    Define the *Canon Log 3* v1.2 log decoding curve / electro-optical transfer
-    function.
+    Apply the *Canon Log 3* v1.2 log decoding inverse opto-electronic transfer
+    function (OETF).
 
     Parameters
     ----------
     clog3
-        *Canon Log 3* non-linear data.
+        *Canon Log 3* v1.2 non-linear encoded data.
     bit_depth
         Bit-depth used for conversion.
     in_normalised_code_value
-        Whether the *Canon Log 3* non-linear data is encoded with normalised
-        code values.
+        Whether the *Canon Log 3* v1.2 non-linear data is encoded with
+        normalised code values.
     out_reflection
         Whether the light level :math:`x` to a camera is reflection.
 
@@ -1288,7 +1283,7 @@ CANON_LOG_3_ENCODING_METHODS: CanonicalMapping = CanonicalMapping(
 )
 CANON_LOG_3_ENCODING_METHODS.__doc__ = """
 Supported *Canon Log 3* log encoding curve / opto-electronic transfer function
-methods.
+(OETF) methods.
 
 References
 ----------
@@ -1304,8 +1299,7 @@ def log_encoding_CanonLog3(
     method: Literal["v1", "v1.2"] | str = "v1.2",
 ) -> NDArrayFloat:
     """
-    Define the *Canon Log 3* log encoding curve / opto-electronic transfer
-    function.
+    Apply the *Canon Log 3* log encoding opto-electronic transfer function (OETF).
 
     Parameters
     ----------
@@ -1324,13 +1318,13 @@ def log_encoding_CanonLog3(
     Returns
     -------
     :class:`numpy.ndarray`
-        *Canon Log 3* non-linear data.
+        *Canon Log 3* non-linear encoded data.
 
     Notes
     -----
-    -   Introspection of the grafting points by Shaw, N. (2018) shows that the
-        *Canon Log 3* v1 IDT was likely derived from its encoding curve as the
-        latter is grafted at *+/-0.014*::
+    -   Introspection of the grafting points by Shaw, N. (2018) shows that
+        the *Canon Log 3* v1 IDT was likely derived from its encoding curve
+        as the latter is grafted at *+/-0.014*::
 
             >>> clog3 = 0.04076162
             >>> (clog3 - 0.073059361) / 2.3069815
@@ -1348,7 +1342,7 @@ def log_encoding_CanonLog3(
     +------------+-----------------------+---------------+
     | **Range**  | **Scale - Reference** | **Scale - 1** |
     +============+=======================+===============+
-    | ``clog2``  | [0, 1]                | [0, 1]        |
+    | ``clog3``  | [0, 1]                | [0, 1]        |
     +------------+-----------------------+---------------+
 
     References
@@ -1376,7 +1370,7 @@ CANON_LOG_3_DECODING_METHODS: CanonicalMapping = CanonicalMapping(
 )
 CANON_LOG_3_DECODING_METHODS.__doc__ = """
 Supported *Canon Log 3* log decoding curve / electro-optical transfer function
-methods.
+(EOTF) methods.
 
 References
 ----------
@@ -1392,13 +1386,13 @@ def log_decoding_CanonLog3(
     method: Literal["v1", "v1.2"] | str = "v1.2",
 ) -> NDArrayFloat:
     """
-    Define the *Canon Log 3* log decoding curve / electro-optical transfer
-    function.
+    Apply the *Canon Log 3* log decoding inverse opto-electronic transfer
+    function (OETF).
 
     Parameters
     ----------
     clog3
-        *Canon Log 3* non-linear data.
+        *Canon Log 3* non-linear encoded data.
     bit_depth
         Bit-depth used for conversion.
     in_normalised_code_value
@@ -1419,7 +1413,7 @@ def log_decoding_CanonLog3(
     +------------+-----------------------+---------------+
     | **Domain** | **Scale - Reference** | **Scale - 1** |
     +============+=======================+===============+
-    | ``clog2``  | [0, 1]                | [0, 1]        |
+    | ``clog3``  | [0, 1]                | [0, 1]        |
     +------------+-----------------------+---------------+
 
     +------------+-----------------------+---------------+

--- a/colour/models/rgb/transfer_functions/cineon.py
+++ b/colour/models/rgb/transfer_functions/cineon.py
@@ -2,7 +2,7 @@
 Kodak Cineon Encoding
 =====================
 
-Define the *Kodak Cineon* encoding:
+Define the *Kodak Cineon* encoding.
 
 -   :func:`colour.models.log_encoding_Cineon`
 -   :func:`colour.models.log_decoding_Cineon`
@@ -44,8 +44,7 @@ def log_encoding_Cineon(
     black_offset: ArrayLike = 10 ** ((95 - 685) / 300),
 ) -> NDArrayFloat:
     """
-    Define the *Cineon* log encoding curve / opto-electronic transfer
-    function.
+    Apply the *Cineon* log encoding opto-electronic transfer function (OETF).
 
     Parameters
     ----------
@@ -57,7 +56,7 @@ def log_encoding_Cineon(
     Returns
     -------
     :class:`numpy.ndarray`
-        Non-linear data :math:`y`.
+        *Cineon* non-linear encoded data :math:`y`.
 
     Notes
     -----
@@ -96,13 +95,12 @@ def log_decoding_Cineon(
     black_offset: ArrayLike = 10 ** ((95 - 685) / 300),
 ) -> NDArrayFloat:
     """
-    Define the *Cineon* log decoding curve / electro-optical transfer
-    function.
+    Apply the *Cineon* log decoding inverse opto-electronic transfer function (OETF).
 
     Parameters
     ----------
     y
-        Non-linear data :math:`y`.
+        *Cineon* non-linear encoded data :math:`y`.
     black_offset
         Black offset.
 

--- a/colour/models/rgb/transfer_functions/common.py
+++ b/colour/models/rgb/transfer_functions/common.py
@@ -34,17 +34,18 @@ def CV_range(
     bit_depth: int = 10, is_legal: bool = False, is_int: bool = False
 ) -> NDArrayReal:
     """
-    Return the code value :math:`CV` range for specified bit-depth, range legality
-    and representation.
+    Return the code value :math:`CV` range for the specified bit-depth,
+    range legality and representation.
 
     Parameters
     ----------
     bit_depth
         Bit-depth of the code value :math:`CV` range.
     is_legal
-        Whether the code value :math:`CV` range is legal.
+        Whether the code value :math:`CV` range represents legal code values.
     is_int
-        Whether the code value :math:`CV` range represents int code values.
+        Whether the code value :math:`CV` range represents int code
+        values.
 
     Returns
     -------
@@ -80,9 +81,9 @@ def legal_to_full(
     out_int: bool = False,
 ) -> NDArrayReal:
     """
-    Convert specified code value :math:`CV` or float equivalent of a code value at
-    a specified bit-depth from legal range (studio swing) to full range
-    (full swing).
+    Convert the specified code value :math:`CV` or float equivalent of a code
+    value at a specified bit-depth from *legal range* (studio swing) to
+    *full range* (full swing).
 
     Parameters
     ----------
@@ -92,11 +93,11 @@ def legal_to_full(
     bit_depth
         Bit-depth used for conversion.
     in_int
-        Whether to treat the input value as int code value or float
-        equivalent of a code value at a specified bit-depth.
+        Whether to treat the input value as integer code value or floating
+        point equivalent of a code value at a specified bit-depth.
     out_int
-        Whether to return value as int code value or float equivalent of a
-        code value at a specified bit-depth.
+        Whether to return value as integer code value or floating point
+        equivalent of a code value at a specified bit-depth.
 
     Returns
     -------
@@ -147,23 +148,23 @@ def full_to_legal(
     out_int: bool = False,
 ) -> NDArrayReal:
     """
-    Convert specified code value :math:`CV` or float equivalent of a code value at
-    a specified bit-depth from full range (full swing) to legal range
-    (studio swing).
+    Convert the specified code value :math:`CV` or float equivalent of a
+    code value at a specified bit-depth from full range (full swing) to
+    legal range (studio swing).
 
     Parameters
     ----------
     CV
-        Full range code value :math:`CV` or float equivalent of a code value at
-        a specified bit-depth.
+        Full range code value :math:`CV` or float equivalent of a code value
+        at a specified bit-depth.
     bit_depth
         Bit-depth used for conversion.
     in_int
-        Whether to treat the input value as int code value or float
-        equivalent of a code value at a specified bit-depth.
+        Whether to treat the input value as integer code value or floating
+        point equivalent of a code value at a specified bit-depth.
     out_int
-        Whether to return value as int code value or float equivalent of a
-        code value at a specified bit-depth.
+        Whether to return value as integer code value or floating point
+        equivalent of a code value at a specified bit-depth.
 
     Returns
     -------

--- a/colour/models/rgb/transfer_functions/davinci_intermediate.py
+++ b/colour/models/rgb/transfer_functions/davinci_intermediate.py
@@ -25,7 +25,7 @@ import numpy as np
 if typing.TYPE_CHECKING:
     from colour.hints import ArrayLike, NDArrayFloat
 
-from colour.utilities import Structure, as_float, from_range_1, to_domain_1
+from colour.utilities import Structure, as_float, from_range_1, optional, to_domain_1
 
 __author__ = "Colour Developers"
 __copyright__ = "Copyright 2013 Colour Developers"
@@ -53,7 +53,7 @@ CONSTANTS_DAVINCI_INTERMEDIATE: Structure = Structure(
 
 def oetf_DaVinciIntermediate(
     L: ArrayLike,
-    constants: Structure = CONSTANTS_DAVINCI_INTERMEDIATE,
+    constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
     Define the *DaVinci Intermediate* opto-electronic transfer function.
@@ -95,6 +95,7 @@ def oetf_DaVinciIntermediate(
     """
 
     L = to_domain_1(L)
+    constants = optional(constants, CONSTANTS_DAVINCI_INTERMEDIATE)
 
     DI_LIN_CUT = constants.DI_LIN_CUT
     DI_A = constants.DI_A
@@ -113,7 +114,7 @@ def oetf_DaVinciIntermediate(
 
 def oetf_inverse_DaVinciIntermediate(
     V: ArrayLike,
-    constants: Structure = CONSTANTS_DAVINCI_INTERMEDIATE,
+    constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
     Define the *DaVinci Intermediate* inverse opto-electronic transfer
@@ -157,6 +158,7 @@ def oetf_inverse_DaVinciIntermediate(
     """
 
     V = to_domain_1(V)
+    constants = optional(constants, CONSTANTS_DAVINCI_INTERMEDIATE)
 
     DI_LOG_CUT = constants.DI_LOG_CUT
     DI_A = constants.DI_A

--- a/colour/models/rgb/transfer_functions/davinci_intermediate.py
+++ b/colour/models/rgb/transfer_functions/davinci_intermediate.py
@@ -3,7 +3,7 @@ DaVinci Intermediate
 ====================
 
 Define the *DaVinci Intermediate* opto-electrical transfer function
-(OETF) and its inverse:
+(OETF) and its inverse.
 
 -   :func:`colour.models.oetf_DaVinciIntermediate`
 -   :func:`colour.models.oetf_inverse_DaVinciIntermediate`
@@ -56,12 +56,12 @@ def oetf_DaVinciIntermediate(
     constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
-    Define the *DaVinci Intermediate* opto-electronic transfer function.
+    Apply the *DaVinci Intermediate* opto-electronic transfer function (OETF).
 
     Parameters
     ----------
     L
-        Linear light value :math`L`.
+        Linear light value :math:`L`.
     constants
         *DaVinci Intermediate* colour component transfer function constants.
 
@@ -117,7 +117,7 @@ def oetf_inverse_DaVinciIntermediate(
     constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
-    Define the *DaVinci Intermediate* inverse opto-electronic transfer
+    Apply the *DaVinci Intermediate* inverse opto-electronic transfer
     function (OETF).
 
     Parameters
@@ -130,20 +130,20 @@ def oetf_inverse_DaVinciIntermediate(
     Returns
     -------
     :class:`numpy.ndarray`
-        Linear light value :math`L`.
+        Linear light value :math:`L`.
 
     Notes
     -----
     +------------+-----------------------+---------------+
     | **Domain** | **Scale - Reference** | **Scale - 1** |
     +============+=======================+===============+
-    | ``y``      | [0, 1]                | [0, 1]        |
+    | ``V``      | [0, 1]                | [0, 1]        |
     +------------+-----------------------+---------------+
 
     +------------+-----------------------+---------------+
     | **Range**  | **Scale - Reference** | **Scale - 1** |
     +============+=======================+===============+
-    | ``x``      | [0, 1]                | [0, 1]        |
+    | ``L``      | [0, 1]                | [0, 1]        |
     +------------+-----------------------+---------------+
 
     References

--- a/colour/models/rgb/transfer_functions/dcdm.py
+++ b/colour/models/rgb/transfer_functions/dcdm.py
@@ -3,7 +3,7 @@ Digital Cinema Distribution Master (DCDM)
 =========================================
 
 Define the *DCDM* electro-optical transfer function (EOTF) and its
-inverse:
+inverse.
 
 -   :func:`colour.models.eotf_inverse_DCDM`
 -   :func:`colour.models.eotf_DCDM`
@@ -47,15 +47,15 @@ __all__ = [
 
 def eotf_inverse_DCDM(XYZ: ArrayLike, out_int: bool = False) -> NDArrayReal:
     """
-    Define the *DCDM* inverse electro-optical transfer function (EOTF).
+    Apply the *DCDM* inverse electro-optical transfer function (EOTF).
 
     Parameters
     ----------
     XYZ
         *CIE XYZ* tristimulus values.
     out_int
-        Whether to return value as int code value or float equivalent of a
-        code value at a specified bit-depth.
+        Whether to return value as integer code value or float equivalent
+        of a code value at a specified bit-depth.
 
     Returns
     -------
@@ -69,8 +69,8 @@ def eotf_inverse_DCDM(XYZ: ArrayLike, out_int: bool = False) -> NDArrayReal:
     Notes
     -----
     -   *DCDM* is an absolute transfer function, thus the domain and range
-        values for the *Reference* and *1* scales are only indicative that the
-        data is not affected by scale transformations.
+        values for the *Reference* and *1* scales are only indicative that
+        the data is not affected by scale transformations.
 
     +----------------+-----------------------+---------------+
     | **Domain \\***  | **Scale - Reference** | **Scale - 1** |
@@ -114,14 +114,14 @@ def eotf_DCDM(
     in_int: bool = False,
 ) -> NDArrayFloat:
     """
-    Define the *DCDM* electro-optical transfer function (EOTF).
+    Apply the *DCDM* electro-optical transfer function (EOTF).
 
     Parameters
     ----------
     XYZ_p
         Non-linear *CIE XYZ'* tristimulus values.
     in_int
-        Whether to treat the input value as int code value or float
+        Whether to treat the input value as integer code value or float
         equivalent of a code value at a specified bit-depth.
 
     Returns
@@ -136,8 +136,8 @@ def eotf_DCDM(
     Notes
     -----
     -   *DCDM* is an absolute transfer function, thus the domain and range
-        values for the *Reference* and *1* scales are only indicative that the
-        data is not affected by scale transformations.
+        values for the *Reference* and *1* scales are only indicative that
+        the data is not affected by scale transformations.
 
     +----------------+-----------------------+---------------+
     | **Domain \\***  | **Scale - Reference** | **Scale - 1** |

--- a/colour/models/rgb/transfer_functions/dicom_gsdf.py
+++ b/colour/models/rgb/transfer_functions/dicom_gsdf.py
@@ -32,7 +32,14 @@ import numpy as np
 if typing.TYPE_CHECKING:
     from colour.hints import ArrayLike, NDArrayFloat, NDArrayReal
 
-from colour.utilities import Structure, as_float, as_int, from_range_1, to_domain_1
+from colour.utilities import (
+    Structure,
+    as_float,
+    as_int,
+    from_range_1,
+    optional,
+    to_domain_1,
+)
 
 __author__ = "Colour Developers"
 __copyright__ = "Copyright 2013 Colour Developers"
@@ -74,7 +81,7 @@ CONSTANTS_DICOMGSDF: Structure = Structure(
 def eotf_inverse_DICOMGSDF(
     L: ArrayLike,
     out_int: bool = False,
-    constants: Structure = CONSTANTS_DICOMGSDF,
+    constants: Structure | None = None,
 ) -> NDArrayReal:
     """
     Define the *DICOM - Grayscale Standard Display Function* inverse
@@ -122,6 +129,7 @@ def eotf_inverse_DICOMGSDF(
     """
 
     L = to_domain_1(L)
+    constants = optional(constants, CONSTANTS_DICOMGSDF)
 
     L_lg = np.log10(L)
 
@@ -156,7 +164,7 @@ def eotf_inverse_DICOMGSDF(
 def eotf_DICOMGSDF(
     J: ArrayLike,
     in_int: bool = False,
-    constants: Structure = CONSTANTS_DICOMGSDF,
+    constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
     Define the *DICOM - Grayscale Standard Display Function* electro-optical
@@ -204,6 +212,7 @@ def eotf_DICOMGSDF(
     """
 
     J = to_domain_1(J)
+    constants = optional(constants, CONSTANTS_DICOMGSDF)
 
     if not in_int:
         J = J * 1023

--- a/colour/models/rgb/transfer_functions/dicom_gsdf.py
+++ b/colour/models/rgb/transfer_functions/dicom_gsdf.py
@@ -3,7 +3,7 @@ DICOM - Grayscale Standard Display Function
 ===========================================
 
 Define the *DICOM - Grayscale Standard Display Function* electro-optical
-transfer function (EOTF) and its inverse:
+transfer function (EOTF) and its inverse.
 
 -   :func:`colour.models.eotf_inverse_DICOMGSDF`
 -   :func:`colour.models.eotf_DICOMGSDF`
@@ -84,7 +84,7 @@ def eotf_inverse_DICOMGSDF(
     constants: Structure | None = None,
 ) -> NDArrayReal:
     """
-    Define the *DICOM - Grayscale Standard Display Function* inverse
+    Apply the *DICOM - Grayscale Standard Display Function* inverse
     electro-optical transfer function (EOTF).
 
     Parameters
@@ -92,8 +92,8 @@ def eotf_inverse_DICOMGSDF(
     L
         *Luminance* :math:`L`.
     out_int
-        Whether to return value as int code value or float equivalent of a
-        code value at a specified bit-depth.
+        Whether to return value as integer code value or float equivalent
+        of a code value at a specified bit-depth.
     constants
         *DICOM - Grayscale Standard Display Function* constants.
 
@@ -167,7 +167,7 @@ def eotf_DICOMGSDF(
     constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
-    Define the *DICOM - Grayscale Standard Display Function* electro-optical
+    Apply the *DICOM - Grayscale Standard Display Function* electro-optical
     transfer function (EOTF).
 
     Parameters
@@ -175,7 +175,7 @@ def eotf_DICOMGSDF(
     J
         Just-Noticeable Difference (JND) Index, :math:`j`.
     in_int
-        Whether to treat the input value as int code value or float
+        Whether to treat the input value as integer code value or float
         equivalent of a code value at a specified bit-depth.
     constants
         *DICOM - Grayscale Standard Display Function* constants.
@@ -183,7 +183,7 @@ def eotf_DICOMGSDF(
     Returns
     -------
     :class:`numpy.ndarray`
-        Corresponding *luminance* :math:`L`.
+        *Luminance* :math:`L`.
 
     Notes
     -----

--- a/colour/models/rgb/transfer_functions/dji_d_log.py
+++ b/colour/models/rgb/transfer_functions/dji_d_log.py
@@ -2,7 +2,7 @@
 DJI D-Log Log Encoding
 ======================
 
-Define the *DJI D-Log* log encoding:
+Define the *DJI D-Log* log encoding.
 
 -   :func:`colour.models.log_encoding_DJIDLog`
 -   :func:`colour.models.log_decoding_DJIDLog`
@@ -41,17 +41,17 @@ __all__ = [
 
 def log_encoding_DJIDLog(x: ArrayLike) -> NDArrayFloat:
     """
-    Define the *DJI D-Log* log encoding curve.
+    Apply the *DJI D-Log* log encoding opto-electronic transfer function (OETF).
 
     Parameters
     ----------
     x
-        Linear reflection data :math`x`.
+        Linear reflection data :math:`x`.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        *DJI D-Log* encoded data :math:`y`.
+        *DJI D-Log* non-linear encoded data :math:`y`.
 
     References
     ----------
@@ -90,17 +90,17 @@ def log_encoding_DJIDLog(x: ArrayLike) -> NDArrayFloat:
 
 def log_decoding_DJIDLog(y: ArrayLike) -> NDArrayFloat:
     """
-    Define the *DJI D-Log* log decoding curve.
+    Apply the *DJI D-Log* log decoding inverse opto-electronic transfer function (OETF).
 
     Parameters
     ----------
     y
-        *DJI D-Log* encoded data :math:`y`.
+        *DJI D-Log* non-linear encoded data :math:`y`.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Linear reflection data :math`x`.
+        Linear reflection data :math:`x`.
 
     References
     ----------

--- a/colour/models/rgb/transfer_functions/exponent.py
+++ b/colour/models/rgb/transfer_functions/exponent.py
@@ -2,7 +2,7 @@
 Basic and Monitor-Curve Exponent Transfer Functions
 ===================================================
 
-Define the exponent transfer functions:
+Define the exponent transfer functions.
 
 -   :func:`colour.models.exponent_function_basic`
 -   :func:`colour.models.exponent_function_monitor_curve`
@@ -56,41 +56,41 @@ def exponent_function_basic(
     ) = "basicFwd",
 ) -> NDArrayFloat:
     """
-    Define the *basic* exponent transfer function.
+    Apply a *basic* exponent transfer function to the specified array.
 
     Parameters
     ----------
     x
-        Data to undergo the basic exponent conversion.
+        Exponentially encoded data :math:`x`.
     exponent
         Exponent value used for the conversion.
     style
-        Defines the behaviour for the transfer function to operate:
+        Specifies the behaviour for the exponentiation function to operate:
 
         -   *basicFwd*: *Basic Forward* exponential behaviour where the
-            definition applies a basic power law using the exponent. Values
-            less than zero are clamped.
+            definition applies a basic power law using the exponent.
+            Values less than zero are clamped.
         -   *basicRev*: *Basic Reverse* exponential behaviour where the
-            definition applies a basic power law using the exponent. Values
-            less than zero are clamped.
-        -   *basicMirrorFwd*: *Basic Mirror Forward* exponential behaviour
-            where the definition applies a basic power law using the exponent
-            for values greater than or equal to zero and mirrors the function
-            for values less than zero (i.e., rotationally symmetric
-            around the origin).
-        -   *basicMirrorRev*: *Basic Mirror Reverse* exponential behaviour
-            where the definition applies a basic power law using the exponent
-            for values greater than or equal to zero and mirrors the function
-            for values less than zero (i.e., rotationally symmetric around the
-            origin).
-        -   *basicPassThruFwd*: *Basic Pass Forward* exponential behaviour
-            where the definition applies a basic power law using the exponent
-            for values greater than or equal to zero and passes values less
-            than zero unchanged.
-        -   *basicPassThruRev*: *Basic Pass Reverse* exponential behaviour
-            where the definition applies a basic power law using the exponent
-            for values greater than or equal to zero and passes values less
-            than zero unchanged.
+            definition applies a basic power law using the exponent.
+            Values less than zero are clamped.
+        -   *basicMirrorFwd*: *Basic Mirror Forward* exponential
+            behaviour where the definition applies a basic power law
+            using the exponent for values greater than or equal to zero
+            and mirrors the function for values less than zero (i.e.,
+            rotationally symmetric around the origin).
+        -   *basicMirrorRev*: *Basic Mirror Reverse* exponential
+            behaviour where the definition applies a basic power law
+            using the exponent for values greater than or equal to zero
+            and mirrors the function for values less than zero (i.e.,
+            rotationally symmetric around the origin).
+        -   *basicPassThruFwd*: *Basic Pass Forward* exponential
+            behaviour where the definition applies a basic power law
+            using the exponent for values greater than or equal to zero
+            and passes values less than zero unchanged.
+        -   *basicPassThruRev*: *Basic Pass Reverse* exponential
+            behaviour where the definition applies a basic power law
+            using the exponent for values greater than or equal to zero
+            and passes values less than zero unchanged.
 
     Returns
     -------
@@ -203,33 +203,35 @@ def exponent_function_monitor_curve(
     ) = "monCurveFwd",
 ) -> NDArrayFloat:
     """
-    Define the *Monitor Curve* exponent transfer function.
+    Apply the *Monitor Curve* exponent transfer function to the specified array.
 
     Parameters
     ----------
     x
-        Data to undergo the monitor curve exponential conversion.
+        Exponentially encoded data :math:`x`.
     exponent
         Exponent value used for the conversion.
     offset
         Offset value used for the conversion.
     style
-        Defines the behaviour for the transfer function to operate:
+        Specifies the behaviour for the exponentiation function to operate:
 
         -   *monCurveFwd*: *Monitor Curve Forward* exponential behaviour
-            where the definition applies a power law function with a linear
-            segment near the origin.
+            where the definition applies a power law function with a
+            linear segment near the origin.
         -   *monCurveRev*: *Monitor Curve Reverse* exponential behaviour
-            where the definition applies a power law function with a linear
-            segment near the origin.
-        -   *monCurveMirrorFwd*: *Monitor Curve Mirror Forward* exponential
-            behaviour where the definition applies a power law function with a
-            linear segment near the origin and mirrors the function for values
-            less than zero (i.e., rotationally symmetric around the origin).
-        -   *monCurveMirrorRev*: *Monitor Curve Mirror Reverse* exponential
-            behaviour where the definition applies a power law function with a
-            linear segment near the origin and mirrors the function for values
-            less than zero (i.e., rotationally symmetric around the origin).
+            where the definition applies a power law function with a
+            linear segment near the origin.
+        -   *monCurveMirrorFwd*: *Monitor Curve Mirror Forward*
+            exponential behaviour where the definition applies a power law
+            function with a linear segment near the origin and mirrors the
+            function for values less than zero (i.e., rotationally
+            symmetric around the origin).
+        -   *monCurveMirrorRev*: *Monitor Curve Mirror Reverse*
+            exponential behaviour where the definition applies a power law
+            function with a linear segment near the origin and mirrors the
+            function for values less than zero (i.e., rotationally
+            symmetric around the origin).
 
     Returns
     -------

--- a/colour/models/rgb/transfer_functions/filmic_pro.py
+++ b/colour/models/rgb/transfer_functions/filmic_pro.py
@@ -2,7 +2,7 @@
 FiLMiC Pro 6 Encoding
 =====================
 
-Define the *FiLMiC Pro 6* encoding:
+Define the *FiLMiC Pro 6* encoding.
 
 -   :func:`colour.models.log_encoding_FilmicPro6`
 -   :func:`colour.models.log_decoding_FilmicPro6`
@@ -41,8 +41,7 @@ __all__ = [
 
 def log_encoding_FilmicPro6(t: ArrayLike) -> NDArrayFloat:
     """
-    Define the *FiLMiC Pro 6* log encoding curve / opto-electronic transfer
-    function.
+    Apply the *FiLMiC Pro 6* log encoding opto-electronic transfer function (OETF).
 
     Parameters
     ----------
@@ -52,7 +51,7 @@ def log_encoding_FilmicPro6(t: ArrayLike) -> NDArrayFloat:
     Returns
     -------
     :class:`numpy.ndarray`
-        Non-linear data :math:`y`.
+        Non-linear encoded data :math:`y`.
 
     Notes
     -----
@@ -68,8 +67,8 @@ def log_encoding_FilmicPro6(t: ArrayLike) -> NDArrayFloat:
     | ``y``      | [0, 1]                | [0, 1]        |
     +------------+-----------------------+---------------+
 
-    -   The *FiLMiC Pro 6* log encoding curve / opto-electronic transfer
-        function is only defined for domain (0, 1].
+    -   The *FiLMiC Pro 6* log encoding curve / opto-electronic
+        transfer function is only defined for domain (0, 1].
 
     References
     ----------
@@ -77,10 +76,11 @@ def log_encoding_FilmicPro6(t: ArrayLike) -> NDArrayFloat:
 
     Warnings
     --------
-    The *FiLMiC Pro 6* log encoding curve / opto-electronic transfer function
-    was fitted with poor precision and has :math:`Y=1.000000819999999` value
-    for :math:`t=1`. It also has no linear segment near zero and will thus be
-    undefined for :math:`t=0` when computing its logarithm.
+    The *FiLMiC Pro 6* log encoding curve / opto-electronic transfer
+    function was fitted with poor precision and has
+    :math:`Y=1.000000819999999` value for :math:`t=1`. It also has no
+    linear segment near zero and will thus be undefined for :math:`t=0`
+    when computing its logarithm.
 
     Examples
     --------
@@ -101,7 +101,7 @@ _CACHE_LOG_DECODING_FILMICPRO_INTERPOLATOR: Extrapolator | None = None
 def _log_decoding_FilmicPro6_interpolator() -> Extrapolator:
     """
     Return the *FiLMiC Pro 6* log decoding curve / electro-optical transfer
-    function interpolator and caches it if not existing.
+    function interpolator, caching it if not already existing.
 
     Returns
     -------
@@ -123,13 +123,13 @@ def _log_decoding_FilmicPro6_interpolator() -> Extrapolator:
 
 def log_decoding_FilmicPro6(y: ArrayLike) -> NDArrayFloat:
     """
-    Define the *FiLMiC Pro 6* log decoding curve / electro-optical transfer
-    function.
+    Apply the *FiLMiC Pro 6* log decoding inverse opto-electronic transfer
+    function (OETF).
 
     Parameters
     ----------
     y
-        Non-linear data :math:`y`.
+        Non-linear encoded data :math:`y`.
 
     Returns
     -------
@@ -160,7 +160,8 @@ def log_decoding_FilmicPro6(y: ArrayLike) -> NDArrayFloat:
     Warnings
     --------
     The *FiLMiC Pro 6* log encoding curve / opto-electronic transfer function
-    has no inverse in :math:`R`, we thus use a *LUT* based inversion.
+    has no inverse in :math:`\\mathbb{R}`, we thus use a *LUT* based
+    inversion.
 
     Examples
     --------

--- a/colour/models/rgb/transfer_functions/filmlight_t_log.py
+++ b/colour/models/rgb/transfer_functions/filmlight_t_log.py
@@ -2,7 +2,7 @@
 FilmLight T-Log Log Encoding
 ============================
 
-Define the *FilmLight T-Log* log encoding:
+Define the *FilmLight T-Log* log encoding.
 
 -   :func:`colour.models.log_encoding_FilmLightTLog`
 -   :func:`colour.models.log_decoding_FilmLightTLog`
@@ -44,18 +44,18 @@ def log_encoding_FilmLightTLog(
     o: float = 0.075,
 ) -> NDArrayFloat:
     """
-    Define the *FilmLight T-Log* log encoding curve.
+    Apply the *FilmLight T-Log* log encoding opto-electronic transfer function (OETF).
 
     Parameters
     ----------
     x
-        Linear reflection data :math`x`.
+        Linear reflection data :math:`x`.
     w
-        Value of :math:`x` for :math:`t = 1.0`.
+        Value of :math:`x` for which :math:`t = 1.0`.
     g
         Gradient at :math:`x = 0.0`.
     o
-        Value of :math:`t` for :math:`x = 0.0`.
+        Value of :math:`t` at :math:`x = 0.0`.
 
     Returns
     -------
@@ -138,23 +138,25 @@ def log_decoding_FilmLightTLog(
     o: float = 0.075,
 ) -> NDArrayFloat:
     """
-    Define the *FilmLight T-Log* log decoding curve.
+    Apply the *FilmLight T-Log* log decoding inverse opto-electronic transfer
+
+    function (OETF).
 
     Parameters
     ----------
     t
-        Non-linear data :math:`t`.
+        *FilmLight T-Log* encoded data :math:`t`.
     w
-        Value of :math:`x` for :math:`t = 1.0`.
+        Value of :math:`x` for which :math:`t = 1.0`.
     g
         Gradient at :math:`x = 0.0`.
     o
-        Value of :math:`t` for :math:`x = 0.0`.
+        Value of :math:`t` at :math:`x = 0.0`.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Linear reflection data :math`x`.
+        Linear reflection data :math:`x`.
 
     References
     ----------

--- a/colour/models/rgb/transfer_functions/fujifilm_f_log.py
+++ b/colour/models/rgb/transfer_functions/fujifilm_f_log.py
@@ -2,7 +2,7 @@
 Fujifilm F-Log Log Encoding
 ===========================
 
-Define the *Fujifilm F-Log* log encoding:
+Define the *Fujifilm F-Log* log encoding.
 
 -   :func:`colour.models.log_encoding_FLog`
 -   :func:`colour.models.log_decoding_FLog`
@@ -78,27 +78,26 @@ def log_encoding_FLog(
     constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
-    Define the *Fujifilm F-Log* log encoding curve / opto-electronic transfer
-    function.
+    Apply the *Fujifilm F-Log* log encoding opto-electronic transfer function (OETF).
 
     Parameters
     ----------
     in_r
-        Linear reflection data :math`in`.
+        Linear reflection data :math:`in`.
     bit_depth
         Bit-depth used for conversion.
     out_normalised_code_value
-        Whether the non-linear *Fujifilm F-Log* data :math:`out` is encoded as
+        Whether the *Fujifilm F-Log* non-linear data :math:`out` is encoded as
         normalised code values.
     in_reflection
-        Whether the light level :math`in` to a camera is reflection.
+        Whether the light level :math:`in` to a camera is reflection.
     constants
         *Fujifilm F-Log* constants.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Non-linear data :math:`out`.
+        *Fujifilm F-Log* non-linear encoded data :math:`out`.
 
     Notes
     -----
@@ -123,8 +122,8 @@ def log_encoding_FLog(
     >>> log_encoding_FLog(0.18)  # doctest: +ELLIPSIS
     0.4593184...
 
-    The values of *2-2. F-Log Code Value* table in :cite:`Fujifilm2022` are
-    obtained as follows:
+    The values of *2-2. F-Log Code Value* table in :cite:`Fujifilm2022`
+    are obtained as follows:
 
     >>> x = np.array([0, 18, 90]) / 100
     >>> np.around(log_encoding_FLog(x, 10, False) * 100, 1)
@@ -166,27 +165,28 @@ def log_decoding_FLog(
     constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
-    Define the *Fujifilm F-Log* log decoding curve / electro-optical transfer
-    function.
+    Apply the *Fujifilm F-Log* log decoding inverse opto-electronic transfer
+
+    function (OETF).
 
     Parameters
     ----------
     out_r
-        Non-linear data :math:`out`.
+        *Fujifilm F-Log* non-linear encoded data :math:`out`.
     bit_depth
         Bit-depth used for conversion.
     in_normalised_code_value
-        Whether the non-linear *Fujifilm F-Log* data :math:`out` is encoded as
+        Whether the *Fujifilm F-Log* non-linear data :math:`out` is encoded as
         normalised code values.
     out_reflection
-        Whether the light level :math`in` to a camera is reflection.
+        Whether the light level :math:`in` to a camera is reflection.
     constants
         *Fujifilm F-Log* constants.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Linear reflection data :math`in`.
+        Linear reflection data :math:`in`.
 
     Notes
     -----
@@ -245,27 +245,26 @@ def log_encoding_FLog2(
     constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
-    Define the *Fujifilm F-Log2* log encoding curve / opto-electronic transfer
-    function.
+    Apply the *Fujifilm F-Log2* log encoding opto-electronic transfer function (OETF).
 
     Parameters
     ----------
     in_r
-        Linear reflection data :math`in`.
+        Linear reflection data :math:`in`.
     bit_depth
-        Bit depth used for conversion.
+        Bit-depth used for conversion.
     out_normalised_code_value
-        Whether the non-linear *Fujifilm F-Log2* data :math:`out` is encoded as
+        Whether the *Fujifilm F-Log2* non-linear data :math:`out` is encoded as
         normalised code values.
     in_reflection
-        Whether the light level :math`in` to a camera is reflection.
+        Whether the light level :math:`in` to a camera is reflection.
     constants
         *Fujifilm F-Log2* constants.
 
     Returns
     -------
     :class:`numpy.floating` or :class:`numpy.ndarray`
-        Non-linear data :math:`out`.
+        *Fujifilm F-Log2* non-linear encoded data :math:`out`.
 
     Notes
     -----
@@ -290,8 +289,8 @@ def log_encoding_FLog2(
     >>> log_encoding_FLog2(0.18)  # doctest: +ELLIPSIS
     0.3910072...
 
-    The values of *2-2. F-Log2 Code Value* table in :cite:`Fujifilm2022a` are
-    obtained as follows:
+    The values of *2-2. F-Log2 Code Value* table in
+    :cite:`Fujifilm2022a` are obtained as follows:
 
     >>> x = np.array([0, 18, 90]) / 100
     >>> np.around(log_encoding_FLog2(x, 10, False) * 100, 1)
@@ -315,27 +314,27 @@ def log_decoding_FLog2(
     constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
-    Define the *Fujifilm F-Log2* log decoding curve / electro-optical transfer
-    function.
+    Apply the *Fujifilm F-Log2* log decoding inverse opto-electronic transfer
+    function (OETF).
 
     Parameters
     ----------
     out_r
-        Non-linear data :math:`out`.
+        *Fujifilm F-Log2* non-linear encoded data :math:`out`.
     bit_depth
-        Bit depth used for conversion.
+        Bit-depth used for conversion.
     in_normalised_code_value
-        Whether the non-linear *Fujifilm F-Log2* data :math:`out` is encoded as
+        Whether the *Fujifilm F-Log2* non-linear data :math:`out` is encoded as
         normalised code values.
     out_reflection
-        Whether the light level :math`in` to a camera is reflection.
+        Whether the light level :math:`in` to a camera is reflection.
     constants
         *Fujifilm F-Log2* constants.
 
     Returns
     -------
     :class:`numpy.floating` or :class:`numpy.ndarray`
-        Linear reflection data :math`in`.
+        Linear reflection data :math:`in`.
 
     Notes
     -----

--- a/colour/models/rgb/transfer_functions/fujifilm_f_log.py
+++ b/colour/models/rgb/transfer_functions/fujifilm_f_log.py
@@ -27,7 +27,7 @@ if typing.TYPE_CHECKING:
     from colour.hints import ArrayLike, NDArrayFloat
 
 from colour.models.rgb.transfer_functions import full_to_legal, legal_to_full
-from colour.utilities import Structure, as_float, from_range_1, to_domain_1
+from colour.utilities import Structure, as_float, from_range_1, optional, to_domain_1
 
 __author__ = "Colour Developers"
 __copyright__ = "Copyright 2013 Colour Developers"
@@ -75,7 +75,7 @@ def log_encoding_FLog(
     bit_depth: int = 10,
     out_normalised_code_value: bool = True,
     in_reflection: bool = True,
-    constants: Structure = CONSTANTS_FLOG,
+    constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
     Define the *Fujifilm F-Log* log encoding curve / opto-electronic transfer
@@ -134,6 +134,7 @@ def log_encoding_FLog(
     """
 
     in_r = to_domain_1(in_r)
+    constants = optional(constants, CONSTANTS_FLOG)
 
     if not in_reflection:
         in_r = in_r * 0.9
@@ -162,7 +163,7 @@ def log_decoding_FLog(
     bit_depth: int = 10,
     in_normalised_code_value: bool = True,
     out_reflection: bool = True,
-    constants: Structure = CONSTANTS_FLOG,
+    constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
     Define the *Fujifilm F-Log* log decoding curve / electro-optical transfer
@@ -212,6 +213,7 @@ def log_decoding_FLog(
     """
 
     out_r = to_domain_1(out_r)
+    constants = optional(constants, CONSTANTS_FLOG)
 
     out_r = out_r if in_normalised_code_value else full_to_legal(out_r, bit_depth)
 
@@ -240,7 +242,7 @@ def log_encoding_FLog2(
     bit_depth: int = 10,
     out_normalised_code_value: bool = True,
     in_reflection: bool = True,
-    constants: Structure = CONSTANTS_FLOG2,
+    constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
     Define the *Fujifilm F-Log2* log encoding curve / opto-electronic transfer
@@ -298,6 +300,8 @@ def log_encoding_FLog2(
     array([ 95, 400, 570])
     """
 
+    constants = optional(constants, CONSTANTS_FLOG2)
+
     return log_encoding_FLog(
         in_r, bit_depth, out_normalised_code_value, in_reflection, constants
     )
@@ -308,7 +312,7 @@ def log_decoding_FLog2(
     bit_depth: int = 10,
     in_normalised_code_value: bool = True,
     out_reflection: bool = True,
-    constants: Structure = CONSTANTS_FLOG2,
+    constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
     Define the *Fujifilm F-Log2* log decoding curve / electro-optical transfer
@@ -356,6 +360,8 @@ def log_decoding_FLog2(
     >>> log_decoding_FLog2(0.39100724189123004)  # doctest: +ELLIPSIS
     0.1799999...
     """
+
+    constants = optional(constants, CONSTANTS_FLOG2)
 
     return log_decoding_FLog(
         out_r, bit_depth, in_normalised_code_value, out_reflection, constants

--- a/colour/models/rgb/transfer_functions/gamma.py
+++ b/colour/models/rgb/transfer_functions/gamma.py
@@ -3,7 +3,7 @@ Gamma Colour Component Transfer Function
 ========================================
 
 Define the gamma encoding / decoding colour component transfer function
-related objects:
+related objects.
 
 - :func:`colour.gamma_function`
 """
@@ -41,32 +41,32 @@ def gamma_function(
     ) = "Indeterminate",
 ) -> NDArrayFloat:
     """
-    Define a typical gamma encoding / decoding function.
+    Apply a gamma encoding or decoding transformation to the specified array.
 
     Parameters
     ----------
     a
-        Array to encode / decode.
+        Array to encode or decode.
     exponent
-        Encoding / decoding exponent.
+        Encoding or decoding exponent.
     negative_number_handling
-        Defines the behaviour for ``a`` negative numbers and / or the
-        definition return value:
+        Behaviour for ``a`` negative numbers and the definition return
+        value:
 
-        -   *Indeterminate*: The behaviour will be indeterminate and
+        -   *Indeterminate*: The behaviour will be indeterminate and the
             definition return value might contain *nans*.
         -   *Mirror*: The definition return value will be mirrored around
-            abscissa and ordinate axis, i.e., Blackmagic Design: Davinci Resolve
-            behaviour.
-        -   *Preserve*: The definition will preserve any negative number in
-            ``a``, i.e., The Foundry Nuke behaviour.
-        -   *Clamp*: The definition will clamp any negative number in ``a`` to
-            0.
+            the abscissa and ordinate axes, i.e., Blackmagic Design:
+            Davinci Resolve behaviour.
+        -   *Preserve*: The definition will preserve any negative number
+            in ``a``, i.e., The Foundry Nuke behaviour.
+        -   *Clamp*: The definition will clamp any negative number in
+            ``a`` to 0.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Encoded / decoded array.
+        Encoded or decoded array.
 
     Examples
     --------

--- a/colour/models/rgb/transfer_functions/gopro.py
+++ b/colour/models/rgb/transfer_functions/gopro.py
@@ -2,7 +2,7 @@
 GoPro Encoding
 ==============
 
-Define the *GoPro* *Protune* encoding:
+Define the *GoPro* *Protune* encoding.
 
 -   :func:`colour.models.log_encoding_Protune`
 -   :func:`colour.models.log_decoding_Protune`
@@ -41,8 +41,7 @@ __all__ = [
 
 def log_encoding_Protune(x: ArrayLike) -> NDArrayFloat:
     """
-    Define the *Protune* log encoding curve / opto-electronic transfer
-    function.
+    Apply the *Protune* log encoding opto-electronic transfer function (OETF).
 
     Parameters
     ----------
@@ -52,7 +51,7 @@ def log_encoding_Protune(x: ArrayLike) -> NDArrayFloat:
     Returns
     -------
     :class:`numpy.ndarray`
-        Non-linear data :math:`y`.
+        Non-linear encoded data :math:`y`.
 
     Notes
     -----
@@ -87,13 +86,12 @@ def log_encoding_Protune(x: ArrayLike) -> NDArrayFloat:
 
 def log_decoding_Protune(y: ArrayLike) -> NDArrayFloat:
     """
-    Define the *Protune* log decoding curve / electro-optical transfer
-    function.
+    Apply the *Protune* log decoding inverse opto-electronic transfer function (OETF).
 
     Parameters
     ----------
     y
-        Non-linear data :math:`y`.
+        Non-linear encoded data :math:`y`.
 
     Returns
     -------

--- a/colour/models/rgb/transfer_functions/itur_bt_1361.py
+++ b/colour/models/rgb/transfer_functions/itur_bt_1361.py
@@ -3,7 +3,7 @@ Recommendation ITU-R BT.1361
 ============================
 
 Define the *Recommendation ITU-R BT.1361* opto-electrical transfer function
-(OETF) and its inverse:
+(OETF) and its inverse.
 
 -   :func:`colour.models.oetf_BT1361`
 -   :func:`colour.models.oetf_inverse_BT1361`
@@ -46,7 +46,7 @@ __all__ = [
 
 def oetf_BT1361(L: ArrayLike) -> NDArrayFloat:
     """
-    Define *Recommendation ITU-R BT.1361* extended color gamut system
+    Apply the *Recommendation ITU-R BT.1361* extended colour gamut system
     opto-electronic transfer function (OETF).
 
     Parameters
@@ -57,7 +57,7 @@ def oetf_BT1361(L: ArrayLike) -> NDArrayFloat:
     Returns
     -------
     :class:`numpy.ndarray`
-        Corresponding non-linear primary signal :math:`E'`.
+        Non-linear primary signal :math:`E'`.
 
     Notes
     -----
@@ -67,11 +67,11 @@ def oetf_BT1361(L: ArrayLike) -> NDArrayFloat:
     | ``L``      | [0, 1]                | [0, 1]        |
     +------------+-----------------------+---------------+
 
-    +------------+-----------------------+-------------------+
-    | **Range**  | **Scale - Reference** | **Scale - 1**     |
-    +============+=======================+===================+
-    | ``E_p'``   | [0, 1]                | [0, 1]            |
-    +------------+-----------------------+-------------------+
+    +------------+-----------------------+---------------+
+    | **Range**  | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``E_p'``   | [0, 1]                | [0, 1]        |
+    +------------+-----------------------+---------------+
 
     References
     ----------
@@ -107,8 +107,8 @@ def oetf_BT1361(L: ArrayLike) -> NDArrayFloat:
 
 def oetf_inverse_BT1361(E_p: ArrayLike) -> NDArrayFloat:
     """
-    Define *Recommendation ITU-R BT.1361* extended color gamut system inverse
-    opto-electronic transfer functions (OETF).
+    Apply the *Recommendation ITU-R BT.1361* extended colour gamut system
+    inverse opto-electronic transfer function (OETF).
 
     Parameters
     ----------
@@ -118,7 +118,7 @@ def oetf_inverse_BT1361(E_p: ArrayLike) -> NDArrayFloat:
     Returns
     -------
     :class:`numpy.ndarray`
-        Corresponding scene *Luminance* :math:`L`.
+        Scene *Luminance* :math:`L`.
 
     Notes
     -----
@@ -133,7 +133,6 @@ def oetf_inverse_BT1361(E_p: ArrayLike) -> NDArrayFloat:
     +============+=======================+===============+
     | ``L``      | [0, 1]                | [0, 1]        |
     +------------+-----------------------+---------------+
-
 
     References
     ----------

--- a/colour/models/rgb/transfer_functions/itur_bt_1886.py
+++ b/colour/models/rgb/transfer_functions/itur_bt_1886.py
@@ -3,7 +3,7 @@ Recommendation ITU-R BT.1886
 ============================
 
 Define the *Recommendation ITU-R BT.1886* electro-optical transfer function
-(EOTF) and its inverse:
+(EOTF) and its inverse.
 
 -   :func:`colour.models.eotf_inverse_BT1886`
 -   :func:`colour.models.eotf_BT1886`
@@ -46,23 +46,26 @@ __all__ = [
 
 def eotf_inverse_BT1886(L: ArrayLike, L_B: float = 0, L_W: float = 1) -> NDArrayFloat:
     """
-    Define *Recommendation ITU-R BT.1886* inverse electro-optical transfer
-    function (EOTF).
+    Apply the *Recommendation ITU-R BT.1886* inverse electro-optical
+    transfer function (EOTF) for flat panel displays.
 
     Parameters
     ----------
     L
         Screen luminance in :math:`cd/m^2`.
     L_B
-        Screen luminance for black.
+        Screen luminance for black in :math:`cd/m^2`.
     L_W
-        Screen luminance for white.
+        Screen luminance for white in :math:`cd/m^2`.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Input video signal level (normalised, black at :math:`V = 0`, to white
-        at :math:`V = 1`.
+        Input video signal level (normalised, with black at :math:`V = 0`
+        and white at :math:`V = 1`). For content mastered per
+        *Recommendation ITU-R BT.709*, 10-bit digital code values
+        :math:`D` map into values of :math:`V` per the following equation:
+        :math:`V = (D-64)/876`
 
     Notes
     -----
@@ -104,21 +107,21 @@ def eotf_inverse_BT1886(L: ArrayLike, L_B: float = 0, L_W: float = 1) -> NDArray
 
 def eotf_BT1886(V: ArrayLike, L_B: float = 0, L_W: float = 1) -> NDArrayFloat:
     """
-    Define *Recommendation ITU-R BT.1886* electro-optical transfer function
-    (EOTF).
+    Apply the *Recommendation ITU-R BT.1886* electro-optical transfer
+    function (EOTF) for flat panel displays.
 
     Parameters
     ----------
     V
-        Input video signal level (normalised, black at :math:`V = 0`, to white
-        at :math:`V = 1`. For content mastered per
-        *Recommendation ITU-R BT.709*, 10-bit digital code values :math:`D` map
-        into values of :math:`V` per the following equation:
+        Input video signal level (normalised, with black at :math:`V = 0`
+        and white at :math:`V = 1`). For content mastered per
+        *Recommendation ITU-R BT.709*, 10-bit digital code values
+        :math:`D` map into values of :math:`V` per the following equation:
         :math:`V = (D-64)/876`
     L_B
-        Screen luminance for black.
+        Screen luminance for black in :math:`cd/m^2`.
     L_W
-        Screen luminance for white.
+        Screen luminance for white in :math:`cd/m^2`.
 
     Returns
     -------

--- a/colour/models/rgb/transfer_functions/itur_bt_2020.py
+++ b/colour/models/rgb/transfer_functions/itur_bt_2020.py
@@ -34,6 +34,7 @@ from colour.utilities import (
     as_float,
     domain_range_scale,
     from_range_1,
+    optional,
     to_domain_1,
 )
 
@@ -74,7 +75,7 @@ References
 def oetf_BT2020(
     E: ArrayLike,
     is_12_bits_system: bool = False,
-    constants: Structure = CONSTANTS_BT2020,
+    constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
     Define *Recommendation ITU-R BT.2020* opto-electronic transfer function
@@ -121,6 +122,7 @@ def oetf_BT2020(
     """
 
     E = to_domain_1(E)
+    constants = optional(constants, CONSTANTS_BT2020)
 
     a = constants.alpha(is_12_bits_system)
     b = constants.beta(is_12_bits_system)
@@ -133,7 +135,7 @@ def oetf_BT2020(
 def oetf_inverse_BT2020(
     E_p: ArrayLike,
     is_12_bits_system: bool = False,
-    constants: Structure = CONSTANTS_BT2020,
+    constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
     Define *Recommendation ITU-R BT.2020* inverse opto-electronic transfer
@@ -178,6 +180,7 @@ def oetf_inverse_BT2020(
     """
 
     E_p = to_domain_1(E_p)
+    constants = optional(constants, CONSTANTS_BT2020)
 
     a = constants.alpha(is_12_bits_system)
     b = constants.beta(is_12_bits_system)

--- a/colour/models/rgb/transfer_functions/itur_bt_2020.py
+++ b/colour/models/rgb/transfer_functions/itur_bt_2020.py
@@ -3,7 +3,7 @@ Recommendation ITU-R BT.2020
 ============================
 
 Define the *Recommendation ITU-R BT.2020* opto-electrical transfer function
-(OETF) and its inverse:
+(OETF) and its inverse.
 
 -   :func:`colour.models.oetf_BT2020`
 -   :func:`colour.models.oetf_inverse_BT2020`
@@ -78,7 +78,7 @@ def oetf_BT2020(
     constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
-    Define *Recommendation ITU-R BT.2020* opto-electronic transfer function
+    Apply the *Recommendation ITU-R BT.2020* opto-electronic transfer function
     (OETF).
 
     Parameters
@@ -88,14 +88,15 @@ def oetf_BT2020(
         proportional to the implicit light intensity that would be detected
         with a reference camera colour channel R, G, B.
     is_12_bits_system
-        *BT.709* *alpha* and *beta* constants are used if system is not 12-bit.
+        *BT.709* *alpha* and *beta* constants are used if system is not
+        12-bit.
     constants
         *Recommendation ITU-R BT.2020* constants.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Resulting non-linear signal :math:`E'`.
+        Non-linear signal :math:`E'`.
 
     Notes
     -----
@@ -138,22 +139,25 @@ def oetf_inverse_BT2020(
     constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
-    Define *Recommendation ITU-R BT.2020* inverse opto-electronic transfer
-    function (OETF).
+    Apply the *Recommendation ITU-R BT.2020* inverse opto-electronic transfer function
+    (OETF).
 
     Parameters
     ----------
     E_p
         Non-linear signal :math:`E'`.
     is_12_bits_system
-        *BT.709* *alpha* and *beta* constants are used if system is not 12-bit.
+        *BT.709* *alpha* and *beta* constants are used if system is not
+        12-bit.
     constants
         *Recommendation ITU-R BT.2020* constants.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Resulting voltage :math:`E`.
+        Voltage :math:`E` normalised by the reference white level and
+        proportional to the implicit light intensity that would be detected
+        with a reference camera colour channel R, G, B.
 
     Notes
     -----

--- a/colour/models/rgb/transfer_functions/itur_bt_2100.py
+++ b/colour/models/rgb/transfer_functions/itur_bt_2100.py
@@ -4,7 +4,7 @@ Recommendation ITU-R BT.2100
 
 Define the *Recommendation ITU-R BT.2100* opto-electrical transfer functions
 (OETF), opto-optical transfer functions (OOTF / OOCF) and electro-optical
-transfer functions (EOTF) and their inverse:
+transfer functions (EOTF) and their inverse.
 
 -   :func:`colour.models.oetf_BT2100_PQ`
 -   :func:`colour.models.oetf_inverse_BT2100_PQ`
@@ -131,23 +131,19 @@ __all__ = [
 
 def oetf_BT2100_PQ(E: ArrayLike) -> NDArrayFloat:
     """
-    Define *Recommendation ITU-R BT.2100* *Reference PQ* opto-electrical
+    Apply the *Recommendation ITU-R BT.2100* *Reference PQ* opto-electronic
     transfer function (OETF).
-
-    The OETF maps relative scene linear light into the non-linear *PQ* signal
-    value.
 
     Parameters
     ----------
     E
-        :math:`E = {R_S, G_S, B_S; Y_S; or I_S}` is the signal determined by
-        scene light and scaled by camera exposure.
+        :math:`E = \\{R_S, G_S, B_S; Y_S; \\text{or } I_S\\}` denotes the
+        signal determined by scene light and scaled by camera exposure.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        :math:`E'` is the resulting non-linear signal (:math:`R'`, :math:`G'`,
-        :math:`B'`).
+        :math:`E'` denotes the non-linear signal :math:`\\{R', G', B'\\}`.
 
     Notes
     -----
@@ -178,20 +174,19 @@ def oetf_BT2100_PQ(E: ArrayLike) -> NDArrayFloat:
 
 def oetf_inverse_BT2100_PQ(E_p: ArrayLike) -> NDArrayFloat:
     """
-    Define *Recommendation ITU-R BT.2100* *Reference PQ* inverse
+    Apply the *Recommendation ITU-R BT.2100* *Reference PQ* inverse
     opto-electrical transfer function (OETF).
 
     Parameters
     ----------
     E_p
-        :math:`E'` is the resulting non-linear signal (:math:`R'`, :math:`G'`,
-        :math:`B'`).
+        :math:`E'` denotes the non-linear signal :math:`\\{R', G', B'\\}`.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        :math:`E = {R_S, G_S, B_S; Y_S; or I_S}` is the signal determined by
-        scene light and scaled by camera exposure.
+        :math:`E = \\{R_S, G_S, B_S; Y_S; \\text{or } I_S\\}` denotes the
+        signal determined by scene light and scaled by camera exposure.
 
     Notes
     -----
@@ -222,22 +217,19 @@ def oetf_inverse_BT2100_PQ(E_p: ArrayLike) -> NDArrayFloat:
 
 def eotf_BT2100_PQ(E_p: ArrayLike) -> NDArrayFloat:
     """
-    Define *Recommendation ITU-R BT.2100* *Reference PQ* electro-optical
+    Apply the *Recommendation ITU-R BT.2100* *Reference PQ* electro-optical
     transfer function (EOTF).
-
-    The EOTF maps the non-linear *PQ* signal into display light.
 
     Parameters
     ----------
     E_p
-        :math:`E'` denotes a non-linear colour value :math:`{R', G', B'}` or
-        :math:`{L', M', S'}` in *PQ* space [0, 1].
+        :math:`E'` denotes the non-linear signal :math:`\\{R', G', B'\\}`.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        :math:`F_D` is the luminance of a displayed linear component
-        :math:`{R_D, G_D, B_D}` or :math:`Y_D` or :math:`I_D`, in
+        Luminance :math:`F_D` of a displayed linear component
+        :math:`\\{R_D, G_D, B_D\\}` or :math:`Y_D` or :math:`I_D`, in
         :math:`cd/m^2`.
 
     Notes
@@ -269,21 +261,21 @@ def eotf_BT2100_PQ(E_p: ArrayLike) -> NDArrayFloat:
 
 def eotf_inverse_BT2100_PQ(F_D: ArrayLike) -> NDArrayFloat:
     """
-    Define *Recommendation ITU-R BT.2100* *Reference PQ* inverse
+    Apply the *Recommendation ITU-R BT.2100* *Reference PQ* inverse
     electro-optical transfer function (EOTF).
 
     Parameters
     ----------
     F_D
-        :math:`F_D` is the luminance of a displayed linear component
-        :math:`{R_D, G_D, B_D}` or :math:`Y_D` or :math:`I_D`, in
+        Luminance :math:`F_D` of a displayed linear component
+        :math:`\\{R_D, G_D, B_D\\}` or :math:`Y_D` or :math:`I_D`, in
         :math:`cd/m^2`.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        :math:`E'` denotes a non-linear colour value :math:`{R', G', B'}` or
-        :math:`{L', M', S'}` in *PQ* space [0, 1].
+        :math:`E'` denotes a non-linear colour value :math:`\\{R', G', B'\\}`
+        or :math:`\\{L', M', S'\\}`.
 
     Notes
     -----
@@ -301,7 +293,8 @@ def eotf_inverse_BT2100_PQ(F_D: ArrayLike) -> NDArrayFloat:
 
     References
     ----------
-    :cite:`Borer2017a`, :cite:`InternationalTelecommunicationUnion2017`
+    :cite:`Borer2017a`,
+    :cite:`InternationalTelecommunicationUnion2017`
 
     Examples
     --------
@@ -314,22 +307,21 @@ def eotf_inverse_BT2100_PQ(F_D: ArrayLike) -> NDArrayFloat:
 
 def ootf_BT2100_PQ(E: ArrayLike) -> NDArrayFloat:
     """
-    Define *Recommendation ITU-R BT.2100* *Reference PQ* opto-optical transfer
-    function (OOTF / OOCF).
-
-    The OOTF maps relative scene linear light to display linear light.
+    Apply the *Recommendation ITU-R BT.2100* *Reference PQ* opto-optical
+    transfer function (OOTF).
 
     Parameters
     ----------
     E
-        :math:`E = {R_S, G_S, B_S; Y_S; or I_S}` is the signal determined by
-        scene light and scaled by camera exposure.
+        :math:`E = \\{R_S, G_S, B_S; Y_S; \\text{or } I_S\\}` denotes the
+        signal determined by scene light and scaled by camera exposure.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        :math:`F_D` is the luminance of a displayed linear component
-        (:math:`R_D`, :math:`G_D`, :math:`B_D`; :math:`Y_D`; or :math:`I_D`).
+        Luminance :math:`F_D` of a displayed linear component
+        :math:`\\{R_D, G_D, B_D\\}` or :math:`Y_D` or :math:`I_D`, in
+        :math:`cd/m^2`.
 
     Notes
     -----
@@ -363,20 +355,21 @@ def ootf_BT2100_PQ(E: ArrayLike) -> NDArrayFloat:
 
 def ootf_inverse_BT2100_PQ(F_D: ArrayLike) -> NDArrayFloat:
     """
-    Define *Recommendation ITU-R BT.2100* *Reference PQ* inverse opto-optical
-    transfer function (OOTF / OOCF).
+    Apply the *Recommendation ITU-R BT.2100* *Reference PQ* inverse
+    opto-optical transfer function (OOTF).
 
     Parameters
     ----------
     F_D
-        :math:`F_D` is the luminance of a displayed linear component
-        (:math:`R_D`, :math:`G_D`, :math:`B_D`; :math:`Y_D`; or :math:`I_D`).
+        Luminance :math:`F_D` of a displayed linear component
+        :math:`\\{R_D, G_D, B_D\\}` or :math:`Y_D` or :math:`I_D`, in
+        :math:`cd/m^2`.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        :math:`E = {R_S, G_S, B_S; Y_S; or I_S}` is the signal determined by
-        scene light and scaled by camera exposure.
+        :math:`E = \\{R_S, G_S, B_S; Y_S; or I_S\\}` denotes the signal
+        determined by scene light and scaled by camera exposure.
 
     Notes
     -----
@@ -429,14 +422,14 @@ References
 
 def gamma_function_BT2100_HLG(L_W: float = 1000) -> float:
     """
-    Return the *Reference HLG* system gamma value for specified display nominal
-    peak luminance.
+    Compute the *Reference HLG* system gamma value for the specified display
+    nominal peak luminance.
 
     Parameters
     ----------
     L_W
-        :math:`L_W` is nominal peak luminance of the display in :math:`cd/m^2`
-        for achromatic pixels.
+        Nominal peak luminance :math:`L_W` of the display in :math:`cd/m^2` for
+        achromatic pixels.
 
     Returns
     -------
@@ -460,25 +453,23 @@ def gamma_function_BT2100_HLG(L_W: float = 1000) -> float:
 
 def oetf_BT2100_HLG(E: ArrayLike, constants: Structure | None = None) -> NDArrayFloat:
     """
-    Define *Recommendation ITU-R BT.2100* *Reference HLG* opto-electrical
+    Apply the *Recommendation ITU-R BT.2100* *Reference HLG* opto-electrical
     transfer function (OETF).
 
     The OETF maps relative scene linear light into the non-linear *HLG* signal
-    value.
 
     Parameters
     ----------
     E
-        :math:`E` is the signal for each colour component
-        :math:`{R_S, G_S, B_S}` proportional to scene linear light and scaled
-        by camera exposure.
+        :math:`E = \\{R_S, G_S, B_S; Y_S; \\text{or } I_S\\}` denotes the
+        signal determined by scene light and scaled by camera exposure.
     constants
         *Recommendation ITU-R BT.2100* *Reference HLG* constants.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        :math:`E'` is the resulting non-linear signal :math:`{R', G', B'}`.
+        :math:`E'` is the resulting non-linear signal :math:`\\{R', G', B'\\}`.
 
     Notes
     -----
@@ -505,6 +496,7 @@ def oetf_BT2100_HLG(E: ArrayLike, constants: Structure | None = None) -> NDArray
     """
 
     E = as_float_array(E)
+    constants = optional(constants, CONSTANTS_BT2100_HLG)
 
     return oetf_ARIBSTDB67(12 * E, constants=constants)
 
@@ -513,22 +505,21 @@ def oetf_inverse_BT2100_HLG(
     E_p: ArrayLike, constants: Structure | None = None
 ) -> NDArrayFloat:
     """
-    Define *Recommendation ITU-R BT.2100* *Reference HLG* inverse
+    Apply the *Recommendation ITU-R BT.2100* *Reference HLG* inverse
     opto-electrical transfer function (OETF).
 
     Parameters
     ----------
     E_p
-        :math:`E'` is the resulting non-linear signal :math:`{R', G', B'}`.
+        :math:`E'` denotes the non-linear signal :math:`\\{R', G', B'\\}`.
     constants
         *Recommendation ITU-R BT.2100* *Reference HLG* constants.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        :math:`E` is the signal for each colour component
-        :math:`{R_S, G_S, B_S}` proportional to scene linear light and scaled
-        by camera exposure.
+        :math:`E = \\{R_S, G_S, B_S; Y_S; \\text{or } I_S\\}` denotes the
+        signal determined by scene light and scaled by camera exposure.
 
     Notes
     -----
@@ -563,19 +554,20 @@ def black_level_lift_BT2100_HLG(
     L_B: float = 0, L_W: float = 1000, gamma: float | None = None
 ) -> float:
     """
-    Return the *Reference HLG* black level lift :math:`\\beta` for specified
-    display luminance for black, nominal peak luminance and system gamma value.
+    Compute the *Reference HLG* black level lift :math:`\\beta` for the
+    specified display luminance for black, nominal peak luminance, and system
+    gamma value.
 
     Parameters
     ----------
     L_B
-        :math:`L_B` is the display luminance for black in :math:`cd/m^2`.
+        Display luminance for black :math:`L_B` in :math:`cd/m^2`.
     L_W
-        :math:`L_W` is nominal peak luminance of the display in :math:`cd/m^2`
-        for achromatic pixels.
+        Nominal peak luminance :math:`L_W` of the display in :math:`cd/m^2` for
+        achromatic pixels.
     gamma
-        System gamma value, 1.2 at the nominal display peak luminance of
-        :math:`1000 cd/m^2`.
+        System gamma value, defaults to 1.2 at the nominal display peak
+        luminance of :math:`1000 cd/m^2`.
 
     Returns
     -------
@@ -609,24 +601,21 @@ def eotf_BT2100_HLG_1(
     constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
-    Define *Recommendation ITU-R BT.2100* *Reference HLG* electro-optical
+    Apply the *Recommendation ITU-R BT.2100* *Reference HLG* electro-optical
     transfer function (EOTF) as specified in *ITU-R BT.2100-1*.
-
-    The EOTF maps the non-linear *HLG* signal into display light.
 
     Parameters
     ----------
     E_p
-        :math:`E'` is the non-linear signal :math:`{R', G', B'}` as defined for
-        the OETF.
+        :math:`E'` denotes the non-linear signal :math:`\\{R', G', B'\\}`.
     L_B
-        :math:`L_B` is the display luminance for black in :math:`cd/m^2`.
+        Display luminance for black :math:`L_B` in :math:`cd/m^2`.
     L_W
-        :math:`L_W` is nominal peak luminance of the display in :math:`cd/m^2`
-        for achromatic pixels.
+        Nominal peak luminance :math:`L_W` of the display in :math:`cd/m^2` for
+        achromatic pixels.
     gamma
-        System gamma value, 1.2 at the nominal display peak luminance of
-        :math:`1000 cd/m^2`.
+        System gamma value, defaults to 1.2 at the nominal display peak
+        luminance of :math:`1000 cd/m^2`.
     constants
         *Recommendation ITU-R BT.2100* *Reference HLG* constants.
 
@@ -634,7 +623,7 @@ def eotf_BT2100_HLG_1(
     -------
     :class:`numpy.ndarray`
         Luminance :math:`F_D` of a displayed linear component
-        :math:`{R_D, G_D, B_D}` or :math:`Y_D` or :math:`I_D`, in
+        :math:`\\{R_D, G_D, B_D\\}` or :math:`Y_D` or :math:`I_D`, in
         :math:`cd/m^2`.
 
     Notes
@@ -678,25 +667,22 @@ def eotf_BT2100_HLG_2(
     constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
-    Define *Recommendation ITU-R BT.2100* *Reference HLG* electro-optical
-    transfer function (EOTF) as specified in *ITU-R BT.2100-2* with the
+    Apply the *Recommendation ITU-R BT.2100* *Reference HLG* electro-optical
+    transfer function (EOTF) as specified in *ITU-R BT.2100-2* with
     modified black level behaviour.
-
-    The EOTF maps the non-linear *HLG* signal into display light.
 
     Parameters
     ----------
     E_p
-        :math:`E'` is the non-linear signal :math:`{R', G', B'}` as defined for
-        the *HLG Reference* OETF.
+        :math:`E'` denotes the non-linear signal :math:`\\{R', G', B'\\}`.
     L_B
-        :math:`L_B` is the display luminance for black in :math:`cd/m^2`.
+        Display luminance for black :math:`L_B` in :math:`cd/m^2`.
     L_W
-        :math:`L_W` is nominal peak luminance of the display in :math:`cd/m^2`
-        for achromatic pixels.
+        Nominal peak luminance :math:`L_W` of the display in :math:`cd/m^2` for
+        achromatic pixels.
     gamma
-        System gamma value, 1.2 at the nominal display peak luminance of
-        :math:`1000 cd/m^2`.
+        System gamma value, defaults to 1.2 at the nominal display peak
+        luminance of :math:`1000 cd/m^2`.
     constants
         *Recommendation ITU-R BT.2100* *Reference HLG* constants.
 
@@ -704,7 +690,7 @@ def eotf_BT2100_HLG_2(
     -------
     :class:`numpy.ndarray`
         Luminance :math:`F_D` of a displayed linear component
-        :math:`{R_D, G_D, B_D}` or :math:`Y_D` or :math:`I_D`, in
+        :math:`\\{R_D, G_D, B_D\\}` or :math:`Y_D` or :math:`I_D`, in
         :math:`cd/m^2`.
 
     Notes
@@ -752,8 +738,8 @@ BT2100_HLG_EOTF_METHODS: CanonicalMapping = CanonicalMapping(
     }
 )
 BT2100_HLG_EOTF_METHODS.__doc__ = """
-Supported *Recommendation ITU-R BT.2100* *Reference HLG* electro-optical
-transfer function (EOTF).
+Define supported *ITU-R BT.2100* *Reference HLG* electro-optical transfer
+function (EOTF) methods.
 
 References
 ----------
@@ -771,24 +757,21 @@ def eotf_BT2100_HLG(
     method: (Literal["ITU-R BT.2100-1", "ITU-R BT.2100-2"] | str) = "ITU-R BT.2100-2",
 ) -> NDArrayFloat:
     """
-    Define *Recommendation ITU-R BT.2100* *Reference HLG* electro-optical
-    transfer function (EOTF).
-
-    The EOTF maps the non-linear *HLG* signal into display light.
+    Apply the *Recommendation ITU-R BT.2100* *Reference HLG*
+    electro-optical transfer function (EOTF).
 
     Parameters
     ----------
     E_p
-        :math:`E'` denotes a non-linear colour value :math:`{R', G', B'}` or
-        :math:`{L', M', S'}` in *HLG* space.
+        :math:`E'` denotes the non-linear signal :math:`\\{R', G', B'\\}`.
     L_B
-        :math:`L_B` is the display luminance for black in :math:`cd/m^2`.
+        Display luminance for black :math:`L_B` in :math:`cd/m^2`.
     L_W
-        :math:`L_W` is nominal peak luminance of the display in :math:`cd/m^2`
-        for achromatic pixels.
+        Nominal peak luminance :math:`L_W` of the display in :math:`cd/m^2` for
+        achromatic pixels.
     gamma
-        System gamma value, 1.2 at the nominal display peak luminance of
-        :math:`1000 cd/m^2`.
+        System gamma value, defaults to 1.2 at the nominal display peak
+        luminance of :math:`1000 cd/m^2`.
     constants
         *Recommendation ITU-R BT.2100* *Reference HLG* constants.
     method
@@ -798,7 +781,7 @@ def eotf_BT2100_HLG(
     -------
     :class:`numpy.ndarray`
         Luminance :math:`F_D` of a displayed linear component
-        :math:`{R_D, G_D, B_D}` or :math:`Y_D` or :math:`I_D`, in
+        :math:`\\{R_D, G_D, B_D\\}` or :math:`Y_D` or :math:`I_D`, in
         :math:`cd/m^2`.
 
     Notes
@@ -846,7 +829,7 @@ def eotf_inverse_BT2100_HLG_1(
     constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
-    Define *Recommendation ITU-R BT.2100* *Reference HLG* inverse
+    Apply the *Recommendation ITU-R BT.2100* *Reference HLG* inverse
     electro-optical transfer function (EOTF) as specified in
     *ITU-R BT.2100-1*.
 
@@ -854,24 +837,23 @@ def eotf_inverse_BT2100_HLG_1(
     ----------
     F_D
         Luminance :math:`F_D` of a displayed linear component
-        :math:`{R_D, G_D, B_D}` or :math:`Y_D` or :math:`I_D`, in
+        :math:`\\{R_D, G_D, B_D\\}` or :math:`Y_D` or :math:`I_D`, in
         :math:`cd/m^2`.
     L_B
-        :math:`L_B` is the display luminance for black in :math:`cd/m^2`.
+        Display luminance for black :math:`L_B` in :math:`cd/m^2`.
     L_W
-        :math:`L_W` is nominal peak luminance of the display in :math:`cd/m^2`
-        for achromatic pixels.
+        Nominal peak luminance :math:`L_W` of the display in :math:`cd/m^2` for
+        achromatic pixels.
     gamma
-        System gamma value, 1.2 at the nominal display peak luminance of
-        :math:`1000 cd/m^2`.
+        System gamma value, defaults to 1.2 at the nominal display peak
+        luminance of :math:`1000 cd/m^2`.
     constants
         *Recommendation ITU-R BT.2100* *Reference HLG* constants.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        :math:`E'` denotes a non-linear colour value :math:`{R', G', B'}` or
-        :math:`{L', M', S'}` in *HLG* space.
+        :math:`E'` denotes the non-linear signal :math:`\\{R', G', B'\\}`.
 
     Notes
     -----
@@ -916,32 +898,31 @@ def eotf_inverse_BT2100_HLG_2(
     constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
-    Define *Recommendation ITU-R BT.2100* *Reference HLG* inverse
-    electro-optical transfer function (EOTF) as specified in
-    *ITU-R BT.2100-2* with the modified black level behaviour.
+    Apply the *Recommendation ITU-R BT.2100* *Reference HLG* inverse
+    electro-optical transfer function (EOTF) as specified in *ITU-R BT.2100-2*
+    with modified black level behaviour.
 
     Parameters
     ----------
     F_D
         Luminance :math:`F_D` of a displayed linear component
-        :math:`{R_D, G_D, B_D}` or :math:`Y_D` or :math:`I_D`, in
+        :math:`\\{R_D, G_D, B_D\\}` or :math:`Y_D` or :math:`I_D`, in
         :math:`cd/m^2`.
     L_B
-        :math:`L_B` is the display luminance for black in :math:`cd/m^2`.
+        Display luminance for black :math:`L_B` in :math:`cd/m^2`.
     L_W
-        :math:`L_W` is nominal peak luminance of the display in :math:`cd/m^2`
-        for achromatic pixels.
+        Nominal peak luminance :math:`L_W` of the display in :math:`cd/m^2` for
+        achromatic pixels.
     gamma
-        System gamma value, 1.2 at the nominal display peak luminance of
-        :math:`1000 cd/m^2`.
+        System gamma value, defaults to 1.2 at the nominal display peak
+        luminance of :math:`1000 cd/m^2`.
     constants
         *Recommendation ITU-R BT.2100* *Reference HLG* constants.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        :math:`E'` denotes a non-linear colour value :math:`{R', G', B'}` or
-        :math:`{L', M', S'}` in *HLG* space.
+        :math:`E'` denotes the non-linear signal :math:`\\{R', G', B'\\}`.
 
     Notes
     -----
@@ -959,7 +940,8 @@ def eotf_inverse_BT2100_HLG_2(
 
     References
     ----------
-    :cite:`Borer2017a`, :cite:`InternationalTelecommunicationUnion2018`
+    :cite:`Borer2017a`,
+    :cite:`InternationalTelecommunicationUnion2018`
 
     Examples
     --------
@@ -990,8 +972,8 @@ BT2100_HLG_EOTF_INVERSE_METHODS: CanonicalMapping = CanonicalMapping(
     }
 )
 BT2100_HLG_EOTF_INVERSE_METHODS.__doc__ = """
-Supported *Recommendation ITU-R BT.2100* *Reference HLG* inverse
-electro-optical transfer function (EOTF).
+Define the supported *ITU-R BT.2100* *Reference HLG* inverse
+electro-optical transfer function (EOTF) methods.
 
 References
 ----------
@@ -1009,23 +991,23 @@ def eotf_inverse_BT2100_HLG(
     method: (Literal["ITU-R BT.2100-1", "ITU-R BT.2100-2"] | str) = "ITU-R BT.2100-2",
 ) -> NDArrayFloat:
     """
-    Define *Recommendation ITU-R BT.2100* *Reference HLG* inverse
+    Apply the *Recommendation ITU-R BT.2100* *Reference HLG* inverse
     electro-optical transfer function (EOTF).
 
     Parameters
     ----------
     F_D
         Luminance :math:`F_D` of a displayed linear component
-        :math:`{R_D, G_D, B_D}` or :math:`Y_D` or :math:`I_D`, in
+        :math:`\\{R_D, G_D, B_D\\}` or :math:`Y_D` or :math:`I_D`, in
         :math:`cd/m^2`.
     L_B
-        :math:`L_B` is the display luminance for black in :math:`cd/m^2`.
+        Display luminance for black :math:`L_B` in :math:`cd/m^2`.
     L_W
-        :math:`L_W` is nominal peak luminance of the display in :math:`cd/m^2`
-        for achromatic pixels.
+        Nominal peak luminance :math:`L_W` of the display in :math:`cd/m^2` for
+        achromatic pixels.
     gamma
-        System gamma value, 1.2 at the nominal display peak luminance of
-        :math:`1000 cd/m^2`.
+        System gamma value, defaults to 1.2 at the nominal display peak
+        luminance of :math:`1000 cd/m^2`.
     constants
         *Recommendation ITU-R BT.2100* *Reference HLG* constants.
     method
@@ -1034,8 +1016,7 @@ def eotf_inverse_BT2100_HLG(
     Returns
     -------
     :class:`numpy.ndarray`
-        :math:`E'` denotes a non-linear colour value :math:`{R', G', B'}` or
-        :math:`{L', M', S'}` in *HLG* space.
+        :math:`E'` denotes the non-linear signal :math:`\\{R', G', B'\\}`.
 
     Notes
     -----
@@ -1080,31 +1061,33 @@ def ootf_BT2100_HLG_1(
     gamma: float | None = None,
 ) -> NDArrayFloat:
     """
-    Define *Recommendation ITU-R BT.2100* *Reference HLG* opto-optical
-    transfer function (OOTF / OOCF) as specified in *ITU-R BT.2100-1*.
+    Apply the *Recommendation ITU-R BT.2100* *Reference HLG*
+
+    opto-optical transfer function
+    (OOTF) as specified in *ITU-R BT.2100-1*.
 
     The OOTF maps relative scene linear light to display linear light.
 
     Parameters
     ----------
     E
-        :math:`E` is the signal for each colour component
-        :math:`{R_S, G_S, B_S}` proportional to scene linear light and scaled
-        by camera exposure.
+        :math:`E = \\{R_S, G_S, B_S; Y_S; \\text{or } I_S\\}` denotes the
+        signal determined by scene light and scaled by camera exposure.
     L_B
-        :math:`L_B` is the display luminance for black in :math:`cd/m^2`.
+        Display luminance for black :math:`L_B` in :math:`cd/m^2`.
     L_W
-        :math:`L_W` is nominal peak luminance of the display in :math:`cd/m^2`
-        for achromatic pixels.
+        Nominal peak luminance :math:`L_W` of the display in :math:`cd/m^2` for
+        achromatic pixels.
     gamma
-        System gamma value, 1.2 at the nominal display peak luminance of
-        :math:`1000 cd/m^2`.
+        System gamma value, defaults to 1.2 at the nominal display peak
+        luminance of :math:`1000 cd/m^2`.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        :math:`F_D` is the luminance of a displayed linear component
-        :math:`{R_D, G_D, or B_D}`, in :math:`cd/m^2`.
+        Luminance :math:`F_D` of a displayed linear component
+        :math:`\\{R_D, G_D, B_D\\}` or :math:`Y_D` or :math:`I_D`, in
+        :math:`cd/m^2`.
 
     Notes
     -----
@@ -1173,29 +1156,29 @@ def ootf_BT2100_HLG_2(
     gamma: float | None = None,
 ) -> NDArrayFloat:
     """
-    Define *Recommendation ITU-R BT.2100* *Reference HLG* opto-optical
-    transfer function (OOTF / OOCF) as specified in *ITU-R BT.2100-2*.
+    Apply the *Recommendation ITU-R BT.2100* *Reference HLG* opto-optical
+    transfer function (OOTF) as specified in *ITU-R BT.2100-2*.
 
     The OOTF maps relative scene linear light to display linear light.
 
     Parameters
     ----------
     E
-        :math:`E` is the signal for each colour component
-        :math:`{R_S, G_S, B_S}` proportional to scene linear light and scaled
-        by camera exposure.
+        :math:`E = \\{R_S, G_S, B_S; Y_S; \\text{or } I_S\\}` denotes the
+        signal determined by scene light and scaled by camera exposure.
     L_W
-        :math:`L_W` is nominal peak luminance of the display in :math:`cd/m^2`
-        for achromatic pixels.
+        Nominal peak luminance :math:`L_W` of the display in :math:`cd/m^2` for
+        achromatic pixels.
     gamma
-        System gamma value, 1.2 at the nominal display peak luminance of
-        :math:`1000 cd/m^2`.
+        System gamma value, defaults to 1.2 at the nominal display peak
+        luminance of :math:`1000 cd/m^2`.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        :math:`F_D` is the luminance of a displayed linear component
-        :math:`{R_D, G_D, or B_D}`, in :math:`cd/m^2`.
+        Luminance :math:`F_D` of a displayed linear component
+        :math:`\\{R_D, G_D, B_D\\}` or :math:`Y_D` or :math:`I_D`, in
+        :math:`cd/m^2`.
 
     Notes
     -----
@@ -1261,8 +1244,8 @@ BT2100_HLG_OOTF_METHODS: CanonicalMapping = CanonicalMapping(
     }
 )
 BT2100_HLG_OOTF_METHODS.__doc__ = """
-Supported *Recommendation ITU-R BT.2100* *Reference HLG* opto-optical transfer
-function (OOTF / OOCF).
+Map *Recommendation ITU-R BT.2100* *Reference HLG* opto-optical transfer
+function (OOTF) methods.
 
 References
 ----------
@@ -1279,33 +1262,31 @@ def ootf_BT2100_HLG(
     method: (Literal["ITU-R BT.2100-1", "ITU-R BT.2100-2"] | str) = "ITU-R BT.2100-2",
 ) -> NDArrayFloat:
     """
-    Define *Recommendation ITU-R BT.2100* *Reference HLG* opto-optical
-    transfer function (OOTF / OOCF).
+    Apply the *Recommendation ITU-R BT.2100* *Reference HLG* opto-optical
+    transfer function (OOTF).
 
     The OOTF maps relative scene linear light to display linear light.
 
     Parameters
     ----------
     E
-        :math:`E` is the signal for each colour component
-        :math:`{R_S, G_S, B_S}` proportional to scene linear light and scaled
-        by camera exposure.
+        :math:`E = \\{R_S, G_S, B_S; Y_S; \\text{or } I_S\\}` denotes the
+        signal determined by scene light and scaled by camera exposure.
     L_B
-        :math:`L_B` is the display luminance for black in :math:`cd/m^2`.
+        Display luminance for black :math:`L_B` in :math:`cd/m^2`.
     L_W
-        :math:`L_W` is nominal peak luminance of the display in :math:`cd/m^2`
+        Nominal peak luminance :math:`L_W` of the display in :math:`cd/m^2`
         for achromatic pixels.
     gamma
-        System gamma value, 1.2 at the nominal display peak luminance of
-        :math:`1000 cd/m^2`.
-    method
-        Computation method.
+        System gamma value, defaults to 1.2 at the nominal display peak
+        luminance of :math:`1000 cd/m^2`.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        :math:`F_D` is the luminance of a displayed linear component
-        :math:`{R_D, G_D, or B_D}`, in :math:`cd/m^2`.
+        Luminance :math:`F_D` of a displayed linear component
+        :math:`\\{R_D, G_D, B_D\\}` or :math:`Y_D` or :math:`I_D`, in
+        :math:`cd/m^2`.
 
     Notes
     -----
@@ -1351,29 +1332,31 @@ def ootf_inverse_BT2100_HLG_1(
     gamma: float | None = None,
 ) -> NDArrayFloat:
     """
-    Define *Recommendation ITU-R BT.2100* *Reference HLG* inverse opto-optical
-    transfer function (OOTF / OOCF) as specified in *ITU-R BT.2100-1*.
+    Apply the *Recommendation ITU-R BT.2100* *Reference HLG* inverse
+    opto-optical transfer function (OOTF) as defined in *ITU-R BT.2100-1*.
+
+    The inverse OOTF maps display linear light to relative scene linear light.
 
     Parameters
     ----------
     F_D
-        :math:`F_D` is the luminance of a displayed linear component
-        :math:`{R_D, G_D, or B_D}`, in :math:`cd/m^2`.
+        Luminance :math:`F_D` of a displayed linear component
+        :math:`\\{R_D, G_D, B_D\\}` or :math:`Y_D` or :math:`I_D`, in
+        :math:`cd/m^2`.
     L_B
-        :math:`L_B` is the display luminance for black in :math:`cd/m^2`.
+        Display luminance for black :math:`L_B` in :math:`cd/m^2`.
     L_W
-        :math:`L_W` is nominal peak luminance of the display in :math:`cd/m^2`
-        for achromatic pixels.
+        Nominal peak luminance :math:`L_W` of the display in :math:`cd/m^2` for
+        achromatic pixels.
     gamma
-        System gamma value, 1.2 at the nominal display peak luminance of
-        :math:`1000 cd/m^2`.
+        System gamma value, defaults to 1.2 at the nominal display peak
+        luminance of :math:`1000 cd/m^2`.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        :math:`E` is the signal for each colour component
-        :math:`{R_S, G_S, B_S}` proportional to scene linear light and scaled
-        by camera exposure.
+        :math:`E = \\{R_S, G_S, B_S; Y_S; \\text{or } I_S\\}` denotes the
+        signal determined by scene light and scaled by camera exposure.
 
     Notes
     -----
@@ -1456,27 +1439,30 @@ def ootf_inverse_BT2100_HLG_2(
     gamma: float | None = None,
 ) -> NDArrayFloat:
     """
-    Define *Recommendation ITU-R BT.2100* *Reference HLG* inverse opto-optical
-    transfer function (OOTF / OOCF) as specified in *ITU-R BT.2100-2*.
+    Apply the *Recommendation ITU-R BT.2100* *Reference HLG* inverse
+    opto-optical transfer function (OOTF) according to *ITU-R BT.2100-2*.
+
+    The inverse OOTF maps display linear light to relative scene linear light.
 
     Parameters
     ----------
     F_D
-        :math:`F_D` is the luminance of a displayed linear component
-        :math:`{R_D, G_D, or B_D}`, in :math:`cd/m^2`.
+        Luminance :math:`F_D` of a displayed linear component
+        :math:`\\{R_D, G_D, B_D\\}` or :math:`Y_D` or :math:`I_D`, in
+        :math:`cd/m^2`.
     L_W
-        :math:`L_W` is nominal peak luminance of the display in :math:`cd/m^2`
-        for achromatic pixels.
+        Nominal peak luminance :math:`L_W` of the display in :math:`cd/m^2` for
+        achromatic pixels.
     gamma
-        System gamma value, 1.2 at the nominal display peak luminance of
-        :math:`1000 cd/m^2`.
+        System gamma value, defaults to 1.2 at the nominal display peak
+        luminance of :math:`1000 cd/m^2`.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        :math:`E` is the signal for each colour component
-        :math:`{R_S, G_S, B_S}` proportional to scene linear light and scaled
-        by camera exposure.
+        :math:`E` denotes the signal for each colour component
+        :math:`\\{R_S, G_S, B_S\\}` proportional to scene linear light and
+        scaled by camera exposure.
 
     Notes
     -----
@@ -1556,8 +1542,8 @@ BT2100_HLG_OOTF_INVERSE_METHODS: CanonicalMapping = CanonicalMapping(
     }
 )
 BT2100_HLG_OOTF_INVERSE_METHODS.__doc__ = """
-Supported *Recommendation ITU-R BT.2100* *Reference HLG* inverse opto-optical
-transfer function (OOTF / OOCF).
+Support methods for the *ITU-R BT.2100* *Reference HLG* inverse
+opto-optical transfer function (OOTF).
 
 References
 ----------
@@ -1574,31 +1560,34 @@ def ootf_inverse_BT2100_HLG(
     method: (Literal["ITU-R BT.2100-1", "ITU-R BT.2100-2"] | str) = "ITU-R BT.2100-2",
 ) -> NDArrayFloat:
     """
-    Define *Recommendation ITU-R BT.2100* *Reference HLG* inverse opto-optical
-    transfer function (OOTF / OOCF).
+    Apply the *Recommendation ITU-R BT.2100* *Reference HLG* inverse
+    opto-optical transfer function (OOTF).
+
+    The inverse OOTF maps display linear light to relative scene linear light.
 
     Parameters
     ----------
     F_D
-        :math:`F_D` is the luminance of a displayed linear component
-        :math:`{R_D, G_D, or B_D}`, in :math:`cd/m^2`.
+        Luminance :math:`F_D` of a displayed linear component
+        :math:`\\{R_D, G_D, B_D\\}` or :math:`Y_D` or :math:`I_D`, in
+        :math:`cd/m^2`.
     L_B
-        :math:`L_B` is the display luminance for black in :math:`cd/m^2`.
+        Display luminance for black :math:`L_B` in :math:`cd/m^2`.
     L_W
-        :math:`L_W` is nominal peak luminance of the display in :math:`cd/m^2`
-        for achromatic pixels.
+        Nominal peak luminance :math:`L_W` of the display in :math:`cd/m^2` for
+        achromatic pixels.
     gamma
-        System gamma value, 1.2 at the nominal display peak luminance of
-        :math:`1000 cd/m^2`.
+        System gamma value, defaults to 1.2 at the nominal display peak
+        luminance of :math:`1000 cd/m^2`.
     method
         Computation method.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        :math:`E` is the signal for each colour component
-        :math:`{R_S, G_S, B_S}` proportional to scene linear light and scaled
-        by camera exposure.
+        :math:`E` denotes the signal for each colour component
+        :math:`\\{R_S, G_S, B_S\\}` proportional to scene linear light and
+        scaled by camera exposure.
 
     Notes
     -----

--- a/colour/models/rgb/transfer_functions/itur_bt_2100.py
+++ b/colour/models/rgb/transfer_functions/itur_bt_2100.py
@@ -458,9 +458,7 @@ def gamma_function_BT2100_HLG(L_W: float = 1000) -> float:
     return as_float_scalar(gamma)
 
 
-def oetf_BT2100_HLG(
-    E: ArrayLike, constants: Structure = CONSTANTS_BT2100_HLG
-) -> NDArrayFloat:
+def oetf_BT2100_HLG(E: ArrayLike, constants: Structure | None = None) -> NDArrayFloat:
     """
     Define *Recommendation ITU-R BT.2100* *Reference HLG* opto-electrical
     transfer function (OETF).
@@ -512,7 +510,7 @@ def oetf_BT2100_HLG(
 
 
 def oetf_inverse_BT2100_HLG(
-    E_p: ArrayLike, constants: Structure = CONSTANTS_BT2100_HLG
+    E_p: ArrayLike, constants: Structure | None = None
 ) -> NDArrayFloat:
     """
     Define *Recommendation ITU-R BT.2100* *Reference HLG* inverse
@@ -555,6 +553,8 @@ def oetf_inverse_BT2100_HLG(
     >>> oetf_inverse_BT2100_HLG(0.212132034355964)  # doctest: +ELLIPSIS
     0.0149999...
     """
+
+    constants = optional(constants, CONSTANTS_BT2100_HLG)
 
     return oetf_inverse_ARIBSTDB67(E_p, constants=constants) / 12
 
@@ -606,7 +606,7 @@ def eotf_BT2100_HLG_1(
     L_B: float = 0,
     L_W: float = 1000,
     gamma: float | None = None,
-    constants: Structure = CONSTANTS_BT2100_HLG,
+    constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
     Define *Recommendation ITU-R BT.2100* *Reference HLG* electro-optical
@@ -663,6 +663,8 @@ def eotf_BT2100_HLG_1(
     6.4859750...
     """
 
+    constants = optional(constants, CONSTANTS_BT2100_HLG)
+
     return ootf_BT2100_HLG_1(
         oetf_inverse_ARIBSTDB67(E_p, constants=constants) / 12, L_B, L_W, gamma
     )
@@ -673,7 +675,7 @@ def eotf_BT2100_HLG_2(
     L_B: float = 0,
     L_W: float = 1000,
     gamma: float | None = None,
-    constants: Structure = CONSTANTS_BT2100_HLG,
+    constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
     Define *Recommendation ITU-R BT.2100* *Reference HLG* electro-optical
@@ -732,6 +734,7 @@ def eotf_BT2100_HLG_2(
     """
 
     E_p = as_float_array(E_p)
+    constants = optional(constants, CONSTANTS_BT2100_HLG)
 
     beta = black_level_lift_BT2100_HLG(L_B, L_W, gamma)
 
@@ -764,7 +767,7 @@ def eotf_BT2100_HLG(
     L_B: float = 0,
     L_W: float = 1000,
     gamma: float | None = None,
-    constants: Structure = CONSTANTS_BT2100_HLG,
+    constants: Structure | None = None,
     method: (Literal["ITU-R BT.2100-1", "ITU-R BT.2100-2"] | str) = "ITU-R BT.2100-2",
 ) -> NDArrayFloat:
     """
@@ -829,6 +832,7 @@ def eotf_BT2100_HLG(
     7.3321975...
     """
 
+    constants = optional(constants, CONSTANTS_BT2100_HLG)
     method = validate_method(method, tuple(BT2100_HLG_EOTF_METHODS))
 
     return BT2100_HLG_EOTF_METHODS[method](E_p, L_B, L_W, gamma, constants)
@@ -839,7 +843,7 @@ def eotf_inverse_BT2100_HLG_1(
     L_B: float = 0,
     L_W: float = 1000,
     gamma: float | None = None,
-    constants: Structure = CONSTANTS_BT2100_HLG,
+    constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
     Define *Recommendation ITU-R BT.2100* *Reference HLG* inverse
@@ -896,6 +900,8 @@ def eotf_inverse_BT2100_HLG_1(
     0.2121320...
     """
 
+    constants = optional(constants, CONSTANTS_BT2100_HLG)
+
     return oetf_ARIBSTDB67(
         ootf_inverse_BT2100_HLG_1(F_D, L_B, L_W, gamma) * 12,
         constants=constants,
@@ -907,7 +913,7 @@ def eotf_inverse_BT2100_HLG_2(
     L_B: float = 0,
     L_W: float = 1000,
     gamma: float | None = None,
-    constants: Structure = CONSTANTS_BT2100_HLG,
+    constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
     Define *Recommendation ITU-R BT.2100* *Reference HLG* inverse
@@ -964,6 +970,8 @@ def eotf_inverse_BT2100_HLG_2(
     0.2121320...
     """
 
+    constants = optional(constants, CONSTANTS_BT2100_HLG)
+
     beta = black_level_lift_BT2100_HLG(L_B, L_W, gamma)
 
     return (
@@ -997,7 +1005,7 @@ def eotf_inverse_BT2100_HLG(
     L_B: float = 0,
     L_W: float = 1000,
     gamma: float | None = None,
-    constants: Structure = CONSTANTS_BT2100_HLG,
+    constants: Structure | None = None,
     method: (Literal["ITU-R BT.2100-1", "ITU-R BT.2100-2"] | str) = "ITU-R BT.2100-2",
 ) -> NDArrayFloat:
     """
@@ -1059,6 +1067,7 @@ def eotf_inverse_BT2100_HLG(
     0.2121320...
     """
 
+    constants = optional(constants, CONSTANTS_BT2100_HLG)
     method = validate_method(method, tuple(BT2100_HLG_EOTF_INVERSE_METHODS))
 
     return BT2100_HLG_EOTF_INVERSE_METHODS[method](F_D, L_B, L_W, gamma, constants)

--- a/colour/models/rgb/transfer_functions/itur_bt_601.py
+++ b/colour/models/rgb/transfer_functions/itur_bt_601.py
@@ -3,7 +3,7 @@ Recommendation ITU-R BT.601-7
 =============================
 
 Define the *Recommendation ITU-R BT.601-7* opto-electrical transfer function
-(OETF) and its inverse:
+(OETF) and its inverse.
 
 -   :func:`colour.models.oetf_BT601`
 -   :func:`colour.models.oetf_inverse_BT601`
@@ -46,8 +46,8 @@ __all__ = [
 
 def oetf_BT601(L: ArrayLike) -> NDArrayFloat:
     """
-    Define *Recommendation ITU-R BT.601-7* opto-electronic transfer function
-    (OETF).
+    Apply the *Recommendation ITU-R BT.601-7* opto-electronic transfer
+    function (OETF).
 
     Parameters
     ----------
@@ -57,7 +57,7 @@ def oetf_BT601(L: ArrayLike) -> NDArrayFloat:
     Returns
     -------
     :class:`numpy.ndarray`
-        Corresponding electrical signal :math:`E`.
+        Electrical signal :math:`E`.
 
     Notes
     -----
@@ -92,8 +92,8 @@ def oetf_BT601(L: ArrayLike) -> NDArrayFloat:
 
 def oetf_inverse_BT601(E: ArrayLike) -> NDArrayFloat:
     """
-    Define *Recommendation ITU-R BT.601-7* inverse opto-electronic transfer
-    function (OETF).
+    Apply the *Recommendation ITU-R BT.601-7* inverse opto-electronic
+    transfer function (OETF).
 
     Parameters
     ----------
@@ -103,7 +103,7 @@ def oetf_inverse_BT601(E: ArrayLike) -> NDArrayFloat:
     Returns
     -------
     :class:`numpy.ndarray`
-        Corresponding *luminance* :math:`L` of the image.
+        *Luminance* :math:`L` of the image.
 
     Notes
     -----

--- a/colour/models/rgb/transfer_functions/itur_bt_709.py
+++ b/colour/models/rgb/transfer_functions/itur_bt_709.py
@@ -3,7 +3,7 @@ Recommendation ITU-R BT.709-6
 =============================
 
 Define the *Recommendation ITU-R BT.709-6* opto-electrical transfer function
-(OETF) and its inverse:
+(OETF) and its inverse.
 
 -   :func:`colour.models.oetf_BT709`
 -   :func:`colour.models.oetf_inverse_BT709`
@@ -42,8 +42,8 @@ __all__ = [
 
 def oetf_BT709(L: ArrayLike) -> NDArrayFloat:
     """
-    Define *Recommendation ITU-R BT.709-6* opto-electronic transfer function
-    (OETF).
+    Apply the *Recommendation ITU-R BT.709-6* opto-electronic transfer
+    function (OETF).
 
     Parameters
     ----------
@@ -53,7 +53,7 @@ def oetf_BT709(L: ArrayLike) -> NDArrayFloat:
     Returns
     -------
     :class:`numpy.ndarray`
-        Corresponding electrical signal :math:`V`.
+        Electrical signal :math:`V`.
 
     Notes
     -----
@@ -84,8 +84,8 @@ def oetf_BT709(L: ArrayLike) -> NDArrayFloat:
 
 def oetf_inverse_BT709(V: ArrayLike) -> NDArrayFloat:
     """
-    Define *Recommendation ITU-R BT.709-6* inverse opto-electronic transfer
-    function (OETF).
+    Apply the *Recommendation ITU-R BT.709-6* inverse opto-electronic
+    transfer function (OETF).
 
     Parameters
     ----------
@@ -95,7 +95,7 @@ def oetf_inverse_BT709(V: ArrayLike) -> NDArrayFloat:
     Returns
     -------
     :class:`numpy.ndarray`
-        Corresponding *luminance* :math:`L` of the image.
+        *Luminance* :math:`L` of the image.
 
     Notes
     -----

--- a/colour/models/rgb/transfer_functions/itut_h_273.py
+++ b/colour/models/rgb/transfer_functions/itut_h_273.py
@@ -3,7 +3,7 @@ Recommendation ITU-T H.273 Transfer Characteristics
 ===================================================
 
 Define the *Recommendation ITU-T H.273* transfer functions that do not belong
-in another specification or standard, or have been modified for inclusion:
+in another specification or standard, or have been modified for inclusion.
 
 -   :func:`colour.models.oetf_H273_Log`
 -   :func:`colour.models.oetf_inverse_H273_Log`
@@ -58,25 +58,25 @@ __all__ = [
     "oetf_inverse_H273_LogSqrt",
     "oetf_H273_IEC61966_2",
     "oetf_inverse_H273_IEC61966_2",
-    "eotf_inverse_H273_ST428_1",
     "eotf_H273_ST428_1",
+    "eotf_inverse_H273_ST428_1",
 ]
 
 
 def oetf_H273_Log(L_c: ArrayLike) -> NDArrayFloat:
     """
-    Define *Recommendation ITU-T H.273* opto-electronic transfer function
-    (OETF) for logarithmic encoding (100:1 range).
+    Apply the *Recommendation ITU-T H.273* opto-electronic transfer function
+    (OETF) for logarithmic encoding with 100:1 dynamic range.
 
     Parameters
     ----------
     L_c
-        Scene *Luminance* :math:`L_c`.
+        Scene *luminance* :math:`L_c`.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Corresponding electrical signal :math:`V`.
+        Electrical signal :math:`V`.
 
     Notes
     -----
@@ -127,8 +127,8 @@ def oetf_H273_Log(L_c: ArrayLike) -> NDArrayFloat:
 
 def oetf_inverse_H273_Log(V: ArrayLike) -> NDArrayFloat:
     """
-    Define *Recommendation ITU-T H.273* inverse-opto-electronic transfer
-    function (OETF) for logarithmic encoding (100:1 range).
+    Apply the *Recommendation ITU-T H.273* inverse opto-electronic transfer
+    function (OETF) for logarithmic encoding with 100:1 dynamic range.
 
     Parameters
     ----------
@@ -138,7 +138,7 @@ def oetf_inverse_H273_Log(V: ArrayLike) -> NDArrayFloat:
     Returns
     -------
     :class:`numpy.ndarray`
-        Corresponding scene *Luminance* :math:`L_c`.
+        Scene *luminance* :math:`L_c`.
 
     Notes
     -----
@@ -188,18 +188,18 @@ def oetf_inverse_H273_Log(V: ArrayLike) -> NDArrayFloat:
 
 def oetf_H273_LogSqrt(L_c: ArrayLike) -> NDArrayFloat:
     """
-    Define *Recommendation ITU-T H.273* opto-electronic transfer function
+    Apply the *Recommendation ITU-T H.273* opto-electronic transfer function
     (OETF) for logarithmic encoding (100\\*Sqrt(10):1 range).
 
     Parameters
     ----------
     L_c
-        Scene *Luminance* :math:`L_c`.
+        Scene *luminance* :math:`L_c`.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Corresponding electrical signal :math:`V`.
+        Electrical signal :math:`V`.
 
     Notes
     -----
@@ -222,7 +222,8 @@ def oetf_H273_LogSqrt(L_c: ArrayLike) -> NDArrayFloat:
     Warnings
     --------
     -   The function is clamped to domain
-        [:func:`colour.models.oetf_H273_LogSqrt` (sqrt(10) / 1000), np.inf].
+        [:func:`colour.models.oetf_H273_LogSqrt` (sqrt(10) / 1000),
+        np.inf].
 
     Examples
     --------
@@ -251,7 +252,7 @@ def oetf_H273_LogSqrt(L_c: ArrayLike) -> NDArrayFloat:
 
 def oetf_inverse_H273_LogSqrt(V: ArrayLike) -> NDArrayFloat:
     """
-    Define *Recommendation ITU-T H.273* inverse-opto-electronic transfer
+    Apply the *Recommendation ITU-T H.273* inverse opto-electronic transfer
     function (OETF) for logarithmic encoding (100\\*Sqrt(10):1 range).
 
     Parameters
@@ -262,7 +263,7 @@ def oetf_inverse_H273_LogSqrt(V: ArrayLike) -> NDArrayFloat:
     Returns
     -------
     :class:`numpy.ndarray`
-        Corresponding scene *Luminance* :math:`L_c`.
+        Scene *luminance* :math:`L_c`.
 
     Notes
     -----
@@ -311,29 +312,28 @@ def oetf_inverse_H273_LogSqrt(V: ArrayLike) -> NDArrayFloat:
 
 def oetf_H273_IEC61966_2(L_c: ArrayLike) -> NDArrayFloat:
     """
-    Define *Recommendation ITU-T H.273* opto-electronic transfer function
-    (OETF) for *IEC 61966-2* family of transfer functions (*2-1 sRGB*,
-    *2-1 sYCC*, *2-4 xvYCC*).
+    Apply the *Recommendation ITU-T H.273* opto-electronic transfer function
+    (OETF) for *IEC 61966-2* family of transfer functions (*2-1 sRGB*, *2-1
+    sYCC*, *2-4 xvYCC*).
 
     Parameters
     ----------
     L_c
-        Scene *Luminance* :math:`L_c`.
+        Scene *luminance* :math:`L_c`.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Corresponding electrical signal :math:`V`.
+        Electrical signal :math:`V`.
 
     Notes
     -----
     Usage in :cite:`InternationalTelecommunicationUnion2021` is as follows:
 
-    -   For *IEC 61966-2-1 sRGB (MatrixCoefficients=0)*, the function is only
-        defined for :math:`L_c` in [0-1] range.
-    -   For *IEC 61966-2-1 sYCC (MatrixCoefficients=5)* and
-        *IEC 61966-2-4 xvYCC*, the function is defined for any real-valued
-        :math:`L_c`.
+    -   For *IEC 61966-2-1 sRGB (MatrixCoefficients=0)*, the function is
+        only defined for :math:`L_c` in [0-1] range.
+    -   For *IEC 61966-2-1 sYCC (MatrixCoefficients=5)* and *IEC 61966-2-4
+        xvYCC*, the function is defined for any real-valued :math:`L_c`.
 
     +------------+-----------------------+---------------+
     | **Domain** | **Scale - Reference** | **Scale - 1** |
@@ -372,9 +372,9 @@ def oetf_H273_IEC61966_2(L_c: ArrayLike) -> NDArrayFloat:
 
 def oetf_inverse_H273_IEC61966_2(V: ArrayLike) -> NDArrayFloat:
     """
-    Define *Recommendation ITU-T H.273* inverse opto-electronic transfer
-    function (OETF) for *IEC 61966-2* family of transfer functions (*2-1 sRGB*,
-    *2-1 sYCC*, *2-4 xvYCC*).
+    Apply the *Recommendation ITU-T H.273* inverse opto-electronic
+    transfer function (OETF) for the *IEC 61966-2* family of transfer
+    functions (*2-1 sRGB*, *2-1 sYCC*, *2-4 xvYCC*).
 
     Parameters
     ----------
@@ -384,16 +384,17 @@ def oetf_inverse_H273_IEC61966_2(V: ArrayLike) -> NDArrayFloat:
     Returns
     -------
     :class:`numpy.ndarray`
-        Corresponding scene luminance :math:`L_c`.
+        Scene *luminance* :math:`L_c`.
 
     Notes
     -----
-    Usage in :cite:`InternationalTelecommunicationUnion2021` is as follows:
+    Usage in :cite:`InternationalTelecommunicationUnion2021` is
+    specified as follows:
 
-    -   For *IEC 61966-2-1 sRGB (MatrixCoefficients=0)*, the function is only
-        defined for :math:`L_c` in [0-1] range.
-    -   For *IEC 61966-2-1 sYCC (MatrixCoefficients=5)* and
-        *IEC 61966-2-4 xvYCC*, the function is defined for any real-valued
+    -   For *IEC 61966-2-1 sRGB (MatrixCoefficients=0)*, the function is
+        only defined for :math:`L_c` in [0-1] range.
+    -   For *IEC 61966-2-1 sYCC (MatrixCoefficients=5)* and *IEC
+        61966-2-4 xvYCC*, the function is defined for any real-valued
         :math:`L_c`.
 
     +------------+-----------------------+---------------+
@@ -431,59 +432,10 @@ def oetf_inverse_H273_IEC61966_2(V: ArrayLike) -> NDArrayFloat:
     return as_float(L_c)
 
 
-def eotf_inverse_H273_ST428_1(L_o: ArrayLike) -> NDArrayFloat:
-    """
-    Define *Recommendation ITU-T H.273* inverse electro-optical transfer
-    function (EOTF) for *SMPTE ST 428-1 (2019)*.
-
-    Parameters
-    ----------
-    L_o
-        Output display *Luminance* :math:`L_o` of the image.
-
-    Returns
-    -------
-    :class:`numpy.ndarray`
-        Corresponding electrical signal :math:`V`.
-
-    Notes
-    -----
-    -   The function specified in :cite:`InternationalTelecommunicationUnion2021`
-        multiplies :math:`L_o` by 48 contrary to what is specified in
-        :cite:`SocietyofMotionPictureandTelevisionEngineers2019` and
-        :func:`colour.models.eotf_inverse_DCDM`.
-
-    +------------+-----------------------+---------------+
-    | **Domain** | **Scale - Reference** | **Scale - 1** |
-    +============+=======================+===============+
-    | ``L_o``    | [0, 1]                | [0, 1]        |
-    +------------+-----------------------+---------------+
-
-    +------------+-----------------------+---------------+
-    | **Range**  | **Scale - Reference** | **Scale - 1** |
-    +============+=======================+===============+
-    | ``V``      | [0, 1]                | [0, 1]        |
-    +------------+-----------------------+---------------+
-
-    References
-    ----------
-    -   :cite:`InternationalTelecommunicationUnion2021`,
-        :cite:`SocietyofMotionPictureandTelevisionEngineers2019`
-
-    Examples
-    --------
-    >>> eotf_inverse_H273_ST428_1(0.18)  # doctest: +ELLIPSIS
-    0.5000483...
-    """
-
-    L_o = to_domain_1(L_o)
-
-    return as_float(from_range_1(eotf_inverse_DCDM(L_o * 48)))
-
-
 def eotf_H273_ST428_1(V: ArrayLike) -> NDArrayFloat:
     """
-    Define the *SMPTE ST 428-1 (2019)* electro-optical transfer function (EOTF).
+    Apply the *SMPTE ST 428-1 (2019)* electro-optical transfer function
+    (EOTF) as specified in *ITU-T H.273*.
 
     Parameters
     ----------
@@ -493,12 +445,13 @@ def eotf_H273_ST428_1(V: ArrayLike) -> NDArrayFloat:
     Returns
     -------
     :class:`numpy.ndarray`
-        Corresponding output display *Luminance* :math:`L_o` of the image.
+        Output display *Luminance* :math:`L_o` of the image.
 
     Notes
     -----
-    -   The function specified in :cite:`InternationalTelecommunicationUnion2021`
-        divides :math:`L_o` by 48 contrary to what is specified in
+    -   The function specified in
+        :cite:`InternationalTelecommunicationUnion2021` divides
+        :math:`L_o` by 48, contrary to what is specified in
         :cite:`SocietyofMotionPictureandTelevisionEngineers2019` and
         :func:`colour.models.eotf_DCDM`.
 
@@ -528,3 +481,54 @@ def eotf_H273_ST428_1(V: ArrayLike) -> NDArrayFloat:
     V = to_domain_1(V)
 
     return as_float(from_range_1(eotf_DCDM(V) / 48))
+
+
+def eotf_inverse_H273_ST428_1(L_o: ArrayLike) -> NDArrayFloat:
+    """
+    Apply the *SMPTE ST 428-1 (2019)* inverse electro-optical transfer function
+    (EOTF) as specified in *ITU-T H.273*.
+
+    Parameters
+    ----------
+    L_o
+        Output display *Luminance* :math:`L_o` of the image.
+
+    Returns
+    -------
+    :class:`numpy.ndarray`
+        Electrical signal :math:`V`.
+
+    Notes
+    -----
+    -   The function specified in
+        :cite:`InternationalTelecommunicationUnion2021` multiplies :math:`L_o`
+        by 48, contrary to what is specified in
+        :cite:`SocietyofMotionPictureandTelevisionEngineers2019` and
+        :func:`colour.models.eotf_inverse_DCDM`.
+
+    +------------+-----------------------+---------------+
+    | **Domain** | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``L_o``    | [0, 1]                | [0, 1]        |
+    +------------+-----------------------+---------------+
+
+    +------------+-----------------------+---------------+
+    | **Range**  | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``V``      | [0, 1]                | [0, 1]        |
+    +------------+-----------------------+---------------+
+
+    References
+    ----------
+    -   :cite:`InternationalTelecommunicationUnion2021`,
+        :cite:`SocietyofMotionPictureandTelevisionEngineers2019`
+
+    Examples
+    --------
+    >>> eotf_inverse_H273_ST428_1(0.18)  # doctest: +ELLIPSIS
+    0.5000483...
+    """
+
+    L_o = to_domain_1(L_o)
+
+    return as_float(from_range_1(eotf_inverse_DCDM(L_o * 48)))

--- a/colour/models/rgb/transfer_functions/leica_l_log.py
+++ b/colour/models/rgb/transfer_functions/leica_l_log.py
@@ -26,7 +26,7 @@ if typing.TYPE_CHECKING:
     from colour.hints import ArrayLike, NDArrayFloat
 
 from colour.models.rgb.transfer_functions import full_to_legal, legal_to_full
-from colour.utilities import Structure, as_float, from_range_1, to_domain_1
+from colour.utilities import Structure, as_float, from_range_1, optional, to_domain_1
 
 __author__ = "Colour Developers"
 __copyright__ = "Copyright 2013 Colour Developers"
@@ -59,7 +59,7 @@ def log_encoding_LLog(
     bit_depth: int = 10,
     out_normalised_code_value: bool = True,
     in_reflection: bool = True,
-    constants: Structure = CONSTANTS_LLOG,
+    constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
     Define the *Leica L-Log* log encoding curve / opto-electronic transfer
@@ -109,6 +109,7 @@ def log_encoding_LLog(
     """
 
     LSR = to_domain_1(LSR)
+    constants = optional(constants, CONSTANTS_LLOG)
 
     if not in_reflection:
         LSR = LSR * 0.9
@@ -137,7 +138,7 @@ def log_decoding_LLog(
     bit_depth: int = 10,
     in_normalised_code_value: bool = True,
     out_reflection: bool = True,
-    constants: Structure = CONSTANTS_LLOG,
+    constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
     Define the *Leica L-Log* log decoding curve / electro-optical transfer
@@ -187,6 +188,7 @@ def log_decoding_LLog(
     """
 
     LLog = to_domain_1(LLog)
+    constants = optional(constants, CONSTANTS_LLOG)
 
     LLog = LLog if in_normalised_code_value else full_to_legal(LLog, bit_depth)
 

--- a/colour/models/rgb/transfer_functions/leica_l_log.py
+++ b/colour/models/rgb/transfer_functions/leica_l_log.py
@@ -2,7 +2,7 @@
 Leica L-Log Log Encoding
 ========================
 
-Define the *Leica L-Log* log encoding:
+Define the *Leica L-Log* log encoding.
 
 -   :func:`colour.models.log_encoding_LLog`
 -   :func:`colour.models.log_decoding_LLog`
@@ -62,8 +62,7 @@ def log_encoding_LLog(
     constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
-    Define the *Leica L-Log* log encoding curve / opto-electronic transfer
-    function.
+    Apply the *Leica L-Log* log encoding opto-electronic transfer function (OETF).
 
     Parameters
     ----------
@@ -72,10 +71,10 @@ def log_encoding_LLog(
     bit_depth
         Bit-depth used for conversion.
     out_normalised_code_value
-        Whether the non-linear *Leica L-Log* data :math:`L-Log` is encoded as
-        normalised code values.
+        Whether the *Leica L-Log* non-linear data :math:`L-Log` is encoded
+        as normalised code values.
     in_reflection
-        Whether the light level :math`in` to a camera is reflection.
+        Whether the light level :math:`in` to a camera is reflection.
     constants
         *Leica L-Log* constants.
 
@@ -141,8 +140,8 @@ def log_decoding_LLog(
     constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
-    Define the *Leica L-Log* log decoding curve / electro-optical transfer
-    function.
+    Apply the *Leica L-Log* log decoding inverse opto-electronic transfer
+    function (OETF).
 
     Parameters
     ----------
@@ -151,10 +150,10 @@ def log_decoding_LLog(
     bit_depth
         Bit-depth used for conversion.
     in_normalised_code_value
-        Whether the non-linear *Leica L-Log* data :math:`L-Log` is encoded as
-        normalised code values.
+        Whether the *Leica L-Log* non-linear data :math:`L-Log` is encoded
+        as normalised code values.
     out_reflection
-        Whether the light level :math`in` to a camera is reflection.
+        Whether the light level :math:`in` to a camera is reflection.
     constants
         *Leica L-Log* constants.
 

--- a/colour/models/rgb/transfer_functions/linear.py
+++ b/colour/models/rgb/transfer_functions/linear.py
@@ -3,7 +3,7 @@ Linear Colour Component Transfer Function
 =========================================
 
 Define the linear encoding / decoding colour component transfer function
-related objects:
+related objects.
 
 - :func:`colour.linear_function`
 """
@@ -37,18 +37,21 @@ def linear_function(a: NDArray) -> NDArrayFloat: ...
 def linear_function(a: ArrayLike) -> DTypeFloat | NDArrayFloat: ...
 def linear_function(a: ArrayLike) -> DTypeFloat | NDArrayFloat:
     """
-    Define a typical linear encoding / decoding function, essentially a
-    pass-through function.
+    Perform pass-through linear encoding/decoding transformation.
+
+    Implement an identity transformation where the output equals the input,
+    commonly used as a reference or default encoding/decoding function in
+    colour science workflows.
 
     Parameters
     ----------
     a
-        Array to encode / decode.
+        Array to encode/decode.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Encoded / decoded array.
+        Encoded/decoded array, identical to input.
 
     Examples
     --------

--- a/colour/models/rgb/transfer_functions/log.py
+++ b/colour/models/rgb/transfer_functions/log.py
@@ -2,7 +2,7 @@
 Common Log Encodings
 ====================
 
-Define the common log encodings:
+Define the common log encodings.
 
 -   :func:`colour.models.logarithmic_function_basic`
 -   :func:`colour.models.logarithmic_function_quasilog`
@@ -87,14 +87,14 @@ def logarithmic_function_basic(
     base: int = 2,
 ) -> NDArrayFloat:
     """
-    Define the basic logarithmic function.
+    Apply a logarithmic or anti-logarithmic transformation to the specified array.
 
     Parameters
     ----------
     x
-        The data to undergo basic logarithmic conversion.
+        Logarithmically encoded data :math:`x`.
     style
-        Defines the behaviour for the logarithmic function to operate:
+        Specifies the behaviour for the logarithmic function to operate:
 
         -   *log10*: Applies a base 10 logarithm to the passed value.
         -   *antiLog10*: Applies a base 10 anti-logarithm to the passed value.
@@ -109,7 +109,7 @@ def logarithmic_function_basic(
     Returns
     -------
     :class:`numpy.ndarray`
-        Logarithmically converted data.
+        Logarithmically transformed data.
 
     Examples
     --------
@@ -171,18 +171,21 @@ def logarithmic_function_quasilog(
     lin_side_offset: float = 0,
 ) -> NDArrayFloat:
     """
-    Define the quasilog logarithmic function.
+    Apply the *Quasilog* logarithmic function for encoding and decoding.
+
+    This function implements a logarithmic transformation with configurable
+    slopes and offsets for both linear and logarithmic sides.
 
     Parameters
     ----------
     x
-        Linear/non-linear data to undergo encoding/decoding.
+        Logarithmically encoded data :math:`x`.
     style
-        Defines the behaviour for the logarithmic function to operate:
+        Specifies the behaviour for the logarithmic function to operate:
 
-        -   *linToLog*: Applies a logarithm to convert linear data to
+        -   *linToLog*: Apply a logarithm to convert linear data to
             logarithmic data.
-        -   *logToLin*: Applies an anti-logarithm to convert logarithmic
+        -   *logToLin*: Apply an anti-logarithm to convert logarithmic
             data to linear data.
     base
         Logarithmic base used for the conversion.
@@ -190,11 +193,11 @@ def logarithmic_function_quasilog(
         Slope (or gain) applied to the log side of the logarithmic function.
         The default value is 1.
     lin_side_slope
-        Slope of the linear side of the logarithmic function. The default value
-        is 1.
+        Slope of the linear side of the logarithmic function. The default
+        value is 1.
     log_side_offset
-        Offset applied to the log side of the logarithmic function. The default
-        value is 0.
+        Offset applied to the log side of the logarithmic function. The
+        default value is 0.
     lin_side_offset
         Offset applied to the linear side of the logarithmic function. The
         default value is 0.
@@ -252,14 +255,17 @@ def logarithmic_function_camera(
     linear_slope: float | None = None,
 ) -> NDArrayFloat:
     """
-    Define the camera logarithmic function.
+    Apply a camera logarithmic function to the specified array.
+
+    Apply a piece-wise function with logarithmic and linear segments
+    for encoding or decoding camera data.
 
     Parameters
     ----------
     x
-        Linear/non-linear data to undergo encoding/decoding.
+        Logarithmically encoded data :math:`x`.
     style
-        Defines the behaviour for the logarithmic function to operate:
+        Specifies the behaviour for the logarithmic function to operate:
 
         -   *cameraLinToLog*: Applies a piece-wise function with logarithmic
             and linear segments on linear values, converting them to non-linear
@@ -270,22 +276,24 @@ def logarithmic_function_camera(
     base
         Logarithmic base used for the conversion.
     log_side_slope
-        Slope (or gain) applied to the log side of the logarithmic segment. The
-        default value is 1.
+        Slope (or gain) applied to the log side of the logarithmic function.
+        The default value is 1.
     lin_side_slope
-        Slope of the linear side of the logarithmic segment. The default value
-        is 1.
+        Slope of the linear side of the logarithmic function. The
+        default value is 1.
     log_side_offset
-        Offset applied to the log side of the logarithmic segment. The default
-        value is 0.
-    lin_side_offset
-        Offset applied to the linear side of the logarithmic segment. The
+        Offset applied to the log side of the logarithmic function. The
         default value is 0.
+    lin_side_offset
+        Offset applied to the linear side of the logarithmic function.
+        The default value is 0.
     lin_side_break
-        Break-point, defined in linear space, at which the piece-wise function
-        transitions between the logarithmic and linear segments.
+        Break-point, defined in linear space, at which the piece-wise
+        function transitions between the logarithmic and linear
+        segments.
     linear_slope
-        Slope of the linear portion of the curve. The default value is *None*.
+        Slope of the linear portion of the curve. The default value is
+        *None*.
 
     Returns
     -------
@@ -374,18 +382,18 @@ def log_encoding_Log2(
     max_exposure: float = 6.5,
 ) -> NDArrayFloat:
     """
-    Define the common *Log2* encoding function.
+    Apply the common *Log2* log encoding opto-electronic transfer function (OETF).
 
     Parameters
     ----------
     lin
-          Linear data to undergo encoding.
+        Linear *Log2* decoded data.
     middle_grey
-          *Middle Grey* exposure value.
+        *Middle Grey* exposure value.
     min_exposure
-          Minimum exposure level.
+        Minimum exposure level.
     max_exposure
-          Maximum exposure level.
+        Maximum exposure level.
 
     Returns
     -------
@@ -430,12 +438,13 @@ def log_decoding_Log2(
     max_exposure: float = 6.5,
 ) -> NDArrayFloat:
     """
-    Define the common *Log2* decoding function.
+    Apply the common *Log2* log decoding inverse opto-electronic transfer
+    function (OETF).
 
     Parameters
     ----------
     log_norm
-        Logarithmic data to undergo decoding.
+        Non-linear *Log2* encoded data.
     middle_grey
         *Middle Grey* exposure value.
     min_exposure
@@ -450,8 +459,8 @@ def log_decoding_Log2(
 
     Notes
     -----
-    -   The common *Log2* decoding function can be used to build logarithmic to
-        linear shapers in the *ACES OCIO configuration*.
+    -   The common *Log2* decoding function can be used to build logarithmic
+        to linear shapers in the *ACES OCIO configuration*.
     -   The shaper with logarithmic encoded values can be decoded back to
         linear domain:
 

--- a/colour/models/rgb/transfer_functions/nikon_n_log.py
+++ b/colour/models/rgb/transfer_functions/nikon_n_log.py
@@ -27,7 +27,7 @@ if typing.TYPE_CHECKING:
     from colour.hints import ArrayLike, NDArrayFloat
 
 from colour.models.rgb.transfer_functions import full_to_legal, legal_to_full
-from colour.utilities import Structure, as_float, from_range_1, to_domain_1
+from colour.utilities import Structure, as_float, from_range_1, optional, to_domain_1
 
 __author__ = "Colour Developers"
 __copyright__ = "Copyright 2013 Colour Developers"
@@ -58,7 +58,7 @@ def log_encoding_NLog(
     bit_depth: int = 10,
     out_normalised_code_value: bool = True,
     in_reflection: bool = True,
-    constants: Structure = CONSTANTS_NLOG,
+    constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
     Define the *Nikon N-Log* log encoding curve / opto-electronic transfer
@@ -108,6 +108,7 @@ def log_encoding_NLog(
     """
 
     y = to_domain_1(y)
+    constants = optional(constants, CONSTANTS_NLOG)
 
     if not in_reflection:
         y = y * 0.9
@@ -134,7 +135,7 @@ def log_decoding_NLog(
     bit_depth: int = 10,
     in_normalised_code_value: bool = True,
     out_reflection: bool = True,
-    constants: Structure = CONSTANTS_NLOG,
+    constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
     Define the *Nikon N-Log* log decoding curve / electro-optical transfer
@@ -184,6 +185,7 @@ def log_decoding_NLog(
     """
 
     x = to_domain_1(x)
+    constants = optional(constants, CONSTANTS_NLOG)
 
     x = x if in_normalised_code_value else full_to_legal(x, bit_depth)
 

--- a/colour/models/rgb/transfer_functions/nikon_n_log.py
+++ b/colour/models/rgb/transfer_functions/nikon_n_log.py
@@ -2,7 +2,7 @@
 Nikon N-Log Log Encoding
 ========================
 
-Define the *Nikon N-Log* log encoding:
+Define the *Nikon N-Log* log encoding.
 
 -   :func:`colour.models.log_encoding_NLog`
 -   :func:`colour.models.log_decoding_NLog`
@@ -61,20 +61,20 @@ def log_encoding_NLog(
     constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
-    Define the *Nikon N-Log* log encoding curve / opto-electronic transfer
-    function.
+    Apply the *Nikon N-Log* log encoding opto-electronic transfer function (OETF).
 
     Parameters
     ----------
     y
-        Reflectance :math:`y`, "y = 0.18" is equivalent to Stop 0.
+        Linear light reflectance :math:`y`, where :math:`y = 0.18` represents
+        middle grey at Stop 0.
     bit_depth
         Bit-depth used for conversion.
     out_normalised_code_value
-        Whether the non-linear *Nikon N-Log* data :math:`x` is encoded as
+        Whether to return the *Nikon N-Log* encoded data :math:`x` as
         normalised code values.
     in_reflection
-        Whether the light level :math`in` to a camera is reflection.
+        Whether the input light level represents reflected light.
     constants
         *Nikon N-Log* constants.
 
@@ -138,27 +138,28 @@ def log_decoding_NLog(
     constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
-    Define the *Nikon N-Log* log decoding curve / electro-optical transfer
-    function.
+    Apply the *Nikon N-Log* log decoding inverse opto-electronic transfer
+    function (OETF).
 
     Parameters
     ----------
     x
-        *N-Log* 10-bit equivalent code value :math:`x`
+        *N-Log* 10-bit equivalent code value :math:`x`.
     bit_depth
         Bit-depth used for conversion.
     in_normalised_code_value
         Whether the non-linear *Nikon N-Log* data :math:`x` is encoded as
         normalised code values.
     out_reflection
-        Whether the light level :math`in` to a camera is reflection.
+        Whether the light level :math:`y` to a camera is reflection.
     constants
         *Nikon N-Log* constants.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Reflectance :math:`y`.
+        Linear light reflectance :math:`y`, where :math:`y = 0.18` represents
+        middle grey at Stop 0.
 
     Notes
     -----

--- a/colour/models/rgb/transfer_functions/panalog.py
+++ b/colour/models/rgb/transfer_functions/panalog.py
@@ -2,7 +2,7 @@
 Panalog Encoding
 ================
 
-Define the *Panalog* encoding:
+Define the *Panalog* encoding.
 
 -   :func:`colour.models.log_encoding_Panalog`
 -   :func:`colour.models.log_decoding_Panalog`
@@ -44,8 +44,7 @@ def log_encoding_Panalog(
     black_offset: ArrayLike = 10 ** ((64 - 681) / 444),
 ) -> NDArrayFloat:
     """
-    Define the *Panalog* log encoding curve / opto-electronic transfer
-    function.
+    Apply the *Panalog* log encoding opto-electronic transfer function (OETF).
 
     Parameters
     ----------
@@ -57,7 +56,7 @@ def log_encoding_Panalog(
     Returns
     -------
     :class:`numpy.ndarray`
-        Non-linear data :math:`y`.
+        *Panalog* non-linear encoded data :math:`y`.
 
     Warnings
     --------
@@ -101,13 +100,12 @@ def log_decoding_Panalog(
     black_offset: ArrayLike = 10 ** ((64 - 681) / 444),
 ) -> NDArrayFloat:
     """
-    Define the *Panalog* log decoding curve / electro-optical transfer
-    function.
+    Apply the *Panalog* log decoding inverse opto-electronic transfer function (OETF).
 
     Parameters
     ----------
     y
-        Non-linear data :math:`y`.
+        *Panalog* non-linear encoded data :math:`y`.
     black_offset
         Black offset.
 
@@ -118,8 +116,8 @@ def log_decoding_Panalog(
 
     Warnings
     --------
-    These are estimations known to be close enough, the actual log encoding
-    curves are not published.
+    These are estimations known to be close enough, the actual log
+    encoding curves are not published.
 
     Notes
     -----

--- a/colour/models/rgb/transfer_functions/panasonic_v_log.py
+++ b/colour/models/rgb/transfer_functions/panasonic_v_log.py
@@ -2,7 +2,7 @@
 Panasonic V-Log Log Encoding
 ============================
 
-Define the *Panasonic V-Log* log encoding:
+Define the *Panasonic V-Log* log encoding.
 
 -   :func:`colour.models.log_encoding_VLog`
 -   :func:`colour.models.log_decoding_VLog`
@@ -53,27 +53,26 @@ def log_encoding_VLog(
     constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
-    Define the *Panasonic V-Log* log encoding curve / opto-electronic transfer
-    function.
+    Apply the *Panasonic V-Log* log encoding opto-electronic transfer function (OETF).
 
     Parameters
     ----------
     L_in
-        Linear reflection data :math`L_{in}`.
+        Linear reflection data :math:`L_{in}`.
     bit_depth
         Bit-depth used for conversion.
     out_normalised_code_value
-        Whether the non-linear *Panasonic V-Log* data :math:`V_{out}` is
+        Whether the *Panasonic V-Log* non-linear data :math:`V_{out}` is
         encoded as normalised code values.
     in_reflection
-        Whether the light level :math`L_{in}` to a camera is reflection.
+        Whether the light level :math:`L_{in}` to a camera is reflection.
     constants
         *Panasonic V-Log* constants.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Non-linear data :math:`V_{out}`.
+        *Panasonic V-Log* mon-linear encoded data :math:`V_{out}`.
 
     Notes
     -----
@@ -144,27 +143,28 @@ def log_decoding_VLog(
     constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
-    Define the *Panasonic V-Log* log decoding curve / electro-optical transfer
-    function.
+    Apply the *Panasonic V-Log* log decoding inverse opto-electronic transfer
+
+    function (OETF).
 
     Parameters
     ----------
     V_out
-        Non-linear data :math:`V_{out}`.
+        *Panasonic V-Log* mon-linear encoded data :math:`V_{out}`.
     bit_depth
         Bit-depth used for conversion.
     in_normalised_code_value
-        Whether the non-linear *Panasonic V-Log* data :math:`V_{out}` is
+        Whether the *Panasonic V-Log* non-linear data :math:`V_{out}` is
         encoded as normalised code values.
     out_reflection
-        Whether the light level :math`L_{in}` to a camera is reflection.
+        Whether the light level :math:`L_{in}` to a camera is reflection.
     constants
         *Panasonic V-Log* constants.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Linear reflection data :math`L_{in}`.
+        Linear reflection data :math:`L_{in}`.
 
     Notes
     -----

--- a/colour/models/rgb/transfer_functions/panasonic_v_log.py
+++ b/colour/models/rgb/transfer_functions/panasonic_v_log.py
@@ -24,7 +24,7 @@ if typing.TYPE_CHECKING:
     from colour.hints import ArrayLike, NDArrayFloat
 
 from colour.models.rgb.transfer_functions import full_to_legal, legal_to_full
-from colour.utilities import Structure, as_float, from_range_1, to_domain_1
+from colour.utilities import Structure, as_float, from_range_1, optional, to_domain_1
 
 __author__ = "Colour Developers"
 __copyright__ = "Copyright 2013 Colour Developers"
@@ -50,7 +50,7 @@ def log_encoding_VLog(
     bit_depth: int = 10,
     out_normalised_code_value: bool = True,
     in_reflection: bool = True,
-    constants: Structure = CONSTANTS_VLOG,
+    constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
     Define the *Panasonic V-Log* log encoding curve / opto-electronic transfer
@@ -115,6 +115,7 @@ def log_encoding_VLog(
     """
 
     L_in = to_domain_1(L_in)
+    constants = optional(constants, CONSTANTS_VLOG)
 
     if not in_reflection:
         L_in = L_in * 0.9
@@ -140,7 +141,7 @@ def log_decoding_VLog(
     bit_depth: int = 10,
     in_normalised_code_value: bool = True,
     out_reflection: bool = True,
-    constants: Structure = CONSTANTS_VLOG,
+    constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
     Define the *Panasonic V-Log* log decoding curve / electro-optical transfer
@@ -190,6 +191,7 @@ def log_decoding_VLog(
     """
 
     V_out = to_domain_1(V_out)
+    constants = optional(constants, CONSTANTS_VLOG)
 
     V_out = V_out if in_normalised_code_value else full_to_legal(V_out, bit_depth)
 

--- a/colour/models/rgb/transfer_functions/pivoted_log.py
+++ b/colour/models/rgb/transfer_functions/pivoted_log.py
@@ -2,7 +2,7 @@
 Pivoted Log Encoding
 ====================
 
-Define the *Pivoted Log* encoding:
+Define the *Pivoted Log* encoding.
 
 -   :func:`colour.models.log_encoding_PivotedLog`
 -   :func:`colour.models.log_decoding_PivotedLog`
@@ -47,26 +47,33 @@ def log_encoding_PivotedLog(
     density_per_code_value: float = 0.002,
 ) -> NDArrayFloat:
     """
-    Define the *Josh Pines* style *Pivoted Log* log encoding curve /
-    opto-electronic transfer function.
+    Apply the *Josh Pines* style *Pivoted Log* log encoding
+    opto-electronic transfer function (OETF).
 
     Parameters
     ----------
     x
         Linear data :math:`x`.
     log_reference
-        Log reference.
+        Log reference that defines the pivot point in code values where
+        the logarithmic encoding is centred. Typical value is 445.
     linear_reference
-        Linear reference.
+        Linear reference that establishes the relationship between linear
+        scene-referred values and the logarithmic code values. Typical
+        value is 0.18, representing 18% grey.
     negative_gamma
-        Negative gamma.
+        Negative gamma that controls the slope and curvature of the
+        logarithmic portion of the encoding curve. Lower values produce
+        steeper curves with more contrast in the shadows.
     density_per_code_value
-        Density per code value.
+        Density per code value that determines the logarithmic step size
+        and affects the overall contrast and dynamic range of the encoded
+        values.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Non-linear data :math:`y`.
+        Logarithmically encoded data :math:`y`.
 
     Notes
     -----
@@ -110,21 +117,28 @@ def log_decoding_PivotedLog(
     density_per_code_value: float = 0.002,
 ) -> NDArrayFloat:
     """
-    Define the *Josh Pines* style *Pivoted Log* log decoding curve /
-    electro-optical transfer function.
+    Apply the *Josh Pines* style *Pivoted Log* log decoding inverse
+    opto-electronic transfer function (OETF).
 
     Parameters
     ----------
     y
-        Non-linear data :math:`y`.
+        Logarithmically encoded data :math:`y`.
     log_reference
-        Log reference.
+        Log reference that defines the pivot point in code values where
+        the logarithmic encoding is centred. Typical value is 445.
     linear_reference
-        Linear reference.
+        Linear reference that establishes the relationship between linear
+        scene-referred values and the logarithmic code values. Typical
+        value is 0.18, representing 18% grey.
     negative_gamma
-        Negative gamma.
+        Negative gamma that controls the slope and curvature of the
+        logarithmic portion of the encoding curve. Lower values produce
+        steeper curves with more contrast in the shadows.
     density_per_code_value
-        Density per code value.
+        Density per code value that determines the logarithmic step size
+        and affects the overall contrast and dynamic range of the encoded
+        values.
 
     Returns
     -------

--- a/colour/models/rgb/transfer_functions/red.py
+++ b/colour/models/rgb/transfer_functions/red.py
@@ -2,7 +2,7 @@
 RED Log Encodings
 =================
 
-Define the *RED* log encodings:
+Define the *RED* log encodings.
 
 -   :func:`colour.models.log_encoding_REDLog`
 -   :func:`colour.models.log_decoding_REDLog`
@@ -88,20 +88,19 @@ def log_encoding_REDLog(
     black_offset: ArrayLike = 10 ** ((0 - 1023) / 511),
 ) -> NDArrayFloat:
     """
-    Define the *REDLog* log encoding curve / opto-electronic transfer
-    function.
+    Apply the *REDLog* log encoding opto-electronic transfer function (OETF).
 
     Parameters
     ----------
     x
         Linear data :math:`x`.
     black_offset
-        Black offset.
+        Black offset value.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Non-linear data :math:`y`.
+        *REDLog* non-linear encoded data :math:`y`.
 
     Notes
     -----
@@ -140,15 +139,14 @@ def log_decoding_REDLog(
     black_offset: ArrayLike = 10 ** ((0 - 1023) / 511),
 ) -> NDArrayFloat:
     """
-    Define the *REDLog* log decoding curve / electro-optical transfer
-    function.
+    Apply the *REDLog* log decoding inverse opto-electronic transfer function (OETF).
 
     Parameters
     ----------
     y
-        Non-linear data :math:`y`.
+        *REDLog* non-linear encoded data :math:`y`.
     black_offset
-        Black offset.
+        Black offset value.
 
     Returns
     -------
@@ -192,20 +190,19 @@ def log_encoding_REDLogFilm(
     black_offset: ArrayLike = 10 ** ((95 - 685) / 300),
 ) -> NDArrayFloat:
     """
-    Define the *REDLogFilm* log encoding curve / opto-electronic transfer
-    function.
+    Apply the *REDLogFilm* log encoding opto-electronic transfer function (OETF).
 
     Parameters
     ----------
     x
         Linear data :math:`x`.
     black_offset
-        Black offset.
+        Black offset value.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Non-linear data :math:`y`.
+        *REDLogFilm* non-linear encoded data :math:`y`.
 
     Notes
     -----
@@ -239,15 +236,15 @@ def log_decoding_REDLogFilm(
     black_offset: ArrayLike = 10 ** ((95 - 685) / 300),
 ) -> NDArrayFloat:
     """
-    Define the *REDLogFilm* log decoding curve / electro-optical transfer
-    function.
+    Apply the *REDLogFilm* log decoding inverse opto-electronic transfer
+    function (OETF).
 
     Parameters
     ----------
     y
-        Non-linear data :math:`y`.
+        *REDLogFilm* non-linear encoded data :math:`y`.
     black_offset
-        Black offset.
+        Black offset value.
 
     Returns
     -------
@@ -283,8 +280,9 @@ def log_decoding_REDLogFilm(
 
 def log_encoding_Log3G10_v1(x: ArrayLike) -> NDArrayFloat:
     """
-    Define the *Log3G10* *v1* log encoding curve / opto-electronic transfer
-    function, the curve used in *REDCINE-X PRO Beta 42* and *Resolve 12.5.2*.
+    Apply the *Log3G10* *v1* log encoding opto-electronic transfer function (OETF).
+
+    From *REDCINE-X PRO Beta 42* and *Resolve 12.5.2*.
 
     Parameters
     ----------
@@ -294,7 +292,7 @@ def log_encoding_Log3G10_v1(x: ArrayLike) -> NDArrayFloat:
     Returns
     -------
     :class:`numpy.ndarray`
-        Non-linear data :math:`y`.
+        *Log3G10* *v1* non-linear encoded data :math:`y`.
 
     Notes
     -----
@@ -329,13 +327,15 @@ def log_encoding_Log3G10_v1(x: ArrayLike) -> NDArrayFloat:
 
 def log_decoding_Log3G10_v1(y: ArrayLike) -> NDArrayFloat:
     """
-    Define the *Log3G10* *v1* log decoding curve / electro-optical transfer
-    function, the curve used in *REDCINE-X PRO Beta 42* and *Resolve 12.5.2*.
+    Apply the *Log3G10* *v1* log decoding inverse opto-electronic transfer
+    function (OETF).
+
+    From *REDCINE-X PRO Beta 42* and *Resolve 12.5.2*.
 
     Parameters
     ----------
     y
-        Non-linear data :math:`y`.
+        *Log3G10* *v1* non-linear encoded data :math:`y`.
 
     Returns
     -------
@@ -375,8 +375,9 @@ def log_decoding_Log3G10_v1(y: ArrayLike) -> NDArrayFloat:
 
 def log_encoding_Log3G10_v2(x: ArrayLike) -> NDArrayFloat:
     """
-    Define the *Log3G10* *v2* log encoding curve / opto-electronic transfer
-    function, the current curve in *REDCINE-X PRO*.
+    Apply the *Log3G10* *v2* log encoding opto-electronic transfer function (OETF).
+
+    Current curve used in *REDCINE-X PRO*.
 
     Parameters
     ----------
@@ -386,7 +387,7 @@ def log_encoding_Log3G10_v2(x: ArrayLike) -> NDArrayFloat:
     Returns
     -------
     :class:`numpy.ndarray`
-        Non-linear data :math:`y`.
+       *Log3G10* *v2* non-linear encoded data :math:`y`.
 
     Notes
     -----
@@ -421,13 +422,15 @@ def log_encoding_Log3G10_v2(x: ArrayLike) -> NDArrayFloat:
 
 def log_decoding_Log3G10_v2(y: ArrayLike) -> NDArrayFloat:
     """
-    Define the *Log3G10* *v2* log decoding curve / electro-optical transfer
-    function, the current curve in *REDCINE-X PRO*.
+    Apply the *Log3G10* *v2* log decoding inverse opto-electronic transfer
+    function (OETF).
+
+    Current curve used in *REDCINE-X PRO*.
 
     Parameters
     ----------
     y
-        Non-linear data :math:`y`.
+       *Log3G10* *v2* non-linear encoded data :math:`y`.
 
     Returns
     -------
@@ -467,8 +470,9 @@ def log_decoding_Log3G10_v2(y: ArrayLike) -> NDArrayFloat:
 
 def log_encoding_Log3G10_v3(x: ArrayLike) -> NDArrayFloat:
     """
-    Define the *Log3G10* *v3* log encoding curve / opto-electronic transfer
-    function, the curve described in the *RedLog3G10* Whitepaper.
+    Apply the *Log3G10* *v3* log encoding opto-electronic transfer function (OETF).
+
+    As described in the *RedLog3G10* whitepaper.
 
     Parameters
     ----------
@@ -478,7 +482,7 @@ def log_encoding_Log3G10_v3(x: ArrayLike) -> NDArrayFloat:
     Returns
     -------
     :class:`numpy.ndarray`
-        Non-linear data :math:`y`.
+        *Log3G10* *v3* non-linear encoded data :math:`y`.
 
     Notes
     -----
@@ -520,18 +524,20 @@ def log_encoding_Log3G10_v3(x: ArrayLike) -> NDArrayFloat:
 
 def log_decoding_Log3G10_v3(y: ArrayLike) -> NDArrayFloat:
     """
-    Define the *Log3G10* *v3* log decoding curve / electro-optical transfer
-    function, the curve described in the *RedLog3G10* whitepaper.
+    Apply the *Log3G10* *v3* log decoding inverse opto-electronic transfer
+    function (OETF).
+
+    As described in the *RedLog3G10* whitepaper.
 
     Parameters
     ----------
     y
-        Non-linear data :math:`y`.
+        *Log3G10* *v3* non-linear encoded data :math:`y`.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Linear data :math:`x`.
+        Linear *Log3G10* *v3* data :math:`x`.
 
     Notes
     -----
@@ -581,8 +587,8 @@ LOG3G10_ENCODING_METHODS: CanonicalMapping = CanonicalMapping(
     }
 )
 LOG3G10_ENCODING_METHODS.__doc__ = """
-Supported *Log3G10* log encoding curve / opto-electronic transfer function
-methods.
+Supported *Log3G10* log encoding curve / opto-electronic transfer (OETF)
+function methods.
 
 References
 ----------
@@ -595,8 +601,7 @@ def log_encoding_Log3G10(
     method: Literal["v1", "v2", "v3"] | str = "v3",
 ) -> NDArrayFloat:
     """
-    Define the *Log3G10* log encoding curve / opto-electronic transfer
-    function.
+    Apply the *Log3G10* log encoding opto-electronic transfer function (OETF).
 
     Parameters
     ----------
@@ -608,7 +613,7 @@ def log_encoding_Log3G10(
     Returns
     -------
     :class:`numpy.ndarray`
-        Non-linear data :math:`y`.
+        *Log3G10* non-linear encoded data :math:`y`.
 
     Notes
     -----
@@ -625,13 +630,13 @@ def log_encoding_Log3G10(
     +------------+-----------------------+---------------+
 
     -   The *Log3G10* *v1* log encoding curve is the one used in
-        *REDCINE-X Beta 42*. *Resolve 12.5.2* also uses the *v1* curve. *RED*
-        is planning to use the *Log3G10* *v2* log encoding curve in the release
-        version of the *RED SDK*.
-    -   The intent of the *Log3G10* *v1* log encoding curve is that zero maps
-        to zero, 0.18 maps to 1/3, and 10 stops above 0.18 maps to 1.0.
-        The name indicates this in a similar way to the naming conventions of
-        *Sony HyperGamma* curves.
+        *REDCINE-X Beta 42*. *Resolve 12.5.2* also uses the *v1* curve.
+        *RED* is planning to use the *Log3G10* *v2* log encoding curve in
+        the release version of the *RED SDK*.
+    -   The intent of the *Log3G10* *v1* log encoding curve is that zero
+        maps to zero, 0.18 maps to 1/3, and 10 stops above 0.18 maps to
+        1.0. The name indicates this in a similar way to the naming
+        conventions of *Sony HyperGamma* curves.
 
         The constants used in the functions do not in fact quite hit these
         values, but rather than use corrected constants, the functions here
@@ -679,8 +684,8 @@ LOG3G10_DECODING_METHODS = CanonicalMapping(
     }
 )
 LOG3G10_DECODING_METHODS.__doc__ = """
-Supported *Log3G10* log decoding curve / electro-optical transfer function
-methods.
+Supported *Log3G10* log decoding curve / electro-optical transfer (EOTF)
+function methods.
 
 References
 ----------
@@ -692,13 +697,12 @@ def log_decoding_Log3G10(
     y: ArrayLike, method: Literal["v1", "v2", "v3"] | str = "v3"
 ) -> NDArrayFloat:
     """
-    Define the *Log3G10* log decoding curve / electro-optical transfer
-    function.
+    Apply the *Log3G10* log decoding inverse opto-electronic transfer function (OETF).
 
     Parameters
     ----------
     y
-        Non-linear data :math:`y`.
+        *Log3G10* non-linear encoded data :math:`y`.
     method
         Computation method.
 
@@ -740,8 +744,7 @@ def log_decoding_Log3G10(
 
 def log_encoding_Log3G12(x: ArrayLike) -> NDArrayFloat:
     """
-    Define the *Log3G12* log encoding curve / opto-electronic transfer
-    function.
+    Apply the *Log3G12* log encoding opto-electronic transfer function (OETF).
 
     Parameters
     ----------
@@ -751,7 +754,7 @@ def log_encoding_Log3G12(x: ArrayLike) -> NDArrayFloat:
     Returns
     -------
     :class:`numpy.ndarray`
-        Non-linear data :math:`y`.
+        *Log3G12* non-linear encoded data :math:`y`.
 
     Notes
     -----
@@ -786,13 +789,12 @@ def log_encoding_Log3G12(x: ArrayLike) -> NDArrayFloat:
 
 def log_decoding_Log3G12(y: ArrayLike) -> NDArrayFloat:
     """
-    Define the *Log3G12* log decoding curve / electro-optical transfer
-    function.
+    Apply the *Log3G12* log decoding inverse opto-electronic transfer function (OETF).
 
     Parameters
     ----------
     y
-        Non-linear data :math:`y`.
+        *Log3G12* non-linear encoded data :math:`y`.
 
     Returns
     -------

--- a/colour/models/rgb/transfer_functions/rimm_romm_rgb.py
+++ b/colour/models/rgb/transfer_functions/rimm_romm_rgb.py
@@ -3,7 +3,7 @@ RIMM, ROMM and ERIMM Encodings
 ==============================
 
 Define the *RIMM, ROMM and ERIMM* encodings opto-electrical transfer functions
-(OETF) and electro-optical transfer functions (EOTF):
+(OETF) and electro-optical transfer functions (EOTF).
 
 -   :func:`colour.models.cctf_encoding_ROMMRGB`
 -   :func:`colour.models.cctf_decoding_ROMMRGB`
@@ -67,7 +67,7 @@ def cctf_encoding_ROMMRGB(
     X: ArrayLike, bit_depth: int = 8, out_int: bool = False
 ) -> NDArrayReal:
     """
-    Define the *ROMM RGB* encoding colour component transfer function
+    Apply the *ROMM RGB* encoding colour component transfer function
     (Encoding CCTF).
 
     Parameters
@@ -77,13 +77,13 @@ def cctf_encoding_ROMMRGB(
     bit_depth
         Bit-depth used for conversion.
     out_int
-        Whether to return value as int code value or float equivalent of a
-        code value at a specified bit-depth.
+        Whether to return value as integer code value or floating point
+        equivalent of a code value at a specified bit-depth.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Non-linear data :math:`X'_{ROMM}`.
+        Non-linear encoded data :math:`X'_{ROMM}`.
 
     Notes
     -----
@@ -134,18 +134,18 @@ def cctf_decoding_ROMMRGB(
     in_int: bool = False,
 ) -> NDArrayFloat:
     """
-    Define the *ROMM RGB* decoding colour component transfer function
-    (Encoding CCTF).
+    Apply the *ROMM RGB* decoding colour component transfer function
+    (Decoding CCTF).
 
     Parameters
     ----------
     X_p
-        Non-linear data :math:`X'_{ROMM}`.
+        Non-linear encoded data :math:`X'_{ROMM}`.
     bit_depth
         Bit-depth used for conversion.
     in_int
-        Whether to treat the input value as int code value or float
-        equivalent of a code value at a specified bit-depth.
+        Whether to treat the input value as integer code value or floating
+        point equivalent of a code value at a specified bit-depth.
 
     Returns
     -------
@@ -224,11 +224,8 @@ def cctf_encoding_RIMMRGB(
     E_clip: float = 2.0,
 ) -> NDArrayReal:
     """
-    Define the *RIMM RGB* encoding colour component transfer function
+    Apply the *RIMM RGB* encoding colour component transfer function
     (Encoding CCTF).
-
-    *RIMM RGB* encoding non-linearity is based on that specified by
-    *Recommendation ITU-R BT.709-6*.
 
     Parameters
     ----------
@@ -237,15 +234,15 @@ def cctf_encoding_RIMMRGB(
     bit_depth
         Bit-depth used for conversion.
     out_int
-        Whether to return value as int code value or float equivalent of a
-        code value at a specified bit-depth.
+        Whether to return value as integer code value or floating point
+        equivalent of a code value at a specified bit-depth.
     E_clip
-        Maximum exposure level.
+        Maximum exposure limit.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Non-linear data :math:`X'_{RIMM}`.
+        Non-linear encoded data :math:`X'_{RIMM}`.
 
     Notes
     -----
@@ -301,20 +298,20 @@ def cctf_decoding_RIMMRGB(
     E_clip: float = 2.0,
 ) -> NDArrayFloat:
     """
-    Define the *RIMM RGB* decoding colour component transfer function
-    (Encoding CCTF).
+    Apply the *RIMM RGB* decoding colour component transfer function
+    (Decoding CCTF).
 
     Parameters
     ----------
     X_p
-        Non-linear data :math:`X'_{RIMM}`.
+        Non-linear encoded data :math:`X'_{RIMM}`.
     bit_depth
         Bit-depth used for conversion.
     in_int
-        Whether to treat the input value as int code value or float
-        equivalent of a code value at a specified bit-depth.
+        Whether to treat the input value as integer code value or floating
+        point equivalent of a code value at a specified bit-depth.
     E_clip
-        Maximum exposure level.
+        Maximum exposure limit.
 
     Returns
     -------
@@ -379,8 +376,7 @@ def log_encoding_ERIMMRGB(
     E_clip: float = 316.2,
 ) -> NDArrayReal:
     """
-    Define the *ERIMM RGB* log encoding curve / opto-electronic transfer
-    function (OETF).
+    Apply the *ERIMM RGB* log encoding opto-electronic transfer function (OETF).
 
     Parameters
     ----------
@@ -389,8 +385,8 @@ def log_encoding_ERIMMRGB(
     bit_depth
         Bit-depth used for conversion.
     out_int
-        Whether to return value as int code value or float equivalent of a
-        code value at a specified bit-depth.
+        Whether to return value as integer code value or floating point
+        equivalent of a code value at a specified bit-depth.
     E_min
         Minimum exposure limit.
     E_clip
@@ -399,7 +395,7 @@ def log_encoding_ERIMMRGB(
     Returns
     -------
     :class:`numpy.ndarray`
-        Non-linear data :math:`X'_{ERIMM}`.
+        Non-linear encoded data :math:`X'_{ERIMM}`.
 
     Notes
     -----
@@ -468,18 +464,17 @@ def log_decoding_ERIMMRGB(
     E_clip: float = 316.2,
 ) -> NDArrayFloat:
     """
-    Define the *ERIMM RGB* log decoding curve / electro-optical transfer
-    function (EOTF).
+    Apply the *ERIMM RGB* log decoding inverse opto-electronic transfer function (OETF).
 
     Parameters
     ----------
     X_p
-        Non-linear data :math:`X'_{ERIMM}`.
+        Non-linear encoded data :math:`X'_{ERIMM}`.
     bit_depth
         Bit-depth used for conversion.
     in_int
-        Whether to treat the input value as int code value or float
-        equivalent of a code value at a specified bit-depth.
+        Whether to treat the input value as integer code value or floating
+        point equivalent of a code value at a specified bit-depth.
     E_min
         Minimum exposure limit.
     E_clip

--- a/colour/models/rgb/transfer_functions/smpte_240m.py
+++ b/colour/models/rgb/transfer_functions/smpte_240m.py
@@ -3,7 +3,7 @@ SMPTE 240M
 ==========
 
 Define the *SMPTE 240M* opto-electrical transfer function (OETF) and
-electro-optical transfer function (EOTF):
+electro-optical transfer function (EOTF).
 
 -   :func:`colour.models.oetf_SMPTE240M`
 -   :func:`colour.models.eotf_SMPTE240M`
@@ -45,7 +45,7 @@ __all__ = [
 
 def oetf_SMPTE240M(L_c: ArrayLike) -> NDArrayFloat:
     """
-    Define *SMPTE 240M* opto-electrical transfer function (OETF).
+    Apply the *SMPTE 240M* opto-electronic transfer function (OETF).
 
     Parameters
     ----------
@@ -56,8 +56,8 @@ def oetf_SMPTE240M(L_c: ArrayLike) -> NDArrayFloat:
     Returns
     -------
     :class:`numpy.ndarray`
-        Video signal output :math:`V_c` of the reference camera normalised to
-        the system reference white.
+        Video signal output :math:`V_c` of the reference camera normalised
+        to the system reference white.
 
     Notes
     -----
@@ -92,7 +92,7 @@ def oetf_SMPTE240M(L_c: ArrayLike) -> NDArrayFloat:
 
 def eotf_SMPTE240M(V_r: ArrayLike) -> NDArrayFloat:
     """
-    Define *SMPTE 240M* electro-optical transfer function (EOTF).
+    Apply the *SMPTE 240M* electro-optical transfer function (EOTF).
 
     Parameters
     ----------
@@ -103,21 +103,21 @@ def eotf_SMPTE240M(V_r: ArrayLike) -> NDArrayFloat:
     Returns
     -------
     :class:`numpy.ndarray`
-         Light output :math:`L_r` from the reference reproducer normalised to
-         the system reference white.
+        Light output :math:`L_r` from the reference reproducer normalised
+        to the system reference white.
 
     Notes
     -----
     +------------+-----------------------+---------------+
     | **Domain** | **Scale - Reference** | **Scale - 1** |
     +============+=======================+===============+
-    | ``V_c``    | [0, 1]                | [0, 1]        |
+    | ``V_r``    | [0, 1]                | [0, 1]        |
     +------------+-----------------------+---------------+
 
     +------------+-----------------------+---------------+
     | **Range**  | **Scale - Reference** | **Scale - 1** |
     +============+=======================+===============+
-    | ``L_c``    | [0, 1]                | [0, 1]        |
+    | ``L_r``    | [0, 1]                | [0, 1]        |
     +------------+-----------------------+---------------+
 
     References

--- a/colour/models/rgb/transfer_functions/sony.py
+++ b/colour/models/rgb/transfer_functions/sony.py
@@ -2,7 +2,7 @@
 Sony Encodings
 ==============
 
-Define the *Sony* log encodings:
+Define the *Sony* log encodings.
 
 -   :func:`colour.models.log_encoding_SLog`
 -   :func:`colour.models.log_decoding_SLog`
@@ -67,8 +67,8 @@ def log_encoding_SLog(
     in_reflection: bool = True,
 ) -> NDArrayFloat:
     """
-    Define the *Sony S-Log* log encoding curve / opto-electronic transfer
-    function.
+    Apply the *Sony S-Log* log encoding opto-electronic transfer function
+    (OETF).
 
     Parameters
     ----------
@@ -78,7 +78,7 @@ def log_encoding_SLog(
     bit_depth
         Bit-depth used for conversion.
     out_normalised_code_value
-        Whether the non-linear *Sony S-Log* data :math:`y` is encoded as
+        Whether the *Sony S-Log* non-linear data :math:`y` is encoded as
         normalised code values.
     in_reflection
         Whether the light level :math:`x` to a camera is reflection.
@@ -86,7 +86,7 @@ def log_encoding_SLog(
     Returns
     -------
     :class:`numpy.ndarray`
-        Non-linear *Sony S-Log* data :math:`y`.
+        *Sony S-Log* non-linear encoded data :math:`y`.
 
     Notes
     -----
@@ -144,20 +144,20 @@ def log_decoding_SLog(
     out_reflection: bool = True,
 ) -> NDArrayFloat:
     """
-    Define the *Sony S-Log* log decoding curve / electro-optical transfer
-    function.
+    Apply the *Sony S-Log* log decoding inverse opto-electronic transfer
+    function (OETF).
 
     Parameters
     ----------
     y
-        Non-linear *Sony S-Log* data :math:`y`.
+        *Sony S-Log* non-linear encoded data :math:`y`.
     bit_depth
         Bit-depth used for conversion.
     in_normalised_code_value
-        Whether the non-linear *Sony S-Log* data :math:`y` is encoded as
+        Whether the *Sony S-Log* non-linear data :math:`y` is encoded as
         normalised code values.
     out_reflection
-        Whether the light level :math:`x` to a camera is reflection.
+        Whether the output light level :math:`x` represents reflection.
 
     Returns
     -------
@@ -213,8 +213,8 @@ def log_encoding_SLog2(
     in_reflection: bool = True,
 ) -> NDArrayFloat:
     """
-    Define the *Sony S-Log2* log encoding curve / opto-electronic transfer
-    function.
+    Apply the *Sony S-Log2* log encoding opto-electronic transfer function
+    (OETF).
 
     Parameters
     ----------
@@ -224,7 +224,7 @@ def log_encoding_SLog2(
     bit_depth
         Bit-depth used for conversion.
     out_normalised_code_value
-        Whether the non-linear *Sony S-Log2* data :math:`y` is encoded as
+        Whether the *Sony S-Log2* non-linear data :math:`y` is encoded as
         normalised code values.
     in_reflection
         Whether the light level :math:`x` to a camera is reflection.
@@ -232,7 +232,7 @@ def log_encoding_SLog2(
     Returns
     -------
     :class:`numpy.ndarray`
-        Non-linear *Sony S-Log2* data :math:`y`.
+        *Sony S-Log2* non-linear encoded data :math:`y`.
 
     Notes
     -----
@@ -281,20 +281,20 @@ def log_decoding_SLog2(
     out_reflection: bool = True,
 ) -> NDArrayFloat:
     """
-    Define the *Sony S-Log2* log decoding curve / electro-optical transfer
-    function.
+    Apply the *Sony S-Log2* log decoding inverse opto-electronic transfer
+    function (OETF).
 
     Parameters
     ----------
     y
-        Non-linear *Sony S-Log2* data :math:`y`.
+        *Sony S-Log2* non-linear encoded data :math:`y`.
     bit_depth
         Bit-depth used for conversion.
     in_normalised_code_value
-        Whether the non-linear *Sony S-Log2* data :math:`y` is encoded as
+        Whether the *Sony S-Log2* non-linear data :math:`y` is encoded as
         normalised code values.
     out_reflection
-        Whether the light level :math:`x` to a camera is reflection.
+        Whether the output light level :math:`x` represents reflection.
 
     Returns
     -------
@@ -340,8 +340,8 @@ def log_encoding_SLog3(
     in_reflection: bool = True,
 ) -> NDArrayFloat:
     """
-    Define the *Sony S-Log3* log encoding curve / opto-electronic transfer
-    function.
+    Apply the *Sony S-Log3* log encoding opto-electronic transfer function
+    (OETF).
 
     Parameters
     ----------
@@ -351,7 +351,7 @@ def log_encoding_SLog3(
     bit_depth
         Bit-depth used for conversion.
     out_normalised_code_value
-        Whether the non-linear *Sony S-Log3* data :math:`y` is encoded as
+        Whether the *Sony S-Log3* non-linear data data :math:`y` is encoded as
         normalised code values.
     in_reflection
         Whether the light level :math:`x` to a camera is reflection.
@@ -359,7 +359,7 @@ def log_encoding_SLog3(
     Returns
     -------
     :class:`numpy.ndarray`
-        Non-linear *Sony S-Log3* data :math:`y`.
+        *Sony S-Log3* non-linear encoded data :math:`y`.
 
     Notes
     -----
@@ -417,20 +417,20 @@ def log_decoding_SLog3(
     out_reflection: bool = True,
 ) -> NDArrayFloat:
     """
-    Define the *Sony S-Log3* log decoding curve / electro-optical transfer
-    function.
+    Apply the *Sony S-Log3* log decoding inverse opto-electronic transfer
+    function (OETF).
 
     Parameters
     ----------
     y
-        Non-linear *Sony S-Log3* data :math:`y`.
+        *Sony S-Log3* non-linear encoded data :math:`y`.
     bit_depth
         Bit-depth used for conversion.
     in_normalised_code_value
-        Whether the non-linear *Sony S-Log3* data :math:`y` is encoded as
+        Whether the *Sony S-Log3* non-linear data :math:`y` is encoded as
         normalised code values.
     out_reflection
-        Whether the light level :math:`x` to a camera is reflection.
+        Whether the output light level :math:`x` represents reflection.
 
     Returns
     -------

--- a/colour/models/rgb/transfer_functions/srgb.py
+++ b/colour/models/rgb/transfer_functions/srgb.py
@@ -3,7 +3,7 @@ SRGB
 ====
 
 Define the *sRGB* electro-optical transfer function (EOTF) and its
-inverse:
+inverse.
 
 -   :func:`colour.models.eotf_inverse_sRGB`
 -   :func:`colour.models.eotf_sRGB`
@@ -51,7 +51,7 @@ __all__ = [
 
 def eotf_inverse_sRGB(L: ArrayLike) -> NDArrayFloat:
     """
-    Define the *IEC 61966-2-1:1999* *sRGB* inverse electro-optical transfer
+    Apply the *IEC 61966-2-1:1999* *sRGB* inverse electro-optical transfer
     function (EOTF).
 
     Parameters
@@ -62,7 +62,7 @@ def eotf_inverse_sRGB(L: ArrayLike) -> NDArrayFloat:
     Returns
     -------
     :class:`numpy.ndarray`
-        Corresponding electrical signal :math:`V`.
+        Electrical signal :math:`V`.
 
     Notes
     -----
@@ -98,7 +98,7 @@ def eotf_inverse_sRGB(L: ArrayLike) -> NDArrayFloat:
 
 def eotf_sRGB(V: ArrayLike) -> NDArrayFloat:
     """
-    Define the *IEC 61966-2-1:1999* *sRGB* electro-optical transfer function
+    Apply the *IEC 61966-2-1:1999* *sRGB* electro-optical transfer function
     (EOTF).
 
     Parameters
@@ -109,7 +109,7 @@ def eotf_sRGB(V: ArrayLike) -> NDArrayFloat:
     Returns
     -------
     :class:`numpy.ndarray`
-        Corresponding *luminance* :math:`L` of the image.
+        *Luminance* :math:`L` of the image.
 
     Notes
     -----

--- a/colour/models/rgb/transfer_functions/st_2084.py
+++ b/colour/models/rgb/transfer_functions/st_2084.py
@@ -31,7 +31,7 @@ from colour.algebra import spow
 if typing.TYPE_CHECKING:
     from colour.hints import ArrayLike, NDArrayFloat
 
-from colour.utilities import Structure, as_float, as_float_array
+from colour.utilities import Structure, as_float, as_float_array, optional
 
 __author__ = "Colour Developers"
 __copyright__ = "Copyright 2013 Colour Developers"
@@ -62,7 +62,7 @@ Constants for *SMPTE ST 2084:2014* inverse electro-optical transfer function
 def eotf_inverse_ST2084(
     C: ArrayLike,
     L_p: float = 10000,
-    constants: Structure = CONSTANTS_ST2084,
+    constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
     Define *SMPTE ST 2084:2014* optimised perceptual inverse electro-optical
@@ -123,6 +123,7 @@ def eotf_inverse_ST2084(
     """
 
     C = as_float_array(C)
+    constants = optional(constants, CONSTANTS_ST2084)
 
     c_1 = constants.c_1
     c_2 = constants.c_2
@@ -140,7 +141,7 @@ def eotf_inverse_ST2084(
 def eotf_ST2084(
     N: ArrayLike,
     L_p: float = 10000,
-    constants: Structure = CONSTANTS_ST2084,
+    constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
     Define *SMPTE ST 2084:2014* optimised perceptual electro-optical transfer
@@ -202,6 +203,7 @@ def eotf_ST2084(
     """
 
     N = as_float_array(N)
+    constants = optional(constants, CONSTANTS_ST2084)
 
     c_1 = constants.c_1
     c_2 = constants.c_2

--- a/colour/models/rgb/transfer_functions/st_2084.py
+++ b/colour/models/rgb/transfer_functions/st_2084.py
@@ -3,7 +3,7 @@ SMPTE ST 2084:2014
 ==================
 
 Define the *SMPTE ST 2084:2014* electro-optical transfer function (EOTF) and
-its inverse:
+its inverse.
 
 -   :func:`colour.models.eotf_inverse_ST2084`
 -   :func:`colour.models.eotf_ST2084`
@@ -65,8 +65,8 @@ def eotf_inverse_ST2084(
     constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
-    Define *SMPTE ST 2084:2014* optimised perceptual inverse electro-optical
-    transfer function (EOTF).
+    Apply the *SMPTE ST 2084:2014* perceptual quantizer (PQ) inverse
+    electro-optical transfer function (EOTF).
 
     Parameters
     ----------
@@ -74,18 +74,19 @@ def eotf_inverse_ST2084(
         Target optical output :math:`C` in :math:`cd/m^2` of the ideal
         reference display.
     L_p
-        System peak luminance :math:`cd/m^2`, this parameter should stay at its
-        default :math:`10000 cd/m^2` value for practical applications. It is
-        exposed so that the definition can be used as a fitting function.
+        System peak luminance in :math:`cd/m^2`. This parameter should remain
+        at its default value of :math:`10000 cd/m^2` for practical
+        applications. It is exposed to enable the definition's use as a
+        fitting function.
     constants
         *SMPTE ST 2084:2014* constants.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Color value abbreviated as :math:`N`, that is directly proportional to
-        the encoded signal representation, and which is not directly
-        proportional to the optical output of a display device.
+        Colour value abbreviated as :math:`N`, directly proportional to the
+        encoded signal representation and not directly proportional to the
+        optical output of a display device.
 
     Warnings
     --------
@@ -93,11 +94,11 @@ def eotf_inverse_ST2084(
 
     Notes
     -----
-    -   *SMPTE ST 2084:2014* is an absolute transfer function, thus the
+    -   *SMPTE ST 2084:2014* is an absolute transfer function; thus, the
         domain and range values for the *Reference* and *1* scales are only
         indicative that the data is not affected by scale transformations.
-        The effective domain of *SMPTE ST 2084:2014* inverse electro-optical
-        transfer function (EOTF) is [0.0001, 10000].
+        The effective domain of the *SMPTE ST 2084:2014* inverse
+        electro-optical transfer function (EOTF) is [0.0001, 10000].
 
     +------------+-----------------------+---------------+
     | **Domain** | **Scale - Reference** | **Scale - 1** |
@@ -144,30 +145,28 @@ def eotf_ST2084(
     constants: Structure | None = None,
 ) -> NDArrayFloat:
     """
-    Define *SMPTE ST 2084:2014* optimised perceptual electro-optical transfer
-    function (EOTF).
-
-    This perceptual quantizer (PQ) has been modeled by Dolby Laboratories
-    using *Barten (1999)* contrast sensitivity function.
+    Apply the *SMPTE ST 2084:2014* perceptual quantizer (PQ) electro-optical
+    transfer function (EOTF).
 
     Parameters
     ----------
     N
-        Color value abbreviated as :math:`N`, that is directly proportional to
-        the encoded signal representation, and which is not directly
-        proportional to the optical output of a display device.
+        Colour value abbreviated as :math:`N`, directly proportional to the
+        encoded signal representation and not directly proportional to the
+        optical output of a display device.
     L_p
-        System peak luminance :math:`cd/m^2`, this parameter should stay at its
-        default :math:`10000 cd/m^2` value for practical applications. It is
-        exposed so that the definition can be used as a fitting function.
+        System peak luminance in :math:`cd/m^2`. This parameter should remain
+        at its default value of :math:`10000 cd/m^2` for practical
+        applications. It is exposed to enable the definition's use as a
+        fitting function.
     constants
         *SMPTE ST 2084:2014* constants.
 
     Returns
     -------
     :class:`numpy.ndarray`
-          Target optical output :math:`C` in :math:`cd/m^2` of the ideal
-          reference display.
+        Target optical output :math:`C` in :math:`cd/m^2` of the ideal
+        reference display.
 
     Warnings
     --------

--- a/colour/models/rgb/transfer_functions/viper_log.py
+++ b/colour/models/rgb/transfer_functions/viper_log.py
@@ -2,7 +2,7 @@
 Viper Log Encoding
 ==================
 
-Define the *Viper Log* encoding:
+Define the *Viper Log* encoding.
 
 -   :func:`colour.models.log_encoding_ViperLog`
 -   :func:`colour.models.log_decoding_ViperLog`
@@ -41,8 +41,7 @@ __all__ = [
 
 def log_encoding_ViperLog(x: ArrayLike) -> NDArrayFloat:
     """
-    Define the *Viper Log* log encoding curve / opto-electronic transfer
-    function.
+    Apply the *Viper Log* log encoding opto-electronic transfer function (OETF).
 
     Parameters
     ----------
@@ -52,7 +51,7 @@ def log_encoding_ViperLog(x: ArrayLike) -> NDArrayFloat:
     Returns
     -------
     :class:`numpy.ndarray`
-        Non-linear data :math:`y`.
+        Non-linear encoded data :math:`y`.
 
     Notes
     -----
@@ -87,13 +86,12 @@ def log_encoding_ViperLog(x: ArrayLike) -> NDArrayFloat:
 
 def log_decoding_ViperLog(y: ArrayLike) -> NDArrayFloat:
     """
-    Define the *Viper Log* log decoding curve / electro-optical transfer
-    function.
+    Apply the *Viper Log* log decoding inverse opto-electronic transfer function (OETF).
 
     Parameters
     ----------
     y
-        Non-linear data :math:`y`.
+        Non-linear encoded data :math:`y`.
 
     Returns
     -------

--- a/colour/models/rgb/ycbcr.py
+++ b/colour/models/rgb/ycbcr.py
@@ -2,7 +2,7 @@
 Y'CbCr Colour Encoding
 ======================
 
-Define the *Y'CbCr* colour encoding related attributes and objects:
+Define the *Y'CbCr* colour encoding related attributes and objects.
 
 -   :attr:`colour.WEIGHTS_YCBCR`
 -   :func:`colour.matrix_YCbCr`
@@ -119,8 +119,12 @@ References
 
 def round_BT2100(a: ArrayLike) -> NDArrayFloat:
     """
-    Round specified array :math:`a` to the nearest int using the method define
-    as `Round` in *RecommendationITU-R BT.2100*.
+    Round the specified array :math:`a` to the nearest integer using the
+    rounding method defined in *Recommendation ITU-R BT.2100*.
+
+    This function implements the specific rounding behaviour required by
+    *Recommendation ITU-R BT.2100*, where values are rounded to the nearest
+    integer with 0.5 rounding up.
 
     Parameters
     ----------
@@ -147,8 +151,8 @@ def round_BT2100(a: ArrayLike) -> NDArrayFloat:
 
 def ranges_YCbCr(bits: int, is_legal: bool, is_int: bool) -> NDArrayFloat:
     """
-    Return the *Y'CbCr* colour encoding ranges array for specified bit-depth,
-    range legality and representation.
+    Return the *Y'CbCr* colour encoding ranges array for the specified
+    bit-depth, range legality and representation.
 
     Parameters
     ----------
@@ -157,7 +161,7 @@ def ranges_YCbCr(bits: int, is_legal: bool, is_int: bool) -> NDArrayFloat:
     is_legal
         Whether the *Y'CbCr* colour encoding ranges array is legal.
     is_int
-        Whether the *Y'CbCr* colour encoding ranges array represents int
+        Whether the *Y'CbCr* colour encoding ranges array represents integer
         code values.
 
     Returns
@@ -206,11 +210,11 @@ def matrix_YCbCr(
     is_int: bool = False,
 ) -> NDArrayFloat:
     """
-    Compute the *Y'CbCr* to *R'G'B'* matrix for specified weights, bit-depth,
-    range legality and representation.
+    Compute the *Y'CbCr* to *R'G'B'* matrix for the specified weights,
+    bit-depth, range legality and representation.
 
-    The related offset for the *R'G'B'* to *Y'CbCr* matrix can be computed with
-    the :func:`colour.offset_YCbCr` definition.
+    The related offset for the *R'G'B'* to *Y'CbCr* matrix can be computed
+    with the :func:`colour.offset_YCbCr` definition.
 
     Parameters
     ----------
@@ -290,8 +294,8 @@ def offset_YCbCr(
     bits: int = 8, is_legal: bool = False, is_int: bool = False
 ) -> NDArrayFloat:
     """
-    Compute the *R'G'B'* to *Y'CbCr* offsets for specified bit-depth, range
-    legality and representation.
+    Compute the *R'G'B'* to *Y'CbCr* offsets for the specified bit-depth,
+    range legality and representation.
 
     The related *R'G'B'* to *Y'CbCr* matrix can be computed with the
     :func:`colour.matrix_YCbCr` definition.
@@ -309,7 +313,7 @@ def offset_YCbCr(
     Returns
     -------
     :class:`numpy.ndarray`
-        *Y'CbCr* matrix.
+        *Y'CbCr* offsets.
 
     Examples
     --------
@@ -353,18 +357,19 @@ def RGB_to_YCbCr(
         *(0.2126, 0.0722)*, the weightings for *ITU-R BT.709*.
     in_bits
         Bit-depth for int input, or used in the calculation of the
-        denominator for legal range float values, i.e., 8-bit means the float
-        value for legal white is *235 / 255*. Default is *10*.
+        denominator for legal range float values, i.e., 8-bit means the
+        float value for legal white is *235 / 255*. Default is *10*.
     in_legal
-        Whether to treat the input values as legal range. Default is *False*.
+        Whether to treat the input values as legal range. Default is
+        *False*.
     in_int
         Whether to treat the input values as ``in_bits`` int code values.
         Default is *False*.
     out_bits
         Bit-depth for int output, or used in the calculation of the
-        denominator for legal range float values, i.e., 8-bit means the float
-        value for legal white is *235 / 255*. Ignored if ``out_legal`` and
-        ``out_int`` are both *False*. Default is *8*.
+        denominator for legal range float values, i.e., 8-bit means the
+        float value for legal white is *235 / 255*. Ignored if
+        ``out_legal`` and ``out_int`` are both *False*. Default is *8*.
     out_legal
         Whether to return legal range values. Default is *True*.
     out_int
@@ -379,8 +384,8 @@ def RGB_to_YCbCr(
     in_range
         Array overriding the computed range such as
         *in_range = (RGB_min, RGB_max)*. If ``in_range`` is undefined,
-        *RGB_min* and *RGB_max* will be computed using :func:`colour.CV_range`
-        definition.
+        *RGB_min* and *RGB_max* will be computed using
+        :func:`colour.CV_range` definition.
     out_range
         Array overriding the computed range such as
         *out_range = (Y_min, Y_max, C_min, C_max)`. If ``out_range`` is
@@ -394,10 +399,12 @@ def RGB_to_YCbCr(
 
     Warnings
     --------
-    For *Recommendation ITU-R BT.2020*, :func:`colour.RGB_to_YCbCr` definition
-    is only applicable to the non-constant luminance implementation.
-    :func:`colour.RGB_to_YcCbcCrc` definition should be used for the constant
-    luminance case as per :cite:`InternationalTelecommunicationUnion2015h`.
+    For *Recommendation ITU-R BT.2020*,
+    :func:`colour.RGB_to_YCbCr` definition is only applicable to the
+    non-constant luminance implementation.
+    :func:`colour.RGB_to_YcCbcCrc` definition should be used for the
+    constant luminance case as per
+    :cite:`InternationalTelecommunicationUnion2015h`.
 
     Notes
     -----
@@ -414,16 +421,17 @@ def RGB_to_YCbCr(
     +----------------+-----------------------+---------------+
 
     \\* This definition has input and output int switches, thus the
-    domain-range scale information is only specified for the floating point mode.
+    domain-range scale information is only specified for the floating point
+    mode.
 
     -   The default arguments, ``**{'in_bits': 10, 'in_legal': False,
-        'in_int': False, 'out_bits': 8, 'out_legal': True, 'out_int': False}``
-        transform a float *R'G'B'* input array normalised to domain [0, 1]
-        (``in_bits`` is ignored) to a float *Y'CbCr* output array where *Y'* is
-        normalised to range [16 / 255, 235 / 255] and *Cb* and *Cr* are
-        normalised to range [16 / 255, 240./255]. The float values are
-        calculated based on an [0, 255] int range, but no 8-bit
-        quantisation or clamping are performed.
+        'in_int': False, 'out_bits': 8, 'out_legal': True, 'out_int':
+        False}`` transform a float *R'G'B'* input array normalised to
+        domain [0, 1] (``in_bits`` is ignored) to a float *Y'CbCr* output
+        array where *Y'* is normalised to range [16 / 255, 235 / 255] and
+        *Cb* and *Cr* are normalised to range [16 / 255, 240./255]. The
+        float values are calculated based on an [0, 255] int range, but no
+        8-bit quantisation or clamping are performed.
 
     References
     ----------
@@ -438,15 +446,15 @@ def RGB_to_YCbCr(
     >>> RGB_to_YCbCr(RGB)  # doctest: +ELLIPSIS
     array([ 0.9215686...,  0.5019607...,  0.5019607...])
 
-    Matching the float output of *The Foundry Nuke*'s *Colorspace* node set to
-    *YCbCr*:
+    Matching the float output of *The Foundry Nuke*'s *Colorspace* node
+    set to *YCbCr*:
 
     >>> RGB_to_YCbCr(RGB, out_range=(16 / 255, 235 / 255, 15.5 / 255, 239.5 / 255))
     ... # doctest: +ELLIPSIS
     array([ 0.9215686...,  0.5       ,  0.5       ])
 
-    Matching the float output of *The Foundry Nuke*'s *Colorspace* node set to
-    *YPbPr*:
+    Matching the float output of *The Foundry Nuke*'s *Colorspace* node
+    set to *YPbPr*:
 
     >>> RGB_to_YCbCr(RGB, out_legal=False, out_int=False)
     ... # doctest: +ELLIPSIS
@@ -471,13 +479,14 @@ def RGB_to_YCbCr(
     ... # doctest: +ELLIPSIS
     array([ 36, 136, 175]...)
 
-    Note the use of [0.5, 255.5] for the *Cb / Cr* range, which is required so
-    that the *Cb* and *Cr* output is centered about 128. Using 255 centres it
-    about 127.5, meaning that there is no int code value to represent
-    achromatic colours. This does however create the possibility of output
-    int codes with value of 256, which cannot be stored in 8-bit int
-    representation. *Recommendation ITU-T T.871* specifies these should be
-    clamped to 255, which is applied with the default ``clamp_int=True``.
+    Note the use of [0.5, 255.5] for the *Cb / Cr* range, which is
+    required so that the *Cb* and *Cr* output is centered about 128. Using
+    255 centres it about 127.5, meaning that there is no int code value to
+    represent achromatic colours. This does however create the possibility
+    of output int codes with value of 256, which cannot be stored in 8-bit
+    int representation. *Recommendation ITU-T T.871* specifies these should
+    be clamped to 255, which is applied with the default
+    ``clamp_int=True``.
 
     These *JFIF JPEG* ranges are also obtained as follows:
 
@@ -538,8 +547,8 @@ def YCbCr_to_RGB(
     **kwargs: Any,
 ) -> NDArrayReal:
     """
-    Convert an array of *Y'CbCr* colour encoding values to the corresponding
-    *R'G'B'* values array.
+    Convert an array of *Y'CbCr* colour encoding values to the
+    corresponding *R'G'B'* values array.
 
     Parameters
     ----------
@@ -551,39 +560,43 @@ def YCbCr_to_RGB(
         *(0.2126, 0.0722)*, the weightings for *ITU-R BT.709*.
     in_bits
         Bit-depth for int input, or used in the calculation of the
-        denominator for legal range float values, i.e., 8-bit means the float
-        value for legal white is *235 / 255*. Default is *8*.
+        denominator for legal range float values, i.e., 8-bit means
+        the float value for legal white is *235 / 255*. Default is
+        *8*.
     in_legal
-        Whether to treat the input values as legal range. Default is *True*.
+        Whether to treat the input values as legal range. Default is
+        *True*.
     in_int
-        Whether to treat the input values as ``in_bits`` int code values.
-        Default is *False*.
+        Whether to treat the input values as ``in_bits`` int code
+        values. Default is *False*.
     out_bits
         Bit-depth for int output, or used in the calculation of the
-        denominator for legal range float values, i.e., 8-bit means the float
-        value for legal white is *235 / 255*. Ignored if ``out_legal`` and
-        ``out_int`` are both *False*. Default is *10*.
+        denominator for legal range float values, i.e., 8-bit means
+        the float value for legal white is *235 / 255*. Ignored if
+        ``out_legal`` and ``out_int`` are both *False*. Default is
+        *10*.
     out_legal
         Whether to return legal range values. Default is *False*.
     out_int
-        Whether to return values as ``out_bits`` int code values. Default
-        is *False*.
+        Whether to return values as ``out_bits`` int code values.
+        Default is *False*.
     clamp_int
-        Whether to clamp int output to allowable range for ``out_bits``.
-        Default is *True*.
+        Whether to clamp int output to allowable range for
+        ``out_bits``. Default is *True*.
 
     Other Parameters
     ----------------
     in_range
         Array overriding the computed range such as
-        *in_range = (Y_min, Y_max, C_min, C_max)*. If ``in_range`` is
-        undefined, *Y_min*, *Y_max*, *C_min* and *C_max* will be computed using
-        :func:`colour.models.rgb.ycbcr.ranges_YCbCr` definition.
+        *in_range = (Y_min, Y_max, C_min, C_max)*. If ``in_range``
+        is undefined, *Y_min*, *Y_max*, *C_min* and *C_max* will be
+        computed using :func:`colour.models.rgb.ycbcr.ranges_YCbCr`
+        definition.
     out_range
         Array overriding the computed range such as
-        *out_range = (RGB_min, RGB_max)*. If ``out_range`` is undefined,
-        *RGB_min* and *RGB_max* will be computed using :func:`colour.CV_range`
-        definition.
+        *out_range = (RGB_min, RGB_max)*. If ``out_range`` is
+        undefined, *RGB_min* and *RGB_max* will be computed using
+        :func:`colour.CV_range` definition.
 
     Returns
     -------
@@ -605,14 +618,17 @@ def YCbCr_to_RGB(
     +----------------+-----------------------+---------------+
 
     \\* This definition has input and output int switches, thus the
-    domain-range scale information is only specified for the floating point mode.
+    domain-range scale information is only specified for the floating point
+    mode.
 
     Warnings
     --------
-    For *Recommendation ITU-R BT.2020*, :func:`colour.YCbCr_to_RGB`
-    definition is only applicable to the non-constant luminance implementation.
-    :func:`colour.YcCbcCrc_to_RGB` definition should be used for the constant
-    luminance case as per :cite:`InternationalTelecommunicationUnion2015h`.
+    For *Recommendation ITU-R BT.2020*,
+    :func:`colour.YCbCr_to_RGB` definition is only applicable to
+    the non-constant luminance implementation.
+    :func:`colour.YcCbcCrc_to_RGB` definition should be used for
+    the constant luminance case as per
+    :cite:`InternationalTelecommunicationUnion2015h`.
 
     References
     ----------
@@ -684,8 +700,8 @@ def RGB_to_YcCbcCrc(
     out_legal
         Whether to return legal range values. Default is *True*.
     out_int
-        Whether to return values as ``out_bits`` int code values. Default
-        is *False*.
+        Whether to return values as ``out_bits`` int code values. Default is
+        *False*.
     is_12_bits_system
         *Recommendation ITU-R BT.2020* OETF (OECF) adopts different parameters
         for 10 and 12 bit systems. Default is *False*.
@@ -718,13 +734,13 @@ def RGB_to_YcCbcCrc(
     +----------------+-----------------------+---------------+
 
     \\* This definition has input and output int switches, thus the
-    domain-range scale information is only specified for the floating point mode.
+    domain-range scale information is only specified for the floating point
+    mode.
 
     Warnings
     --------
-    This definition is specifically for usage with
-    *Recommendation ITU-R BT.2020* when adopting the constant luminance
-    implementation.
+    This definition is specifically for usage with *Recommendation ITU-R
+    BT.2020* when adopting the constant luminance implementation.
 
     References
     ----------
@@ -791,24 +807,25 @@ def YcCbcCrc_to_RGB(
         Input *Yc'Cbc'Crc'* colour encoding array of linear float values.
     in_bits
         Bit-depth for int input, or used in the calculation of the
-        denominator for legal range float values, i.e., 8-bit means the float
-        value for legal white is *235 / 255*. Default is *10*.
+        denominator for legal range float values, i.e., 8-bit means the
+        float value for legal white is *235 / 255*. Default is *10*.
     in_legal
-        Whether to treat the input values as legal range. Default is *False*.
+        Whether to treat the input values as legal range. Default is
+        *True*.
     in_int
         Whether to treat the input values as ``in_bits`` int code values.
         Default is *False*.
     is_12_bits_system
-        *Recommendation ITU-R BT.2020* EOTF (EOCF) adopts different parameters
-        for 10 and 12 bit systems. Default is *False*.
+        *Recommendation ITU-R BT.2020* EOTF (EOCF) adopts different
+        parameters for 10 and 12 bit systems. Default is *False*.
 
     Other Parameters
     ----------------
     in_range
         Array overriding the computed range such as
         *in_range = (Y_min, Y_max, C_min, C_max)*. If ``in_range`` is
-        undefined, *Y_min*, *Y_max*, *C_min* and *C_max* will be computed using
-        :func:`colour.models.rgb.ycbcr.ranges_YCbCr` definition.
+        undefined, *Y_min*, *Y_max*, *C_min* and *C_max* will be computed
+        using :func:`colour.models.rgb.ycbcr.ranges_YCbCr` definition.
 
     Returns
     -------
@@ -830,7 +847,8 @@ def YcCbcCrc_to_RGB(
     +----------------+-----------------------+---------------+
 
     \\* This definition has input and output int switches, thus the
-    domain-range scale information is only specified for the floating point mode.
+    domain-range scale information is only specified for the floating point
+    mode.
 
     Warnings
     --------

--- a/colour/models/rgb/ycocg.py
+++ b/colour/models/rgb/ycocg.py
@@ -1,6 +1,6 @@
 """
 YCoCg Colour Encoding
-======================
+=====================
 
 Define the *YCoCg* colour encoding related transformations:
 

--- a/colour/models/sucs.py
+++ b/colour/models/sucs.py
@@ -2,18 +2,16 @@
 sUCS Colourspace
 ================
 
-Define the *sUCS* colourspace transformations:
+Define the *sUCS* colourspace transformations.
 
 -   :func:`colour.XYZ_to_sUCS`
 -   :func:`colour.sUCS_to_XYZ`
-
-And computation of correlates:
-
 -   :func:`colour.sUCS_chroma`
 -   :func:`colour.sUCS_hue_angle`
 
-The sUCS (Simple Uniform Colour Space) is designed for simplicity and perceptual
-uniformity. This implementation is based on the work by *Li & Luo (2024)*.
+The *sUCS* (Simple Uniform Colour Space) is designed for simplicity and
+perceptual uniformity. This implementation is based on the work by
+*Li & Luo (2024)*.
 
 References
 ----------
@@ -110,7 +108,7 @@ def XYZ_to_sUCS(XYZ: ArrayLike) -> NDArrayFloat:
     Parameters
     ----------
     XYZ
-        *CIE XYZ* tristimulus values, assumed to be adapted to
+        *CIE XYZ* tristimulus values, adapted to
         *CIE Standard Illuminant D65* and in domain [0, 1] (where white
         :math:`Y` is 1.0).
 
@@ -134,7 +132,7 @@ def XYZ_to_sUCS(XYZ: ArrayLike) -> NDArrayFloat:
     |            |                       |                  |
     |            | ``a`` : [-100, +100]  | ``a`` : [-1, +1] |
     |            |                       |                  |
-    |            | ``b`` : [-100,+100]   | ``b`` : [-1, +1] |
+    |            | ``b`` : [-100, +100]  | ``b`` : [-1, +1] |
     +------------+-----------------------+------------------+
 
     -   Input *CIE XYZ* tristimulus values must be adapted to
@@ -176,8 +174,9 @@ def sUCS_to_XYZ(Iab: ArrayLike) -> NDArrayFloat:
     Returns
     -------
     :class:`numpy.ndarray`
-        *CIE XYZ* tristimulus values, adapted to *CIE Standard Illuminant D65*
-        and in domain [0, 1] (where white :math:`Y` is 1.0).
+        *CIE XYZ* tristimulus values, adapted to
+        *CIE Standard Illuminant D65* and in domain [0, 1] (where white
+        :math:`Y` is 1.0).
 
     Notes
     -----
@@ -223,7 +222,7 @@ def sUCS_to_XYZ(Iab: ArrayLike) -> NDArrayFloat:
 
 def sUCS_chroma(Iab: ArrayLike) -> NDArrayFloat:
     """
-    Compute the chroma component from *sUCS* colourspace.
+    Compute the chroma component from the *sUCS* colourspace.
 
     Parameters
     ----------
@@ -233,7 +232,7 @@ def sUCS_chroma(Iab: ArrayLike) -> NDArrayFloat:
     Returns
     -------
     :class:`numpy.ndarray`
-         Chroma component.
+        Chroma component.
 
     Notes
     -----
@@ -244,7 +243,7 @@ def sUCS_chroma(Iab: ArrayLike) -> NDArrayFloat:
     |            |                       |                  |
     |            | ``a`` : [-100, +100]  | ``a`` : [-1, +1] |
     |            |                       |                  |
-    |            | ``b`` : [-100,+100]   | ``b`` : [-1, +1] |
+    |            | ``b`` : [-100, +100]  | ``b`` : [-1, +1] |
     +------------+-----------------------+------------------+
 
     +------------+-----------------------+-----------------+
@@ -273,7 +272,7 @@ def sUCS_chroma(Iab: ArrayLike) -> NDArrayFloat:
 
 def sUCS_hue_angle(Iab: ArrayLike) -> NDArrayFloat:
     """
-    Compute the hue angle in degrees from *sUCS* colourspace.
+    Compute the hue angle in degrees from the *sUCS* colourspace.
 
     Parameters
     ----------
@@ -294,7 +293,7 @@ def sUCS_hue_angle(Iab: ArrayLike) -> NDArrayFloat:
     |            |                       |                  |
     |            | ``a`` : [-100, +100]  | ``a`` : [-1, +1] |
     |            |                       |                  |
-    |            | ``b`` : [-100,+100]   | ``b`` : [-1, +1] |
+    |            | ``b`` : [-100, +100]  | ``b`` : [-1, +1] |
     +------------+-----------------------+------------------+
 
     +------------+-----------------------+-----------------+
@@ -323,8 +322,8 @@ def sUCS_hue_angle(Iab: ArrayLike) -> NDArrayFloat:
 
 def sUCS_Iab_to_sUCS_ICh(Iab: ArrayLike) -> NDArrayFloat:
     """
-    Convert from *sUCS* :math:`Iab` rectangular coordinates to *sUCS* :math:`ICh`
-    cylindrical coordinates.
+    Convert from *sUCS* :math:`Iab` rectangular coordinates to *sUCS*
+    :math:`ICh` cylindrical coordinates.
 
     Parameters
     ----------
@@ -380,8 +379,8 @@ def sUCS_Iab_to_sUCS_ICh(Iab: ArrayLike) -> NDArrayFloat:
 
 def sUCS_ICh_to_sUCS_Iab(ICh: ArrayLike) -> NDArrayFloat:
     """
-    Convert from *sUCS* :math:`ICh` cylindrical coordinates to *sUCS* :math:`Iab`
-    rectangular coordinates.
+    Convert from *sUCS* :math:`ICh` cylindrical coordinates to *sUCS*
+    :math:`Iab` rectangular coordinates.
 
     Parameters
     ----------

--- a/colour/models/yrg.py
+++ b/colour/models/yrg.py
@@ -2,7 +2,7 @@
 Yrg Colourspace - Kirk (2019)
 =============================
 
-Define the *Kirk (2019)* *Yrg* colourspace:
+Define the *Kirk (2019)* *Yrg* colourspace transformations.
 
 -   :func:`colour.models.LMS_to_Yrg`
 -   :func:`colour.models.Yrg_to_LMS`
@@ -64,17 +64,19 @@ values.
 
 def LMS_to_Yrg(LMS: ArrayLike) -> NDArrayFloat:
     """
-    Convert from *LMS* colourspace to *Kirk (2019)* *Yrg* colourspace.
+    Convert from *LMS* cone fundamentals colourspace to *Kirk (2019)* *Yrg*
+    colourspace.
 
     Parameters
     ----------
     LMS
-        *LMS* colourspace values.
+        *LMS* cone fundamentals colourspace values.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        *Kirk (2019)* *Yrg* :math:`Yrg` luminance, redness, and greenness.
+        *Kirk (2019)* *Yrg* colourspace array with :math:`Y` luminance,
+        :math:`r` redness, and :math:`g` greenness components.
 
     Notes
     -----
@@ -126,17 +128,19 @@ def LMS_to_Yrg(LMS: ArrayLike) -> NDArrayFloat:
 
 def Yrg_to_LMS(Yrg: ArrayLike) -> NDArrayFloat:
     """
-    Convert from *Kirk (2019)* *Yrg* colourspace to *LMS* colourspace.
+    Convert from *Kirk (2019)* *Yrg* colourspace to *LMS* cone
+    fundamentals colourspace.
 
     Parameters
     ----------
     Yrg
-        *Kirk (2019)* *Yrg* :math:`Yrg` luminance, redness, and greenness.
+        *Kirk (2019)* *Yrg* colourspace array with :math:`Y` luminance,
+        :math:`r` redness, and :math:`g` greenness components.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        *LMS* colourspace values.
+        *LMS* cone fundamentals colourspace values.
 
     Notes
     -----
@@ -190,12 +194,13 @@ def XYZ_to_Yrg(XYZ: ArrayLike) -> NDArrayFloat:
     Parameters
     ----------
     XYZ
-        *CIE XYZ* tristimulus values values.
+        *CIE XYZ* tristimulus values.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        *Kirk (2019)* *Yrg* :math:`Yrg` luminance, redness, and greenness.
+        *Kirk (2019)* *Yrg* colourspace array with :math:`Y` luminance,
+        :math:`r` redness, and :math:`g` greenness components.
 
     Notes
     -----
@@ -232,17 +237,19 @@ def XYZ_to_Yrg(XYZ: ArrayLike) -> NDArrayFloat:
 
 def Yrg_to_XYZ(Yrg: ArrayLike) -> NDArrayFloat:
     """
-    Convert from *Kirk (2019)* *Yrg* colourspace to *CIE XYZ* tristimulus values.
+    Convert from *Kirk (2019)* *Yrg* colourspace to *CIE XYZ* tristimulus
+    values.
 
     Parameters
     ----------
     Yrg
-        *Kirk (2019)* *Yrg* :math:`Yrg` luminance, redness, and greenness.
+        *Kirk (2019)* *Yrg* colourspace array with :math:`Y` luminance,
+        :math:`r` redness, and :math:`g` greenness components.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        *CIE XYZ* tristimulus values values.
+        *CIE XYZ* tristimulus values.
 
     Notes
     -----

--- a/colour/notation/css_color_3.py
+++ b/colour/notation/css_color_3.py
@@ -2,7 +2,8 @@
 CSS Color Module Level 3 - Web Colours
 ======================================
 
-Define the conversion of colour keywords to *RGB* colourspace:
+Define the conversion utilities for CSS Color Module Level 3 colour keywords
+to *RGB* colourspace representations.
 
 -   :attr:`colour.notation.keyword_to_RGB_CSSColor3`
 
@@ -51,8 +52,8 @@ def keyword_to_RGB_CSSColor3(keyword: str) -> NDArrayFloat:
 
     Notes
     -----
-    -   All the RGB colors are specified in the *IEC 61966-2-1:1999* *sRGB*
-        colourspace.
+    -   All the RGB colors are specified in the *IEC 61966-2-1:1999*
+        *sRGB* colourspace.
 
     Examples
     --------

--- a/colour/notation/hexadecimal.py
+++ b/colour/notation/hexadecimal.py
@@ -2,7 +2,8 @@
 Hexadecimal Notation
 ====================
 
-Define the objects for hexadecimal notation:
+Define objects for converting between RGB colour values and hexadecimal
+notation.
 
 -   :func:`colour.notation.RGB_to_HEX`
 -   :func:`colour.notation.HEX_to_RGB`
@@ -48,12 +49,12 @@ def RGB_to_HEX(RGB: ArrayLike) -> NDArrayStr:
     Parameters
     ----------
     RGB
-        *RGB* colourspace array.
+        *RGB* colourspace array with values typically normalised to [0, 1].
 
     Returns
     -------
     :class:`str` or :class:`numpy.array`
-        Hexadecimal representation.
+        Hexadecimal representation as a string in the format '#RRGGBB'.
 
     Notes
     -----
@@ -102,12 +103,12 @@ def HEX_to_RGB(HEX: ArrayLike) -> NDArrayFloat:
     Parameters
     ----------
     HEX
-        Hexadecimal representation.
+        Hexadecimal representation as a string in the format '#RRGGBB'.
 
     Returns
     -------
     :class:`numpy.array`
-        *RGB* colourspace array.
+        *RGB* colourspace array with values typically normalised to [0, 1].
 
     Notes
     -----

--- a/colour/notation/munsell.py
+++ b/colour/notation/munsell.py
@@ -2,45 +2,47 @@
 Munsell Renotation System
 =========================
 
-Define various objects for *Munsell Renotation System* computations:
+Define objects for *Munsell Renotation System* computations.
 
--   :func:`colour.notation.munsell_value_Priest1920`: *Munsell* value :math:`V`
-    computation of specified *luminance* :math:`Y` using
+-   :func:`colour.notation.munsell_value_Priest1920`: Compute *Munsell* value
+    :math:`V` from the specified *luminance* :math:`Y` using
     *Priest, Gibson and MacNicholas (1920)* method.
--   :func:`colour.notation.munsell_value_Munsell1933`: *Munsell* value
-    :math:`V` computation of specified *luminance* :math:`Y` using
+-   :func:`colour.notation.munsell_value_Munsell1933`: Compute *Munsell* value
+    :math:`V` from the specified *luminance* :math:`Y` using
     *Munsell, Sloan and Godlove (1933)* method.
--   :func:`colour.notation.munsell_value_Moon1943`: *Munsell* value :math:`V`
-    computation of specified *luminance* :math:`Y` using
+-   :func:`colour.notation.munsell_value_Moon1943`: Compute *Munsell* value
+    :math:`V` from the specified *luminance* :math:`Y` using
     *Moon and Spencer (1943)* method.
--   :func:`colour.notation.munsell_value_Saunderson1944`: *Munsell* value
-    :math:`V` computation of specified *luminance* :math:`Y` using
+-   :func:`colour.notation.munsell_value_Saunderson1944`: Compute *Munsell*
+    value :math:`V` from the specified *luminance* :math:`Y` using
     *Saunderson and Milner (1944)* method.
--   :func:`colour.notation.munsell_value_Ladd1955`: *Munsell* value :math:`V`
-    computation of specified *luminance* :math:`Y` using *Ladd and Pinney (1955)*
+-   :func:`colour.notation.munsell_value_Ladd1955`: Compute *Munsell* value
+    :math:`V` from the specified *luminance* :math:`Y` using
+    *Ladd and Pinney (1955)* method.
+-   :func:`colour.notation.munsell_value_McCamy1987`: Compute *Munsell* value
+    :math:`V` from the specified *luminance* :math:`Y` using *McCamy (1987)*
     method.
--   :func:`colour.notation.munsell_value_McCamy1987`: *Munsell* value :math:`V`
-    computation of specified *luminance* :math:`Y` using *McCamy (1987)* method.
--   :func:`colour.notation.munsell_value_ASTMD1535`: *Munsell* value
-    :math:`V` computation of specified *luminance* :math:`Y` using
-    *ASTM D1535-08e1* method.
+-   :func:`colour.notation.munsell_value_ASTMD1535`: Compute *Munsell* value
+    :math:`V` from the specified *luminance* :math:`Y` using *ASTM D1535-08e1*
+    method.
 -   :attr:`colour.MUNSELL_VALUE_METHODS`: Supported *Munsell* value
     computation methods.
--   :func:`colour.munsell_value`: *Munsell* value :math:`V` computation of
-    specified *luminance* :math:`Y` using specified method.
+-   :func:`colour.munsell_value`: Compute *Munsell* value :math:`V` from
+    specified *luminance* :math:`Y` using the specified method.
 -   :func:`colour.munsell_colour_to_xyY`
 -   :func:`colour.xyY_to_munsell_colour`
 
 Notes
 -----
 -   The Munsell Renotation data commonly available within the *all.dat*,
-    *experimental.dat* and *real.dat* files features *CIE xyY* colourspace values
-    that are scaled by a :math:`1 / 0.975 \\simeq 1.02568` factor. If you are
-    performing conversions using *Munsell* *Colorlab* specification,
+    *experimental.dat* and *real.dat* files features *CIE xyY* colourspace
+    values that are scaled by a :math:`1 / 0.975 \\simeq 1.02568` factor. If
+    you are performing conversions using *Munsell* *Colorlab* specification,
     e.g., *2.5R 9/2*, according to *ASTM D1535-08e1* method, you should not
     scale the output :math:`Y` Luminance. However, if you use directly the
     *CIE xyY* colourspace values from the Munsell Renotation data, you should
-    scale the :math:`Y` Luminance before conversions by a :math:`0.975` factor.
+    scale the :math:`Y` Luminance before conversions by a :math:`0.975`
+    factor.
 
     *ASTM D1535-08e1* states that::
 
@@ -275,8 +277,8 @@ _CACHE_MUNSELL_MAXIMUM_CHROMAS_FROM_RENOTATION: dict = CACHE_REGISTRY.register_c
 
 def _munsell_specifications() -> NDArrayFloat:
     """
-    Return the *Munsell Renotation System* specifications and caches them if
-    not existing.
+    Return the *Munsell Renotation System* specifications and cache them if
+    not already existing.
 
     The *Munsell Renotation System* data is stored in
     :attr:`colour.notation.MUNSELL_COLOURS` attribute in a 2 columns form::
@@ -288,7 +290,8 @@ def _munsell_specifications() -> NDArrayFloat:
             (("7.5GY", 0.2, 2.0), (0.262, 0.837, 0.237)),
         )
 
-    The first column is converted from *Munsell* colour to specification using
+    The first column is converted from *Munsell* colour to specification
+    using
     :func:`colour.notation.munsell.munsell_colour_to_munsell_specification`
     definition:
 
@@ -321,13 +324,13 @@ def _munsell_specifications() -> NDArrayFloat:
 
 def _munsell_value_ASTMD1535_interpolator() -> Extrapolator:
     """
-    Return the *Munsell* value interpolator for *ASTM D1535-08e1* method and
-    caches it if not existing.
+    Return the *Munsell* value interpolator for the *ASTM D1535-08e1*
+    method, caching it if not existing.
 
     Returns
     -------
     :class:`colour.Extrapolator`
-        *Munsell* value interpolator for *ASTM D1535-08e1* method.
+        *Munsell* value interpolator for the *ASTM D1535-08e1* method.
     """
 
     global _CACHE_MUNSELL_VALUE_ASTM_D1535_08_INTERPOLATOR  # noqa: PLW0602
@@ -356,8 +359,8 @@ def _munsell_maximum_chromas_from_renotation() -> Tuple[
     Tuple[Tuple[float, float], float], ...
 ]:
     """
-    Return the maximum *Munsell* chromas from *Munsell Renotation System* data
-    and caches them if not existing.
+    Return the maximum *Munsell* chromas from *Munsell Renotation System*
+    data.
 
     Returns
     -------
@@ -398,8 +401,8 @@ def _munsell_maximum_chromas_from_renotation() -> Tuple[
 
 def munsell_value_Priest1920(Y: ArrayLike) -> NDArrayFloat:
     """
-    Compute the *Munsell* value :math:`V` of specified *luminance* :math:`Y` using
-    *Priest et al. (1920)* method.
+    Compute the *Munsell* value :math:`V` from the specified *luminance*
+    :math:`Y` using *Priest et al. (1920)* method.
 
     Parameters
     ----------
@@ -444,8 +447,8 @@ def munsell_value_Priest1920(Y: ArrayLike) -> NDArrayFloat:
 
 def munsell_value_Munsell1933(Y: ArrayLike) -> NDArrayFloat:
     """
-    Compute the *Munsell* value :math:`V` of specified *luminance* :math:`Y` using
-    *Munsell et al. (1933)* method.
+    Compute *Munsell* value :math:`V` from the specified *luminance* :math:`Y`
+    using *Munsell et al. (1933)* method.
 
     Parameters
     ----------
@@ -490,9 +493,8 @@ def munsell_value_Munsell1933(Y: ArrayLike) -> NDArrayFloat:
 
 def munsell_value_Moon1943(Y: ArrayLike) -> NDArrayFloat:
     """
-    Compute the *Munsell* value :math:`V` of specified *luminance* :math:`Y` using
-    *Moon and Spencer (1943)* method.
-
+    Compute *Munsell* value :math:`V` from the specified *luminance* :math:`Y`
+    using *Moon and Spencer (1943)* method.
 
     Parameters
     ----------
@@ -537,8 +539,8 @@ def munsell_value_Moon1943(Y: ArrayLike) -> NDArrayFloat:
 
 def munsell_value_Saunderson1944(Y: ArrayLike) -> NDArrayFloat:
     """
-    Compute the *Munsell* value :math:`V` of specified *luminance* :math:`Y` using
-    *Saunderson and Milner (1944)* method.
+    Compute the *Munsell* value :math:`V` from the specified *luminance* :math:`Y`
+    using *Saunderson and Milner (1944)* method.
 
     Parameters
     ----------
@@ -583,8 +585,8 @@ def munsell_value_Saunderson1944(Y: ArrayLike) -> NDArrayFloat:
 
 def munsell_value_Ladd1955(Y: ArrayLike) -> NDArrayFloat:
     """
-    Compute the *Munsell* value :math:`V` of specified *luminance* :math:`Y` using
-    *Ladd and Pinney (1955)* method.
+    Compute *Munsell* value :math:`V` from the specified *luminance* :math:`Y`
+    using *Ladd and Pinney (1955)* method.
 
     Parameters
     ----------
@@ -629,8 +631,8 @@ def munsell_value_Ladd1955(Y: ArrayLike) -> NDArrayFloat:
 
 def munsell_value_McCamy1987(Y: ArrayLike) -> NDArrayFloat:
     """
-    Compute the *Munsell* value :math:`V` of specified *luminance* :math:`Y` using
-    *McCamy (1987)* method.
+    Compute *Munsell* value :math:`V` from the specified *luminance* :math:`Y`
+    using *McCamy (1987)* method.
 
     Parameters
     ----------
@@ -686,13 +688,13 @@ def munsell_value_McCamy1987(Y: ArrayLike) -> NDArrayFloat:
 
 def munsell_value_ASTMD1535(Y: ArrayLike) -> NDArrayFloat:
     """
-    Compute the *Munsell* value :math:`V` of specified *luminance* :math:`Y` using
-    an inverse lookup table from *ASTM D1535-08e1* method.
+    Compute the *Munsell* value :math:`V` from the specified *luminance*
+    :math:`Y` using an inverse lookup table from *ASTM D1535-08e1* method.
 
     Parameters
     ----------
     Y
-        *Luminance* :math:`Y`
+        *Luminance* :math:`Y`.
 
     Returns
     -------
@@ -713,8 +715,8 @@ def munsell_value_ASTMD1535(Y: ArrayLike) -> NDArrayFloat:
     | ``V``      | [0, 10]               | [0, 1]        |
     +------------+-----------------------+---------------+
 
-    -   The *Munsell* value* computation with *ASTM D1535-08e1* method is only
-        defined for domain [0, 100].
+    -   The *Munsell* value computation with *ASTM D1535-08e1* method is
+        only defined for domain [0, 100].
 
     References
     ----------
@@ -774,8 +776,8 @@ def munsell_value(
     ) = "ASTM D1535",
 ) -> NDArrayFloat:
     """
-    Compute the *Munsell* value :math:`V` of specified *luminance* :math:`Y` using
-    specified method.
+    Compute the *Munsell* value :math:`V` from the specified *luminance*
+    :math:`Y` using the specified computational method.
 
     Parameters
     ----------
@@ -833,12 +835,12 @@ def munsell_value(
 
 def _munsell_scale_factor() -> NDArrayFloat:
     """
-    Return the domain-range scale factor for *Munsell Renotation System*.
+    Return the domain-range scale factor for the *Munsell Renotation System*.
 
     Returns
     -------
     :class:`numpy.NDArrayFloat`
-        Domain-range scale factor for *Munsell Renotation System*.
+        Domain-range scale factor for the *Munsell Renotation System*.
     """
 
     return np.array([10, 10, 50 if get_domain_range_scale() == "1" else 2, 10])
@@ -846,7 +848,7 @@ def _munsell_scale_factor() -> NDArrayFloat:
 
 def _munsell_specification_to_xyY(specification: ArrayLike) -> NDArrayFloat:
     """
-    Convert specified *Munsell* *Colorlab* specification to *CIE xyY* colourspace.
+    Convert from *Munsell* *Colorlab* specification to *CIE xyY* colourspace.
 
     Parameters
     ----------
@@ -926,7 +928,8 @@ def _munsell_specification_to_xyY(specification: ArrayLike) -> NDArrayFloat:
 
 def munsell_specification_to_xyY(specification: ArrayLike) -> NDArrayFloat:
     """
-    Convert specified *Munsell* *Colorlab* specification to *CIE xyY* colourspace.
+    Convert specified *Munsell* *Colorlab* specification to *CIE xyY*
+    colourspace.
 
     Parameters
     ----------
@@ -984,12 +987,13 @@ def munsell_specification_to_xyY(specification: ArrayLike) -> NDArrayFloat:
 
 def munsell_colour_to_xyY(munsell_colour: ArrayLike) -> NDArrayFloat:
     """
-    Convert specified *Munsell* colour to *CIE xyY* colourspace.
+    Convert the specified *Munsell* colour to *CIE xyY* colourspace.
 
     Parameters
     ----------
     munsell_colour
-        *Munsell* colour.
+        *Munsell* colour notation formatted as "H V/C" where H is hue,
+        V is value, and C is chroma.
 
     Returns
     -------
@@ -1030,7 +1034,8 @@ def munsell_colour_to_xyY(munsell_colour: ArrayLike) -> NDArrayFloat:
 
 def _xyY_to_munsell_specification(xyY: ArrayLike) -> NDArrayFloat:
     """
-    Convert from *CIE xyY* colourspace to *Munsell* *Colorlab* specification.
+    Convert from *CIE xyY* colourspace to *Munsell* *Colorlab*
+    specification.
 
     Parameters
     ----------
@@ -1045,11 +1050,11 @@ def _xyY_to_munsell_specification(xyY: ArrayLike) -> NDArrayFloat:
     Raises
     ------
     ValueError
-        If the specified *CIE xyY* colourspace array is not within MacAdam
-        limits.
+        If the specified *CIE xyY* colourspace array is not within
+        MacAdam limits.
     RuntimeError
-        If the maximum iterations count has been reached without converging to
-        a result.
+        If the maximum iterations count has been reached without
+        converging to a result.
     """
 
     xyY = as_float_array(xyY)
@@ -1337,7 +1342,8 @@ def _xyY_to_munsell_specification(xyY: ArrayLike) -> NDArrayFloat:
 
 def xyY_to_munsell_specification(xyY: ArrayLike) -> NDArrayFloat:
     """
-    Convert from *CIE xyY* colourspace to *Munsell* *Colorlab* specification.
+    Convert from *CIE xyY* colourspace to *Munsell* *Colorlab*
+    specification.
 
     Parameters
     ----------
@@ -1352,11 +1358,11 @@ def xyY_to_munsell_specification(xyY: ArrayLike) -> NDArrayFloat:
     Raises
     ------
     ValueError
-        If the specified *CIE xyY* colourspace array is not within MacAdam
-        limits.
+        If the specified *CIE xyY* colourspace array is not within
+        MacAdam limits.
     RuntimeError
-        If the maximum iterations count has been reached without converging to
-        a result.
+        If the maximum iterations count has been reached without
+        converging to a result.
 
     Notes
     -----
@@ -1406,23 +1412,25 @@ def xyY_to_munsell_colour(
     chroma_decimals: int = 1,
 ) -> str | NDArrayStr:
     """
-    Convert from *CIE xyY* colourspace to *Munsell* colour.
+    Convert from *CIE xyY* colourspace to *Munsell* colour notation.
 
     Parameters
     ----------
     xyY
-        *CIE xyY* colourspace array.
+        *CIE xyY* colourspace array representing chromaticity coordinates
+        and luminance.
     hue_decimals
-        Hue formatting decimals.
+        Number of decimal places for formatting the hue component.
     value_decimals
-        Value formatting decimals.
+        Number of decimal places for formatting the value component.
     chroma_decimals
-        Chroma formatting decimals.
+        Number of decimal places for formatting the chroma component.
 
     Returns
     -------
     :class:`str` or :class:`numpy.NDArrayFloat`
-        *Munsell* colour.
+        *Munsell* colour notation formatted as "H V/C" where H is hue,
+        V is value, and C is chroma.
 
     Notes
     -----
@@ -1480,8 +1488,8 @@ def parse_munsell_colour(munsell_colour: str) -> NDArrayFloat:
     Raises
     ------
     ValueError
-        If the specified specification is not a valid *Munsell Renotation System*
-        colour specification.
+        If the specified specification is not a valid *Munsell Renotation
+        System* colour specification.
 
     Examples
     --------
@@ -1523,7 +1531,8 @@ def parse_munsell_colour(munsell_colour: str) -> NDArrayFloat:
 
 def is_grey_munsell_colour(specification: ArrayLike) -> bool:
     """
-    Return whether specified *Munsell* *Colorlab* specification is a grey colour.
+    Determine whether the specified *Munsell* *Colorlab* specification
+    represents a grey colour.
 
     Parameters
     ----------
@@ -1533,7 +1542,7 @@ def is_grey_munsell_colour(specification: ArrayLike) -> bool:
     Returns
     -------
     :class:`bool`
-        Is specification a grey colour.
+        Whether the specification represents a grey colour.
 
     Examples
     --------
@@ -1552,12 +1561,12 @@ def is_grey_munsell_colour(specification: ArrayLike) -> bool:
 
 def normalise_munsell_specification(specification: ArrayLike) -> NDArrayFloat:
     """
-    Normalise specified *Munsell* *Colorlab* specification.
+    Normalise the specified *Munsell* *Colorlab* specification.
 
     Parameters
     ----------
     specification
-        *Munsell* *Colorlab* specification.
+        *Munsell* *Colorlab* specification to be normalised.
 
     Returns
     -------
@@ -1593,18 +1602,19 @@ def munsell_colour_to_munsell_specification(
     munsell_colour: str,
 ) -> NDArrayFloat:
     """
-    Retrieve a normalised *Munsell* *Colorlab* specification from specified
-    *Munsell* colour.
+    Convert from *Munsell* colour notation to *Munsell* *Colorlab*
+    specification.
 
     Parameters
     ----------
     munsell_colour
-        *Munsell* colour.
+        *Munsell* colour notation.
 
     Returns
     -------
     :class:`numpy.NDArrayFloat`
-        Normalised *Munsell* *Colorlab* specification.
+        *Munsell* *Colorlab* specification as a 4-element array containing hue,
+        value, chroma, and code values.
 
     Examples
     --------
@@ -1624,23 +1634,25 @@ def munsell_specification_to_munsell_colour(
     chroma_decimals: int = 1,
 ) -> str:
     """
-    Convert from *Munsell* *Colorlab* specification to specified *Munsell* colour.
+    Convert from *Munsell* *Colorlab* specification to *Munsell* colour
+    notation.
 
     Parameters
     ----------
     specification
-        *Munsell* *Colorlab* specification.
+        *Munsell* *Colorlab* specification as a 4-element array containing hue,
+        value, chroma, and code values.
     hue_decimals
-        Hue formatting decimals.
+        Number of decimal places for hue formatting.
     value_decimals
-        Value formatting decimals.
+        Number of decimal places for value formatting.
     chroma_decimals
-        Chroma formatting decimals.
+        Number of decimal places for chroma formatting.
 
     Returns
     -------
     :class:`str`
-        *Munsell* colour.
+        *Munsell* colour notation.
 
     Examples
     --------
@@ -1704,19 +1716,19 @@ def xyY_from_renotation(
     relative_tolerance: float = TOLERANCE_RELATIVE_DEFAULT,
 ) -> NDArrayFloat:
     """
-    Return specified existing *Munsell* *Colorlab* specification *CIE xyY*
-    colourspace vector from *Munsell Renotation System* data.
+    Compute the *CIE xyY* colourspace vector for the specified *Munsell*
+    *Colorlab* specification from *Munsell Renotation System* data.
 
     Parameters
     ----------
     specification
         *Munsell* *Colorlab* specification.
     absolute_tolerance
-        Absolute tolerance to find the existing *Munsell Renotation System*
-        data.
+        Absolute tolerance for finding the corresponding *Munsell
+        Renotation System* data.
     relative_tolerance
-        Relative tolerance to find the existing *Munsell Renotation System*
-        data.
+        Relative tolerance for finding the corresponding *Munsell
+        Renotation System* data.
 
     Returns
     -------
@@ -1726,8 +1738,8 @@ def xyY_from_renotation(
     Raises
     ------
     ValueError
-        If the specified specification doesn't exist in *Munsell Renotation System*
-        data.
+        If the specified specification does not exist in the *Munsell
+        Renotation System* data.
 
     Examples
     --------
@@ -1763,8 +1775,8 @@ def xyY_from_renotation(
 
 def is_specification_in_renotation(specification: ArrayLike) -> bool:
     """
-    Return whether specified *Munsell* *Colorlab* specification is in
-    *Munsell Renotation System* data.
+    Determine whether the specified *Munsell* *Colorlab* specification exists
+    in the *Munsell Renotation System* data.
 
     Parameters
     ----------
@@ -1794,9 +1806,8 @@ def is_specification_in_renotation(specification: ArrayLike) -> bool:
 
 def bounding_hues_from_renotation(hue_and_code: ArrayLike) -> NDArrayFloat:
     """
-    Return for a specified *Munsell* *Colorlab* specification hue and *Munsell*
-    *Colorlab* specification code the two bounding hues from
-    *Munsell Renotation System* data.
+    Return the two bounding hues from *Munsell Renotation System* data for
+    a specified *Munsell* *Colorlab* specification hue and code.
 
     Parameters
     ----------
@@ -1862,8 +1873,8 @@ def bounding_hues_from_renotation(hue_and_code: ArrayLike) -> NDArrayFloat:
 
 def hue_to_hue_angle(hue_and_code: ArrayLike) -> float:
     """
-    Convert from the *Munsell* *Colorlab* specification hue and *Munsell*
-    *Colorlab* specification code to hue angle in degrees.
+    Convert from *Munsell* *Colorlab* specification hue and code to hue angle
+    in degrees.
 
     Parameters
     ----------
@@ -1899,8 +1910,8 @@ def hue_to_hue_angle(hue_and_code: ArrayLike) -> float:
 
 def hue_angle_to_hue(hue_angle: float) -> NDArrayFloat:
     """
-    Convert from hue angle in degrees to the *Munsell* *Colorlab*
-    specification hue and code.
+    Convert from hue angle in degrees to *Munsell* *Colorlab* specification hue
+    and code.
 
     Parameters
     ----------
@@ -1910,8 +1921,8 @@ def hue_angle_to_hue(hue_angle: float) -> NDArrayFloat:
     Returns
     -------
     :class:`numpy.NDArrayFloat`
-        (*Munsell* *Colorlab* specification hue, *Munsell* *Colorlab*
-        specification code).
+        *Munsell* *Colorlab* specification hue and *Munsell* *Colorlab*
+        specification code.
 
     References
     ----------
@@ -1959,15 +1970,14 @@ def hue_angle_to_hue(hue_angle: float) -> NDArrayFloat:
 
 def hue_to_ASTM_hue(hue_and_code: ArrayLike) -> float:
     """
-    Convert from the *Munsell* *Colorlab* specification hue and *Munsell*
-    *Colorlab* specification codeto *ASTM* hue number.
+    Convert the *Munsell* *Colorlab* specification hue and code to *ASTM* hue
+    number.
 
     Parameters
     ----------
     hue_and_code
         *Munsell* *Colorlab* specification hue and *Munsell* *Colorlab*
         specification code.
-
 
     Returns
     -------
@@ -1995,9 +2005,12 @@ def interpolation_method_from_renotation_ovoid(
     specification: ArrayLike,
 ) -> Literal["Linear", "Radial"] | None:
     """
-    Return whether to use linear or radial interpolation when drawing ovoids
-    through data points in the *Munsell Renotation System* data from specified
-    specification.
+    Determine the interpolation method for drawing ovoids in the *Munsell
+    Renotation System*.
+
+    Determine whether to use linear or radial interpolation when drawing
+    ovoids through data points in the *Munsell Renotation System* data from
+    the specified *Munsell* *Colorlab* specification.
 
     Parameters
     ----------
@@ -2271,11 +2284,12 @@ def interpolation_method_from_renotation_ovoid(
 
 def xy_from_renotation_ovoid(specification: ArrayLike) -> NDArrayFloat:
     """
-    Convert specified *Munsell* *Colorlab* specification to *CIE xy* chromaticity
-    coordinates on *Munsell Renotation System* ovoid.
+    Convert specified *Munsell* *Colorlab* specification to *CIE xy*
+    chromaticity coordinates on *Munsell Renotation System* ovoid.
+
     The *CIE xy* point will be on the ovoid about the achromatic point,
-    corresponding to the *Munsell* *Colorlab* specification
-    value and chroma.
+    corresponding to the *Munsell* *Colorlab* specification value and
+    chroma.
 
     Parameters
     ----------
@@ -2485,15 +2499,14 @@ def LCHab_to_munsell_specification(LCHab: ArrayLike) -> NDArrayFloat:
 
 def maximum_chroma_from_renotation(hue_and_value_and_code: ArrayLike) -> float:
     """
-    Return the maximum *Munsell* chroma from *Munsell Renotation System* data
-    using specified *Munsell* *Colorlab* specification hue, *Munsell* *Colorlab*
-    specification value and *Munsell* *Colorlab* specification code.
+    Return the maximum *Munsell* chroma from *Munsell Renotation System*
+    data using the specified *Munsell* *Colorlab* specification hue, value, and
+    code.
 
     Parameters
     ----------
     hue_and_value_and_code
-        *Munsell* *Colorlab* specification hue, *Munsell* *Colorlab*
-        specification value and *Munsell* *Colorlab* specification code.
+        *Munsell* *Colorlab* specification hue, value, and code.
 
     Returns
     -------
@@ -2575,8 +2588,9 @@ def maximum_chroma_from_renotation(hue_and_value_and_code: ArrayLike) -> float:
 
 def munsell_specification_to_xy(specification: ArrayLike) -> NDArrayFloat:
     """
-    Convert specified *Munsell* *Colorlab* specification to *CIE xy* chromaticity
-    coordinates by interpolating over *Munsell Renotation System* data.
+    Convert the specified *Munsell* *Colorlab* specification to *CIE xy*
+    chromaticity coordinates by interpolating over *Munsell Renotation
+    System* data.
 
     Parameters
     ----------

--- a/colour/notation/munsell.py
+++ b/colour/notation/munsell.py
@@ -1575,7 +1575,7 @@ def normalise_munsell_specification(specification: ArrayLike) -> NDArrayFloat:
     specification = as_float_array(specification)
 
     if is_grey_munsell_colour(specification):
-        return specification * np.array([np.nan, 1, np.nan, np.nan])  # pyright: ignore
+        return specification * np.array([np.nan, 1, np.nan, np.nan])
 
     hue, value, chroma, code = specification
 

--- a/colour/phenomena/rayleigh.py
+++ b/colour/phenomena/rayleigh.py
@@ -2,7 +2,8 @@
 Rayleigh Optical Depth - Scattering in the Atmosphere
 =====================================================
 
-Implement *Rayleigh* scattering / optical depth in the atmosphere computation:
+Implement *Rayleigh* scattering and optical depth computation in the
+atmosphere.
 
 -   :func:`colour.scattering_cross_section`
 -   :func:`colour.phenomena.rayleigh_optical_depth`
@@ -89,9 +90,9 @@ def air_refraction_index_Penndorf1957(
     wavelength: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Compute the air refraction index :math:`n_s` from specified wavelength
-    :math:`\\lambda` in  micrometers (:math:`\\mu m`) using *Penndorf (1957)*
-    method.
+    Compute the air refraction index :math:`n_s` from the specified wavelength
+    :math:`\\lambda` in micrometers (:math:`\\mu m`) using the
+    *Penndorf (1957)* method.
 
     Parameters
     ----------
@@ -122,9 +123,9 @@ def air_refraction_index_Edlen1966(
     wavelength: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Compute the air refraction index :math:`n_s` from specified wavelength
-    :math:`\\lambda` in micrometers (:math:`\\mu m`) using *Edlen (1966)*
-    method.
+    Compute the air refraction index :math:`n_s` from the specified wavelength
+    :math:`\\lambda` in micrometers (:math:`\\mu m`) using the
+    *Edlen (1966)* method.
 
     Parameters
     ----------
@@ -155,8 +156,8 @@ def air_refraction_index_Peck1972(
     wavelength: ArrayLike,
 ) -> NDArrayFloat:
     """
-    Compute the air refraction index :math:`n_s` from specified wavelength
-    :math:`\\lambda` in micrometers (:math:`\\mu m`) using
+    Compute the air refraction index :math:`n_s` from the specified wavelength
+    :math:`\\lambda` in micrometers (:math:`\\mu m`) using the
     *Peck and Reeder (1972)* method.
 
     Parameters
@@ -189,8 +190,8 @@ def air_refraction_index_Bodhaine1999(
     CO2_concentration: ArrayLike = CONSTANT_STANDARD_CO2_CONCENTRATION,
 ) -> NDArrayFloat:
     """
-    Compute the air refraction index :math:`n_s` from specified wavelength
-    :math:`\\lambda` in micrometers (:math:`\\mu m`) using
+    Compute the air refraction index :math:`n_s` from the specified wavelength
+    :math:`\\lambda` in micrometers (:math:`\\mu m`) using the
     *Bodhaine, Wood, Dutton and Slusser (1999)* method.
 
     Parameters
@@ -224,7 +225,7 @@ def air_refraction_index_Bodhaine1999(
 
 def N2_depolarisation(wavelength: ArrayLike) -> NDArrayFloat:
     """
-    Compute the depolarisation of nitrogen :math:`N_2` as function of
+    Compute the depolarisation of nitrogen :math:`N_2` as a function of
     wavelength :math:`\\lambda` in micrometers (:math:`\\mu m`).
 
     Parameters
@@ -250,7 +251,7 @@ def N2_depolarisation(wavelength: ArrayLike) -> NDArrayFloat:
 
 def O2_depolarisation(wavelength: ArrayLike) -> NDArrayFloat:
     """
-    Compute the depolarisation of oxygen :math:`O_2` as function of
+    Compute the depolarisation of oxygen :math:`O_2` as a function of
     wavelength :math:`\\lambda` in micrometers (:math:`\\mu m`).
 
     Parameters
@@ -276,8 +277,8 @@ def O2_depolarisation(wavelength: ArrayLike) -> NDArrayFloat:
 
 def F_air_Penndorf1957(wavelength: ArrayLike) -> NDArrayFloat:
     """
-    Compute :math:`(6+3_p)/(6-7_p)`, the depolarisation term :math:`F(air)` or
-    *King Factor* using *Penndorf (1957)* method.
+    Compute the depolarisation term :math:`F(air)` or *King Factor* using
+    the *Penndorf (1957)* method.
 
     Parameters
     ----------
@@ -287,13 +288,13 @@ def F_air_Penndorf1957(wavelength: ArrayLike) -> NDArrayFloat:
     Returns
     -------
     :class:`numpy.ndarray`
-        Air depolarisation.
+        Air depolarisation term.
 
     Notes
     -----
-    -   The argument *wavelength* is only provided for consistency with the
-        other air depolarisation methods but is actually not used as this
-        definition is essentially a constant in its current implementation.
+    -   The *wavelength* parameter is provided for consistency with other
+        air depolarisation methods but is not used in this implementation,
+        which returns a constant value.
 
     Examples
     --------
@@ -308,8 +309,8 @@ def F_air_Penndorf1957(wavelength: ArrayLike) -> NDArrayFloat:
 
 def F_air_Young1981(wavelength: ArrayLike) -> NDArrayFloat:
     """
-    Compute :math:`(6+3_p)/(6-7_p)`, the depolarisation term :math:`F(air)` or
-    *King Factor* using *Young (1981)* method.
+    Compute the depolarisation term :math:`F(air)` or *King Factor* using
+    the *Young (1981)* method.
 
     Parameters
     ----------
@@ -319,13 +320,13 @@ def F_air_Young1981(wavelength: ArrayLike) -> NDArrayFloat:
     Returns
     -------
     :class:`numpy.ndarray`
-        Air depolarisation.
+        Air depolarisation term.
 
     Notes
     -----
-    -   The argument *wavelength* is only provided for consistency with the
-        other air depolarisation methods but is actually not used as this
-        definition is essentially a constant in its current implementation.
+    -   The *wavelength* parameter is provided for consistency with other
+        air depolarisation methods but is not used in this implementation,
+        which returns a constant value.
 
     Examples
     --------
@@ -340,8 +341,8 @@ def F_air_Young1981(wavelength: ArrayLike) -> NDArrayFloat:
 
 def F_air_Bates1984(wavelength: ArrayLike) -> NDArrayFloat:
     """
-    Compute :math:`(6+3_p)/(6-7_p)`, the depolarisation term :math:`F(air)` or
-    *King Factor* as function of wavelength :math:`\\lambda` in micrometers
+    Compute the depolarisation term :math:`F(air)` or *King Factor* using
+    the *Bates (1984)* method.
     (:math:`\\mu m`) using *Bates (1984)* method.
 
     Parameters
@@ -352,7 +353,7 @@ def F_air_Bates1984(wavelength: ArrayLike) -> NDArrayFloat:
     Returns
     -------
     :class:`numpy.ndarray`
-        Air depolarisation.
+        Air depolarisation term.
 
     Examples
     --------
@@ -373,10 +374,10 @@ def F_air_Bodhaine1999(
     CO2_concentration: ArrayLike = CONSTANT_STANDARD_CO2_CONCENTRATION,
 ) -> NDArrayFloat:
     """
-    Compute :math:`(6+3_p)/(6-7_p)`, the depolarisation term :math:`F(air)` or
-    *King Factor* as function of wavelength :math:`\\lambda` in micrometers
-    (:math:`\\mu m`) and :math:`CO_2` concentration in parts per million (ppm)
-    using *Bodhaine, Wood, Dutton and Slusser (1999)* method.
+    Compute the depolarisation term :math:`F(air)` or *King Factor* as a
+    function of wavelength :math:`\\lambda` in micrometers (:math:`\\mu m`)
+    and :math:`CO_2` concentration in parts per million (ppm) using the
+    *Bodhaine, Wood, Dutton and Slusser (1999)* method.
 
     Parameters
     ----------
@@ -388,7 +389,7 @@ def F_air_Bodhaine1999(
     Returns
     -------
     :class:`numpy.ndarray`
-        Air depolarisation.
+        Air depolarisation term.
 
     Examples
     --------
@@ -430,10 +431,11 @@ def molecular_density(
 
     Notes
     -----
-    -   The *Avogadro*'s number used in this implementation is the one given by
-        by the Committee on Data for Science and Technology (CODATA):
-        :math:`6.02214179x10^{23}`, which is different from the reference
-        :cite:`Bodhaine1999a` value :math:`6.0221367x10^{23}`.
+    -   The *Avogadro*'s number used in this implementation is the one
+        specified by the Committee on Data for Science and Technology
+        (CODATA): :math:`6.02214179 \\times 10^{23}`, which differs from
+        the reference :cite:`Bodhaine1999a` value
+        :math:`6.0221367 \\times 10^{23}`.
 
     Examples
     --------
@@ -454,8 +456,8 @@ def mean_molecular_weights(
     CO2_concentration: ArrayLike = CONSTANT_STANDARD_CO2_CONCENTRATION,
 ) -> NDArrayFloat:
     """
-    Compute the mean molecular weights :math:`m_a` for dry air as function of
-    :math:`CO_2` concentration in parts per million (ppm).
+    Compute the mean molecular weights :math:`m_a` for dry air as a function
+    of :math:`CO_2` concentration in parts per million (ppm).
 
     Parameters
     ----------
@@ -485,9 +487,9 @@ def gravity_List1968(
     altitude: ArrayLike = CONSTANT_DEFAULT_ALTITUDE,
 ) -> NDArrayFloat:
     """
-    Compute the gravity :math:`g` in :math:`cm/s_2` (gal) representative of the
-    mass-weighted column of air molecules above the site of specified latitude
-    and altitude using *list (1968)* method.
+    Compute the gravity :math:`g` in :math:`cm/s^2` (gal) representative of
+    the mass-weighted column of air molecules above the site at the specified
+    latitude and altitude using the *List (1968)* method.
 
     Parameters
     ----------
@@ -499,7 +501,7 @@ def gravity_List1968(
     Returns
     -------
     :class:`numpy.ndarray`
-        Gravity :math:`g` in :math:`cm/s_2` (gal).
+        Gravity :math:`g` in :math:`cm/s^2` (gal).
 
     Examples
     --------
@@ -540,10 +542,10 @@ def scattering_cross_section(
 ) -> NDArrayFloat:
     """
     Compute the scattering cross-section per molecule :math:`\\sigma` of dry
-    air as function of wavelength :math:`\\lambda` in centimeters (cm) using
-    specified :math:`CO_2` concentration in parts per million (ppm) and
-    temperature :math:`T[K]` in kelvin degrees following *Van de Hulst (1957)*
-    method.
+    air as a function of wavelength :math:`\\lambda` in centimeters (cm)
+    using the specified :math:`CO_2` concentration in parts per million
+    (ppm) and temperature :math:`T[K]` in kelvin degrees following the
+    *Van de Hulst (1957)* method.
 
     Parameters
     ----------
@@ -569,8 +571,8 @@ def scattering_cross_section(
     Warnings
     --------
     Unlike most objects of :mod:`colour.phenomena.rayleigh` module,
-    :func:`colour.scattering_cross_section` expects wavelength :math:`\\lambda`
-    to be expressed in centimeters (cm).
+    :func:`colour.scattering_cross_section` expects wavelength
+    :math:`\\lambda` to be expressed in centimeters (cm).
 
     References
     ----------
@@ -616,8 +618,8 @@ def rayleigh_optical_depth(
     F_air_function: Callable = F_air_Bodhaine1999,
 ) -> NDArrayFloat:
     """
-    Compute the *Rayleigh* optical depth :math:`T_r(\\lambda)` as function of
-    wavelength :math:`\\lambda` in centimeters (cm).
+    Compute the *Rayleigh* optical depth :math:`T_r(\\lambda)` as a function
+    of wavelength :math:`\\lambda` in centimeters (cm).
 
     Parameters
     ----------
@@ -638,8 +640,8 @@ def rayleigh_optical_depth(
     n_s_function
         Air refraction index :math:`n_s` computation method.
     F_air_function
-        :math:`(6+3_p)/(6-7_p)`, the depolarisation term :math:`F(air)` or
-        *King Factor* computation method.
+        :math:`(6+3_p)/(6-7_p)`, the depolarisation term :math:`F(air)`
+        or *King Factor* computation method.
 
     Returns
     -------
@@ -703,7 +705,8 @@ def sd_rayleigh_scattering(
     F_air_function: Callable = F_air_Bodhaine1999,
 ) -> SpectralDistribution:
     """
-    Compute the *Rayleigh* spectral distribution for specified spectral shape.
+    Generate *Rayleigh* scattering spectral distribution for the specified
+    spectral shape.
 
     Parameters
     ----------

--- a/colour/plotting/blindness.py
+++ b/colour/plotting/blindness.py
@@ -2,7 +2,7 @@
 Colour Blindness Plotting
 =========================
 
-Define the colour blindness plotting objects:
+Define the colour blindness plotting objects.
 
 -   :func:`colour.plotting.plot_cvd_simulation_Machado2009`
 """
@@ -53,8 +53,8 @@ def plot_cvd_simulation_Machado2009(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Perform colour vision deficiency simulation on specified *RGB* colourspace
-    array using *Machado et al. (2009)* model.
+    Perform colour vision deficiency simulation on the specified *RGB*
+    colourspace array using the *Machado et al. (2009)* model.
 
     Parameters
     ----------
@@ -65,7 +65,7 @@ def plot_cvd_simulation_Machado2009(
     severity
         Severity of the colour vision deficiency in domain [0, 1].
     M_a
-        Anomalous trichromacy matrix to use instead of Machado (2010)
+        Anomalous trichromacy matrix to use instead of the Machado (2010)
         pre-computed matrix.
 
     Other Parameters

--- a/colour/plotting/characterisation.py
+++ b/colour/plotting/characterisation.py
@@ -2,7 +2,7 @@
 Characterisation Plotting
 =========================
 
-Define the characterisation plotting objects:
+Define the characterisation plotting objects.
 
 -   :func:`colour.plotting.plot_single_colour_checker`
 -   :func:`colour.plotting.plot_multi_colour_checkers`
@@ -62,13 +62,13 @@ def plot_single_colour_checker(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot specified colour checker.
+    Plot the specified colour checker.
 
     Parameters
     ----------
     colour_checker
-        Color checker to plot. ``colour_checker`` can be of any type or form
-        supported by the
+        Colour checker to plot. ``colour_checker`` can be of any type or
+        form supported by the
         :func:`colour.plotting.common.filter_colour_checkers` definition.
 
     Other Parameters
@@ -111,14 +111,15 @@ def plot_multi_colour_checkers(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot and compares specified colour checkers.
+    Plot and compare the specified colour checkers.
 
     Parameters
     ----------
     colour_checkers
-        Color checker to plot, count must be less than or equal to 2.
-        ``colour_checkers`` elements can be of any type or form supported by
-        the :func:`colour.plotting.common.filter_colour_checkers` definition.
+        Colour checkers to plot, count must be less than or equal to 2.
+        ``colour_checkers`` elements can be of any type or form supported
+        by the :func:`colour.plotting.common.filter_colour_checkers`
+        definition.
 
     Other Parameters
     ----------------

--- a/colour/plotting/colorimetry.py
+++ b/colour/plotting/colorimetry.py
@@ -125,7 +125,7 @@ def plot_single_sd(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot specified spectral distribution.
+    Plot the specified spectral distribution.
 
     Parameters
     ----------
@@ -136,18 +136,19 @@ def plot_single_sd(
         spectrum domain and colours. ``cmfs`` can be of any type or form
         supported by the :func:`colour.plotting.common.filter_cmfs` definition.
     out_of_gamut_clipping
-        Whether to clip out of gamut colours otherwise, the colours will be
-        offset by the absolute minimal colour leading to a rendering on
-        gray background, less saturated and smoother.
+        Whether to clip out of gamut colours. Otherwise, the colours will
+        be offset by the absolute minimal colour, resulting in rendering
+        on a gray background that is less saturated and smoother.
     modulate_colours_with_sd_amplitude
         Whether to modulate the colours with the spectral distribution
         amplitude.
     equalize_sd_amplitude
         Whether to equalize the spectral distribution amplitude.
-        Equalization occurs after the colours modulation thus setting both
-        arguments to *True* will generate a spectrum strip where each
-        wavelength colour is modulated by the spectral distribution amplitude.
-        The usual 5% margin above the spectral distribution is also omitted.
+        Equalization occurs after the colours modulation; thus, setting
+        both arguments to *True* will generate a spectrum strip where each
+        wavelength colour is modulated by the spectral distribution
+        amplitude. The usual 5% margin above the spectral distribution is
+        also omitted.
 
     Other Parameters
     ----------------
@@ -284,41 +285,43 @@ def plot_multi_sds(
     Parameters
     ----------
     sds
-        Spectral distributions or multi-spectral distributions to
-        plot. `sds` can be a single
+        Spectral distributions or multi-spectral distributions to plot.
+        ``sds`` can be a single
         :class:`colour.MultiSpectralDistributions` class instance, a list
-        of :class:`colour.MultiSpectralDistributions` class instances or a
-        List of :class:`colour.SpectralDistribution` class instances.
+        of :class:`colour.MultiSpectralDistributions` class instances or
+        a list of :class:`colour.SpectralDistribution` class instances.
     plot_kwargs
-        Keyword arguments for the :func:`matplotlib.pyplot.plot` definition,
-        used to control the style of the plotted spectral distributions.
-        `plot_kwargs`` can be either a single dictionary applied to all the
-        plotted spectral distributions with the same settings or a sequence of
-        dictionaries with different settings for each plotted spectral
-        distributions. The following special keyword arguments can also be
-        used:
+        Keyword arguments for the :func:`matplotlib.pyplot.plot`
+        definition, used to control the style of the plotted spectral
+        distributions. ``plot_kwargs`` can be either a single dictionary
+        applied to all the plotted spectral distributions with the same
+        settings or a sequence of dictionaries with different settings
+        for each plotted spectral distribution. The following special
+        keyword arguments can also be used:
 
         -   ``illuminant`` : The illuminant used to compute the spectral
-            distributions colours. The default is the illuminant associated
-            with the whitepoint of the default plotting colourspace.
-            ``illuminant`` can be of any type or form supported by the
-            :func:`colour.plotting.common.filter_cmfs` definition.
-        -   ``cmfs`` : The standard observer colour matching functions used for
-            computing the spectral distributions colours. ``cmfs`` can be of
-            any type or form supported by the
+            distributions colours. The default is the illuminant
+            associated with the whitepoint of the default plotting
+            colourspace. ``illuminant`` can be of any type or form
+            supported by the :func:`colour.plotting.common.filter_cmfs`
+            definition.
+        -   ``cmfs`` : The standard observer colour matching functions
+            used for computing the spectral distributions colours.
+            ``cmfs`` can be of any type or form supported by the
             :func:`colour.plotting.common.filter_cmfs` definition.
         -   ``normalise_sd_colours`` : Whether to normalise the computed
             spectral distributions colours. The default is *True*.
         -   ``use_sd_colours`` : Whether to use the computed spectral
-            distributions colours under the plotting colourspace illuminant.
-            Alternatively, it is possible to use the
-            :func:`matplotlib.pyplot.plot` definition ``color`` argument with
-            pre-computed values. The default is *True*.
+            distributions colours under the plotting colourspace
+            illuminant. Alternatively, it is possible to use the
+            :func:`matplotlib.pyplot.plot` definition ``color`` argument
+            with pre-computed values. The default is *True*.
 
     Other Parameters
     ----------------
     kwargs
-        {:func:`colour.plotting.artist`, :func:`colour.plotting.render`},
+        {:func:`colour.plotting.artist`,
+        :func:`colour.plotting.render`},
         See the documentation of the previously listed definitions.
 
     Returns
@@ -493,14 +496,14 @@ def plot_multi_cmfs(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot specified colour matching functions.
+    Plot the specified colour matching functions.
 
     Parameters
     ----------
     cmfs
         Colour matching functions to plot. ``cmfs`` elements can be of any
-        type or form supported by the :func:`colour.plotting.common.filter_cmfs`
-        definition.
+        type or form supported by the
+        :func:`colour.plotting.common.filter_cmfs` definition.
 
     Other Parameters
     ----------------
@@ -590,13 +593,14 @@ def plot_single_illuminant_sd(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot specified single illuminant spectral distribution.
+    Plot the specified single illuminant spectral distribution.
 
     Parameters
     ----------
     illuminant
-        Illuminant to plot. ``illuminant`` can be of any type or form supported
-        by the :func:`colour.plotting.common.filter_illuminants` definition.
+        Illuminant to plot. ``illuminant`` can be of any type or form
+        supported by the :func:`colour.plotting.common.filter_illuminants`
+        definition.
     cmfs
         Standard observer colour matching functions used for computing the
         spectrum domain and colours. ``cmfs`` can be of any type or form
@@ -650,14 +654,14 @@ def plot_multi_illuminant_sds(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot specified illuminants spectral distributions.
+    Plot the spectral distributions of the specified illuminants.
 
     Parameters
     ----------
     illuminants
-        Illuminants to plot. ``illuminants`` elements can be of any type or
-        form supported by the :func:`colour.plotting.common.filter_illuminants`
-        definition.
+        Illuminants to plot. ``illuminants`` elements can be of any type
+        or form supported by the
+        :func:`colour.plotting.common.filter_illuminants` definition.
 
     Other Parameters
     ----------------
@@ -722,8 +726,8 @@ def plot_visible_spectrum(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot the visible colours spectrum using specified standard observer *CIE XYZ*
-    colour matching functions.
+    Plot the visible colour spectrum using the specified standard observer
+    *CIE XYZ* colour matching functions.
 
     Parameters
     ----------
@@ -732,9 +736,9 @@ def plot_visible_spectrum(
         spectrum domain and colours. ``cmfs`` can be of any type or form
         supported by the :func:`colour.plotting.common.filter_cmfs` definition.
     out_of_gamut_clipping
-        Whether to clip out of gamut colours otherwise, the colours will be
-        offset by the absolute minimal colour leading to a rendering on
-        gray background, less saturated and smoother.
+        Whether to clip out of gamut colours. Otherwise, the colours will
+        be offset by the absolute minimal colour, resulting in rendering
+        on a gray background that is less saturated and smoother.
 
     Other Parameters
     ----------------
@@ -797,13 +801,14 @@ def plot_single_lightness_function(
     function: Callable | str, **kwargs: Any
 ) -> Tuple[Figure, Axes]:
     """
-    Plot specified *Lightness* function.
+    Plot the specified *Lightness* function.
 
     Parameters
     ----------
     function
-        *Lightness* function to plot. ``function`` can be of any type or form
-        supported by the :func:`colour.plotting.common.filter_passthrough` definition.
+        *Lightness* function to plot. ``function`` can be of any type or
+        form supported by the
+        :func:`colour.plotting.common.filter_passthrough` definition.
 
     Other Parameters
     ----------------
@@ -840,7 +845,7 @@ def plot_multi_lightness_functions(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot specified *Lightness* functions.
+    Plot the specified *Lightness* functions.
 
     Parameters
     ----------
@@ -893,7 +898,7 @@ def plot_single_luminance_function(
     function: Callable | str, **kwargs: Any
 ) -> Tuple[Figure, Axes]:
     """
-    Plot specified *Luminance* function.
+    Plot the specified *Luminance* function.
 
     Parameters
     ----------
@@ -935,7 +940,7 @@ def plot_multi_luminance_functions(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot specified *Luminance* functions.
+    Plot the specified *Luminance* functions.
 
     Parameters
     ----------
@@ -993,7 +998,7 @@ def plot_blackbody_spectral_radiance(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot specified blackbody spectral radiance.
+    Plot the spectral radiance of a blackbody at the specified temperature.
 
     Parameters
     ----------
@@ -1090,16 +1095,17 @@ def plot_blackbody_colours(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot blackbody colours.
+    Plot blackbody colours across a temperature range.
 
     Parameters
     ----------
     shape
-        Spectral shape to use as plot boundaries.
+        Spectral shape defining the temperature range and sampling interval
+        for the plot boundaries.
     cmfs
         Standard observer colour matching functions used for computing the
-        blackbody colours. ``cmfs`` can be of any type or form supported by the
-        :func:`colour.plotting.common.filter_cmfs` definition.
+        spectrum domain and colours. ``cmfs`` can be of any type or form
+        supported by the :func:`colour.plotting.common.filter_cmfs` definition.
 
     Other Parameters
     ----------------

--- a/colour/plotting/common.py
+++ b/colour/plotting/common.py
@@ -2,7 +2,7 @@
 Common Plotting
 ===============
 
-Define the common plotting objects:
+Define the common plotting objects.
 
 -   :func:`colour.plotting.colour_style`
 -   :func:`colour.plotting.override_style`
@@ -240,17 +240,17 @@ CONSTANTS_ARROW_STYLE: Structure = Structure(
 
 def colour_style(use_style: bool = True) -> dict:
     """
-    Get *Colour* plotting style.
+    Return the *Colour* plotting style configuration.
 
     Parameters
     ----------
     use_style
-        Whether to use the style and load it into *Matplotlib*.
+        Whether to apply the style configuration to *Matplotlib*.
 
     Returns
     -------
     :class:`dict`
-        *Colour* style.
+        *Colour* plotting style configuration dictionary.
     """
 
     constants = CONSTANTS_COLOUR_STYLE
@@ -328,11 +328,12 @@ def override_style(**kwargs: Any) -> Callable:
     Other Parameters
     ----------------
     kwargs
-        Keywords arguments.
+        Keywords arguments for *Matplotlib* style configuration.
 
     Returns
     -------
     Callable
+        Decorated function with overridden *Matplotlib* style.
 
     Examples
     --------
@@ -369,7 +370,7 @@ def override_style(**kwargs: Any) -> Callable:
 @contextmanager
 def font_scaling(scaling: LiteralFontScaling, value: float) -> Generator:
     """
-    Define a context manager setting temporarily a *Matplotlib* font scaling.
+    Set a temporary *Matplotlib* font scaling using a context manager.
 
     Parameters
     ----------
@@ -421,8 +422,9 @@ def XYZ_to_plotting_colourspace(
     chromatic_adaptation_transform
         *Chromatic adaptation* transform.
     apply_cctf_encoding
-        Apply the default plotting colourspace encoding colour component
-        transfer function / opto-electronic transfer function.
+        Apply the default plotting colourspace encoding colour
+        component transfer function / opto-electronic transfer
+        function.
 
     Returns
     -------
@@ -454,9 +456,9 @@ class ColourSwatch:
     Parameters
     ----------
     RGB
-        RGB Colour.
+        RGB colour values representing the swatch.
     name
-        Colour name.
+        Name identifier for the colour swatch.
     """
 
     RGB: ArrayLike
@@ -465,7 +467,7 @@ class ColourSwatch:
 
 def colour_cycle(**kwargs: Any) -> itertools.cycle:
     """
-    Create a colour cycle iterator using specified colour map.
+    Create a colour cycle iterator using the specified colour map.
 
     Other Parameters
     ----------------
@@ -497,7 +499,7 @@ def colour_cycle(**kwargs: Any) -> itertools.cycle:
 
 class KwargsArtist(TypedDict):
     """
-    Define the keyword argument types for the :func:`colour.plotting.artist`
+    Define keyword argument types for the :func:`colour.plotting.artist`
     definition.
 
     Parameters
@@ -514,7 +516,7 @@ class KwargsArtist(TypedDict):
 
 def artist(**kwargs: KwargsArtist | Any) -> Tuple[Figure, Axes]:
     """
-    Get the current figure and its axes or create a new one.
+    Return the current figure and its axes or create a new one.
 
     Other Parameters
     ----------------
@@ -549,8 +551,8 @@ def artist(**kwargs: KwargsArtist | Any) -> Tuple[Figure, Axes]:
 
 class KwargsCamera(TypedDict):
     """
-    Define the keyword argument types for the :func:`colour.plotting.camera`
-    definition.
+    Define the keyword argument types for the
+    :func:`colour.plotting.camera` definition.
 
     Parameters
     ----------
@@ -575,7 +577,7 @@ class KwargsCamera(TypedDict):
 
 def camera(**kwargs: KwargsCamera | Any) -> Tuple[Figure, Axes3D]:
     """
-    Set the camera settings.
+    Configure camera settings for the current 3D visualization.
 
     Other Parameters
     ----------------
@@ -605,8 +607,8 @@ def camera(**kwargs: KwargsCamera | Any) -> Tuple[Figure, Axes3D]:
 
 class KwargsRender(TypedDict):
     """
-    Define the keyword argument types for the :func:`colour.plotting.render`
-    definition.
+    Define the keyword argument types for the
+    :func:`colour.plotting.render` definition.
 
     Parameters
     ----------
@@ -615,25 +617,24 @@ class KwargsRender(TypedDict):
     axes
         Axes to apply the render elements onto.
     filename
-        Figure will be saved using specified ``filename`` argument.
+        Figure will be saved using the specified ``filename`` argument.
     show
-        Whether to show the figure and call :func:`matplotlib.pyplot.show`
-        definition.
+        Whether to show the figure and call
+        :func:`matplotlib.pyplot.show` definition.
     block
         Whether to wait for all figures to be closed before returning.
-        If `True` block and run the GUI main loop until all figure windows
-        are closed.
-        If `False` ensure that all figure windows are displayed and return
-        immediately.  In this case, you are responsible for ensuring
-        that the event loop is running to have responsive figures.
-        Defaults to True in non-interactive mode and to False in interactive
-        mode.
+        If `True` block and run the GUI main loop until all figure
+        windows are closed. If `False` ensure that all figure windows
+        are displayed and return immediately. In this case, you are
+        responsible for ensuring that the event loop is running to have
+        responsive figures. Defaults to True in non-interactive mode and
+        to False in interactive mode.
     aspect
         Matplotlib axes aspect.
     axes_visible
         Whether the axes are visible. Default is *True*.
     bounding_box
-        Array defining current axes limits such
+        Array defining current axes limits such as
         `bounding_box = (x min, x max, y min, y max)`.
     tight_layout
         Whether to invoke the :func:`matplotlib.pyplot.tight_layout`
@@ -683,7 +684,7 @@ def render(
 ) -> Tuple[Figure, Axes] | Tuple[Figure, Axes3D]:
     """
     Render the current figure while adjusting various settings such as the
-    bounding box, the title or background transparency.
+    bounding box, title, or background transparency.
 
     Other Parameters
     ----------------
@@ -777,15 +778,15 @@ def label_rectangles(
     Parameters
     ----------
     labels
-        Labels to display.
+        Text labels to display above the rectangles.
     rectangles
-        Rectangles to used to set the labels value and position.
+        Rectangle patches used to determine label positions and values.
     rotation
-        Labels orientation.
+        Orientation of the labels.
     text_size
-        Labels text size.
+        Font size for the labels.
     offset
-        Labels offset as percentages of the largest rectangle dimensions.
+        Label offset as percentages of the largest rectangle dimensions.
 
     Other Parameters
     ----------------
@@ -837,7 +838,7 @@ def label_rectangles(
 
 def uniform_axes3d(**kwargs: Any) -> Tuple[Figure, Axes3D]:
     """
-    Set equal aspect ratio to specified 3d axes.
+    Set equal aspect ratio to the specified 3D axes.
 
     Other Parameters
     ----------------
@@ -880,11 +881,12 @@ def filter_passthrough(
     Filter mapping objects matching specified filterers while passing through
     class instances whose type is one of the mapping element types.
 
-    This definition allows passing custom but compatible objects to the various
-    plotting definitions that by default expect the key from a dataset element.
+    Enable passing custom but compatible objects to plotting definitions that
+    by default expect keys from dataset elements.
 
-    For example, a typical call to :func:`colour.plotting.\
-plot_multi_illuminant_sds` definition is as follows:
+    For example, a typical call to the
+    :func:`colour.plotting.plot_multi_illuminant_sds` definition is as
+    follows:
 
     >>> import colour
     >>> colour.plotting.plot_multi_illuminant_sds(["A"])
@@ -906,12 +908,11 @@ plot_multi_illuminant_sds` definition is as follows:
     ... )
     ... # doctest: +SKIP
 
-    Similarly, a typical call to :func:`colour.plotting.\
-plot_planckian_locus_in_chromaticity_diagram_CIE1931` definition is as follows:
+    Similarly, a typical call to the
+    :func:`colour.plotting.plot_planckian_locus_in_chromaticity_diagram_CIE1931`
+    definition is as follows:
 
-    >>> colour.plotting.plot_planckian_locus_in_chromaticity_diagram_CIE1931(
-    ...     ["A"]
-    ... )
+    >>> colour.plotting.plot_planckian_locus_in_chromaticity_diagram_CIE1931(["A"])
     ... # doctest: +SKIP
 
     But it is also possible to pass a custom whitepoint as follows:
@@ -926,9 +927,9 @@ plot_planckian_locus_in_chromaticity_diagram_CIE1931` definition is as follows:
     mapping
         Mapping to filter.
     filterers
-        Filterer or object class instance (which is passed through directly if
-        its type is one of the mapping element types) or list
-        of filterers.
+        Filterer or object class instance (which is passed through directly
+        if its type is one of the mapping element types) or list of
+        filterers.
     allow_non_siblings
         Whether to allow non-siblings to be also passed through.
 
@@ -940,8 +941,8 @@ plot_planckian_locus_in_chromaticity_diagram_CIE1931` definition is as follows:
     Notes
     -----
     -   If the mapping passed is a :class:`colour.utilities.CanonicalMapping`
-        class instance, then the lower, slugified and canonical keys are also
-        used for matching.
+        class instance, then the lower, slugified and canonical keys are
+        also used for matching.
     """
 
     if isinstance(filterers, str) or not isinstance(filterers, (list, tuple)):
@@ -1000,16 +1001,16 @@ def filter_RGB_colourspaces(
     allow_non_siblings: bool = True,
 ) -> Dict[str, RGB_Colourspace]:
     """
-    Filter the *RGB* colourspaces matching specified filterers.
+    Filter the *RGB* colourspaces matching the specified filterers.
 
     Parameters
     ----------
     filterers
-        Filterer or :class:`colour.RGB_Colourspace` class instance (which is
+        Filterer, :class:`colour.RGB_Colourspace` class instance (which is
         passed through directly if its type is one of the mapping element
-        types) or list of filterers. ``filterers`` elements can also be of any
-        form supported by the :func:`colour.plotting.common.filter_passthrough`
-        definition.
+        types), or list of filterers. The ``filterers`` elements can also
+        be of any form supported by the
+        :func:`colour.plotting.common.filter_passthrough` definition.
     allow_non_siblings
         Whether to allow non-siblings to be also passed through.
 
@@ -1029,7 +1030,7 @@ def filter_cmfs(
     allow_non_siblings: bool = True,
 ) -> Dict[str, MultiSpectralDistributions]:
     """
-    Filter the colour matching functions matching specified filterers.
+    Filter the colour matching functions matching the specified filterers.
 
     Parameters
     ----------
@@ -1038,9 +1039,9 @@ def filter_cmfs(
         :class:`colour.RGB_ColourMatchingFunctions` or
         :class:`colour.XYZ_ColourMatchingFunctions` class instance (which is
         passed through directly if its type is one of the mapping element
-        types) or list of filterers. ``filterers`` elements can also be of any
-        form supported by the :func:`colour.plotting.common.filter_passthrough`
-        definition.
+        types) or list of filterers. ``filterers`` elements can also be of
+        any form supported by the
+        :func:`colour.plotting.common.filter_passthrough` definition.
     allow_non_siblings
         Whether to allow non-siblings to be also passed through.
 
@@ -1058,15 +1059,15 @@ def filter_illuminants(
     allow_non_siblings: bool = True,
 ) -> Dict[str, SpectralDistribution]:
     """
-    Filter the illuminants matching specified filterers.
+    Filter the illuminants matching the specified filterers.
 
     Parameters
     ----------
     filterers
         Filterer or :class:`colour.SpectralDistribution` class instance
-        (which is passed through directly if its type is one of the mapping
-        element types) or list of filterers. ``filterers`` elements can also be
-        of any form supported by the
+        (which is passed through directly if its type is one of the
+        mapping element types) or list of filterers. ``filterers``
+        elements can also be of any form supported by the
         :func:`colour.plotting.common.filter_passthrough` definition.
     allow_non_siblings
         Whether to allow non-siblings to be also passed through.
@@ -1095,15 +1096,15 @@ def filter_colour_checkers(
     allow_non_siblings: bool = True,
 ) -> Dict[str, ColourChecker]:
     """
-    Filter the colour checkers matching specified filterers.
+    Filter the colour checkers matching the specified filterers.
 
     Parameters
     ----------
     filterers
         Filterer or :class:`colour.characterisation.ColourChecker` class
-        instance (which is passed through directly if its type is one of the
-        mapping element types) or list of filterers. ``filterers`` elements
-        can also be of any form supported by the
+        instance (which is passed through directly if its type is one of
+        the mapping element types) or list of filterers. ``filterers``
+        elements can also be of any form supported by the
         :func:`colour.plotting.common.filter_passthrough` definition.
     allow_non_siblings
         Whether to allow non-siblings to be also passed through.
@@ -1123,8 +1124,8 @@ def update_settings_collection(
     expected_count: int,
 ) -> None:
     """
-    Update specified settings collection, *in-place*, with specified keyword
-    arguments and expected count of settings collection elements.
+    Update the specified settings collection *in-place* with the specified
+    keyword arguments and expected count of settings collection elements.
 
     Parameters
     ----------
@@ -1176,12 +1177,12 @@ def plot_single_colour_swatch(
     colour_swatch: ArrayLike | ColourSwatch, **kwargs: Any
 ) -> Tuple[Figure, Axes]:
     """
-    Plot specified colour swatch.
+    Plot a single colour swatch.
 
     Parameters
     ----------
     colour_swatch
-        Colour swatch, either a regular `ArrayLike` or a
+        Colour swatch to plot, either a regular `ArrayLike` or a
         :class:`colour.plotting.ColourSwatch` class instance.
 
     Other Parameters
@@ -1233,13 +1234,13 @@ def plot_multi_colour_swatches(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot specified colours swatches.
+    Plot colour swatches with configurable layout and comparison options.
 
     Parameters
     ----------
     colour_swatches
-        Colour swatch sequence, either a regular `ArrayLike` or a sequence of
-        :class:`colour.plotting.ColourSwatch` class instances.
+        Colour swatch sequence, either a regular `ArrayLike` or a sequence
+        of :class:`colour.plotting.ColourSwatch` class instances.
     width
         Colour swatch width.
     height
@@ -1247,13 +1248,13 @@ def plot_multi_colour_swatches(
     spacing
         Colour swatches spacing.
     columns
-        Colour swatches columns count, defaults to the colour swatch count or
-        half of it if comparing.
+        Colour swatches columns count, defaults to the colour swatch count
+        or half of it if comparing.
     direction
         Row stacking direction.
     text_kwargs
-        Keyword arguments for the :func:`matplotlib.pyplot.text` definition.
-        The following special keywords can also be used:
+        Keyword arguments for the :func:`matplotlib.pyplot.text`
+        definition. The following special keywords can also be used:
 
         -   ``offset``: Sets the text offset.
         -   ``visible``: Sets the text visibility.
@@ -1261,16 +1262,18 @@ def plot_multi_colour_swatches(
         Background colour.
     compare_swatches
         Whether to compare the swatches, in which case the colour swatch
-        count must be an even number with alternating reference colour swatches
-        and test colour swatches. *Stacked* will draw the test colour swatch in
-        the center of the reference colour swatch, *Diagonal* will draw
-        the reference colour swatch in the upper left diagonal area and the
-        test colour swatch in the bottom right diagonal area.
+        count must be an even number with alternating reference colour
+        swatches and test colour swatches. *Stacked* will draw the test
+        colour swatch in the center of the reference colour swatch,
+        *Diagonal* will draw the reference colour swatch in the upper left
+        diagonal area and the test colour swatch in the bottom right
+        diagonal area.
 
     Other Parameters
     ----------------
     kwargs
-        {:func:`colour.plotting.artist`, :func:`colour.plotting.render`},
+        {:func:`colour.plotting.artist`,
+        :func:`colour.plotting.render`},
         See the documentation of the previously listed definitions.
 
     Returns
@@ -1441,7 +1444,7 @@ def plot_single_function(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot specified function.
+    Plot the specified function.
 
     Parameters
     ----------
@@ -1450,14 +1453,14 @@ def plot_single_function(
     samples
         Samples to evaluate the functions with.
     log_x
-        Log base to use for the *x* axis scale, if *None*, the *x* axis scale
-        will be linear.
+        Log base to use for the *x* axis scale, if *None*, the *x* axis
+        scale will be linear.
     log_y
-        Log base to use for the *y* axis scale, if *None*, the *y* axis scale
-        will be linear.
+        Log base to use for the *y* axis scale, if *None*, the *y* axis
+        scale will be linear.
     plot_kwargs
-        Keyword arguments for the :func:`matplotlib.pyplot.plot` definition,
-        used to control the style of the plotted function.
+        Keyword arguments for the :func:`matplotlib.pyplot.plot`
+        definition, used to control the style of the plotted function.
 
     Other Parameters
     ----------------
@@ -1519,22 +1522,23 @@ def plot_multi_functions(
     samples
         Samples to evaluate the functions with.
     log_x
-        Log base to use for the *x* axis scale, if *None*, the *x* axis scale
-        will be linear.
+        Log base to use for the *x* axis scale, if *None*, the *x* axis
+        scale will be linear.
     log_y
-        Log base to use for the *y* axis scale, if *None*, the *y* axis scale
-        will be linear.
+        Log base to use for the *y* axis scale, if *None*, the *y* axis
+        scale will be linear.
     plot_kwargs
-        Keyword arguments for the :func:`matplotlib.pyplot.plot` definition,
-        used to control the style of the plotted functions. ``plot_kwargs``
-        can be either a single dictionary applied to all the plotted functions
-        with the same settings or a sequence of dictionaries with different
-        settings for each plotted function.
+        Keyword arguments for the :func:`matplotlib.pyplot.plot`
+        definition, used to control the style of the plotted functions.
+        ``plot_kwargs`` can be either a single dictionary applied to all
+        the plotted functions with the same settings or a sequence of
+        dictionaries with different settings for each plotted function.
 
     Other Parameters
     ----------------
     kwargs
-        {:func:`colour.plotting.artist`, :func:`colour.plotting.render`},
+        {:func:`colour.plotting.artist`,
+        :func:`colour.plotting.render`},
         See the documentation of the previously listed definitions.
 
     Returns
@@ -1623,30 +1627,33 @@ def plot_image(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot specified image.
+    Plot the specified image using matplotlib.
 
     Parameters
     ----------
     image
-        Image to plot.
+        Image array to plot, typically as RGB or grayscale data.
     imshow_kwargs
-        Keyword arguments for the :func:`matplotlib.pyplot.imshow` definition.
+        Keyword arguments for the :func:`matplotlib.pyplot.imshow`
+        definition, controlling image display properties.
     text_kwargs
-        Keyword arguments for the :func:`matplotlib.pyplot.text` definition.
-        The following special keyword arguments can also be used:
+        Keyword arguments for the :func:`matplotlib.pyplot.text`
+        definition, controlling text overlay properties. The following
+        special keyword arguments can also be used:
 
-        -   ``offset`` : Sets the text offset.
+        -   ``offset`` : Sets the text offset position.
 
     Other Parameters
     ----------------
     kwargs
-        {:func:`colour.plotting.artist`, :func:`colour.plotting.render`},
-        See the documentation of the previously listed definitions.
+        {:func:`colour.plotting.artist`,
+        :func:`colour.plotting.render`}, See the documentation of the
+        previously listed definitions for additional plotting controls.
 
     Returns
     -------
     :class:`tuple`
-        Current figure and axes.
+        Current figure and axes objects from matplotlib.
 
     Examples
     --------

--- a/colour/plotting/conftest.py
+++ b/colour/plotting/conftest.py
@@ -2,9 +2,9 @@
 Plotting - Pytest Configuration
 ===============================
 
-Configure *pytest* to use the *Matplotlib* *AGG* headless backend. This allows
-the plotting unittests to run without creating windows in IDEs such as
-*VSCode*.
+Configure *pytest* to use the *Matplotlib* *AGG* headless backend. This
+enables the plotting unit tests to run without creating windows in IDEs such
+as *VSCode*.
 """
 
 import matplotlib as mpl
@@ -29,8 +29,8 @@ def mpl_headless_backend() -> Generator[None, None, None]:
     """
     Configure *Matplotlib* for headless testing.
 
-    This pytest fixture is automatically applied to any tests in this package
-    or any subpackages at the beginning of the pytest session.
+    This pytest fixture is automatically applied to any tests in this
+    package or any subpackages at the beginning of the pytest session.
 
     Yields
     ------

--- a/colour/plotting/corresponding.py
+++ b/colour/plotting/corresponding.py
@@ -2,7 +2,7 @@
 Corresponding Chromaticities Prediction Plotting
 ================================================
 
-Define the corresponding chromaticities prediction plotting objects:
+Define the corresponding chromaticities prediction plotting objects.
 
 -   :func:`colour.plotting.plot_corresponding_chromaticities_prediction`
 """
@@ -62,8 +62,8 @@ def plot_corresponding_chromaticities_prediction(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot specified chromatic adaptation model corresponding chromaticities
-    prediction.
+    Plot the corresponding chromaticities prediction for the specified
+    chromatic adaptation model.
 
     Parameters
     ----------
@@ -73,8 +73,8 @@ def plot_corresponding_chromaticities_prediction(
     model
         Corresponding chromaticities prediction model name.
     corresponding_chromaticities_prediction_kwargs
-        Keyword arguments for the :func:`colour.\
-corresponding_chromaticities_prediction` definition.
+        Keyword arguments for the
+        :func:`colour.corresponding_chromaticities_prediction` definition.
 
     Other Parameters
     ----------------

--- a/colour/plotting/diagrams.py
+++ b/colour/plotting/diagrams.py
@@ -2,7 +2,7 @@
 CIE Chromaticity Diagrams Plotting
 ==================================
 
-Define the *CIE* chromaticity diagrams plotting objects:
+Define the *CIE* chromaticity diagrams plotting objects.
 
 -   :func:`colour.plotting.lines_spectral_locus`
 -   :func:`colour.plotting.plot_chromaticity_diagram_CIE1931`
@@ -228,19 +228,20 @@ def lines_spectral_locus(
     method: (Literal["CIE 1931", "CIE 1960 UCS", "CIE 1976 UCS"] | str) = "CIE 1931",
 ) -> Tuple[NDArray, NDArray]:
     """
-    Return the *Spectral Locus* line vertices, i.e., positions, normals and
-    colours, according to specified method.
+    Return the *Spectral Locus* line vertices, i.e., positions, normals
+    and colours, using the specified method.
 
     Parameters
     ----------
     cmfs
         Standard observer colour matching functions used for computing the
         spectral locus boundaries. ``cmfs`` can be of any type or form
-        supported by the :func:`colour.plotting.common.filter_cmfs` definition.
+        supported by the :func:`colour.plotting.common.filter_cmfs`
+        definition.
     labels
-        Array of wavelength labels used to customise which labels will be drawn
-        around the spectral locus. Passing an empty array will result in no
-        wavelength labels being drawn.
+        Array of wavelength labels used to customise which labels will be
+        drawn around the spectral locus. Passing an empty array will
+        result in no wavelength labels being drawn.
     method
         *Chromaticity Diagram* method.
 
@@ -380,31 +381,33 @@ def plot_spectral_locus(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot the *Spectral Locus* according to specified method.
+    Plot the *Spectral Locus* using the specified method.
 
     Parameters
     ----------
     cmfs
-        Standard observer colour matching functions used for computing the
-        spectral locus boundaries. ``cmfs`` can be of any type or form
-        supported by the :func:`colour.plotting.common.filter_cmfs` definition.
+        Standard observer colour matching functions used for computing
+        the spectral locus boundaries. ``cmfs`` can be of any type or
+        form supported by the :func:`colour.plotting.common.filter_cmfs`
+        definition.
     spectral_locus_colours
-        Colours of the *Spectral Locus*, if ``spectral_locus_colours`` is set
-        to *RGB*, the colours will be computed according to the corresponding
-        chromaticity coordinates.
+        Colours of the *Spectral Locus*, if ``spectral_locus_colours``
+        is set to *RGB*, the colours will be computed using the
+        corresponding chromaticity coordinates.
     spectral_locus_opacity
         Opacity of the *Spectral Locus*.
     spectral_locus_labels
-        Array of wavelength labels used to customise which labels will be drawn
-        around the spectral locus. Passing an empty array will result in no
-        wavelength labels being drawn.
+        Array of wavelength labels used to customise which labels will
+        be drawn around the spectral locus. Passing an empty array will
+        result in no wavelength labels being drawn.
     method
         *Chromaticity Diagram* method.
 
     Other Parameters
     ----------------
     kwargs
-        {:func:`colour.plotting.artist`, :func:`colour.plotting.render`},
+        {:func:`colour.plotting.artist`,
+        :func:`colour.plotting.render`},
         See the documentation of the previously listed definitions.
 
     Returns
@@ -512,17 +515,17 @@ def plot_chromaticity_diagram_colours(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot the *Chromaticity Diagram* colours according to specified method.
+    Plot the *Chromaticity Diagram* colours using the specified method.
 
     Parameters
     ----------
     samples
-        Sample count on one axis when computing the *Chromaticity Diagram*
-        colours.
+        Sample count on one axis when computing the *Chromaticity
+        Diagram* colours.
     diagram_colours
-        Colours of the *Chromaticity Diagram*, if ``diagram_colours`` is set
-        to *RGB*, the colours will be computed according to the corresponding
-        coordinates.
+        Colours of the *Chromaticity Diagram*, if ``diagram_colours``
+        is set to *RGB*, the colours will be computed using the
+        corresponding coordinates.
     diagram_opacity
         Opacity of the *Chromaticity Diagram*.
     diagram_clipping_path
@@ -530,14 +533,16 @@ def plot_chromaticity_diagram_colours(
     cmfs
         Standard observer colour matching functions used for computing the
         spectral locus boundaries. ``cmfs`` can be of any type or form
-        supported by the :func:`colour.plotting.common.filter_cmfs` definition.
+        supported by the :func:`colour.plotting.common.filter_cmfs`
+        definition.
     method
         *Chromaticity Diagram* method.
 
     Other Parameters
     ----------------
     kwargs
-        {:func:`colour.plotting.artist`, :func:`colour.plotting.render`},
+        {:func:`colour.plotting.artist`,
+        :func:`colour.plotting.render`},
         See the documentation of the previously listed definitions.
 
     Returns
@@ -632,14 +637,15 @@ def plot_chromaticity_diagram(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot the *Chromaticity Diagram* according to specified method.
+    Plot the *Chromaticity Diagram* using the specified method.
 
     Parameters
     ----------
     cmfs
         Standard observer colour matching functions used for computing the
         spectral locus boundaries. ``cmfs`` can be of any type or form
-        supported by the :func:`colour.plotting.common.filter_cmfs` definition.
+        supported by the :func:`colour.plotting.common.filter_cmfs`
+        definition.
     show_diagram_colours
         Whether to display the *Chromaticity Diagram* background colours.
     show_spectral_locus
@@ -742,7 +748,8 @@ def plot_chromaticity_diagram_CIE1931(
     cmfs
         Standard observer colour matching functions used for computing the
         spectral locus boundaries. ``cmfs`` can be of any type or form
-        supported by the :func:`colour.plotting.common.filter_cmfs` definition.
+        supported by the :func:`colour.plotting.common.filter_cmfs`
+        definition.
     show_diagram_colours
         Whether to display the *Chromaticity Diagram* background colours.
     show_spectral_locus
@@ -796,7 +803,8 @@ def plot_chromaticity_diagram_CIE1960UCS(
     cmfs
         Standard observer colour matching functions used for computing the
         spectral locus boundaries. ``cmfs`` can be of any type or form
-        supported by the :func:`colour.plotting.common.filter_cmfs` definition.
+        supported by the :func:`colour.plotting.common.filter_cmfs`
+        definition.
     show_diagram_colours
         Whether to display the *Chromaticity Diagram* background colours.
     show_spectral_locus
@@ -850,7 +858,8 @@ def plot_chromaticity_diagram_CIE1976UCS(
     cmfs
         Standard observer colour matching functions used for computing the
         spectral locus boundaries. ``cmfs`` can be of any type or form
-        supported by the :func:`colour.plotting.common.filter_cmfs` definition.
+        supported by the :func:`colour.plotting.common.filter_cmfs`
+        definition.
     show_diagram_colours
         Whether to display the *Chromaticity Diagram* background colours.
     show_spectral_locus
@@ -906,20 +915,21 @@ def plot_sds_in_chromaticity_diagram(
 ) -> Tuple[Figure, Axes]:
     """
     Plot specified spectral distribution chromaticity coordinates into the
-    *Chromaticity Diagram* using specified method.
+    *Chromaticity Diagram* using the specified method.
 
     Parameters
     ----------
     sds
-        Spectral distributions or multi-spectral distributions to
-        plot. `sds` can be a single
-        :class:`colour.MultiSpectralDistributions` class instance, a list
-        of :class:`colour.MultiSpectralDistributions` class instances or a
-        List of :class:`colour.SpectralDistribution` class instances.
+        Spectral distributions or multi-spectral distributions to plot.
+        ``sds`` can be a single :class:`colour.MultiSpectralDistributions`
+        class instance, a list of :class:`colour.MultiSpectralDistributions`
+        class instances or a list of :class:`colour.SpectralDistribution` class
+        instances.
     cmfs
         Standard observer colour matching functions used for computing the
         spectral locus boundaries. ``cmfs`` can be of any type or form
-        supported by the :func:`colour.plotting.common.filter_cmfs` definition.
+        supported by the :func:`colour.plotting.common.filter_cmfs`
+        definition.
     chromaticity_diagram_callable
         Callable responsible for drawing the *Chromaticity Diagram*.
     method
@@ -927,38 +937,39 @@ def plot_sds_in_chromaticity_diagram(
     annotate_kwargs
         Keyword arguments for the :func:`matplotlib.pyplot.annotate`
         definition, used to annotate the resulting chromaticity coordinates
-        with their respective spectral distribution names. ``annotate_kwargs``
-        can be either a single dictionary applied to all the arrows with same
-        settings or a sequence of dictionaries with different settings for each
-        spectral distribution. The following special keyword arguments can also
-        be used:
+        with their respective spectral distribution names.
+        ``annotate_kwargs`` can be either a single dictionary applied to
+        all the arrows with same settings or a sequence of dictionaries
+        with different settings for each spectral distribution. The
+        following special keyword arguments can also be used:
 
         -   ``annotate`` : Whether to annotate the spectral distributions.
     plot_kwargs
-        Keyword arguments for the :func:`matplotlib.pyplot.plot` definition,
-        used to control the style of the plotted spectral distributions.
-        `plot_kwargs`` can be either a single dictionary applied to all the
-        plotted spectral distributions with the same settings or a sequence of
-        dictionaries with different settings for each plotted spectral
-        distributions. The following special keyword arguments can also be
-        used:
+        Keyword arguments for the :func:`matplotlib.pyplot.plot`
+        definition, used to control the style of the plotted spectral
+        distributions. ``plot_kwargs`` can be either a single dictionary
+        applied to all the plotted spectral distributions with the same
+        settings or a sequence of dictionaries with different settings for
+        each plotted spectral distribution. The following special keyword
+        arguments can also be used:
 
         -   ``illuminant`` : The illuminant used to compute the spectral
-            distributions colours. The default is the illuminant associated
-            with the whitepoint of the default plotting colourspace.
-            ``illuminant`` can be of any type or form supported by the
-            :func:`colour.plotting.common.filter_cmfs` definition.
-        -   ``cmfs`` : The standard observer colour matching functions used for
-            computing the spectral distributions colours. ``cmfs`` can be of
-            any type or form supported by the
+            distributions colours. The default is the illuminant
+            associated with the whitepoint of the default plotting
+            colourspace. ``illuminant`` can be of any type or form
+            supported by the :func:`colour.plotting.common.filter_cmfs`
+            definition.
+        -   ``cmfs`` : The standard observer colour matching functions
+            used for computing the spectral distributions colours.
+            ``cmfs`` can be of any type or form supported by the
             :func:`colour.plotting.common.filter_cmfs` definition.
         -   ``normalise_sd_colours`` : Whether to normalise the computed
             spectral distributions colours. The default is *True*.
         -   ``use_sd_colours`` : Whether to use the computed spectral
-            distributions colours under the plotting colourspace illuminant.
-            Alternatively, it is possible to use the
-            :func:`matplotlib.pyplot.plot` definition ``color`` argument with
-            pre-computed values. The default is *True*.
+            distributions colours under the plotting colourspace
+            illuminant. Alternatively, it is possible to use the
+            :func:`matplotlib.pyplot.plot` definition ``color`` argument
+            with pre-computed values. The default is *True*.
 
     Other Parameters
     ----------------
@@ -1131,58 +1142,62 @@ def plot_sds_in_chromaticity_diagram_CIE1931(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot specified spectral distribution chromaticity coordinates into the
+    Plot specified spectral distribution chromaticity coordinates in the
     *CIE 1931 Chromaticity Diagram*.
 
     Parameters
     ----------
     sds
-        Spectral distributions or multi-spectral distributions to
-        plot. `sds` can be a single :class:`colour.MultiSpectralDistributions`
+        Spectral distributions or multi-spectral distributions to plot.
+        ``sds`` can be a single :class:`colour.MultiSpectralDistributions`
         class instance, a list of :class:`colour.MultiSpectralDistributions`
         class instances or a list of :class:`colour.SpectralDistribution` class
         instances.
     cmfs
         Standard observer colour matching functions used for computing the
         spectral locus boundaries. ``cmfs`` can be of any type or form
-        supported by the :func:`colour.plotting.common.filter_cmfs` definition.
+        supported by the :func:`colour.plotting.common.filter_cmfs`
+        definition.
     chromaticity_diagram_callable_CIE1931
-        Callable responsible for drawing the *CIE 1931 Chromaticity Diagram*.
+        Callable responsible for drawing the *CIE 1931 Chromaticity
+        Diagram*.
     annotate_kwargs
         Keyword arguments for the :func:`matplotlib.pyplot.annotate`
-        definition, used to annotate the resulting chromaticity coordinates
-        with their respective spectral distribution names. ``annotate_kwargs``
-        can be either a single dictionary applied to all the arrows with same
-        settings or a sequence of dictionaries with different settings for each
-        spectral distribution. The following special keyword arguments can also
-        be used:
+        definition, used to annotate the resulting chromaticity
+        coordinates with their respective spectral distribution names.
+        ``annotate_kwargs`` can be either a single dictionary applied to
+        all the arrows with same settings or a sequence of dictionaries
+        with different settings for each spectral distribution. The
+        following special keyword arguments can also be used:
 
-        -   ``annotate`` : Whether to annotate the spectral distributions.
+        -   ``annotate`` : Whether to annotate the spectral
+            distributions.
     plot_kwargs
-        Keyword arguments for the :func:`matplotlib.pyplot.plot` definition,
-        used to control the style of the plotted spectral distributions.
-        `plot_kwargs`` can be either a single dictionary applied to all the
-        plotted spectral distributions with the same settings or a sequence of
-        dictionaries with different settings for each plotted spectral
-        distributions. The following special keyword arguments can also be
-        used:
+        Keyword arguments for the :func:`matplotlib.pyplot.plot`
+        definition, used to control the style of the plotted spectral
+        distributions. ``plot_kwargs`` can be either a single dictionary
+        applied to all the plotted spectral distributions with the same
+        settings or a sequence of dictionaries with different settings for
+        each plotted spectral distribution. The following special keyword
+        arguments can also be used:
 
         -   ``illuminant`` : The illuminant used to compute the spectral
-            distributions colours. The default is the illuminant associated
-            with the whitepoint of the default plotting colourspace.
-            ``illuminant`` can be of any type or form supported by the
-            :func:`colour.plotting.common.filter_cmfs` definition.
-        -   ``cmfs`` : The standard observer colour matching functions used for
-            computing the spectral distributions colours. ``cmfs`` can be of
-            any type or form supported by the
+            distributions colours. The default is the illuminant
+            associated with the whitepoint of the default plotting
+            colourspace. ``illuminant`` can be of any type or form
+            supported by the :func:`colour.plotting.common.filter_cmfs`
+            definition.
+        -   ``cmfs`` : The standard observer colour matching functions
+            used for computing the spectral distributions colours.
+            ``cmfs`` can be of any type or form supported by the
             :func:`colour.plotting.common.filter_cmfs` definition.
         -   ``normalise_sd_colours`` : Whether to normalise the computed
             spectral distributions colours. The default is *True*.
         -   ``use_sd_colours`` : Whether to use the computed spectral
-            distributions colours under the plotting colourspace illuminant.
-            Alternatively, it is possible to use the
-            :func:`matplotlib.pyplot.plot` definition ``color`` argument with
-            pre-computed values. The default is *True*.
+            distributions colours under the plotting colourspace
+            illuminant. Alternatively, it is possible to use the
+            :func:`matplotlib.pyplot.plot` definition ``color`` argument
+            with pre-computed values. The default is *True*.
 
     Other Parameters
     ----------------
@@ -1243,59 +1258,62 @@ def plot_sds_in_chromaticity_diagram_CIE1960UCS(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot specified spectral distribution chromaticity coordinates into the
+    Plot spectral distribution chromaticity coordinates in the
     *CIE 1960 UCS Chromaticity Diagram*.
 
     Parameters
     ----------
     sds
-        Spectral distributions or multi-spectral distributions to
-        plot. `sds` can be a single :class:`colour.MultiSpectralDistributions`
+        Spectral distributions or multi-spectral distributions to plot.
+        ``sds`` can be a single :class:`colour.MultiSpectralDistributions`
         class instance, a list of :class:`colour.MultiSpectralDistributions`
         class instances or a list of :class:`colour.SpectralDistribution` class
         instances.
     cmfs
         Standard observer colour matching functions used for computing the
         spectral locus boundaries. ``cmfs`` can be of any type or form
-        supported by the :func:`colour.plotting.common.filter_cmfs` definition.
+        supported by the :func:`colour.plotting.common.filter_cmfs`
+        definition.
     chromaticity_diagram_callable_CIE1960UCS
         Callable responsible for drawing the
         *CIE 1960 UCS Chromaticity Diagram*.
     annotate_kwargs
         Keyword arguments for the :func:`matplotlib.pyplot.annotate`
-        definition, used to annotate the resulting chromaticity coordinates
-        with their respective spectral distribution names. ``annotate_kwargs``
-        can be either a single dictionary applied to all the arrows with same
-        settings or a sequence of dictionaries with different settings for each
-        spectral distribution. The following special keyword arguments can also
-        be used:
+        definition, used to annotate the resulting chromaticity
+        coordinates with their respective spectral distribution names.
+        ``annotate_kwargs`` can be either a single dictionary applied to
+        all the arrows with same settings or a sequence of dictionaries
+        with different settings for each spectral distribution. The
+        following special keyword arguments can also be used:
 
-        -   ``annotate`` : Whether to annotate the spectral distributions.
+        -   ``annotate`` : Whether to annotate the spectral
+            distributions.
     plot_kwargs
-        Keyword arguments for the :func:`matplotlib.pyplot.plot` definition,
-        used to control the style of the plotted spectral distributions.
-        `plot_kwargs`` can be either a single dictionary applied to all the
-        plotted spectral distributions with the same settings or a sequence of
-        dictionaries with different settings for each plotted spectral
-        distributions. The following special keyword arguments can also be
-        used:
+        Keyword arguments for the :func:`matplotlib.pyplot.plot`
+        definition, used to control the style of the plotted spectral
+        distributions. ``plot_kwargs`` can be either a single dictionary
+        applied to all the plotted spectral distributions with the same
+        settings or a sequence of dictionaries with different settings for
+        each plotted spectral distribution. The following special keyword
+        arguments can also be used:
 
         -   ``illuminant`` : The illuminant used to compute the spectral
-            distributions colours. The default is the illuminant associated
-            with the whitepoint of the default plotting colourspace.
-            ``illuminant`` can be of any type or form supported by the
-            :func:`colour.plotting.common.filter_cmfs` definition.
-        -   ``cmfs`` : The standard observer colour matching functions used for
-            computing the spectral distributions colours. ``cmfs`` can be of
-            any type or form supported by the
+            distributions colours. The default is the illuminant
+            associated with the whitepoint of the default plotting
+            colourspace. ``illuminant`` can be of any type or form
+            supported by the :func:`colour.plotting.common.filter_cmfs`
+            definition.
+        -   ``cmfs`` : The standard observer colour matching functions
+            used for computing the spectral distributions colours.
+            ``cmfs`` can be of any type or form supported by the
             :func:`colour.plotting.common.filter_cmfs` definition.
         -   ``normalise_sd_colours`` : Whether to normalise the computed
             spectral distributions colours. The default is *True*.
         -   ``use_sd_colours`` : Whether to use the computed spectral
-            distributions colours under the plotting colourspace illuminant.
-            Alternatively, it is possible to use the
-            :func:`matplotlib.pyplot.plot` definition ``color`` argument with
-            pre-computed values. The default is *True*.
+            distributions colours under the plotting colourspace
+            illuminant. Alternatively, it is possible to use the
+            :func:`matplotlib.pyplot.plot` definition ``color`` argument
+            with pre-computed values. The default is *True*.
 
     Other Parameters
     ----------------
@@ -1356,59 +1374,62 @@ def plot_sds_in_chromaticity_diagram_CIE1976UCS(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot specified spectral distribution chromaticity coordinates into the
+    Plot specified spectral distribution chromaticity coordinates in the
     *CIE 1976 UCS Chromaticity Diagram*.
 
     Parameters
     ----------
     sds
-        Spectral distributions or multi-spectral distributions to
-        plot. `sds` can be a single :class:`colour.MultiSpectralDistributions`
+        Spectral distributions or multi-spectral distributions to plot.
+        ``sds`` can be a single :class:`colour.MultiSpectralDistributions`
         class instance, a list of :class:`colour.MultiSpectralDistributions`
         class instances or a list of :class:`colour.SpectralDistribution` class
         instances.
     cmfs
         Standard observer colour matching functions used for computing the
         spectral locus boundaries. ``cmfs`` can be of any type or form
-        supported by the :func:`colour.plotting.common.filter_cmfs` definition.
+        supported by the :func:`colour.plotting.common.filter_cmfs`
+        definition.
     chromaticity_diagram_callable_CIE1976UCS
         Callable responsible for drawing the
         *CIE 1976 UCS Chromaticity Diagram*.
     annotate_kwargs
         Keyword arguments for the :func:`matplotlib.pyplot.annotate`
-        definition, used to annotate the resulting chromaticity coordinates
-        with their respective spectral distribution names. ``annotate_kwargs``
-        can be either a single dictionary applied to all the arrows with same
-        settings or a sequence of dictionaries with different settings for each
-        spectral distribution. The following special keyword arguments can also
-        be used:
+        definition, used to annotate the resulting chromaticity
+        coordinates with their respective spectral distribution names.
+        ``annotate_kwargs`` can be either a single dictionary applied to
+        all the arrows with same settings or a sequence of dictionaries
+        with different settings for each spectral distribution. The
+        following special keyword arguments can also be used:
 
-        -   ``annotate`` : Whether to annotate the spectral distributions.
+        -   ``annotate`` : Whether to annotate the spectral
+            distributions.
     plot_kwargs
-        Keyword arguments for the :func:`matplotlib.pyplot.plot` definition,
-        used to control the style of the plotted spectral distributions.
-        `plot_kwargs`` can be either a single dictionary applied to all the
-        plotted spectral distributions with the same settings or a sequence of
-        dictionaries with different settings for each plotted spectral
-        distributions. The following special keyword arguments can also be
-        used:
+        Keyword arguments for the :func:`matplotlib.pyplot.plot`
+        definition, used to control the style of the plotted spectral
+        distributions. ``plot_kwargs`` can be either a single dictionary
+        applied to all the plotted spectral distributions with the same
+        settings or a sequence of dictionaries with different settings for
+        each plotted spectral distribution. The following special keyword
+        arguments can also be used:
 
         -   ``illuminant`` : The illuminant used to compute the spectral
-            distributions colours. The default is the illuminant associated
-            with the whitepoint of the default plotting colourspace.
-            ``illuminant`` can be of any type or form supported by the
-            :func:`colour.plotting.common.filter_cmfs` definition.
-        -   ``cmfs`` : The standard observer colour matching functions used for
-            computing the spectral distributions colours. ``cmfs`` can be of
-            any type or form supported by the
+            distributions colours. The default is the illuminant
+            associated with the whitepoint of the default plotting
+            colourspace. ``illuminant`` can be of any type or form
+            supported by the :func:`colour.plotting.common.filter_cmfs`
+            definition.
+        -   ``cmfs`` : The standard observer colour matching functions
+            used for computing the spectral distributions colours.
+            ``cmfs`` can be of any type or form supported by the
             :func:`colour.plotting.common.filter_cmfs` definition.
         -   ``normalise_sd_colours`` : Whether to normalise the computed
             spectral distributions colours. The default is *True*.
         -   ``use_sd_colours`` : Whether to use the computed spectral
-            distributions colours under the plotting colourspace illuminant.
-            Alternatively, it is possible to use the
-            :func:`matplotlib.pyplot.plot` definition ``color`` argument with
-            pre-computed values. The default is *True*.
+            distributions colours under the plotting colourspace
+            illuminant. Alternatively, it is possible to use the
+            :func:`matplotlib.pyplot.plot` definition ``color`` argument
+            with pre-computed values. The default is *True*.
 
     Other Parameters
     ----------------

--- a/colour/plotting/graph.py
+++ b/colour/plotting/graph.py
@@ -2,7 +2,7 @@
 Automatic Colour Conversion Graph Plotting
 ==========================================
 
-Define the automatic colour conversion graph plotting objects:
+Define the automatic colour conversion graph plotting objects.
 
 -   :func:`colour.plotting.plot_automatic_colour_conversion_graph`
 """
@@ -58,8 +58,8 @@ def plot_automatic_colour_conversion_graph(
 
     Notes
     -----
-    -   This definition does not directly plot the *Colour* automatic colour
-        conversion graph but instead write it to an image.
+    -   This definition does not directly plot the *Colour* automatic
+        colour conversion graph but instead writes it to an image.
 
     Examples
     --------

--- a/colour/plotting/models.py
+++ b/colour/plotting/models.py
@@ -211,23 +211,23 @@ def colourspace_model_axis_reorder(
     direction: Literal["Forward", "Inverse"] | str = "Forward",
 ) -> NDArrayFloat:
     """
-    Reorder the axes of specified colourspace model :math:`a` array according to
-    the most common volume plotting axes order.
+    Reorder the axes of the specified colourspace model array :math:`a` to
+    match the standard axes order used for volume plotting.
 
     Parameters
     ----------
     a
-        Colourspace model :math:`a` array.
+        Colourspace model array :math:`a` to be reordered.
     model
-        Colourspace model, see :attr:`colour.COLOURSPACE_MODELS` attribute for
-        the list of supported colourspace models.
+        Colourspace model, see :attr:`colour.COLOURSPACE_MODELS` attribute
+        for the list of supported colourspace models.
     direction
         Reordering direction.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Reordered colourspace model :math:`a` array.
+        Reordered colourspace model array :math:`a`.
 
     Examples
     --------
@@ -271,8 +271,8 @@ def lines_pointer_gamut(
     method: (Literal["CIE 1931", "CIE 1960 UCS", "CIE 1976 UCS"] | str) = "CIE 1931",
 ) -> tuple[NDArray, NDArray]:
     """
-    Return the *Pointer's Gamut* line vertices, i.e., positions, normals and
-    colours, according to specified method.
+    Return the *Pointer's Gamut* line vertices, i.e., positions, normals,
+    and colours, using the specified chromaticity diagram method.
 
     Parameters
     ----------
@@ -363,21 +363,22 @@ def plot_pointer_gamut(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot *Pointer's Gamut* according to specified method.
+    Plot *Pointer's Gamut* using the specified plotting method.
 
     Parameters
     ----------
     pointer_gamut_colours
-       Colours of the *Pointer's Gamut*.
+        Colours of *Pointer's Gamut*.
     pointer_gamut_opacity
-       Opacity of the *Pointer's Gamut*.
+        Opacity of *Pointer's Gamut*.
     method
         Plotting method.
 
     Other Parameters
     ----------------
     kwargs
-        {:func:`colour.plotting.artist`, :func:`colour.plotting.render`},
+        {:func:`colour.plotting.artist`,
+        :func:`colour.plotting.render`},
         See the documentation of the previously listed definitions.
 
     Returns
@@ -467,19 +468,20 @@ def plot_RGB_colourspaces_in_chromaticity_diagram(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot specified *RGB* colourspaces in the *Chromaticity Diagram* according
-    to specified method.
+    Plot specified *RGB* colourspaces in the *Chromaticity Diagram* using
+    the specified method.
 
     Parameters
     ----------
     colourspaces
-        *RGB* colourspaces to plot. ``colourspaces`` elements
-        can be of any type or form supported by the
+        *RGB* colourspaces to plot. ``colourspaces`` elements can be of any
+        type or form supported by the
         :func:`colour.plotting.common.filter_RGB_colourspaces` definition.
     cmfs
         Standard observer colour matching functions used for computing the
         spectral locus boundaries. ``cmfs`` can be of any type or form
-        supported by the :func:`colour.plotting.common.filter_cmfs` definition.
+        supported by the :func:`colour.plotting.common.filter_cmfs`
+        definition.
     chromaticity_diagram_callable
         Callable responsible for drawing the *Chromaticity Diagram*.
     method
@@ -490,14 +492,15 @@ def plot_RGB_colourspaces_in_chromaticity_diagram(
         Whether to display the *Pointer's Gamut*.
     chromatically_adapt
         Whether to chromatically adapt the *RGB* colourspaces specified in
-        ``colourspaces`` to the whitepoint of the default plotting colourspace.
-    plot_kwargs
-        Keyword arguments for the :func:`matplotlib.pyplot.plot` definition,
-        used to control the style of the plotted *RGB* colourspaces.
-        ``plot_kwargs`` can be either a single dictionary applied to all the
-        plotted *RGB* colourspaces with the same settings or a sequence of
-        dictionaries with different settings for each plotted *RGB*
+        ``colourspaces`` to the whitepoint of the default plotting
         colourspace.
+    plot_kwargs
+        Keyword arguments for the :func:`matplotlib.pyplot.plot`
+        definition, used to control the style of the plotted *RGB*
+        colourspaces. ``plot_kwargs`` can be either a single dictionary
+        applied to all the plotted *RGB* colourspaces with the same
+        settings or a sequence of dictionaries with different settings for
+        each plotted *RGB* colourspace.
 
     Other Parameters
     ----------------
@@ -682,22 +685,25 @@ def plot_RGB_colourspaces_in_chromaticity_diagram_CIE1931(
     Parameters
     ----------
     colourspaces
-        *RGB* colourspaces to plot. ``colourspaces`` elements
-        can be of any type or form supported by the
+        *RGB* colourspaces to plot. ``colourspaces`` elements can be of any
+        type or form supported by the
         :func:`colour.plotting.common.filter_RGB_colourspaces` definition.
     cmfs
         Standard observer colour matching functions used for computing the
         spectral locus boundaries. ``cmfs`` can be of any type or form
-        supported by the :func:`colour.plotting.common.filter_cmfs` definition.
+        supported by the :func:`colour.plotting.common.filter_cmfs`
+        definition.
     chromaticity_diagram_callable_CIE1931
-        Callable responsible for drawing the *CIE 1931 Chromaticity Diagram*.
+        Callable responsible for drawing the *CIE 1931 Chromaticity
+        Diagram*.
     show_whitepoints
         Whether to display the *RGB* colourspaces whitepoints.
     show_pointer_gamut
         Whether to display the *Pointer's Gamut*.
     chromatically_adapt
         Whether to chromatically adapt the *RGB* colourspaces specified in
-        ``colourspaces`` to the whitepoint of the default plotting colourspace.
+        ``colourspaces`` to the whitepoint of the default plotting
+        colourspace.
     plot_kwargs
         Keyword arguments for the :func:`matplotlib.pyplot.plot` definition,
         used to control the style of the plotted *RGB* colourspaces.
@@ -772,18 +778,20 @@ def plot_RGB_colourspaces_in_chromaticity_diagram_CIE1960UCS(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot specified *RGB* colourspaces in the *CIE 1960 UCS Chromaticity Diagram*.
+    Plot specified *RGB* colourspaces in the
+    *CIE 1960 UCS Chromaticity Diagram*.
 
     Parameters
     ----------
     colourspaces
-        *RGB* colourspaces to plot. ``colourspaces`` elements
-        can be of any type or form supported by the
+        *RGB* colourspaces to plot. ``colourspaces`` elements can be of any
+        type or form supported by the
         :func:`colour.plotting.common.filter_RGB_colourspaces` definition.
     cmfs
         Standard observer colour matching functions used for computing the
         spectral locus boundaries. ``cmfs`` can be of any type or form
-        supported by the :func:`colour.plotting.common.filter_cmfs` definition.
+        supported by the :func:`colour.plotting.common.filter_cmfs`
+        definition.
     chromaticity_diagram_callable_CIE1960UCS
         Callable responsible for drawing the
         *CIE 1960 UCS Chromaticity Diagram*.
@@ -793,14 +801,15 @@ def plot_RGB_colourspaces_in_chromaticity_diagram_CIE1960UCS(
         Whether to display the *Pointer's Gamut*.
     chromatically_adapt
         Whether to chromatically adapt the *RGB* colourspaces specified in
-        ``colourspaces`` to the whitepoint of the default plotting colourspace.
-    plot_kwargs
-        Keyword arguments for the :func:`matplotlib.pyplot.plot` definition,
-        used to control the style of the plotted *RGB* colourspaces.
-        ``plot_kwargs`` can be either a single dictionary applied to all the
-        plotted *RGB* colourspaces with the same settings or a sequence of
-        dictionaries with different settings for each plotted *RGB*
+        ``colourspaces`` to the whitepoint of the default plotting
         colourspace.
+    plot_kwargs
+        Keyword arguments for the :func:`matplotlib.pyplot.plot`
+        definition, used to control the style of the plotted *RGB*
+        colourspaces. ``plot_kwargs`` can be either a single dictionary
+        applied to all the plotted *RGB* colourspaces with the same
+        settings or a sequence of dictionaries with different settings for
+        each plotted *RGB* colourspace.
 
     Other Parameters
     ----------------
@@ -868,18 +877,20 @@ def plot_RGB_colourspaces_in_chromaticity_diagram_CIE1976UCS(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot specified *RGB* colourspaces in the *CIE 1976 UCS Chromaticity Diagram*.
+    Plot the specified *RGB* colourspaces in the
+    *CIE 1976 UCS Chromaticity Diagram*.
 
     Parameters
     ----------
     colourspaces
-        *RGB* colourspaces to plot. ``colourspaces`` elements
-        can be of any type or form supported by the
+        *RGB* colourspaces to plot. ``colourspaces`` elements can be of any
+        type or form supported by the
         :func:`colour.plotting.common.filter_RGB_colourspaces` definition.
     cmfs
         Standard observer colour matching functions used for computing the
         spectral locus boundaries. ``cmfs`` can be of any type or form
-        supported by the :func:`colour.plotting.common.filter_cmfs` definition.
+        supported by the :func:`colour.plotting.common.filter_cmfs`
+        definition.
     chromaticity_diagram_callable_CIE1976UCS
         Callable responsible for drawing the
         *CIE 1976 UCS Chromaticity Diagram*.
@@ -889,7 +900,8 @@ def plot_RGB_colourspaces_in_chromaticity_diagram_CIE1976UCS(
         Whether to display the *Pointer's Gamut*.
     chromatically_adapt
         Whether to chromatically adapt the *RGB* colourspaces specified in
-        ``colourspaces`` to the whitepoint of the default plotting colourspace.
+        ``colourspaces`` to the whitepoint of the default plotting
+        colourspace.
     plot_kwargs
         Keyword arguments for the :func:`matplotlib.pyplot.plot` definition,
         used to control the style of the plotted *RGB* colourspaces.
@@ -957,8 +969,8 @@ def plot_RGB_chromaticities_in_chromaticity_diagram(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot specified *RGB* colourspace array in the *Chromaticity Diagram* according
-    to specified method.
+    Plot the specified *RGB* colourspace array in the *Chromaticity Diagram*
+    using the specified method.
 
     Parameters
     ----------
@@ -973,15 +985,15 @@ def plot_RGB_chromaticities_in_chromaticity_diagram(
     method
         *Chromaticity Diagram* method.
     scatter_kwargs
-        Keyword arguments for the :func:`matplotlib.pyplot.scatter` definition.
-        The following special keyword arguments can also be used:
+        Keyword arguments for the :func:`matplotlib.pyplot.scatter`
+        definition. The following special keyword arguments can also be used:
 
-        -   ``c`` : If ``c`` is set to *RGB*, the scatter will use the colours
-            as specified by the ``RGB`` argument.
+        -   ``c`` : If ``c`` is set to *RGB*, the scatter will use the
+            colours as specified by the ``RGB`` argument.
         -   ``apply_cctf_encoding`` : If ``apply_cctf_encoding`` is set to
             *False*, the encoding colour component transfer function /
-            opto-electronic transfer function is not applied when encoding the
-            samples to the plotting space.
+            opto-electronic transfer function is not applied when encoding
+            the samples to the plotting space.
 
     Other Parameters
     ----------------
@@ -1087,7 +1099,8 @@ def plot_RGB_chromaticities_in_chromaticity_diagram_CIE1931(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot specified *RGB* colourspace array in the *CIE 1931 Chromaticity Diagram*.
+    Plot specified *RGB* colourspace array in the *CIE 1931 Chromaticity
+    Diagram*.
 
     Parameters
     ----------
@@ -1098,17 +1111,19 @@ def plot_RGB_chromaticities_in_chromaticity_diagram_CIE1931(
         type or form supported by the
         :func:`colour.plotting.common.filter_RGB_colourspaces` definition.
     chromaticity_diagram_callable_CIE1931
-        Callable responsible for drawing the *CIE 1931 Chromaticity Diagram*.
+        Callable responsible for drawing the *CIE 1931 Chromaticity
+        Diagram*.
     scatter_kwargs
-        Keyword arguments for the :func:`matplotlib.pyplot.scatter` definition.
-        The following special keyword arguments can also be used:
+        Keyword arguments for the :func:`matplotlib.pyplot.scatter`
+        definition. The following special keyword arguments can also be
+        used:
 
-        -   ``c`` : If ``c`` is set to *RGB*, the scatter will use the colours
-            as specified by the ``RGB`` argument.
+        -   ``c`` : If ``c`` is set to *RGB*, the scatter will use the
+            colours as specified by the ``RGB`` argument.
         -   ``apply_cctf_encoding`` : If ``apply_cctf_encoding`` is set to
             *False*, the encoding colour component transfer function /
-            opto-electronic transfer function is not applied when encoding the
-            samples to the plotting space.
+            opto-electronic transfer function is not applied when encoding
+            the samples to the plotting space.
 
     Other Parameters
     ----------------
@@ -1165,7 +1180,7 @@ def plot_RGB_chromaticities_in_chromaticity_diagram_CIE1960UCS(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot specified *RGB* colourspace array in the
+    Plot the specified *RGB* colourspace array in the
     *CIE 1960 UCS Chromaticity Diagram*.
 
     Parameters
@@ -1180,15 +1195,16 @@ def plot_RGB_chromaticities_in_chromaticity_diagram_CIE1960UCS(
         Callable responsible for drawing the
         *CIE 1960 UCS Chromaticity Diagram*.
     scatter_kwargs
-        Keyword arguments for the :func:`matplotlib.pyplot.scatter` definition.
-        The following special keyword arguments can also be used:
+        Keyword arguments for the :func:`matplotlib.pyplot.scatter`
+        definition. The following special keyword arguments can also be
+        used:
 
-        -   ``c`` : If ``c`` is set to *RGB*, the scatter will use the colours
-            as specified by the ``RGB`` argument.
+        -   ``c`` : If ``c`` is set to *RGB*, the scatter will use the
+            colours as specified by the ``RGB`` argument.
         -   ``apply_cctf_encoding`` : If ``apply_cctf_encoding`` is set to
             *False*, the encoding colour component transfer function /
-            opto-electronic transfer function is not applied when encoding the
-            samples to the plotting space.
+            opto-electronic transfer function is not applied when encoding
+            the samples to the plotting space.
 
     Other Parameters
     ----------------
@@ -1245,7 +1261,7 @@ def plot_RGB_chromaticities_in_chromaticity_diagram_CIE1976UCS(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot specified *RGB* colourspace array in the
+    Plot the specified *RGB* colourspace array in the
     *CIE 1976 UCS Chromaticity Diagram*.
 
     Parameters
@@ -1260,15 +1276,16 @@ def plot_RGB_chromaticities_in_chromaticity_diagram_CIE1976UCS(
         Callable responsible for drawing the
         *CIE 1976 UCS Chromaticity Diagram*.
     scatter_kwargs
-        Keyword arguments for the :func:`matplotlib.pyplot.scatter` definition.
-        The following special keyword arguments can also be used:
+        Keyword arguments for the :func:`matplotlib.pyplot.scatter`
+        definition. The following special keyword arguments can also be
+        used:
 
-        -   ``c`` : If ``c`` is set to *RGB*, the scatter will use the colours
-            as specified by the ``RGB`` argument.
+        -   ``c`` : If ``c`` is set to *RGB*, the scatter will use the
+            colours as specified by the ``RGB`` argument.
         -   ``apply_cctf_encoding`` : If ``apply_cctf_encoding`` is set to
             *False*, the encoding colour component transfer function /
-            opto-electronic transfer function is not applied when encoding the
-            samples to the plotting space.
+            opto-electronic transfer function is not applied when encoding
+            the samples to the plotting space.
 
     Other Parameters
     ----------------
@@ -1316,7 +1333,7 @@ def ellipses_MacAdam1942(
     method: (Literal["CIE 1931", "CIE 1960 UCS", "CIE 1976 UCS"] | str) = "CIE 1931",
 ) -> List[NDArrayFloat]:
     """
-    Return *MacAdam (1942) Ellipses (Observer PGN)* coefficients according to
+    Return *MacAdam (1942) Ellipses (Observer PGN)* coefficients using the
     specified method.
 
     Parameters
@@ -1366,7 +1383,7 @@ def plot_ellipses_MacAdam1942_in_chromaticity_diagram(
 ) -> Tuple[Figure, Axes]:
     """
     Plot *MacAdam (1942) Ellipses (Observer PGN)* in the
-    *Chromaticity Diagram* according to specified method.
+    *Chromaticity Diagram* using the specified method.
 
     Parameters
     ----------
@@ -1375,12 +1392,13 @@ def plot_ellipses_MacAdam1942_in_chromaticity_diagram(
     method
         *Chromaticity Diagram* method.
     chromaticity_diagram_clipping
-        Whether to clip the *Chromaticity Diagram* colours with the ellipses.
+        Whether to clip the *Chromaticity Diagram* colours with the
+        ellipses.
     ellipse_kwargs
-        Parameters for the :class:`Ellipse` class, ``ellipse_kwargs`` can
-        be either a single dictionary applied to all the ellipses with same
-        settings or a sequence of dictionaries with different settings for each
-        ellipse.
+        Parameters for the :class:`Ellipse` class. ``ellipse_kwargs``
+        can be either a single dictionary applied to all the ellipses
+        with the same settings or a sequence of dictionaries with
+        different settings for each ellipse.
 
     Other Parameters
     ----------------
@@ -1499,10 +1517,10 @@ def plot_ellipses_MacAdam1942_in_chromaticity_diagram_CIE1931(
         Whether to clip the *CIE 1931 Chromaticity Diagram* colours with the
         ellipses.
     ellipse_kwargs
-        Parameters for the :class:`Ellipse` class, ``ellipse_kwargs`` can
-        be either a single dictionary applied to all the ellipses with same
-        settings or a sequence of dictionaries with different settings for each
-        ellipse.
+        Parameters for the :class:`Ellipse` class. ``ellipse_kwargs``
+        can be either a single dictionary applied to all the ellipses
+        with the same settings or a sequence of dictionaries with
+        different settings for each ellipse.
 
     Other Parameters
     ----------------
@@ -1561,13 +1579,13 @@ def plot_ellipses_MacAdam1942_in_chromaticity_diagram_CIE1960UCS(
         Callable responsible for drawing the
         *CIE 1960 UCS Chromaticity Diagram*.
     chromaticity_diagram_clipping
-        Whether to clip the *CIE 1960 UCS Chromaticity Diagram* colours with
-        the ellipses.
+        Whether to clip the *CIE 1960 UCS Chromaticity Diagram* colours
+        with the ellipses.
     ellipse_kwargs
-        Parameters for the :class:`Ellipse` class, ``ellipse_kwargs`` can
-        be either a single dictionary applied to all the ellipses with same
-        settings or a sequence of dictionaries with different settings for each
-        ellipse.
+        Parameters for the :class:`Ellipse` class. ``ellipse_kwargs``
+        can be either a single dictionary applied to all the ellipses
+        with the same settings or a sequence of dictionaries with
+        different settings for each ellipse.
 
     Other Parameters
     ----------------
@@ -1626,13 +1644,13 @@ def plot_ellipses_MacAdam1942_in_chromaticity_diagram_CIE1976UCS(
         Callable responsible for drawing the
         *CIE 1976 UCS Chromaticity Diagram*.
     chromaticity_diagram_clipping
-        Whether to clip the *CIE 1976 UCS Chromaticity Diagram* colours with
-        the ellipses.
+        Whether to clip the *CIE 1976 UCS Chromaticity Diagram* colours
+        with the ellipses.
     ellipse_kwargs
-        Parameters for the :class:`Ellipse` class, ``ellipse_kwargs`` can
-        be either a single dictionary applied to all the ellipses with same
-        settings or a sequence of dictionaries with different settings for each
-        ellipse.
+        Parameters for the :class:`Ellipse` class. ``ellipse_kwargs``
+        can be either a single dictionary applied to all the ellipses
+        with the same settings or a sequence of dictionaries with
+        different settings for each ellipse.
 
     Other Parameters
     ----------------
@@ -1682,8 +1700,8 @@ def plot_single_cctf(
     Parameters
     ----------
     cctf
-        Colour component transfer function to plot. ``function`` can be of any
-        type or form supported by the
+        Colour component transfer function to plot. ``function`` can be of
+        any type or form supported by the
         :func:`colour.plotting.common.filter_passthrough` definition.
     cctf_decoding
         Plot the decoding colour component transfer function instead.
@@ -1726,7 +1744,7 @@ def plot_multi_cctfs(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot specified colour component transfer functions.
+    Plot the specified colour component transfer functions.
 
     Parameters
     ----------
@@ -1822,8 +1840,8 @@ def plot_constant_hue_loci(
         Keyword arguments for the :func:`matplotlib.pyplot.scatter` definition.
         The following special keyword arguments can also be used:
 
-        -   ``c`` : If ``c`` is set to *RGB*, the scatter will use the colours
-            as specified by the ``RGB`` argument.
+        -   ``c`` : If ``c`` is set to *RGB*, the scatter will use the
+            colours as specified by the ``RGB`` argument.
     convert_kwargs
         Keyword arguments for the :func:`colour.convert` definition.
 

--- a/colour/plotting/notation.py
+++ b/colour/plotting/notation.py
@@ -2,7 +2,7 @@
 Colour Notation Systems Plotting
 ================================
 
-Define the colour notation systems plotting objects:
+Define the colour notation systems plotting objects.
 
 -   :func:`colour.plotting.plot_single_munsell_value_function`
 -   :func:`colour.plotting.plot_multi_munsell_value_functions`
@@ -42,14 +42,14 @@ def plot_single_munsell_value_function(
     function: Callable | str, **kwargs: Any
 ) -> Tuple[Figure, Axes]:
     """
-    Plot specified *Lightness* function.
+    Plot the specified *Munsell* value function.
 
     Parameters
     ----------
     function
-        *Munsell* value function to plot. ``function`` can be of any type or
-        form supported by the :func:`colour.plotting.common.filter_passthrough`
-        definition.
+        *Munsell* value function to plot. ``function`` can be of any type
+        or form supported by the
+        :func:`colour.plotting.common.filter_passthrough` definition.
 
     Other Parameters
     ----------------
@@ -86,13 +86,13 @@ def plot_multi_munsell_value_functions(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot specified *Munsell* value functions.
+    Plot the specified *Munsell* value functions.
 
     Parameters
     ----------
     functions
-        *Munsell* value functions to plot. ``functions`` elements can be of any
-        type or form supported by the
+        *Munsell* value functions to plot. ``functions`` elements can be of
+        any type or form supported by the
         :func:`colour.plotting.common.filter_passthrough` definition.
 
     Other Parameters

--- a/colour/plotting/phenomena.py
+++ b/colour/plotting/phenomena.py
@@ -2,7 +2,7 @@
 Optical Phenomenon Plotting
 ===========================
 
-Define the optical phenomena plotting objects:
+Define the optical phenomena plotting objects.
 
 -   :func:`colour.plotting.plot_single_sd_rayleigh_scattering`
 -   :func:`colour.plotting.plot_the_blue_sky`
@@ -81,15 +81,16 @@ def plot_single_sd_rayleigh_scattering(
     temperature
         Air temperature :math:`T[K]` in kelvin degrees.
     pressure
-        Surface pressure :math:`P` of the measurement site.
+        Surface pressure :math:`P` at the measurement site.
     latitude
         Latitude of the site in degrees.
     altitude
         Altitude of the site in meters.
     cmfs
-        Standard observer colour matching functions used for computing the
-        spectrum domain and colours. ``cmfs`` can be of any type or form
-        supported by the :func:`colour.plotting.common.filter_cmfs` definition.
+        Standard observer colour matching functions used for computing
+        the spectrum domain and colours. ``cmfs`` can be of any type or
+        form supported by the :func:`colour.plotting.common.filter_cmfs`
+        definition.
 
     Other Parameters
     ----------------
@@ -141,14 +142,15 @@ def plot_the_blue_sky(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot the blue sky.
+    Plot the blue sky spectral radiance distribution.
 
     Parameters
     ----------
     cmfs
         Standard observer colour matching functions used for computing the
         spectrum domain and colours. ``cmfs`` can be of any type or form
-        supported by the :func:`colour.plotting.common.filter_cmfs` definition.
+        supported by the :func:`colour.plotting.common.filter_cmfs`
+        definition.
 
     Other Parameters
     ----------------

--- a/colour/plotting/quality.py
+++ b/colour/plotting/quality.py
@@ -2,7 +2,7 @@
 Colour Quality Plotting
 =======================
 
-Define the colour quality plotting objects:
+Define the colour quality plotting objects.
 
 -   :func:`colour.plotting.plot_single_sd_colour_rendering_index_bars`
 -   :func:`colour.plotting.plot_multi_sds_colour_rendering_indexes_bars`
@@ -85,13 +85,14 @@ def plot_colour_quality_bars(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot the colour quality data of specified illuminants or light sources colour
-    quality specifications.
+    Plot the colour quality data of the specified illuminants or light sources
+    colour quality specifications.
 
     Parameters
     ----------
     specifications
-        Array of illuminants or light sources colour quality specifications.
+        Array of illuminants or light sources colour quality
+        specifications.
     labels
         Add labels above bars.
     hatching
@@ -251,14 +252,14 @@ def plot_single_sd_colour_rendering_index_bars(
     sd: SpectralDistribution, **kwargs: Any
 ) -> Tuple[Figure, Axes]:
     """
-    Plot the *Colour Rendering Index* (CRI) of specified illuminant or light
-    source spectral distribution.
+    Plot the *Colour Rendering Index* (CRI) of the specified illuminant or
+    light source spectral distribution.
 
     Parameters
     ----------
     sd
-        Illuminant or light source spectral distribution to plot the
-        *Colour Rendering Index* (CRI).
+        Illuminant or light source spectral distribution for which to plot
+        the *Colour Rendering Index* (CRI).
 
     Other Parameters
     ----------------
@@ -301,17 +302,17 @@ def plot_multi_sds_colour_rendering_indexes_bars(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot the *Colour Rendering Index* (CRI) of specified illuminants or light
-    sources spectral distributions.
+    Plot the *Colour Rendering Index* (CRI) of the specified illuminants or
+    light sources spectral distributions.
 
     Parameters
     ----------
     sds
-        Spectral distributions or multi-spectral distributions to
-        plot. `sds` can be a single
-        :class:`colour.MultiSpectralDistributions` class instance, a list
-        of :class:`colour.MultiSpectralDistributions` class instances or a
-        List of :class:`colour.SpectralDistribution` class instances.
+        Spectral distributions or multi-spectral distributions to plot.
+        `sds` can be a single :class:`colour.MultiSpectralDistributions`
+        class instance, a list of  :class:`colour.MultiSpectralDistributions`
+        class instances or a list of :class:`colour.SpectralDistribution` class
+        instances.
 
     Other Parameters
     ----------------
@@ -381,14 +382,14 @@ def plot_single_sd_colour_quality_scale_bars(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot the *Colour Quality Scale* (CQS) of specified illuminant or light source
-    spectral distribution.
+    Plot the *Colour Quality Scale* (CQS) of the specified illuminant or
+    light source spectral distribution.
 
     Parameters
     ----------
     sd
-        Illuminant or light source spectral distribution to plot the
-        *Colour Quality Scale* (CQS).
+        Illuminant or light source spectral distribution for which to plot
+        the *Colour Quality Scale* (CQS).
     method
         *Colour Quality Scale* (CQS) computation method.
 
@@ -436,17 +437,17 @@ def plot_multi_sds_colour_quality_scales_bars(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot the *Colour Quality Scale* (CQS) of specified illuminants or light
+    Plot the *Colour Quality Scale* (CQS) of the specified illuminants or light
     sources spectral distributions.
 
     Parameters
     ----------
     sds
-        Spectral distributions or multi-spectral distributions to
-        plot. `sds` can be a single
-        :class:`colour.MultiSpectralDistributions` class instance, a list
-        of :class:`colour.MultiSpectralDistributions` class instances or a
-        List of :class:`colour.SpectralDistribution` class instances.
+        Spectral distributions or multi-spectral distributions to plot.
+        `sds` can be a single :class:`colour.MultiSpectralDistributions`
+        class instance, a list of  :class:`colour.MultiSpectralDistributions`
+        class instances or a list of :class:`colour.SpectralDistribution` class
+        instances.
     method
         *Colour Quality Scale* (CQS) computation method.
 

--- a/colour/plotting/section.py
+++ b/colour/plotting/section.py
@@ -2,7 +2,7 @@
 Gamut Section Plotting
 ======================
 
-Define the gamut section plotting objects:
+Define the gamut section plotting objects.
 
 -   :func:`colour.plotting.section.plot_hull_section_colours`
 -   :func:`colour.plotting.section.plot_hull_section_contour`
@@ -97,7 +97,12 @@ __all__ = [
 MAPPING_AXIS_TO_PLANE: CanonicalMapping = CanonicalMapping(
     {"+x": (1, 2), "+y": (0, 2), "+z": (0, 1)}
 )
-MAPPING_AXIS_TO_PLANE.__doc__ = """Axis to plane mapping."""
+MAPPING_AXIS_TO_PLANE.__doc__ = """
+Mapping from axes to their orthogonal planes.
+
+Maps each positive axis ('+x', '+y', '+z') to the indices of the two
+dimensions that form the perpendicular plane in 3D space.
+"""
 
 
 @required("trimesh")
@@ -115,16 +120,16 @@ def plot_hull_section_colours(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot the section colours of specified *trimesh* hull along specified axis and
-    origin.
+    Plot the section colours of the specified *trimesh* hull along the
+    specified axis and origin.
 
     Parameters
     ----------
     hull
         *Trimesh* hull.
     model
-        Colourspace model, see :attr:`colour.COLOURSPACE_MODELS` attribute for
-        the list of supported colourspace models.
+        Colourspace model, see :attr:`colour.COLOURSPACE_MODELS` attribute
+        for the list of supported colourspace models.
     axis
         Axis the hull section will be normal to.
     origin
@@ -133,8 +138,7 @@ def plot_hull_section_colours(
         Whether to normalise ``axis`` to the extent of the hull along it.
     section_colours
         Colours of the hull section, if ``section_colours`` is set to *RGB*,
-        the colours will be computed according to the corresponding
-        coordinates.
+        the colours will be computed using the corresponding coordinates.
     section_opacity
         Opacity of the hull section colours.
     convert_kwargs
@@ -285,16 +289,16 @@ def plot_hull_section_contour(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot the section contour of specified *trimesh* hull along specified axis and
-    origin.
+    Plot the section contour of the specified *trimesh* hull along the
+    specified axis and origin.
 
     Parameters
     ----------
     hull
         *Trimesh* hull.
     model
-        Colourspace model, see :attr:`colour.COLOURSPACE_MODELS` attribute for
-        the list of supported colourspace models.
+        Colourspace model, see :attr:`colour.COLOURSPACE_MODELS` attribute
+        for the list of supported colourspace models.
     axis
         Axis the hull section will be normal to.
     origin
@@ -302,8 +306,8 @@ def plot_hull_section_contour(
     normalise
         Whether to normalise ``axis`` to the extent of the hull along it.
     contour_colours
-        Colours of the hull section contour, if ``contour_colours`` is set to
-        *RGB*, the colours will be computed according to the corresponding
+        Colours of the hull section contour, if ``contour_colours`` is set
+        to *RGB*, the colours will be computed using the corresponding
         coordinates.
     contour_opacity
         Opacity of the hull section contour.
@@ -419,23 +423,25 @@ def plot_visible_spectrum_section(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot the visible spectrum volume, i.e., *Rösch-MacAdam* colour solid,
-    section colours along specified axis and origin.
+    Plot the visible spectrum volume section colours along the specified axis
+    and origin.
+
+    The visible spectrum volume represents the *Rösch-MacAdam* colour solid.
 
     Parameters
     ----------
     cmfs
         Standard observer colour matching functions, default to the
-        *CIE 1931 2 Degree Standard Observer*.  ``cmfs`` can be of any type or
-        form supported by the :func:`colour.plotting.common.filter_cmfs`
+        *CIE 1931 2 Degree Standard Observer*.  ``cmfs`` can be of any type
+        or form supported by the :func:`colour.plotting.common.filter_cmfs`
         definition.
     illuminant
         Illuminant spectral distribution, default to *CIE Illuminant D65*.
         ``illuminant`` can be of any type or form supported by the
         :func:`colour.plotting.common.filter_illuminants` definition.
     model
-        Colourspace model, see :attr:`colour.COLOURSPACE_MODELS` attribute for
-        the list of supported colourspace models.
+        Colourspace model, see :attr:`colour.COLOURSPACE_MODELS` attribute
+        for the list of supported colourspace models.
     axis
         Axis the hull section will be normal to.
     origin
@@ -566,26 +572,29 @@ def plot_RGB_colourspace_section(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot specified *RGB* colourspace section colours along specified axis and origin.
+    Plot the specified *RGB* colourspace section colours along the
+    specified axis and origin.
 
     Parameters
     ----------
     colourspace
-        *RGB* colourspace of the *RGB* array. ``colourspace`` can be of any
-        type or form supported by the
-        :func:`colour.plotting.common.filter_RGB_colourspaces` definition.
+        *RGB* colourspace of the *RGB* array. ``colourspace`` can be of
+        any type or form supported by the
+        :func:`colour.plotting.common.filter_RGB_colourspaces`
+        definition.
     model
-        Colourspace model, see :attr:`colour.COLOURSPACE_MODELS` attribute for
-        the list of supported colourspace models.
+        Colourspace model, see :attr:`colour.COLOURSPACE_MODELS`
+        attribute for the list of supported colourspace models.
     axis
         Axis the hull section will be normal to.
     origin
         Coordinate along ``axis`` at which to plot the hull section.
     normalise
-        Whether to normalise ``axis`` to the extent of the hull along it.
+        Whether to normalise ``axis`` to the extent of the hull along
+        it.
     size:
-        Size of the underlying *RGB* colourspace cube; used for plotting HDR
-        related sections.
+        Size of the underlying *RGB* colourspace cube; used for plotting
+        HDR related sections.
     show_section_colours
         Whether to show the hull section colours.
     show_section_contour

--- a/colour/plotting/temperature.py
+++ b/colour/plotting/temperature.py
@@ -3,7 +3,7 @@ Colour Temperature & Correlated Colour Temperature Plotting
 ===========================================================
 
 Define the colour temperature and correlated colour temperature plotting
-objects:
+objects.
 
 -   :func:`colour.plotting.lines_daylight_locus`
 -   :func:`colour.plotting.lines_planckian_locus`
@@ -102,20 +102,22 @@ def lines_daylight_locus(
     method: (Literal["CIE 1931", "CIE 1960 UCS", "CIE 1976 UCS"] | str) = "CIE 1931",
 ) -> Tuple[NDArray]:
     """
-    Return the *Daylight Locus* line vertices, i.e., positions, normals and
-    colours, according to specified method.
+    Return the *Daylight Locus* line vertices including positions, normals,
+    and colours using the specified chromaticity diagram method.
 
     Parameters
     ----------
     mireds
-        Whether to use micro reciprocal degrees for the iso-temperature lines.
+        Whether to use micro reciprocal degrees for the iso-temperature
+        lines.
     method
-        *Daylight Locus* method.
+        *Daylight Locus* chromaticity diagram method.
 
     Returns
     -------
     :class:`tuple`
-        Tuple of *Spectral Locus* vertices.
+        Tuple of *Daylight Locus* line vertices containing position,
+        normal, and colour data.
 
     Examples
     --------
@@ -174,18 +176,19 @@ def plot_daylight_locus(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot the *Daylight Locus* according to specified method.
+    Plot the *Daylight Locus* using the specified chromaticity diagram
+    method.
 
     Parameters
     ----------
     daylight_locus_colours
-        Colours of the *Daylight Locus*, if ``daylight_locus_colours`` is set
-        to *RGB*, the colours will be computed according to the corresponding
-        chromaticity coordinates.
+        Colours of the *Daylight Locus*. If set to *RGB*, the colours will
+        be computed from the corresponding chromaticity coordinates.
     daylight_locus_opacity
-       Opacity of the *Daylight Locus*.
+        Opacity of the *Daylight Locus*.
     daylight_locus_mireds
-        Whether to use micro reciprocal degrees for the iso-temperature lines.
+        Whether to use micro reciprocal degrees for the iso-temperature
+        lines.
     method
         *Chromaticity Diagram* method.
 
@@ -265,20 +268,21 @@ def lines_planckian_locus(
     method: (Literal["CIE 1931", "CIE 1960 UCS", "CIE 1976 UCS"] | str) = "CIE 1931",
 ) -> Tuple[NDArray, NDArray]:
     """
-    Return the *Planckian Locus* line vertices, i.e., positions, normals and
-    colours, according to specified method.
+    Return the *Planckian Locus* line vertices with positions, normals, and
+    colours using the specified chromaticity diagram method.
 
     Parameters
     ----------
     labels
-        Array of labels used to customise which iso-temperature lines will be
-        drawn along the *Planckian Locus*. Passing an empty array will result
-        in no iso-temperature lines being drawn.
+        Array of labels used to customise which iso-temperature lines will
+        be drawn along the *Planckian Locus*. Passing an empty array will
+        result in no iso-temperature lines being drawn.
     mireds
-        Whether to use micro reciprocal degrees for the iso-temperature lines.
+        Whether to use micro reciprocal degrees for the iso-temperature
+        lines.
     iso_temperature_lines_D_uv
-        Iso-temperature lines :math:`\\Delta_{uv}` length on each side of the
-        *Planckian Locus*.
+        Iso-temperature lines :math:`\\Delta_{uv}` length on each side of
+        the *Planckian Locus*.
     method
         *Planckian Locus* method.
 
@@ -397,25 +401,26 @@ def plot_planckian_locus(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot the *Planckian Locus* according to specified method.
+    Plot the *Planckian Locus* using the specified method.
 
     Parameters
     ----------
     planckian_locus_colours
-        Colours of the *Planckian Locus*, if ``planckian_locus_colours`` is set
-        to *RGB*, the colours will be computed according to the corresponding
+        Colours of the *Planckian Locus*, if ``planckian_locus_colours`` is
+        set to *RGB*, the colours will be computed using the corresponding
         chromaticity coordinates.
     planckian_locus_opacity
        Opacity of the *Planckian Locus*.
     planckian_locus_labels
-        Array of labels used to customise which iso-temperature lines will be
-        drawn along the *Planckian Locus*. Passing an empty array will result
-        in no iso-temperature lines being drawn.
+        Array of labels used to customise which iso-temperature lines will
+        be drawn along the *Planckian Locus*. Passing an empty array will
+        result in no iso-temperature lines being drawn.
     planckian_locus_mireds
-        Whether to use micro reciprocal degrees for the iso-temperature lines.
+        Whether to use micro reciprocal degrees for the iso-temperature
+        lines.
     planckian_locus_iso_temperature_lines_D_uv
-        Iso-temperature lines :math:`\\Delta_{uv}` length on each side of the
-        *Planckian Locus*.
+        Iso-temperature lines :math:`\\Delta_{uv}` length on each side of
+        the *Planckian Locus*.
     method
         *Chromaticity Diagram* method.
 
@@ -537,7 +542,7 @@ def plot_planckian_locus_in_chromaticity_diagram(
 ) -> Tuple[Figure, Axes]:
     """
     Plot the *Planckian Locus* and specified illuminants in the
-    *Chromaticity Diagram* according to specified method.
+    *Chromaticity Diagram* using the specified method.
 
     Parameters
     ----------
@@ -551,20 +556,22 @@ def plot_planckian_locus_in_chromaticity_diagram(
         *Chromaticity Diagram* method.
     annotate_kwargs
         Keyword arguments for the :func:`matplotlib.pyplot.annotate`
-        definition, used to annotate the resulting chromaticity coordinates
-        with their respective spectral distribution names. ``annotate_kwargs``
-        can be either a single dictionary applied to all the arrows with same
-        settings or a sequence of dictionaries with different settings for each
-        spectral distribution. The following special keyword arguments can also
+        definition, used to annotate the resulting chromaticity
+        coordinates with their respective spectral distribution names.
+        ``annotate_kwargs`` can be either a single dictionary applied
+        to all the arrows with same settings or a sequence of
+        dictionaries with different settings for each spectral
+        distribution. The following special keyword arguments can also
         be used:
 
         -   ``annotate`` : Whether to annotate the spectral distributions.
     plot_kwargs
-        Keyword arguments for the :func:`matplotlib.pyplot.plot` definition,
-        used to control the style of the plotted illuminants. ``plot_kwargs``
-        can be either a single dictionary applied to all the plotted
-        illuminants with the same settings or a sequence of dictionaries with
-        different settings for eachplotted illuminant.
+        Keyword arguments for the :func:`matplotlib.pyplot.plot`
+        definition, used to control the style of the plotted
+        illuminants. ``plot_kwargs`` can be either a single dictionary
+        applied to all the plotted illuminants with the same settings
+        or a sequence of dictionaries with different settings for each
+        plotted illuminant.
 
     Other Parameters
     ----------------
@@ -730,24 +737,25 @@ def plot_planckian_locus_in_chromaticity_diagram_CIE1931(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot the *Planckian Locus* and specified illuminants in
+    Plot the *Planckian Locus* and specified illuminants in the
     *CIE 1931 Chromaticity Diagram*.
 
     Parameters
     ----------
     illuminants
-        Illuminants to plot. ``illuminants`` elements can be of any
-        type or form supported by the
+        Illuminants to plot. ``illuminants`` elements can be of any type or
+        form supported by the
         :func:`colour.plotting.common.filter_passthrough` definition.
     chromaticity_diagram_callable_CIE1931
         Callable responsible for drawing the *CIE 1931 Chromaticity Diagram*.
     annotate_kwargs
         Keyword arguments for the :func:`matplotlib.pyplot.annotate`
-        definition, used to annotate the resulting chromaticity coordinates
-        with their respective spectral distribution names. ``annotate_kwargs``
-        can be either a single dictionary applied to all the arrows with same
-        settings or a sequence of dictionaries with different settings for each
-        spectral distribution. The following special keyword arguments can also
+        definition, used to annotate the resulting chromaticity
+        coordinates with their respective spectral distribution names.
+        ``annotate_kwargs`` can be either a single dictionary applied
+        to all the arrows with same settings or a sequence of
+        dictionaries with different settings for each spectral
+        distribution. The following special keyword arguments can also
         be used:
 
         -   ``annotate`` : Whether to annotate the spectral distributions.
@@ -756,7 +764,7 @@ def plot_planckian_locus_in_chromaticity_diagram_CIE1931(
         used to control the style of the plotted illuminants. ``plot_kwargs``
         can be either a single dictionary applied to all the plotted
         illuminants with the same settings or a sequence of dictionaries with
-        different settings for eachplotted illuminant.
+        different settings for each plotted illuminant.
 
     Other Parameters
     ----------------
@@ -809,34 +817,35 @@ def plot_planckian_locus_in_chromaticity_diagram_CIE1960UCS(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot the *Planckian Locus* and specified illuminants in
+    Plot the *Planckian Locus* and specified illuminants in the
     *CIE 1960 UCS Chromaticity Diagram*.
 
     Parameters
     ----------
     illuminants
-        Illuminants to plot. ``illuminants`` elements can be of any
-        type or form supported by the
+        Illuminants to plot. ``illuminants`` elements can be of any type or
+        form supported by the
         :func:`colour.plotting.common.filter_passthrough` definition.
     chromaticity_diagram_callable_CIE1960UCS
         Callable responsible for drawing the
         *CIE 1960 UCS Chromaticity Diagram*.
     annotate_kwargs
         Keyword arguments for the :func:`matplotlib.pyplot.annotate`
-        definition, used to annotate the resulting chromaticity coordinates
-        with their respective spectral distribution names. ``annotate_kwargs``
-        can be either a single dictionary applied to all the arrows with same
-        settings or a sequence of dictionaries with different settings for each
-        spectral distribution. The following special keyword arguments can also
+        definition, used to annotate the resulting chromaticity
+        coordinates with their respective spectral distribution names.
+        ``annotate_kwargs`` can be either a single dictionary applied
+        to all the arrows with same settings or a sequence of
+        dictionaries with different settings for each spectral
+        distribution. The following special keyword arguments can also
         be used:
 
         -   ``annotate`` : Whether to annotate the spectral distributions.
     plot_kwargs
-        Keyword arguments for the :func:`matplotlib.pyplot.plot` definition,
-        used to control the style of the plotted illuminants. ``plot_kwargs``
-        can be either a single dictionary applied to all the plotted
-        illuminants with the same settings or a sequence of dictionaries with
-        different settings for eachplotted illuminant.
+        Keyword arguments for the :func:`matplotlib.pyplot.plot`
+        definition, used to control the style of the plotted illuminants.
+        ``plot_kwargs`` can be either a single dictionary applied to all
+        the plotted illuminants with the same settings or a sequence of
+        dictionaries with different settings for each plotted illuminant.
 
     Other Parameters
     ----------------
@@ -890,34 +899,35 @@ def plot_planckian_locus_in_chromaticity_diagram_CIE1976UCS(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot the *Planckian Locus* and specified illuminants in
+    Plot the *Planckian Locus* and specified illuminants in the
     *CIE 1976 UCS Chromaticity Diagram*.
 
     Parameters
     ----------
     illuminants
-        Illuminants to plot. ``illuminants`` elements can be of any
-        type or form supported by the
+        Illuminants to plot. ``illuminants`` elements can be of any type
+        or form supported by the
         :func:`colour.plotting.common.filter_passthrough` definition.
     chromaticity_diagram_callable_CIE1976UCS
         Callable responsible for drawing the
         *CIE 1976 UCS Chromaticity Diagram*.
     annotate_kwargs
         Keyword arguments for the :func:`matplotlib.pyplot.annotate`
-        definition, used to annotate the resulting chromaticity coordinates
-        with their respective spectral distribution names. ``annotate_kwargs``
-        can be either a single dictionary applied to all the arrows with same
-        settings or a sequence of dictionaries with different settings for each
-        spectral distribution. The following special keyword arguments can also
+        definition, used to annotate the resulting chromaticity
+        coordinates with their respective spectral distribution names.
+        ``annotate_kwargs`` can be either a single dictionary applied
+        to all the arrows with same settings or a sequence of
+        dictionaries with different settings for each spectral
+        distribution. The following special keyword arguments can also
         be used:
 
         -   ``annotate`` : Whether to annotate the spectral distributions.
     plot_kwargs
-        Keyword arguments for the :func:`matplotlib.pyplot.plot` definition,
-        used to control the style of the plotted illuminants. ``plot_kwargs``
-        can be either a single dictionary applied to all the plotted
-        illuminants with the same settings or a sequence of dictionaries with
-        different settings for eachplotted illuminant.
+        Keyword arguments for the :func:`matplotlib.pyplot.plot`
+        definition, used to control the style of the plotted illuminants.
+        ``plot_kwargs`` can be either a single dictionary applied to all
+        the plotted illuminants with the same settings or a sequence of
+        dictionaries with different settings for each plotted illuminant.
 
     Other Parameters
     ----------------

--- a/colour/plotting/tests/test_common.py
+++ b/colour/plotting/tests/test_common.py
@@ -589,11 +589,7 @@ class TestPlotImage:
         """Test :func:`colour.plotting.common.plot_image` definition."""
 
         path = os.path.join(
-            colour.__path__[0],  # pyright: ignore
-            "..",
-            "docs",
-            "_static",
-            "Logo_Medium_001.png",
+            colour.__path__[0], "..", "docs", "_static", "Logo_Medium_001.png"
         )
 
         # Distribution does not ship the documentation thus we are skipping

--- a/colour/plotting/tests/test_quality.py
+++ b/colour/plotting/tests/test_quality.py
@@ -54,7 +54,7 @@ class TestPlotColourQualityBars:
         cqs_i = colour_quality_scale(illuminant, additional_data=True)
         cqs_l = colour_quality_scale(light_source, additional_data=True)
 
-        figure, axes = plot_colour_quality_bars([cqs_i, cqs_l])  # pyright: ignore
+        figure, axes = plot_colour_quality_bars([cqs_i, cqs_l])
 
         assert isinstance(figure, Figure)
         assert isinstance(axes, Axes)

--- a/colour/plotting/tm3018/components.py
+++ b/colour/plotting/tm3018/components.py
@@ -3,7 +3,7 @@ ANSI/IES TM-30-18 Colour Rendition Report Components
 ====================================================
 
 Define the *ANSI/IES TM-30-18 Colour Rendition Report* components plotting
-objects:
+objects for comprehensive colour rendition evaluation and visualization.
 
 -   :func:`colour.plotting.tm3018.components.plot_spectra_ANSIIESTM3018`
 -   :func:`colour.plotting.tm3018.components.plot_colour_vector_graphic`
@@ -211,8 +211,8 @@ def plot_spectra_ANSIIESTM3018(
     specification: ColourQuality_Specification_ANSIIESTM3018, **kwargs: Any
 ) -> Tuple[Figure, Axes]:
     """
-    Plot a comparison of the spectral distributions of a test emission source
-    and a reference illuminant for *ANSI/IES TM-30-18 Colour Rendition Report*.
+    Plot the spectral distributions of a test emission source and reference
+    illuminant for *ANSI/IES TM-30-18 Colour Rendition Report*.
 
     Parameters
     ----------
@@ -228,7 +228,7 @@ def plot_spectra_ANSIIESTM3018(
     Returns
     -------
     :class:`tuple`
-        Current figure and axes
+        Current figure and axes.
 
     Examples
     --------
@@ -285,8 +285,8 @@ def plot_colour_vector_graphic(
     specification: ColourQuality_Specification_ANSIIESTM3018, **kwargs: Any
 ) -> Tuple[Figure, Axes]:
     """
-    Plot *Color Vector Graphic* according to
-    *ANSI/IES TM-30-18 Colour Rendition Report*.
+    Plot *Color Vector Graphic* using the *ANSI/IES TM-30-18 Colour
+    Rendition Report*.
 
     Parameters
     ----------
@@ -302,7 +302,7 @@ def plot_colour_vector_graphic(
     Returns
     -------
     :class:`tuple`
-        Current figure and axes
+        Current figure and axes.
 
     Examples
     --------
@@ -484,8 +484,8 @@ def plot_16_bin_bars(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot the 16 bin bars for specified values according to
-    *ANSI/IES TM-30-18 Colour Rendition Report*.
+    Plot 16 bin bars for the specified values using *ANSI/IES TM-30-18 Colour
+    Rendition Report*.
 
     Parameters
     ----------
@@ -507,7 +507,7 @@ def plot_16_bin_bars(
     Returns
     -------
     :class:`tuple`
-        Current figure and axes
+        Current figure and axes.
 
     Examples
     --------
@@ -581,8 +581,8 @@ def plot_local_chroma_shifts(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot the local chroma shifts according to
-    *ANSI/IES TM-30-18 Colour Rendition Report*.
+    Plot the local chroma shifts using the *ANSI/IES TM-30-18 Colour
+    Rendition Report*.
 
     Parameters
     ----------
@@ -600,7 +600,7 @@ def plot_local_chroma_shifts(
     Returns
     -------
     :class:`tuple`
-        Current figure and axes
+        Current figure and axes.
 
     Examples
     --------
@@ -639,8 +639,8 @@ def plot_local_hue_shifts(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot the local hue shifts according to
-    *ANSI/IES TM-30-18 Colour Rendition Report*.
+    Plot the local hue shifts using *ANSI/IES TM-30-18 Colour Rendition
+    Report*.
 
     Parameters
     ----------
@@ -658,7 +658,7 @@ def plot_local_hue_shifts(
     Returns
     -------
     :class:`tuple`
-        Current figure and axes
+        Current figure and axes.
 
     Examples
     --------
@@ -693,15 +693,15 @@ def plot_local_colour_fidelities(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Plot the local colour fidelities according to
-    *ANSI/IES TM-30-18 Colour Rendition Report*.
+    Plot local colour fidelities using the *ANSI/IES TM-30-18 Colour
+    Rendition Report* specification.
 
     Parameters
     ----------
     specification
         *ANSI/IES TM-30-18 Colour Rendition Report* specification.
     x_ticker
-        Whether to show the *X* axis ticker and the associated label.
+        Whether to display the *X* axis ticker and its associated label.
 
     Other Parameters
     ----------------
@@ -712,7 +712,7 @@ def plot_local_colour_fidelities(
     Returns
     -------
     :class:`tuple`
-        Current figure and axes
+        Current figure and axes.
 
     Examples
     --------
@@ -745,8 +745,8 @@ def plot_colour_fidelity_indexes(
     specification: ColourQuality_Specification_ANSIIESTM3018, **kwargs: Any
 ) -> Tuple[Figure, Axes]:
     """
-    Plot the local chroma shifts according to
-    *ANSI/IES TM-30-18 Colour Rendition Report*.
+    Plot colour fidelity indexes using *ANSI/IES TM-30-18 Colour Rendition
+    Report*.
 
     Parameters
     ----------
@@ -762,7 +762,7 @@ def plot_colour_fidelity_indexes(
     Returns
     -------
     :class:`tuple`
-        Current figure and axes
+        Current figure and axes.
 
     Examples
     --------

--- a/colour/plotting/tm3018/report.py
+++ b/colour/plotting/tm3018/report.py
@@ -5,10 +5,8 @@ ANSI/IES TM-30-18 Colour Rendition Report
 Define the *ANSI/IES TM-30-18 Colour Rendition Report* plotting objects:
 
 -   :func:`colour.plotting.tm3018.plot_single_sd_colour_rendition_report_full`
--   :func:`colour.plotting.
-tm3018.plot_single_sd_colour_rendition_report_intermediate`
--   :func:`colour.plotting.
-tm3018.plot_single_sd_colour_rendition_report_simple`
+-   :func:`colour.plotting.tm3018.plot_single_sd_colour_rendition_report_intermediate`
+-   :func:`colour.plotting.tm3018.plot_single_sd_colour_rendition_report_simple`
 -   :func:`colour.plotting.plot_single_sd_colour_rendition_report`
 """
 
@@ -161,7 +159,7 @@ _VALUE_NOT_APPLICABLE: str = "N/A"
 
 def _plot_report_header(axes: Axes) -> Axes:
     """
-    Plot the report header, i.e., the title, on specified axes.
+    Plot the report header on the specified axes.
 
     Parameters
     ----------
@@ -171,7 +169,7 @@ def _plot_report_header(axes: Axes) -> Axes:
     Returns
     -------
     :class:`matplotlib.axes._axes.Axes`
-        Axes the report header was added to.
+        Axes with the report header added.
     """
 
     axes.set_axis_off()
@@ -191,7 +189,7 @@ def _plot_report_header(axes: Axes) -> Axes:
 
 def _plot_report_footer(axes: Axes) -> Axes:
     """
-    Plot the report footer on specified axes.
+    Plot the report footer on the specified axes.
 
     Parameters
     ----------
@@ -201,7 +199,7 @@ def _plot_report_footer(axes: Axes) -> Axes:
     Returns
     -------
     :class:`matplotlib.axes._axes.Axes`
-        Axes the report footer was added to.
+        Axes with the report footer added.
     """
 
     try:
@@ -240,8 +238,8 @@ def plot_single_sd_colour_rendition_report_full(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Generate the full *ANSI/IES TM-30-18 Colour Rendition Report* for specified
-    spectral distribution.
+    Generate the full *ANSI/IES TM-30-18 Colour Rendition Report* for the
+    specified spectral distribution.
 
     Parameters
     ----------
@@ -249,32 +247,32 @@ def plot_single_sd_colour_rendition_report_full(
         Spectral distribution of the emission source to generate the report
         for.
     source
-        Emission source name, defaults to
+        Emission source name, defaults to the
         `colour.SpectralDistribution_IESTM2714.header.description` or
-        `colour.SpectralDistribution_IESTM2714.name` properties value.
+        `colour.SpectralDistribution_IESTM2714.name` property value.
     date
-        Emission source measurement date, defaults to
+        Emission source measurement date, defaults to the
         `colour.SpectralDistribution_IESTM2714.header.report_date` property
         value.
     manufacturer
-        Emission source manufacturer, defaults to
+        Emission source manufacturer, defaults to the
         `colour.SpectralDistribution_IESTM2714.header.manufacturer` property
         value.
     model
-        Emission source model, defaults to
-        `colour.SpectralDistribution_IESTM2714.header.catalog_number` property
-        value.
+        Emission source model, defaults to the
+        `colour.SpectralDistribution_IESTM2714.header.catalog_number`
+        property value.
     notes
-        Notes pertaining to the emission source, defaults to
+        Notes pertaining to the emission source, defaults to the
         `colour.SpectralDistribution_IESTM2714.header.comments` property
         value.
     report_size
-        Report size, default to A4 paper size in inches.
+        Report size, defaults to A4 paper size in inches.
     report_row_height_ratios
         Report size row height ratios.
     report_box_padding
-        Report box padding, tries to define the padding around the figure and
-        in-between the axes.
+        Report box padding, defines the padding around the figure and
+        between the axes.
 
     Other Parameters
     ----------------
@@ -543,8 +541,8 @@ def plot_single_sd_colour_rendition_report_intermediate(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Generate the intermediate *ANSI/IES TM-30-18 Colour Rendition Report* for
-    specified spectral distribution.
+    Generate the intermediate *ANSI/IES TM-30-18 Colour Rendition Report*
+    for the specified spectral distribution.
 
     Parameters
     ----------
@@ -552,12 +550,12 @@ def plot_single_sd_colour_rendition_report_intermediate(
         Spectral distribution of the emission source to generate the report
         for.
     report_size
-        Report size, default to A4 paper size in inches.
+        Report size, defaults to A4 paper size in inches.
     report_row_height_ratios
         Report size row height ratios.
     report_box_padding
-        Report box padding, tries to define the padding around the figure and
-        in-between the axes.
+        Report box padding, defines the padding around the figure and
+        between the axes.
 
     Other Parameters
     ----------------
@@ -637,8 +635,8 @@ def plot_single_sd_colour_rendition_report_simple(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Generate the simple *ANSI/IES TM-30-18 Colour Rendition Report* for specified
-    spectral distribution.
+    Generate the simple *ANSI/IES TM-30-18 Colour Rendition Report* for the
+    specified spectral distribution.
 
     Parameters
     ----------
@@ -646,12 +644,12 @@ def plot_single_sd_colour_rendition_report_simple(
         Spectral distribution of the emission source to generate the report
         for.
     report_size
-        Report size, default to A4 paper size in inches.
+        Report size, defaults to A4 paper size in inches.
     report_row_height_ratios
         Report size row height ratios.
     report_box_padding
-        Report box padding, tries to define the padding around the figure and
-        in-between the axes.
+        Report box padding, defines the padding around the figure and
+        between the axes.
 
     Other Parameters
     ----------------
@@ -719,14 +717,14 @@ def plot_single_sd_colour_rendition_report(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
-    Generate the *ANSI/IES TM-30-18 Colour Rendition Report* for specified
-    spectral distribution according to specified method.
+    Generate the *ANSI/IES TM-30-18 Colour Rendition Report* for the
+    specified spectral distribution using the specified method.
 
     Parameters
     ----------
     sd
-        Spectral distribution of the emission source to generate the report
-        for.
+        Spectral distribution of the emission source to generate the
+        report for.
     method
         Report plotting method.
 

--- a/colour/plotting/volume.py
+++ b/colour/plotting/volume.py
@@ -2,7 +2,7 @@
 Colour Models Volume Plotting
 =============================
 
-Define the colour models volume and gamut plotting objects:
+Define the colour models volume and gamut plotting objects.
 
 -   :func:`colour.plotting.plot_RGB_colourspaces_gamuts`
 -   :func:`colour.plotting.plot_RGB_scatter`
@@ -81,8 +81,8 @@ def nadir_grid(
     **kwargs: Any,
 ) -> Tuple[NDArrayFloat, NDArrayFloat, NDArrayFloat]:
     """
-    Return a grid on *CIE xy* plane made of quad geometric elements and its
-    associated faces and edges colours. Ticks and labels are added to the
+    Generate a grid on the *CIE xy* plane made of quad geometric elements
+    with associated face and edge colours. Add ticks and labels to the
     specified axes according to the extended grid settings.
 
     Parameters
@@ -131,7 +131,7 @@ def nadir_grid(
     Returns
     -------
     :class:`tuple`
-        Grid quads, faces colours, edges colours.
+        Grid quads, face colours, edge colours.
 
     Examples
     --------
@@ -336,24 +336,24 @@ def RGB_identity_cube(
     ) = None,
 ) -> Tuple[NDArrayFloat, NDArrayFloat]:
     """
-    Return an *RGB* identity cube made of quad geometric elements and its
-    associated *RGB* colours.
+    Generate an *RGB* identity cube composed of quad geometric elements with
+    its associated *RGB* colours.
 
     Parameters
     ----------
     width_segments
-        Cube segments, quad counts along the width.
+        Number of quad segments along the cube width.
     height_segments
-        Cube segments, quad counts along the height.
+        Number of quad segments along the cube height.
     depth_segments
-        Cube segments, quad counts along the depth.
+        Number of quad segments along the cube depth.
     planes
         Grid primitives to include in the cube construction.
 
     Returns
     -------
     :class:`tuple`
-        Cube quads, *RGB* colours.
+        Cube quads and *RGB* colours.
 
     Examples
     --------
@@ -433,7 +433,8 @@ def plot_RGB_colourspaces_gamuts(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes3D]:
     """
-    Plot specified *RGB* colourspaces gamuts in specified reference colourspace.
+    Plot the gamuts of the specified *RGB* colourspaces in the specified
+    reference colourspace.
 
     Parameters
     ----------
@@ -442,12 +443,13 @@ def plot_RGB_colourspaces_gamuts(
         can be of any type or form supported by the
         :func:`colour.plotting.common.filter_RGB_colourspaces` definition.
     model
-        Colourspace model, see :attr:`colour.COLOURSPACE_MODELS` attribute for
-        the list of supported colourspace models.
+        Colourspace model, see :attr:`colour.COLOURSPACE_MODELS` attribute
+        for the list of supported colourspace models.
     segments
-        Edge segments count for each *RGB* colourspace cubes.
+        Edge segments count for each *RGB* colourspace cube.
     show_grid
-        Whether to show a grid at the bottom of the *RGB* colourspace cubes.
+        Whether to show a grid at the bottom of the *RGB* colourspace
+        cubes.
     grid_segments
         Edge segments count for the grid.
     show_spectral_locus
@@ -457,23 +459,27 @@ def plot_RGB_colourspaces_gamuts(
     cmfs
         Standard observer colour matching functions used for computing the
         spectral locus boundaries. ``cmfs`` can be of any type or form
-        supported by the :func:`colour.plotting.common.filter_cmfs` definition.
+        supported by the :func:`colour.plotting.common.filter_cmfs`
+        definition.
     chromatically_adapt
         Whether to chromatically adapt the *RGB* colourspaces specified in
-        ``colourspaces`` to the whitepoint of the default plotting colourspace.
+        ``colourspaces`` to the whitepoint of the default plotting
+        colourspace.
     convert_kwargs
         Keyword arguments for the :func:`colour.convert` definition.
 
     Other Parameters
     ----------------
     edge_colours
-        Edge colours array such as `edge_colours = (None, (0.5, 0.5, 1.0))`.
+        Edge colours array such as
+        `edge_colours = (None, (0.5, 0.5, 1.0))`.
     edge_alpha
         Edge opacity value such as `edge_alpha = (0.0, 1.0)`.
     face_alpha
         Face opacity value such as `face_alpha = (0.5, 1.0)`.
     face_colours
-        Face colours array such as `face_colours = (None, (0.5, 0.5, 1.0))`.
+        Face colours array such as
+        `face_colours = (None, (0.5, 0.5, 1.0))`.
     kwargs
         {:func:`colour.plotting.artist`,
         :func:`colour.plotting.volume.nadir_grid`},
@@ -677,7 +683,7 @@ def plot_RGB_scatter(
     **kwargs: Any,
 ) -> Tuple[Figure, Axes3D]:
     """
-    Plot specified *RGB* colourspace array in a scatter plot.
+    Plot the specified *RGB* colourspace array in a scatter plot.
 
     Parameters
     ----------
@@ -688,16 +694,17 @@ def plot_RGB_scatter(
         type or form supported by the
         :func:`colour.plotting.common.filter_RGB_colourspaces` definition.
     model
-        Colourspace model, see :attr:`colour.COLOURSPACE_MODELS` attribute for
-        the list of supported colourspace models.
+        Colourspace model, see :attr:`colour.COLOURSPACE_MODELS` attribute
+        for the list of supported colourspace models.
     colourspaces
         *RGB* colourspaces to plot the gamuts of. ``colourspaces`` elements
         can be of any type or form supported by the
         :func:`colour.plotting.common.filter_RGB_colourspaces` definition.
     segments
-        Edge segments count for each *RGB* colourspace cubes.
+        Edge segments count for each *RGB* colourspace cube.
     show_grid
-        Whether to show a grid at the bottom of the *RGB* colourspace cubes.
+        Whether to show a grid at the bottom of the *RGB* colourspace
+        cubes.
     grid_segments
         Edge segments count for the grid.
     show_spectral_locus
@@ -709,10 +716,12 @@ def plot_RGB_scatter(
     cmfs
         Standard observer colour matching functions used for computing the
         spectral locus boundaries. ``cmfs`` can be of any type or form
-        supported by the :func:`colour.plotting.common.filter_cmfs` definition.
+        supported by the :func:`colour.plotting.common.filter_cmfs`
+        definition.
     chromatically_adapt
         Whether to chromatically adapt the *RGB* colourspaces specified in
-        ``colourspaces`` to the whitepoint of the default plotting colourspace.
+        ``colourspaces`` to the whitepoint of the default plotting
+        colourspace.
     convert_kwargs
         Keyword arguments for the :func:`colour.convert` definition.
 

--- a/colour/quality/__init__.py
+++ b/colour/quality/__init__.py
@@ -79,8 +79,8 @@ def colour_fidelity_index(
     | ColourQuality_Specification_ANSIIESTM3018
 ):
     """
-    Compute the *Colour Fidelity Index* (CFI) :math:`R_f` of specified
-    spectral distribution using specified method.
+    Compute the *Colour Fidelity Index* (CFI) :math:`R_f` of the specified
+    spectral distribution using the specified method.
 
     Parameters
     ----------

--- a/colour/quality/cfi2017.py
+++ b/colour/quality/cfi2017.py
@@ -2,7 +2,7 @@
 CIE 2017 Colour Fidelity Index
 ==============================
 
-Define the *CIE 2017 Colour Fidelity Index* (CFI) computation objects:
+Define the *CIE 2017 Colour Fidelity Index* (CFI) computation objects.
 
 - :class:`colour.quality.ColourRendering_Specification_CIE2017`
 - :func:`colour.quality.colour_fidelity_index_CIE2017`
@@ -94,7 +94,31 @@ _CACHE_TCS_CIE2017: dict = CACHE_REGISTRY.register_cache(
 
 @dataclass
 class DataColorimetry_TCS_CIE2017:
-    """Define the class storing *test colour samples* colorimetry data."""
+    """
+    Store colorimetry data for *test colour samples* used in CIE 2017
+    colour fidelity calculations.
+
+    This dataclass encapsulates the colorimetric properties of test colour
+    samples as specified by CIE 2017, including their tristimulus values,
+    colour appearance model specifications, and perceptual colour
+    coordinates in both cylindrical and rectangular representations.
+
+    Attributes
+    ----------
+    name
+        Identifier(s) for the test colour sample(s).
+    XYZ
+        CIE XYZ tristimulus values of the test colour samples.
+    CAM
+        CIECAM02 colour appearance model specification containing the
+        complete appearance correlates.
+    JMh
+        Perceptual colour coordinates in cylindrical representation with
+        *lightness* (J), *colourfulness* (M), and *hue angle* (h).
+    Jpapbp
+        Perceptual colour coordinates in rectangular representation with
+        *lightness* (J) and opponent colour dimensions (a', b').
+    """
 
     name: str | list[str]
     XYZ: NDArrayFloat
@@ -161,8 +185,8 @@ def colour_fidelity_index_CIE2017(
     sd_test: SpectralDistribution, additional_data: bool = False
 ) -> float | ColourRendering_Specification_CIE2017:
     """
-    Compute the *CIE 2017 Colour Fidelity Index* (CFI) :math:`R_f` of specified
-    spectral distribution.
+    Compute the *CIE 2017 Colour Fidelity Index* (CFI) :math:`R_f` of the
+    specified spectral distribution.
 
     Parameters
     ----------
@@ -266,11 +290,11 @@ def colour_fidelity_index_CIE2017(
 
 def load_TCS_CIE2017(shape: SpectralShape) -> MultiSpectralDistributions:
     """
-    Load the *CIE 2017 Test Colour Samples* dataset appropriate for the specified
-    spectral shape.
+    Load the *CIE 2017 Test Colour Samples* dataset appropriate for the
+    specified spectral shape.
 
-    The datasets are cached and won't be loaded again on subsequent calls to
-    this definition.
+    The datasets are cached and will not be loaded again on subsequent
+    calls to this definition.
 
     Parameters
     ----------
@@ -318,8 +342,8 @@ def load_TCS_CIE2017(shape: SpectralShape) -> MultiSpectralDistributions:
 def CCT_reference_illuminant(sd: SpectralDistribution) -> NDArrayFloat:
     """
     Compute the reference illuminant correlated colour temperature
-    :math:`T_{cp}` and :math:`\\Delta_{uv}` for specified test spectral
-    distribution using *Ohno (2013)* method.
+    :math:`T_{cp}` and :math:`\\Delta_{uv}` for the specified test spectral
+    distribution using the *Ohno (2013)* method.
 
     Parameters
     ----------
@@ -348,9 +372,9 @@ def CCT_reference_illuminant(sd: SpectralDistribution) -> NDArrayFloat:
 
 def sd_reference_illuminant(CCT: float, shape: SpectralShape) -> SpectralDistribution:
     """
-    Compute the reference illuminant for a specified correlated colour temperature
-    :math:`T_{cp}` for use in *CIE 2017 Colour Fidelity Index* (CFI)
-    computation.
+    Compute the reference illuminant for the specified correlated colour
+    temperature :math:`T_{cp}` for use in *CIE 2017 Colour Fidelity Index*
+    (CFI) computation.
 
     Parameters
     ----------
@@ -439,15 +463,15 @@ def tcs_colorimetry_data(
     cmfs: MultiSpectralDistributions,
 ) -> Tuple[DataColorimetry_TCS_CIE2017, ...]:
     """
-    Compute the *test colour samples* colorimetry data under specified test light
-    source or reference illuminant spectral distribution for the
+    Compute the *test colour samples* colorimetry data under the specified
+    test light source or reference illuminant spectral distribution for the
     *CIE 2017 Colour Fidelity Index* (CFI) computations.
 
     Parameters
     ----------
     sd_irradiance
-        Test light source or reference illuminant spectral distribution, i.e.,
-        the irradiance emitter.
+        Test light source or reference illuminant spectral distribution,
+        i.e., the irradiance emitter.
     sds_tcs
         *Test colour samples* spectral reflectance distributions.
     cmfs
@@ -456,8 +480,8 @@ def tcs_colorimetry_data(
     Returns
     -------
     :class:`tuple`
-        *Test colour samples* colorimetry data under the specified test light
-        source or reference illuminant spectral distribution.
+        *Test colour samples* colorimetry data under the specified test
+        light source or reference illuminant spectral distribution.
 
     Examples
     --------
@@ -542,8 +566,8 @@ def tcs_colorimetry_data(
 
 def delta_E_to_R_f(delta_E: ArrayLike) -> NDArrayFloat:
     """
-    Convert from colour-appearance difference to
-    *CIE 2017 Colour Fidelity Index* (CFI) :math:`R_f` value.
+    Convert colour-appearance difference to *CIE 2017 Colour Fidelity Index*
+    (CFI) :math:`R_f` value.
 
     Parameters
     ----------
@@ -553,7 +577,8 @@ def delta_E_to_R_f(delta_E: ArrayLike) -> NDArrayFloat:
     Returns
     -------
     :class:`numpy.ndarray`
-        Corresponding *CIE 2017 Colour Fidelity Index* (CFI) :math:`R_f` value.
+        Corresponding *CIE 2017 Colour Fidelity Index* (CFI) :math:`R_f`
+        value.
     """
 
     delta_E = as_float_array(delta_E)

--- a/colour/quality/cqs.py
+++ b/colour/quality/cqs.py
@@ -2,7 +2,7 @@
 Colour Quality Scale
 ====================
 
-Define the *Colour Quality Scale* (CQS) computation objects:
+Define the *Colour Quality Scale* (CQS) computation objects.
 
 -   :class:`colour.quality.ColourRendering_Specification_CQS`
 -   :func:`colour.colour_quality_scale`
@@ -88,7 +88,24 @@ GAMUT_AREA_D65: int = 8210
 
 @dataclass
 class DataColorimetry_VS:
-    """Define the class storing *VS test colour samples* colorimetry data."""
+    """
+    Store colorimetry data for *VS test colour samples*.
+
+    This dataclass encapsulates the colorimetric measurements and derived
+    values for Visual Spectrum (VS) test colour samples used in colour
+    quality evaluation.
+
+    Attributes
+    ----------
+    name
+        Sample identifier or designation.
+    XYZ
+        Tristimulus values under the test illuminant.
+    Lab
+        *CIE L\\*a\\*b\\** colour space coordinates.
+    C
+        Chroma values calculated from the *CIE L\\*a\\*b\\** coordinates.
+    """
 
     name: str
     XYZ: NDArrayFloat
@@ -99,8 +116,22 @@ class DataColorimetry_VS:
 @dataclass
 class DataColourQualityScale_VS:
     """
-    Define the class storing *VS test colour samples* colour quality scale
-    data.
+    Store colour quality scale data for *VS test colour samples*.
+
+    This dataclass encapsulates the colour quality metrics computed for VS
+    (Visual Samples) test colour samples, including quality assessment and
+    colour difference measurements used in colour rendering evaluations.
+
+    Attributes
+    ----------
+    name
+        Identifier or descriptor for the test colour sample.
+    Q_a
+        Colour quality scale value for the sample.
+    D_C_ab
+        Chroma difference in *CIE L\\*a\\*b\\** colourspace.
+    D_E_ab
+        Total colour difference in *CIE L\\*a\\*b\\** colourspace.
     """
 
     name: str
@@ -123,23 +154,24 @@ class ColourRendering_Specification_CQS:
     Q_a
         Colour quality scale :math:`Q_a`.
     Q_f
-        Colour fidelity scale :math:`Q_f` intended to evaluate the fidelity
-        of object colour appearances (compared to the reference illuminant of
-        the same correlated colour temperature and illuminance).
+        Colour fidelity scale :math:`Q_f` intended to evaluate the
+        fidelity of object colour appearances (compared to the reference
+        illuminant of the same correlated colour temperature and
+        illuminance).
     Q_p
-        Colour preference scale :math:`Q_p` similar to colour quality scale
-        :math:`Q_a` but placing additional weight on preference of object
-        colour appearance, set to *None* in *NIST CQS 9.0* method. This metric
-        is based on the notion that increases in chroma are generally preferred
-        and should be rewarded.
+        Colour preference scale :math:`Q_p` similar to colour quality
+        scale :math:`Q_a` but placing additional weight on preference of
+        object colour appearance, set to *None* in *NIST CQS 9.0* method.
+        This metric is based on the notion that increases in chroma are
+        generally preferred and should be rewarded.
     Q_g
-         Gamut area scale :math:`Q_g` representing the relative gamut formed
-         by the (:math:`a^*`, :math:`b^*`) coordinates of the 15 samples
-         illuminated by the test light source in the *CIE L\\*a\\*b\\** object
-         colourspace.
+        Gamut area scale :math:`Q_g` representing the relative gamut
+        formed by the (:math:`a^*`, :math:`b^*`) coordinates of the 15
+        samples illuminated by the test light source in the
+        *CIE L\\*a\\*b\\** object colourspace.
     Q_d
-        Relative gamut area scale :math:`Q_d`, set to *None* in *NIST CQS 9.0*
-        method.
+        Relative gamut area scale :math:`Q_d`, set to *None* in
+        *NIST CQS 9.0* method.
     Q_as
         Individual *Colour Quality Scale* (CQS) data for each sample.
     colorimetry_data
@@ -147,7 +179,7 @@ class ColourRendering_Specification_CQS:
 
     References
     ----------
-    :cite:`Davis2010a`, :cite:`Ohno2008a`,  :cite:`Ohno2013`
+    :cite:`Davis2010a`, :cite:`Ohno2008a`, :cite:`Ohno2013`
     """
 
     name: str
@@ -205,8 +237,8 @@ def colour_quality_scale(
     method: Literal["NIST CQS 7.4", "NIST CQS 9.0"] | str = "NIST CQS 9.0",
 ) -> float | ColourRendering_Specification_CQS:
     """
-    Compute the *Colour Quality Scale* (CQS) of specified spectral distribution
-    using specified method.
+    Compute the *Colour Quality Scale* (CQS) of the specified spectral
+    distribution using the specified method.
 
     Parameters
     ----------
@@ -219,8 +251,7 @@ def colour_quality_scale(
 
     Returns
     -------
-    :class:`float` or \
-:class:`colour.quality.ColourRendering_Specification_CQS`
+    :class:`float` or :class:`colour.quality.ColourRendering_Specification_CQS`
         *Colour Quality Scale* (CQS).
 
     References
@@ -328,8 +359,8 @@ def colour_quality_scale(
 
 def gamut_area(Lab: ArrayLike) -> float:
     """
-    Compute the gamut area :math:`G` covered by specified *CIE L\\*a\\*b\\**
-    matrices.
+    Compute the gamut area :math:`G` covered by the specified
+    *CIE L\\*a\\*b\\** colourspace matrices.
 
     Parameters
     ----------
@@ -444,8 +475,8 @@ def CCT_factor(
     reference_data: Tuple[DataColorimetry_VS, ...], XYZ_r: ArrayLike
 ) -> float:
     """
-    Compute the correlated colour temperature factor penalizing lamps with
-    extremely low correlated colour temperatures.
+    Compute the correlated colour temperature factor that penalizes lamps
+    with extremely low correlated colour temperatures.
 
     Parameters
     ----------
@@ -480,8 +511,9 @@ def CCT_factor(
 
 def scale_conversion(D_E_ab: float, CCT_f: float, scaling_f: float) -> float:
     """
-    Compute the *Colour Quality Scale* (CQS) for specified :math:`\\Delta E_{ab}`
-    value and specified correlated colour temperature penalizing factor.
+    Compute the *Colour Quality Scale* (CQS) for the specified
+    :math:`\\Delta E_{ab}` value and correlated colour temperature
+    penalizing factor.
 
     Parameters
     ----------
@@ -505,16 +537,16 @@ def delta_E_RMS(
     CQS_data: Dict[int, DataColourQualityScale_VS], attribute: str
 ) -> float:
     """
-    Compute the root-mean-square average for specified *Colour Quality Scale*
-    (CQS) data.
+    Compute the root-mean-square average for the specified *Colour Quality
+    Scale* (CQS) data using the specified colorimetry attribute.
 
     Parameters
     ----------
     CQS_data
         *Colour Quality Scale* (CQS) data.
     attribute
-        Colorimetry data attribute to use to compute the root-mean-square
-        average.
+        Colorimetry data attribute to use for computing the
+        root-mean-square average.
 
     Returns
     -------
@@ -543,19 +575,20 @@ def colour_quality_scales(
     Parameters
     ----------
     test_data
-        Test data.
+        Test data for the VS colour samples.
     reference_data
-        Reference data.
+        Reference data for the VS colour samples.
     scaling_f
-        Scaling factor constant.
+        Scaling factor constant for normalizing the colour rendering
+        scales.
     CCT_f
-        Factor penalizing lamps with extremely low correlated colour
-        temperatures.
+        Factor penalizing light sources with extremely low correlated
+        colour temperatures.
 
     Returns
     -------
     :class:`dict`
-        *VS Test colour samples* colour rendering scales.
+        *VS test colour samples* colour rendering scales.
     """
 
     Q_as = {}

--- a/colour/quality/cri.py
+++ b/colour/quality/cri.py
@@ -2,7 +2,7 @@
 Colour Rendering Index
 ======================
 
-Define the *Colour Rendering Index* (CRI) computation objects:
+Define the *Colour Rendering Index* (CRI) computation objects.
 
 -   :class:`colour.quality.ColourRendering_Specification_CRI`
 -   :func:`colour.colour_rendering_index`
@@ -65,7 +65,27 @@ __all__ = [
 
 @dataclass
 class DataColorimetry_TCS:
-    """Define the class storing *test colour samples* colorimetry data."""
+    """
+    Store colorimetric data for *test colour samples* used in colour
+    rendering index calculations.
+
+    This dataclass encapsulates the colorimetric properties of test colour
+    samples, including their tristimulus values, chromaticity coordinates,
+    and colour appearance attributes required for evaluating light source
+    colour rendering performance.
+
+    Attributes
+    ----------
+    name
+        Identifier for the test colour sample.
+    XYZ
+        *CIE XYZ* tristimulus values of the test colour sample.
+    uv
+        *CIE 1960 UCS* chromaticity coordinates of the test colour sample.
+    UVW
+        *CIE 1964 U*V*W** colour space coordinates of the test colour
+        sample.
+    """
 
     name: str
     XYZ: NDArrayFloat
@@ -76,7 +96,15 @@ class DataColorimetry_TCS:
 @dataclass
 class DataColourQualityScale_TCS:
     """
-    Define the class storing *test colour samples* colour rendering index data.
+    Store colour rendering index quality scale data for individual *test
+    colour samples*.
+
+    Attributes
+    ----------
+    name
+        Identifier of the test colour sample.
+    Q_a
+        Colour rendering index :math:`Q_a` value for the test colour sample.
     """
 
     name: str
@@ -88,16 +116,22 @@ class ColourRendering_Specification_CRI:
     """
     Define the *Colour Rendering Index* (CRI) colour quality specification.
 
+    This dataclass represents the colour quality assessment results using
+    the CRI method, which evaluates how accurately a light source renders
+    colours compared to a reference illuminant.
+
     Parameters
     ----------
     name
         Name of the test spectral distribution.
     Q_a
-        *Colour Rendering Index* (CRI) :math:`Q_a`.
+        *Colour Rendering Index* (CRI) :math:`Q_a` general index value.
     Q_as
-        Individual *colour rendering indexes* data for each sample.
+        Individual *colour rendering indexes* data for each test colour
+        sample.
     colorimetry_data
-        Colorimetry data for the test and reference computations.
+        Colorimetry data for the test and reference illuminant
+        computations.
 
     References
     ----------
@@ -155,8 +189,8 @@ def colour_rendering_index(
     method: Literal["CIE 1995", "CIE 2024"] | str = "CIE 1995",
 ) -> float | ColourRendering_Specification_CRI:
     """
-    Compute the *Colour Rendering Index* (CRI) :math:`Q_a` of specified spectral
-    distribution.
+    Compute the *Colour Rendering Index* (CRI) :math:`Q_a` of the specified
+    spectral distribution.
 
     Parameters
     ----------
@@ -169,8 +203,7 @@ def colour_rendering_index(
 
     Returns
     -------
-    :class:`float` or \
-:class:`colour.quality.ColourRendering_Specification_CRI`
+    :class:`float` or :class:`colour.quality.ColourRendering_Specification_CRI`
         *Colour Rendering Index* (CRI).
 
     References
@@ -340,14 +373,15 @@ def colour_rendering_indexes(
     Parameters
     ----------
     test_data
-        Test data.
+        Test data colorimetry for the *test colour samples*.
     reference_data
-        Reference data.
+        Reference data colorimetry for the *test colour samples*.
 
     Returns
     -------
     :class:`dict`
-        *Test colour samples* *Colour Rendering Index* (CRI).
+        *Test colour samples* *Colour Rendering Index* (CRI) values
+        mapped by sample number.
     """
 
     Q_as = {}

--- a/colour/quality/ssi.py
+++ b/colour/quality/ssi.py
@@ -1,16 +1,16 @@
 """
 Academy Spectral Similarity Index (SSI)
-=======================================
+========================================
 
-Define the *Academy Spectral Similarity Index* (SSI) computation objects:
+Define the *Academy Spectral Similarity Index* (SSI) computation objects.
 
 -   :func:`colour.spectral_similarity_index`
 
 References
 ----------
 -   :cite:`TheAcademyofMotionPictureArtsandSciences2020a` : The Academy of
-    Motion Picture Arts and Sciences. (2020). Academy Spectral Similarity Index
-    (SSI): Overview (pp. 1-7). Retrieved June 5, 2023, from
+    Motion Picture Arts and Sciences. (2020). Academy Spectral Similarity
+    Index (SSI): Overview (pp. 1-7). Retrieved June 5, 2023, from
     https://www.oscars.org/sites/oscars/files/ssi_overview_2020-09-16.pdf
 """
 
@@ -55,8 +55,9 @@ def spectral_similarity_index(
     round_result: bool = True,
 ) -> NDArrayFloat:
     """
-    Compute the *Academy Spectral Similarity Index* (SSI) of specified test
-    spectral distribution with specified reference spectral distribution.
+    Compute the *Academy Spectral Similarity Index* (SSI) of the specified
+    test spectral distribution with the specified reference spectral
+    distribution.
 
     Parameters
     ----------

--- a/colour/quality/tm3018.py
+++ b/colour/quality/tm3018.py
@@ -3,7 +3,7 @@ ANSI/IES TM-30-18 Colour Fidelity Index
 =======================================
 
 Define the *ANSI/IES TM-30-18 Colour Fidelity Index* (CFI) computation
-objects:
+objects.
 
 - :class:`colour.quality.ColourQuality_Specification_ANSIIESTM3018`
 - :func:`colour.quality.colour_fidelity_index_ANSIIESTM3018`
@@ -39,8 +39,8 @@ from colour.utilities import as_float_array, as_float_scalar, as_int_array
 @dataclass
 class ColourQuality_Specification_ANSIIESTM3018:
     """
-    Define the *ANSI/IES TM-30-18 Colour Fidelity Index* (CFI) colour quality
-    specification.
+    Define the *ANSI/IES TM-30-18 Colour Fidelity Index* (CFI) colour
+    quality specification.
 
     Parameters
     ----------
@@ -63,11 +63,11 @@ class ColourQuality_Specification_ANSIIESTM3018:
     R_g
         Gamut index :math:`R_g`.
     bins
-        List of 16 lists, each containing the indexes of colour samples that
-        lie in the respective hue bin.
+        List of 16 lists, each containing the indexes of colour samples
+        that lie in the respective hue bin.
     averages_test
-        Averages of *CAM02-UCS* a', b' coordinates for each hue bin for test
-        samples.
+        Averages of *CAM02-UCS* a', b' coordinates for each hue bin for
+        test samples.
     averages_reference
         Averages for reference samples.
     average_norms
@@ -121,7 +121,7 @@ def colour_fidelity_index_ANSIIESTM3018(
 ) -> float | ColourQuality_Specification_ANSIIESTM3018:
     """
     Compute the *ANSI/IES TM-30-18 Colour Fidelity Index* (CFI) :math:`R_f`
-    of specified spectral distribution.
+    for the specified test spectral distribution.
 
     Parameters
     ----------
@@ -133,7 +133,7 @@ def colour_fidelity_index_ANSIIESTM3018(
     Returns
     -------
     :class:`float` or \
-:class:`colour.quality.ColourQuality_Specification_ANSIIESTM3018`
+    :class:`colour.quality.ColourQuality_Specification_ANSIIESTM3018`
         *ANSI/IES TM-30-18 Colour Fidelity Index* (CFI).
 
     References

--- a/colour/recovery/__init__.py
+++ b/colour/recovery/__init__.py
@@ -118,8 +118,8 @@ def XYZ_to_sd(
     **kwargs: Any,
 ) -> SpectralDistribution:
     """
-    Recover the spectral distribution of specified *CIE XYZ* tristimulus
-    values using specified method.
+    Recover the spectral distribution of the specified *CIE XYZ* tristimulus
+    values using the specified method.
 
     Parameters
     ----------
@@ -133,7 +133,8 @@ def XYZ_to_sd(
     ----------------
     additional_data
         {:func:`colour.recovery.XYZ_to_sd_Jakob2019`},
-        If *True*, ``error`` will be returned alongside ``sd``.
+        If *True*, ``error`` will be returned alongside the recovered
+        spectral distribution.
     basis_functions
         {:func:`colour.recovery.RGB_to_sd_Mallett2019`},
         Basis functions for the method. The default is to use the built-in
@@ -142,30 +143,22 @@ def XYZ_to_sd(
     clip
         {:func:`colour.recovery.XYZ_to_sd_Otsu2018`},
         If *True*, the default, values below zero and above unity in the
-        recovered spectral distributions will be clipped. This ensures that the
-        returned reflectance is physical and conserves energy, but will cause
-        noticeable colour differences in case of very saturated colours.
+        recovered spectral distributions will be clipped. This ensures that
+        the returned reflectance is physical and conserves energy, but will
+        cause noticeable colour differences in case of very saturated
+        colours.
     cmfs
         {:func:`colour.recovery.XYZ_to_sd_Meng2015`},
         Standard observer colour matching functions.
-    colourspace
-        {:func:`colour.recovery.XYZ_to_sd_Jakob2019`},
-        *RGB* colourspace of the target colour. Note that no chromatic
-        adaptation is performed between ``illuminant`` and the colourspace
-        whitepoint.
     dataset
         {:func:`colour.recovery.XYZ_to_sd_Otsu2018`},
-        Dataset to use for reconstruction. The default is to use the published
-        data.
+        Dataset to use for reconstruction. The default is to use the
+        published data.
     illuminant
         {:func:`colour.recovery.XYZ_to_sd_Jakob2019`,
         :func:`colour.recovery.XYZ_to_sd_Meng2015`},
         Illuminant spectral distribution, default to
         *CIE Standard Illuminant D65*.
-    interval
-        {:func:`colour.recovery.XYZ_to_sd_Meng2015`},
-        Wavelength :math:`\\lambda_{i}` range interval in nm. The smaller
-        ``interval`` is, the longer the computations will be.
     optimisation_kwargs
         {:func:`colour.recovery.XYZ_to_sd_Jakob2019`,
         :func:`colour.recovery.XYZ_to_sd_Meng2015`},
@@ -186,8 +179,8 @@ def XYZ_to_sd(
     +------------+-----------------------+---------------+
 
     -   *Smits (1999)* method will internally convert specified *CIE XYZ*
-        tristimulus values to *sRGB* colourspace array assuming equal energy
-        illuminant *E*.
+        tristimulus values to *sRGB* colourspace array assuming equal
+        energy illuminant *E*.
 
     References
     ----------

--- a/colour/recovery/datasets/otsu2018.py
+++ b/colour/recovery/datasets/otsu2018.py
@@ -1320,6 +1320,6 @@ SELECTOR_ARRAY_OTSU2018: NDArrayFloat = np.array(
     ]
 )
 """
-Array describing how to select the appropriate cluster for specified *CIE xy*
+Array describing how to select the appropriate cluster for the specified *CIE xy*
 chromaticity coordinates.
 """

--- a/colour/recovery/jakob2019.py
+++ b/colour/recovery/jakob2019.py
@@ -3,7 +3,7 @@ Jakob and Hanika (2019) - Reflectance Recovery
 ==============================================
 
 Define the objects for reflectance recovery, i.e., spectral upsampling, using
-*Jakob and Hanika (2019)* method:
+*Jakob and Hanika (2019)* method.
 
 -   :func:`colour.recovery.sd_Jakob2019`
 -   :func:`colour.recovery.find_coefficients_Jakob2019`
@@ -95,9 +95,11 @@ SPECTRAL_SHAPE_JAKOB2019: SpectralShape = SpectralShape(360, 780, 5)
 
 class StopMinimizationEarlyError(Exception):
     """
-    The exception used to stop :func:`scipy.optimize.minimize` once the
-    value of the minimized function is small enough. *SciPy* doesn't currently
-    offer a better way of doing it.
+    Define an exception to halt :func:`scipy.optimize.minimize` when the
+    minimized function value becomes sufficiently small.
+
+    *SciPy* does not currently provide a native mechanism for early
+    termination based on function value thresholds.
 
     Attributes
     ----------
@@ -112,8 +114,7 @@ class StopMinimizationEarlyError(Exception):
     @property
     def coefficients(self) -> NDArrayFloat:
         """
-        Getter property for the *Jakob and Hanika (2019)* exception
-        coefficients.
+        Getter for the *Jakob and Hanika (2019)* exception coefficients.
 
         Returns
         -------
@@ -126,13 +127,14 @@ class StopMinimizationEarlyError(Exception):
     @property
     def error(self) -> float:
         """
-        Getter property for the *Jakob and Hanika (2019)* exception error
+        Getter for the *Jakob and Hanika (2019)* spectral upsampling error
         value.
 
         Returns
         -------
         :class:`float`
-            *Jakob and Hanika (2019)* exception coefficients.
+            *Jakob and Hanika (2019)* spectral upsampling error value
+            representing the quality of the coefficient fitting process.
         """
 
         return self._error
@@ -142,14 +144,14 @@ def sd_Jakob2019(
     coefficients: ArrayLike, shape: SpectralShape = SPECTRAL_SHAPE_JAKOB2019
 ) -> SpectralDistribution:
     """
-    Generate a spectral distribution following the spectral model specified by
+    Generate a spectral distribution using the spectral model specified by
     *Jakob and Hanika (2019)*.
 
     Parameters
     ----------
     coefficients
-        Dimensionless coefficients for *Jakob and Hanika (2019)* reflectance
-        spectral model.
+        Dimensionless coefficients for the *Jakob and Hanika (2019)*
+        reflectance spectral model.
     shape
         Shape used by the spectral distribution.
 
@@ -241,13 +243,13 @@ def error_function(
 ):
     """
     Compute :math:`\\Delta E_{76}` between the target colour and the colour
-    defined by specified spectral model, along with its gradient.
+    defined by the specified spectral model, along with its gradient.
 
     Parameters
     ----------
     coefficients
-        Dimensionless coefficients for *Jakob and Hanika (2019)* reflectance
-        spectral model.
+        Dimensionless coefficients for *Jakob and Hanika (2019)*
+        reflectance spectral model.
     target
         *CIE L\\*a\\*b\\** colourspace array of the target colour.
     cmfs
@@ -255,8 +257,9 @@ def error_function(
     illuminant
         Illuminant spectral distribution.
     max_error
-        Raise ``StopMinimizationEarlyError`` if the error is smaller than this.
-        The default is *None* and the function doesn't raise anything.
+        Raise ``StopMinimizationEarlyError`` if the error is smaller than
+        this. The default is *None* and the function doesn't raise
+        anything.
     additional_data
         If *True*, some intermediate calculations are returned, for use in
         correctness tests: R, XYZ and Lab.
@@ -264,12 +267,12 @@ def error_function(
     Returns
     -------
     :class:`tuple` or :class:`tuple`
-        Tuple of computed :math:`\\Delta E_{76}` error and gradient of error,
-        i.e., the first derivatives of error with respect to the input
-        coefficients or tuple of computed :math:`\\Delta E_{76}` error,
-        gradient of error, computed spectral reflectance, *CIE XYZ* tristimulus
-        values corresponding to ``R`` and *CIE L\\*a\\*b\\** colourspace array
-        corresponding to ``XYZ``.
+        Tuple of computed :math:`\\Delta E_{76}` error and gradient of
+        error, i.e., the first derivatives of error with respect to the
+        input coefficients or tuple of computed :math:`\\Delta E_{76}`
+        error, gradient of error, computed spectral reflectance, *CIE XYZ*
+        tristimulus values corresponding to ``R`` and *CIE L\\*a\\*b\\**
+        colourspace array corresponding to ``XYZ``.
 
     Raises
     ------
@@ -340,13 +343,14 @@ def dimensionalise_coefficients(
     coefficients: ArrayLike, shape: SpectralShape
 ) -> NDArrayFloat:
     """
-    Rescale the dimensionless coefficients to specified spectral shape.
+    Rescale dimensionless coefficients to the specified spectral shape.
 
     A dimensionless form of the reflectance spectral model is used in the
     optimisation process. Instead of the usual spectral shape, specified in
-    nanometers, it is normalised to the [0, 1] range. A side effect is that
-    computed coefficients work only with the normalised range and need to be
-    rescaled to regain units and be compatible with standard shapes.
+    nanometres, it is normalised to the [0, 1] range. A side effect is
+    that computed coefficients work only with the normalised range and
+    need to be rescaled to regain units and be compatible with standard
+    shapes.
 
     Parameters
     ----------
@@ -375,20 +379,22 @@ def dimensionalise_coefficients(
 
 def lightness_scale(steps: int) -> NDArrayFloat:
     """
-    Create a non-linear lightness scale, as described in *Jakob and Hanika
-    (2019)*. The spacing between very dark and very bright (and saturated)
-    colours is made smaller, because in those regions coefficients tend to
-    change rapidly and a finer resolution is needed.
+    Generate a non-linear lightness scale as described in *Jakob and Hanika
+    (2019)*.
+
+    The scale reduces spacing between very dark and very bright (and
+    saturated) colours, providing finer resolution in regions where
+    coefficients change rapidly.
 
     Parameters
     ----------
     steps
-        Samples/steps count along the non-linear lightness scale.
+        Number of samples along the non-linear lightness scale.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Non-linear lightness scale.
+        Non-linear lightness scale array.
 
     Examples
     --------
@@ -411,7 +417,7 @@ def find_coefficients_Jakob2019(
     dimensionalise: bool = True,
 ) -> Tuple[NDArrayFloat, float]:
     """
-    Compute the coefficients for *Jakob and Hanika (2019)* reflectance
+    Find the coefficients for the *Jakob and Hanika (2019)* reflectance
     spectral model.
 
     Parameters
@@ -428,18 +434,19 @@ def find_coefficients_Jakob2019(
         Starting coefficients for the solver.
     max_error
         Maximal acceptable error. Set higher to save computational time.
-        If *None*, the solver will keep going until it is very close to the
-        minimum. The default is ``ACCEPTABLE_DELTA_E``.
+        If *None*, the solver will keep going until it is very close to
+        the minimum. The default is ``ACCEPTABLE_DELTA_E``.
     dimensionalise
-        If *True*, returned coefficients are dimensionful and will not work
-        correctly if fed back as ``coefficients_0``. The default is *True*.
+        If *True*, returned coefficients are dimensionful and will not
+        work correctly if fed back as ``coefficients_0``. The default
+        is *True*.
 
     Returns
     -------
     :class:`tuple`
-        Tuple of computed coefficients that best fit the specified colour and
-        :math:`\\Delta E_{76}` between the target colour and the colour
-        corresponding to the computed coefficients.
+        Tuple of computed coefficients that best fit the specified
+        colour and :math:`\\Delta E_{76}` between the target colour and
+        the colour corresponding to the computed coefficients.
 
     References
     ----------
@@ -555,13 +562,14 @@ def XYZ_to_sd_Jakob2019(
     additional_data: bool = False,
 ) -> Tuple[SpectralDistribution, float] | SpectralDistribution:
     """
-    Recover the spectral distribution of specified *CIE XYZ* tristimulus
+    Recover the spectral distribution from the specified *CIE XYZ* tristimulus
     values using *Jakob and Hanika (2019)* method.
 
     Parameters
     ----------
     XYZ
-        *CIE XYZ* tristimulus values to recover the spectral distribution from.
+        *CIE XYZ* tristimulus values to recover the spectral distribution
+        from.
     cmfs
         Standard observer colour matching functions, default to the
         *CIE 1931 2 Degree Standard Observer*.
@@ -572,15 +580,15 @@ def XYZ_to_sd_Jakob2019(
         Parameters for :func:`colour.recovery.find_coefficients_Jakob2019`
         definition.
     additional_data
-        If *True*, ``error`` will be returned alongside the recovered spectral
-        distribution.
+        If *True*, ``error`` will be returned alongside the recovered
+        spectral distribution.
 
     Returns
     -------
     :class:`tuple` or :class:`colour.SpectralDistribution`
         Tuple of recovered spectral distribution and :math:`\\Delta E_{76}`
-        between the target colour and the colour corresponding to the computed
-        coefficients or recovered spectral distribution.
+        between the target colour and the colour corresponding to the
+        computed coefficients or recovered spectral distribution.
 
     References
     ----------
@@ -680,15 +688,15 @@ def XYZ_to_sd_Jakob2019(
 
 
 class LUT3D_Jakob2019:
-    """
+    r"""
     Define a class for working with pre-computed lookup tables for the
-    *Jakob and Hanika (2019)* spectral upsampling method. It allows significant
-    time savings by performing the expensive numerical optimisation ahead of
-    time and storing the results in a file.
+    *Jakob and Hanika (2019)* spectral upsampling method. This class
+    enables significant time savings by performing expensive numerical
+    optimisation ahead of time and storing the results in a file.
 
-    The file format is compatible with the code and *\\*.coeff* files in the
-    supplemental material published alongside the article. They are directly
-    available from
+    The file format is compatible with the code and *\*.coeff* files in the
+    supplemental material published alongside the article. These files are
+    directly available from
     `Colour - Datasets <https://github.com/colour-science/colour-datasets>`__
     under the record *4050598*.
 
@@ -799,8 +807,10 @@ class LUT3D_Jakob2019:
     @property
     def size(self) -> int:
         """
-        Getter property for the *Jakob and Hanika (2019)* interpolator
-        size, i.e., the sample count on one side of the 3D table.
+        Getter for the *Jakob and Hanika (2019)* interpolator size.
+
+        The size represents the sample count on one side of the 3D lookup
+        table used for spectral upsampling.
 
         Returns
         -------
@@ -813,8 +823,8 @@ class LUT3D_Jakob2019:
     @property
     def lightness_scale(self) -> NDArrayFloat:
         """
-        Getter property for the *Jakob and Hanika (2019)* interpolator
-        lightness scale.
+        Getter for the *Jakob and Hanika (2019)* interpolator lightness
+        scale.
 
         Returns
         -------
@@ -827,8 +837,7 @@ class LUT3D_Jakob2019:
     @property
     def coefficients(self) -> NDArrayFloat:
         """
-        Getter property for the *Jakob and Hanika (2019)* interpolator
-        coefficients.
+        Getter for the *Jakob and Hanika (2019)* interpolator coefficients.
 
         Returns
         -------
@@ -841,7 +850,7 @@ class LUT3D_Jakob2019:
     @property
     def interpolator(self) -> RegularGridInterpolator:
         """
-        Getter property for the *Jakob and Hanika (2019)* interpolator.
+        Getter for the *Jakob and Hanika (2019)* interpolator.
 
         Returns
         -------
@@ -873,8 +882,8 @@ class LUT3D_Jakob2019:
         print_callable: Callable = print,
     ) -> None:
         """
-        Generate the lookup table data for specified *RGB* colourspace, colour
-        matching functions, illuminant and specified size.
+        Generate the lookup table data for the specified *RGB* colourspace,
+        colour matching functions, illuminant and resolution.
 
         Parameters
         ----------
@@ -1023,8 +1032,10 @@ class LUT3D_Jakob2019:
 
     def RGB_to_coefficients(self, RGB: ArrayLike) -> NDArrayFloat:
         """
-        Look up a specified *RGB* colourspace array and return corresponding
-        coefficients. Interpolation is used for colours not on the table grid.
+        Look up the specified *RGB* colourspace array and return the
+        corresponding coefficients.
+
+        Interpolation is used for colours not on the table grid.
 
         Parameters
         ----------
@@ -1035,8 +1046,8 @@ class LUT3D_Jakob2019:
         -------
         :class:`numpy.ndarray`
             Corresponding coefficients that can be passed to
-            :func:`colour.recovery.jakob2019.sd_Jakob2019` to obtain a spectral
-            distribution.
+            :func:`colour.recovery.jakob2019.sd_Jakob2019` to obtain a
+            spectral distribution.
 
         Raises
         ------
@@ -1083,8 +1094,8 @@ class LUT3D_Jakob2019:
         self, RGB: ArrayLike, shape: SpectralShape = SPECTRAL_SHAPE_JAKOB2019
     ) -> SpectralDistribution:
         """
-        Look up a specified *RGB* colourspace array and return the corresponding
-        spectral distribution.
+        Look up a specified *RGB* colourspace array and return the
+        corresponding spectral distribution.
 
         Parameters
         ----------
@@ -1096,7 +1107,7 @@ class LUT3D_Jakob2019:
         Returns
         -------
         :class:`colour.SpectralDistribution`
-            Spectral distribution corresponding with the RGB* colourspace
+            Spectral distribution corresponding with the *RGB* colourspace
             array.
 
         Examples

--- a/colour/recovery/jiang2013.py
+++ b/colour/recovery/jiang2013.py
@@ -2,8 +2,8 @@
 Jiang et al. (2013) - Camera RGB Sensitivities Recovery
 =======================================================
 
-Define the objects for camera *RGB* sensitivities recovery using
-*Jiang, Liu, Gu and Süsstrunk (2013)* method:
+Define the objects for camera *RGB* sensitivities recovery using the
+*Jiang, Liu, Gu and Süsstrunk (2013)* method.
 
 -   :func:`colour.recovery.PCA_Jiang2013`
 -   :func:`colour.recovery.RGB_to_sd_camera_sensitivity_Jiang2013`
@@ -100,7 +100,7 @@ def PCA_Jiang2013(
     | Tuple[NDArrayFloat, NDArrayFloat, NDArrayFloat]
 ):
     """
-    Perform the *Principal Component Analysis* (PCA) on specified camera *RGB*
+    Perform *Principal Component Analysis* (PCA) on specified camera *RGB*
     sensitivities.
 
     Parameters
@@ -110,8 +110,8 @@ def PCA_Jiang2013(
     eigen_w_v_count
         Eigen-values :math:`w` and eigen-vectors :math:`v` count.
     additional_data
-        Whether to return both the eigen-values :math:`w` and eigen-vectors
-        :math:`v`.
+        Whether to return both the eigen-values :math:`w` and
+        eigen-vectors :math:`v`.
 
     Returns
     -------
@@ -176,8 +176,8 @@ def RGB_to_sd_camera_sensitivity_Jiang2013(
     shape: SpectralShape | None = None,
 ) -> SpectralDistribution:
     """
-    Recover a single camera *RGB* sensitivity for specified camera *RGB* values
-    using *Jiang et al. (2013)* method.
+    Recover a single camera *RGB* sensitivity for the specified camera *RGB*
+    values using *Jiang et al. (2013)* method.
 
     Parameters
     ----------
@@ -187,15 +187,15 @@ def RGB_to_sd_camera_sensitivity_Jiang2013(
         Illuminant spectral distribution used to produce the camera *RGB*
         values.
     reflectances
-        Reflectance spectral distributions used to produce the camera *RGB*
-        values.
+        Reflectance spectral distributions used to produce the camera
+        *RGB* values.
     eigen_w
-        Eigen-vectors :math:`v` for the particular camera *RGB* sensitivity
-        being recovered.
+        Eigen-vectors :math:`v` for the particular camera *RGB*
+        sensitivity being recovered.
     shape
         Spectral shape of the recovered camera *RGB* sensitivity,
-        ``illuminant`` and ``reflectances`` will be aligned to it if passed,
-        otherwise, ``illuminant`` shape is used.
+        ``illuminant`` and ``reflectances`` will be aligned to it if
+        passed, otherwise, ``illuminant`` shape is used.
 
     Returns
     -------
@@ -308,8 +308,8 @@ def RGB_to_msds_camera_sensitivities_Jiang2013(
     shape: SpectralShape | None = None,
 ) -> MultiSpectralDistributions:
     """
-    Recover the camera *RGB* sensitivities for specified camera *RGB* values
-    using *Jiang et al. (2013)* method.
+    Recover the camera *RGB* sensitivities for the specified camera *RGB*
+    values using *Jiang et al. (2013)* method.
 
     Parameters
     ----------
@@ -319,16 +319,16 @@ def RGB_to_msds_camera_sensitivities_Jiang2013(
         Illuminant spectral distribution used to produce the camera *RGB*
         values.
     reflectances
-        Reflectance spectral distributions used to produce the camera *RGB*
-        values.
+        Reflectance spectral distributions used to produce the camera
+        *RGB* values.
     basis_functions
-        Basis functions for the method. The default is to use the built-in
-        *sRGB* basis functions, i.e.,
+        Basis functions for the method. The default is to use the
+        built-in *sRGB* basis functions, i.e.,
         :attr:`colour.recovery.BASIS_FUNCTIONS_DYER2017`.
     shape
-        Spectral shape of the recovered camera *RGB* sensitivities,
-        ``illuminant`` and ``reflectances`` will be aligned to it if passed,
-        otherwise, ``illuminant`` shape is used.
+        Spectral shape of the recovered camera *RGB* sensitivities.
+        The ``illuminant`` and ``reflectances`` will be aligned to it if
+        passed, otherwise, the ``illuminant`` shape is used.
 
     Returns
     -------

--- a/colour/recovery/mallett2019.py
+++ b/colour/recovery/mallett2019.py
@@ -3,7 +3,7 @@ Mallett and Yuksel (2019) - Reflectance Recovery
 ================================================
 
 Define the objects for reflectance recovery, i.e., spectral upsampling, using
-*Mallett and Yuksel (2019)* method:
+*Mallett and Yuksel (2019)* method.
 
 -   :func:`colour.recovery.spectral_primary_decomposition_Mallett2019`
 -   :func:`colour.recovery.RGB_to_sd_Mallett2019`
@@ -58,8 +58,8 @@ def spectral_primary_decomposition_Mallett2019(
     optimisation_kwargs: dict | None = None,
 ) -> MultiSpectralDistributions:
     """
-    Perform the spectral primary decomposition as described in *Mallett and
-    Yuksel (2019)* for specified *RGB* colourspace.
+    Perform spectral primary decomposition as described in *Mallett and
+    Yuksel (2019)* for the specified *RGB* colourspace.
 
     Parameters
     ----------
@@ -86,7 +86,7 @@ def spectral_primary_decomposition_Mallett2019(
     Returns
     -------
     :class:`colour.MultiSpectralDistributions`
-        Basis functions for specified *RGB* colourspace.
+        Basis functions for the specified *RGB* colourspace.
 
     References
     ----------
@@ -94,14 +94,14 @@ def spectral_primary_decomposition_Mallett2019(
 
     Notes
     -----
-    -   In-addition to the *BT.709* primaries used by the *sRGB* colourspace,
-        :cite:`Mallett2019` tried *BT.2020*, *P3 D65*, *Adobe RGB 1998*,
-        *NTSC (1987)*, *Pal/Secam*, *ProPhoto RGB*,
-        and *Adobe Wide Gamut RGB* primaries, every one of which encompasses a
-        larger (albeit not-always-enveloping) set of *CIE L\\*a\\*b\\** colours
-        than BT.709. Of these, only *Pal/Secam* produces a feasible basis,
-        which is relatively unsurprising since it is very similar to *BT.709*,
-        whereas the others are significantly larger.
+    -   In addition to the *BT.709* primaries used by the *sRGB*
+        colourspace, :cite:`Mallett2019` tested *BT.2020*, *P3 D65*,
+        *Adobe RGB 1998*, *NTSC (1987)*, *Pal/Secam*, *ProPhoto RGB*, and
+        *Adobe Wide Gamut RGB* primaries, every one of which encompasses a
+        larger (albeit not always enveloping) set of *CIE L\\*a\\*b\\**
+        colours than BT.709. Of these, only *Pal/Secam* produces a
+        feasible basis, which is relatively unsurprising since it is very
+        similar to *BT.709*, whereas the others are significantly larger.
 
     Examples
     --------
@@ -222,8 +222,8 @@ def RGB_to_sd_Mallett2019(
     basis_functions: MultiSpectralDistributions = MSDS_BASIS_FUNCTIONS_sRGB_MALLETT2019,
 ) -> SpectralDistribution:
     """
-    Recover the spectral distribution of specified *RGB* colourspace array using
-    *Mallett and Yuksel (2019)* method.
+    Recover the spectral distribution of the specified *RGB* colourspace
+    array using *Mallett and Yuksel (2019)* method.
 
     Parameters
     ----------
@@ -245,14 +245,14 @@ def RGB_to_sd_Mallett2019(
 
     Notes
     -----
-    -   In-addition to the *BT.709* primaries used by the *sRGB* colourspace,
-        :cite:`Mallett2019` tried *BT.2020*, *P3 D65*, *Adobe RGB 1998*,
-        *NTSC (1987)*, *Pal/Secam*, *ProPhoto RGB*,
-        and *Adobe Wide Gamut RGB* primaries, every one of which encompasses a
-        larger (albeit not-always-enveloping) set of *CIE L\\*a\\*b\\** colours
-        than BT.709. Of these, only *Pal/Secam* produces a feasible basis,
-        which is relatively unsurprising since it is very similar to *BT.709*,
-        whereas the others are significantly larger.
+    -   In addition to the *BT.709* primaries used by the *sRGB*
+        colourspace, :cite:`Mallett2019` tested *BT.2020*, *P3 D65*,
+        *Adobe RGB 1998*, *NTSC (1987)*, *Pal/Secam*, *ProPhoto RGB*, and
+        *Adobe Wide Gamut RGB* primaries, every one of which encompasses a
+        larger (albeit not always enveloping) set of *CIE L\\*a\\*b\\**
+        colours than BT.709. Of these, only *Pal/Secam* produces a
+        feasible basis, which is relatively unsurprising since it is very
+        similar to *BT.709*, whereas the others are significantly larger.
 
     Examples
     --------

--- a/colour/recovery/meng2015.py
+++ b/colour/recovery/meng2015.py
@@ -2,8 +2,8 @@
 Meng et al. (2015) - Reflectance Recovery
 =========================================
 
-Define the objects for reflectance recovery using
-*Meng, Simon and Hanika (2015)* method:
+Define the objects for reflectance recovery using the *Meng, Simon and
+Hanika (2015)* method.
 
 -   :func:`colour.recovery.XYZ_to_sd_Meng2015`
 
@@ -61,24 +61,25 @@ def XYZ_to_sd_Meng2015(
     optimisation_kwargs: dict | None = None,
 ) -> SpectralDistribution:
     """
-    Recover the spectral distribution of specified *CIE XYZ* tristimulus values
-    using *Meng et al. (2015)* method.
+    Recover the spectral distribution from the specified *CIE XYZ* tristimulus
+    values using the *Meng et al. (2015)* method.
 
     Parameters
     ----------
     XYZ
-        *CIE XYZ* tristimulus values to recover the spectral distribution from.
+        *CIE XYZ* tristimulus values from which to recover the spectral
+        distribution.
     cmfs
         Standard observer colour matching functions. The wavelength
         :math:`\\lambda_{i}` range interval of the colour matching functions
-        affects directly the time the computations take. The current default
-        interval of 5 is a good compromise between precision and time spent,
-        default to the *CIE 1931 2 Degree Standard Observer*.
+        directly affects the computation time. The current default interval
+        of 5 provides a good compromise between precision and computation
+        time. Defaults to the *CIE 1931 2 Degree Standard Observer*.
     illuminant
-        Illuminant spectral distribution, default to
+        Illuminant spectral distribution. Defaults to
         *CIE Standard Illuminant D65*.
     optimisation_kwargs
-        Parameters for :func:`scipy.optimize.minimize` definition.
+        Parameters for the :func:`scipy.optimize.minimize` definition.
 
     Returns
     -------
@@ -88,7 +89,7 @@ def XYZ_to_sd_Meng2015(
     Raises
     ------
     RuntimeError
-        If the optimisation failed.
+        If the optimisation fails.
 
     Notes
     -----
@@ -100,9 +101,9 @@ def XYZ_to_sd_Meng2015(
 
     -   The definition used to convert spectrum to *CIE XYZ* tristimulus
         values is :func:`colour.colorimetry.spectral_to_XYZ_integration`
-        definition because it processes any measurement interval opposed to
-        :func:`colour.colorimetry.sd_to_XYZ_ASTME308` definition that
-        handles only measurement interval of 1, 5, 10 or 20nm.
+        because it processes any measurement interval, as opposed to
+        :func:`colour.colorimetry.sd_to_XYZ_ASTME308` which handles only
+        measurement intervals of 1, 5, 10 or 20nm.
 
     References
     ----------

--- a/colour/recovery/otsu2018.py
+++ b/colour/recovery/otsu2018.py
@@ -1089,7 +1089,7 @@ class Node_Otsu2018(TreeNode):
         """
 
         self.data = None
-        self.children = list(children)  # pyright: ignore
+        self.children = list(children)
 
         self._best_partition = None
         self._partition_axis = axis

--- a/colour/recovery/otsu2018.py
+++ b/colour/recovery/otsu2018.py
@@ -3,7 +3,7 @@ Otsu, Yamamoto and Hachisuka (2018) - Reflectance Recovery
 ==========================================================
 
 Define the objects for reflectance recovery, i.e., spectral upsampling, using
-*Otsu et al. (2018)* method:
+*Otsu et al. (2018)* method.
 
 -   :class:`colour.recovery.Dataset_Otsu2018`
 -   :func:`colour.recovery.XYZ_to_sd_Otsu2018`
@@ -93,14 +93,13 @@ __all__ = [
 
 class Dataset_Otsu2018:
     """
-    Store all the information needed for the *Otsu et al. (2018)* spectral
+    Store all information required for the *Otsu et al. (2018)* spectral
     upsampling method.
 
-    Datasets can be either generated and converted as a
+    Datasets can be generated and converted as a
     :class:`colour.recovery.Dataset_Otsu2018` class instance using the
-    :meth:`colour.recovery.Tree_Otsu2018.to_dataset` method or
-    alternatively, loaded from disk with the
-    :meth:`colour.recovery.Dataset_Otsu2018.read` method.
+    :meth:`colour.recovery.Tree_Otsu2018.to_dataset` method or loaded from
+    disk with the :meth:`colour.recovery.Dataset_Otsu2018.read` method.
 
     Parameters
     ----------
@@ -111,7 +110,7 @@ class Dataset_Otsu2018:
     means
         Mean for every cluster.
     selector_array
-        Array describing how to select the appropriate cluster. See
+        Array describing how to select the appropriate cluster. See the
         :meth:`colour.recovery.Dataset_Otsu2018.select` method for details.
 
     Attributes
@@ -180,12 +179,12 @@ class Dataset_Otsu2018:
     @property
     def shape(self) -> SpectralShape | None:
         """
-        Getter property for the shape used by the *Otsu et al. (2018)* dataset.
+        Getter for the spectral shape of the *Otsu et al. (2018)* dataset.
 
         Returns
         -------
         :class:`colour.SpectralShape` or :py:data:`None`
-            Shape used by the *Otsu et al. (2018)* dataset.
+            Spectral shape used by the *Otsu et al. (2018)* dataset.
         """
 
         return self._shape
@@ -193,8 +192,7 @@ class Dataset_Otsu2018:
     @property
     def basis_functions(self) -> NDArrayFloat | None:
         """
-        Getter property for the basis functions of the *Otsu et al. (2018)*
-        dataset.
+        Getter for the basis functions of the *Otsu et al. (2018)* dataset.
 
         Returns
         -------
@@ -207,7 +205,7 @@ class Dataset_Otsu2018:
     @property
     def means(self) -> NDArrayFloat | None:
         """
-        Getter property for means of the *Otsu et al. (2018)* dataset.
+        Getter for the means of the *Otsu et al. (2018)* dataset.
 
         Returns
         -------
@@ -220,8 +218,7 @@ class Dataset_Otsu2018:
     @property
     def selector_array(self) -> NDArrayFloat | None:
         """
-        Getter property for the selector array of the *Otsu et al. (2018)*
-        dataset.
+        Getter for the selector array of the *Otsu et al. (2018)* dataset.
 
         Returns
         -------
@@ -251,7 +248,7 @@ class Dataset_Otsu2018:
 
     def select(self, xy: ArrayLike) -> int:
         """
-        Determine the cluster index appropriate for the specified *CIE xy*
+        Select the cluster index for the specified *CIE xy* chromaticity
         coordinates.
 
         Parameters
@@ -294,8 +291,8 @@ class Dataset_Otsu2018:
 
     def cluster(self, xy: ArrayLike) -> Tuple[NDArrayFloat, NDArrayFloat]:
         """
-        Retrieve the basis functions and dataset mean for the specified *CIE xy*
-        coordinates.
+        Retrieve the basis functions and dataset mean for the specified
+        *CIE xy* chromaticity coordinates.
 
         Parameters
         ----------
@@ -324,12 +321,12 @@ class Dataset_Otsu2018:
 
     def read(self, path: str | PathLike) -> None:
         """
-        Read and loads a dataset from an *.npz* file.
+        Read and load a dataset from an *.npz* file.
 
         Parameters
         ----------
         path
-            Path to the file.
+            File path for reading the dataset.
 
         Examples
         --------
@@ -367,7 +364,7 @@ class Dataset_Otsu2018:
 
     def write(self, path: str | PathLike) -> None:
         """
-        Write the dataset to an *.npz* file at specified path.
+        Write the dataset to an *.npz* file at the specified path.
 
         Parameters
         ----------
@@ -444,13 +441,14 @@ def XYZ_to_sd_Otsu2018(
     clip: bool = True,
 ) -> SpectralDistribution:
     """
-    Recover the spectral distribution of specified *CIE XYZ* tristimulus values
-    using *Otsu et al. (2018)* method.
+    Recover the spectral distribution of the specified *CIE XYZ* tristimulus
+    values using *Otsu et al. (2018)* method.
 
     Parameters
     ----------
     XYZ
-        *CIE XYZ* tristimulus values to recover the spectral distribution from.
+        *CIE XYZ* tristimulus values to recover the spectral distribution
+        from.
     cmfs
         Standard observer colour matching functions, default to the
         *CIE 1931 2 Degree Standard Observer*.
@@ -458,13 +456,14 @@ def XYZ_to_sd_Otsu2018(
         Illuminant spectral distribution, default to
         *CIE Standard Illuminant D65*.
     dataset
-        Dataset to use for reconstruction. The default is to use the published
-        data.
+        Dataset to use for reconstruction. The default is to use the
+        published data.
     clip
         If *True*, the default, values below zero and above unity in the
-        recovered spectral distributions will be clipped. This ensures that the
-        returned reflectance is physical and conserves energy, but will cause
-        noticeable colour differences in case of very saturated colours.
+        recovered spectral distributions will be clipped. This ensures that
+        the returned reflectance is physical and conserves energy, but will
+        cause noticeable colour differences in case of very saturated
+        colours.
 
     Returns
     -------
@@ -586,16 +585,15 @@ def XYZ_to_sd_Otsu2018(
 @dataclass
 class PartitionAxis:
     """
-    Represent a horizontal or vertical line, partitioning the 2D space in
+    Represent a horizontal or vertical line that partitions 2D space into
     two half-planes.
 
     Parameters
     ----------
     origin
-        The x coordinate of a vertical line or the y coordinate of a horizontal
-        line.
+        X-coordinate of a vertical line or Y-coordinate of a horizontal line.
     direction
-        *0* if vertical, *1* if horizontal.
+        Direction indicator: *0* for vertical, *1* for horizontal.
 
     Methods
     -------
@@ -624,13 +622,13 @@ class PartitionAxis:
 
 class Data_Otsu2018:
     """
-    Store the reference reflectances and derived information along with the
-    methods to process them for a leaf :class:`colour.recovery.otsu2018.Node`
-    class instance.
+    Store reference reflectances and derived information, and provide methods
+    to process them for a leaf :class:`colour.recovery.otsu2018.Node` class
+    instance.
 
-    This class also supports partitioning: Creating two smaller instances of
-    :class:`colour.recovery.otsu2018.Data` class by splitting along an
-    horizontal or a vertical axis on the *CIE xy* plane.
+    Support partitioning by creating two smaller instances of
+    :class:`colour.recovery.otsu2018.Data` through splitting along a
+    horizontal or vertical axis on the *CIE xy* chromaticity plane.
 
     Parameters
     ----------
@@ -686,7 +684,7 @@ class Data_Otsu2018:
     @property
     def reflectances(self) -> NDArrayFloat | None:
         """
-        Getter and setter property for the reference reflectances.
+        Getter and setter for the reference reflectances.
 
         Parameters
         ----------
@@ -723,7 +721,7 @@ class Data_Otsu2018:
     @property
     def cmfs(self) -> MultiSpectralDistributions:
         """
-        Getter property for the standard observer colour matching functions.
+        Getter for the standard observer colour matching functions.
 
         Returns
         -------
@@ -736,12 +734,12 @@ class Data_Otsu2018:
     @property
     def illuminant(self) -> SpectralDistribution:
         """
-        Getter property for the illuminant.
+        Getter for the illuminant spectral distribution.
 
         Returns
         -------
         :class:`colour.SpectralDistribution`
-            Illuminant.
+            Illuminant spectral distribution.
         """
 
         return self._illuminant
@@ -749,12 +747,12 @@ class Data_Otsu2018:
     @property
     def basis_functions(self) -> NDArrayFloat | None:
         """
-        Getter property for the basis functions.
+        Getter for the basis functions.
 
         Returns
         -------
         :class:`numpy.ndarray`
-            Basis functions.
+            Basis functions used for spectral representation.
         """
 
         return self._basis_functions
@@ -762,12 +760,14 @@ class Data_Otsu2018:
     @property
     def mean(self) -> NDArrayFloat | None:
         """
-        Getter property for the mean distribution.
+        Getter for the mean distribution of the basis functions.
 
         Returns
         -------
         :class:`numpy.ndarray` or :py:data:`None`
-            Mean distribution.
+            Mean distribution representing the average values across the
+            basis functions, or :py:data:`None` if no mean has been
+            computed or specified.
         """
 
         return self._mean
@@ -786,7 +786,7 @@ class Data_Otsu2018:
 
     def __len__(self) -> int:
         """
-        Determine the number of colours in the data.
+        Return the number of colours in the data.
 
         Returns
         -------
@@ -799,7 +799,7 @@ class Data_Otsu2018:
     def origin(self, i: int, direction: int) -> float:
         """
         Retrieve the origin *CIE x* or *CIE y* chromaticity coordinate for
-        specified index and direction.
+        the specified index and direction.
 
         Parameters
         ----------
@@ -828,7 +828,7 @@ class Data_Otsu2018:
 
     def partition(self, axis: PartitionAxis) -> Tuple[Data_Otsu2018, Data_Otsu2018]:
         """
-        Partition the data using specified partition axis.
+        Partition the data using the specified partition axis.
 
         Parameters
         ----------
@@ -874,8 +874,8 @@ class Data_Otsu2018:
 
     def PCA(self) -> None:
         """
-        Perform the *Principal Component Analysis* (PCA) on the data and sets
-        the relevant attributes accordingly.
+        Perform *Principal Component Analysis* (PCA) on the data and set the
+        relevant attributes accordingly.
         """
 
         if self._M is None and self._reflectances is not None:
@@ -910,8 +910,8 @@ class Data_Otsu2018:
         Parameters
         ----------
         XYZ
-            *CIE XYZ* tristimulus values to recover the spectral distribution
-            from.
+            *CIE XYZ* tristimulus values to recover the spectral
+            distribution from.
 
         Returns
         -------
@@ -921,8 +921,8 @@ class Data_Otsu2018:
         Raises
         ------
         ValueError
-            If the matrix :math:`M`, the mean tristimulus values or the basis
-            functions are undefined.
+            If the matrix :math:`M`, the mean tristimulus values or the
+            basis functions are undefined.
         """
 
         if (
@@ -947,15 +947,16 @@ class Data_Otsu2018:
 
     def reconstruction_error(self) -> float:
         """
-        Compute the reconstruction error of the data. The error is computed by
-        reconstructing the reflectances for the reference *CIE XYZ* tristimulus
-        values using PCA and, comparing the reconstructed reflectances against
-        the reference reflectances.
+        Compute the reconstruction error of the data.
+
+        The error is computed by reconstructing the reflectances for the
+        reference *CIE XYZ* tristimulus values using PCA and comparing the
+        reconstructed reflectances against the reference reflectances.
 
         Returns
         -------
         :class:`float`
-            The reconstruction error for the data.
+            Reconstruction error for the data.
 
         Raises
         ------
@@ -964,8 +965,8 @@ class Data_Otsu2018:
 
         Notes
         -----
-        -   The reconstruction error is cached upon being computed and thus is
-            only computed once per node.
+        -   The reconstruction error is cached upon being computed and thus
+            is only computed once per node.
         """
 
         if self._reconstruction_error is not None:
@@ -994,8 +995,8 @@ class Data_Otsu2018:
 
 class Node_Otsu2018(TreeNode):
     """
-    Represent a node in a :meth:`colour.recovery.Tree_Otsu2018` class instance
-    node tree.
+    Represent a node in a :meth:`colour.recovery.Tree_Otsu2018` class
+    instance node tree.
 
     Parameters
     ----------
@@ -1036,7 +1037,7 @@ class Node_Otsu2018(TreeNode):
     @property
     def partition_axis(self) -> PartitionAxis | None:
         """
-        Getter property for the node partition axis.
+        Getter for the node partition axis.
 
         Returns
         -------
@@ -1049,7 +1050,7 @@ class Node_Otsu2018(TreeNode):
     @property
     def row(self) -> Tuple[float, float, Self, Self]:
         """
-        Getter property for the node row for the selector array.
+        Getter for the node row of the selector array.
 
         Returns
         -------
@@ -1076,7 +1077,7 @@ class Node_Otsu2018(TreeNode):
 
     def split(self, children: Sequence[Self], axis: PartitionAxis) -> None:
         """
-        Convert the leaf node into an inner node using specified children and
+        Convert the leaf node into an inner node using the specified children and
         partition axis.
 
         Parameters
@@ -1098,21 +1099,22 @@ class Node_Otsu2018(TreeNode):
         self, minimum_cluster_size: int
     ) -> Tuple[Sequence[Node_Otsu2018], PartitionAxis, float]:
         """
-        Find the best partition for the node that minimises the leaf
-        reconstruction error.
+        Minimise the leaf reconstruction error by finding the best partition
+        for the node.
 
         Parameters
         ----------
         minimum_cluster_size
-            Smallest acceptable cluster size. It must be at least 3 or the
-            *Principal Component Analysis* (PCA) is not possible.
+            Smallest acceptable cluster size. Must be at least 3 to enable
+            *Principal Component Analysis* (PCA).
 
         Returns
         -------
         :class:`tuple`
-            Tuple of tuple of nodes created by splitting a node with a specified
-            partition, partition axis, i.e., the horizontal or vertical line,
-            partitioning the 2D space in two half-planes and partition error.
+            Tuple containing nodes created by splitting this node with the
+            optimal partition, the partition axis (horizontal or vertical
+            line partitioning the 2D space into two half-planes), and the
+            partition error.
         """
 
         if self._best_partition is not None:
@@ -1172,29 +1174,32 @@ class Node_Otsu2018(TreeNode):
 
     def leaf_reconstruction_error(self) -> float:
         """
-        Compute the reconstruction error of the node data. The error is
-        computed by reconstructing the reflectances for the data reference
-        *CIE XYZ* tristimulus values using PCA and, comparing the reconstructed
-        reflectances against the data reference reflectances.
+        Compute the reconstruction error of the node data.
+
+        The error is computed by reconstructing the reflectances for the data
+        reference *CIE XYZ* tristimulus values using PCA and comparing the
+        reconstructed reflectances against the data reference reflectances.
 
         Returns
         -------
         :class:`float`
-            The reconstruction errors summation for the node data.
+            Reconstruction errors summation for the node data.
         """
 
         return self.data.reconstruction_error()
 
     def branch_reconstruction_error(self) -> float:
         """
-        Compute the reconstruction error for all the leaves data connected to
-        the node or its children, i.e., the reconstruction errors summation for
-        all the leaves in the branch.
+        Compute the reconstruction error for all leaves data connected to the
+        node or its children.
+
+        The reconstruction error is the summation of errors for all leaves in
+        the branch.
 
         Returns
         -------
         :class:`float`
-            Reconstruction errors summation for all the leaves' data in the
+            Summation of reconstruction errors for all leaves data in the
             branch.
         """
 
@@ -1208,13 +1213,13 @@ class Node_Otsu2018(TreeNode):
 
 class Tree_Otsu2018(Node_Otsu2018):
     """
-    A sub-class of :class:`colour.recovery.otsu2018.Node` class representing
-    the root node of a tree containing information shared with all the nodes,
-    such as the standard observer colour matching functions and the illuminant,
+    Sub-class of :class:`colour.recovery.otsu2018.Node` representing the
+    root node of a tree containing information shared with all nodes, such
+    as the standard observer colour matching functions and the illuminant,
     if any is used.
 
-    Global operations involving the entire tree, such as optimisation and
-    conversion to dataset, are implemented in this sub-class.
+    Implement global operations involving the entire tree, such as
+    optimisation and conversion to dataset.
 
     Parameters
     ----------
@@ -1353,7 +1358,7 @@ class Tree_Otsu2018(Node_Otsu2018):
     @property
     def reflectances(self) -> NDArrayFloat:
         """
-        Getter property for the reference reflectances.
+        Getter for the reference reflectances.
 
         Returns
         -------
@@ -1366,7 +1371,7 @@ class Tree_Otsu2018(Node_Otsu2018):
     @property
     def cmfs(self) -> MultiSpectralDistributions:
         """
-        Getter property for the standard observer colour matching functions.
+        Getter for the standard observer colour matching functions.
 
         Returns
         -------
@@ -1379,12 +1384,12 @@ class Tree_Otsu2018(Node_Otsu2018):
     @property
     def illuminant(self) -> SpectralDistribution:
         """
-        Getter property for the illuminant.
+        Getter for the test illuminant.
 
         Returns
         -------
         :class:`colour.SpectralDistribution`
-            Illuminant.
+            Test illuminant spectral distribution.
         """
 
         return self._illuminant
@@ -1396,20 +1401,20 @@ class Tree_Otsu2018(Node_Otsu2018):
         print_callable: Callable = print,
     ) -> None:
         """
-        Optimise the tree by repeatedly performing optimal partitioning of the
+        Optimise the tree by repeatedly performing optimal partitioning of
         nodes, creating a tree that minimises the total reconstruction error.
 
         Parameters
         ----------
         iterations
-            Maximum number of splits. If the dataset is too small, this number
-            might not be reached. The default is to create 8 clusters, like in
-            :cite:`Otsu2018`.
+            Maximum number of splits. If the dataset is too small, this
+            number might not be reached. The default is to create 8 clusters,
+            as described in :cite:`Otsu2018`.
         minimum_cluster_size
             Smallest acceptable cluster size. By default, it is chosen
-            automatically, based on the size of the dataset and desired number
-            of clusters. It must be at least 3 or the
-            *Principal Component Analysis* (PCA) is not be possible.
+            automatically based on the dataset size and desired number of
+            clusters. It must be at least 3 or *Principal Component Analysis*
+            (PCA) will not be possible.
         print_callable
             Callable used to print progress and diagnostic information.
 
@@ -1553,12 +1558,12 @@ the initial error.
         based on data stored in the tree.
 
         The dataset can then be saved to disk or used to recover reflectance
-        with :func:`colour.recovery.XYZ_to_sd_Otsu2018` definition.
+        with the :func:`colour.recovery.XYZ_to_sd_Otsu2018` definition.
 
         Returns
         -------
         :class:`colour.recovery.Dataset_Otsu2018`
-            The dataset object.
+            Dataset object.
 
         Examples
         --------
@@ -1584,7 +1589,7 @@ the initial error.
         else:
 
             def add_rows(node: Node_Otsu2018, data: dict | None = None) -> dict | None:
-                """Add rows for specified node and its children."""
+                """Add rows for the specified node and its children."""
 
                 data = optional(data, {"rows": [], "node_to_leaf_id": {}, "leaf_id": 0})
 

--- a/colour/recovery/smits1999.py
+++ b/colour/recovery/smits1999.py
@@ -2,7 +2,7 @@
 Smits (1999) - Reflectance Recovery
 ===================================
 
-Define the objects for reflectance recovery using *Smits (1999)* method.
+Define objects for reflectance recovery using the *Smits (1999)* method.
 
 References
 ----------
@@ -68,8 +68,9 @@ References
 
 def XYZ_to_RGB_Smits1999(XYZ: ArrayLike) -> NDArrayFloat:
     """
-    Convert from *CIE XYZ* tristimulus values to *RGB* colourspace with
-    conditions required by the current *Smits (1999)* method implementation.
+    Convert from *CIE XYZ* tristimulus values to *RGB* colourspace using
+    the conditions required by the current *Smits (1999)* method
+    implementation.
 
     Parameters
     ----------
@@ -94,8 +95,8 @@ def XYZ_to_RGB_Smits1999(XYZ: ArrayLike) -> NDArrayFloat:
 
 def RGB_to_sd_Smits1999(RGB: ArrayLike) -> SpectralDistribution:
     """
-    Recover the spectral distribution of specified *RGB* colourspace array using
-    *Smits (1999)* method.
+    Recover the spectral distribution of the specified *RGB* colourspace array
+    using the *Smits (1999)* method.
 
     Parameters
     ----------

--- a/colour/recovery/tests/test_jakob2019.py
+++ b/colour/recovery/tests/test_jakob2019.py
@@ -83,7 +83,7 @@ class TestErrorFunction:
         ]
 
         for coefficients in coefficient_list:
-            error, _derror, R, XYZ, Lab = error_function(  # pyright: ignore
+            error, _derror, R, XYZ, Lab = error_function(
                 coefficients,
                 self._Lab_e,
                 self._cmfs,

--- a/colour/temperature/__init__.py
+++ b/colour/temperature/__init__.py
@@ -124,8 +124,9 @@ colour temperature :math:`T_{cp}` computation methods.
 
 References
 ----------
-:cite:`AdobeSystems2013`, :cite:`AdobeSystems2013a`, :cite:`CIETC1-482004i`,
-:cite:`Krystek1985b`, :cite:`Ohno2014a`, :cite:`Wyszecki2000y`
+:cite:`AdobeSystems2013`, :cite:`AdobeSystems2013a`,
+:cite:`CIETC1-482004i`, :cite:`Krystek1985b`, :cite:`Ohno2014a`,
+:cite:`Wyszecki2000y`
 
 Aliases:
 
@@ -145,8 +146,8 @@ def uv_to_CCT(
 ) -> NDArrayFloat:
     """
     Compute the correlated colour temperature :math:`T_{cp}` and
-    :math:`\\Delta_{uv}` from specified *CIE UCS* colourspace *uv* chromaticity
-    coordinates using specified method.
+    :math:`\\Delta_{uv}` from the specified *CIE UCS* colourspace *uv*
+    chromaticity coordinates using the specified method.
 
     Parameters
     ----------
@@ -217,8 +218,9 @@ Supported correlated colour temperature :math:`T_{cp}` to *CIE UCS* colourspace
 
 References
 ----------
-:cite:`AdobeSystems2013`, :cite:`AdobeSystems2013a`, :cite:`CIETC1-482004i`,
-:cite:`Krystek1985b`, :cite:`Ohno2014a`, :cite:`Wyszecki2000y`
+:cite:`AdobeSystems2013`, :cite:`AdobeSystems2013a`,
+:cite:`CIETC1-482004i`, :cite:`Krystek1985b`, :cite:`Ohno2014a`,
+:cite:`Wyszecki2000y`
 
 Aliases:
 
@@ -237,8 +239,9 @@ def CCT_to_uv(
     **kwargs: Any,
 ) -> NDArrayFloat:
     """
-    Compute the *CIE UCS* colourspace *uv* chromaticity coordinates from specified
-    correlated colour temperature :math:`T_{cp}` using specified method.
+    Compute the *CIE UCS* colourspace *uv* chromaticity coordinates from the
+    specified correlated colour temperature :math:`T_{cp}` and
+    :math:`\\Delta_{uv}` using the specified method.
 
     Parameters
     ----------
@@ -332,8 +335,8 @@ def xy_to_CCT(
     ) = "CIE Illuminant D Series",
 ) -> NDArrayFloat:
     """
-    Compute the correlated colour temperature :math:`T_{cp}` from specified
-    *CIE xy* chromaticity coordinates using specified method.
+    Compute the correlated colour temperature :math:`T_{cp}` from the
+    specified *CIE xy* chromaticity coordinates using the specified method.
 
     Parameters
     ----------
@@ -417,8 +420,8 @@ def CCT_to_xy(
     ) = "CIE Illuminant D Series",
 ) -> NDArrayFloat:
     """
-    Compute the *CIE xy* chromaticity coordinates from specified correlated colour
-    temperature :math:`T_{cp}` using specified method.
+    Compute the *CIE xy* chromaticity coordinates from the specified
+    correlated colour temperature :math:`T_{cp}` using the specified method.
 
     Parameters
     ----------

--- a/colour/temperature/cie_d.py
+++ b/colour/temperature/cie_d.py
@@ -3,14 +3,14 @@ CIE Illuminant D Series Correlated Colour Temperature
 =====================================================
 
 Define the *CIE Illuminant D Series* correlated colour temperature
-:math:`T_{cp} computations objects:
+:math:`T_{cp}` computation objects.
 
--   :func:`colour.temperature.xy_to_CCT_CIE_D`: Correlated colour temperature
-    :math:`T_{cp}` computation of a *CIE Illuminant D Series* from its *CIE xy*
-    chromaticity coordinates.
--   :func:`colour.temperature.CCT_to_xy_CIE_D`: *CIE xy* chromaticity
-    coordinates computation of a *CIE Illuminant D Series* from its correlated
-    colour temperature :math:`T_{cp}`.
+-   :func:`colour.temperature.xy_to_CCT_CIE_D`: Compute correlated colour
+    temperature :math:`T_{cp}` of a *CIE Illuminant D Series* from its
+    *CIE xy* chromaticity coordinates.
+-   :func:`colour.temperature.CCT_to_xy_CIE_D`: Compute *CIE xy*
+    chromaticity coordinates of a *CIE Illuminant D Series* from its
+    correlated colour temperature :math:`T_{cp}`.
 
 References
 ----------
@@ -52,7 +52,8 @@ def xy_to_CCT_CIE_D(
 ) -> NDArrayFloat:
     """
     Compute the correlated colour temperature :math:`T_{cp}` of a
-    *CIE Illuminant D Series* from its *CIE xy* chromaticity coordinates.
+    *CIE Illuminant D Series* from the specified *CIE xy* chromaticity
+    coordinates.
 
     Parameters
     ----------
@@ -68,11 +69,11 @@ def xy_to_CCT_CIE_D(
 
     Warnings
     --------
-    The *CIE Illuminant D Series* method does not give an analytical inverse
+    The *CIE Illuminant D Series* method does not provide an analytical inverse
     transformation to compute the correlated colour temperature :math:`T_{cp}`
-    from given *CIE xy* chromaticity coordinates, the current implementation
-    relies on optimisation using :func:`scipy.optimize.minimize` definition and
-    thus has reduced precision and poor performance.
+    from the specified *CIE xy* chromaticity coordinates. The current
+    implementation relies on optimisation using :func:`scipy.optimize.minimize`
+    definition and thus has reduced precision and poor performance.
 
     References
     ----------
@@ -123,7 +124,7 @@ def xy_to_CCT_CIE_D(
 def CCT_to_xy_CIE_D(CCT: ArrayLike) -> NDArrayFloat:
     """
     Compute the *CIE xy* chromaticity coordinates of a
-    *CIE Illuminant D Series* from its correlated colour temperature
+    *CIE Illuminant D Series* from the specified correlated colour temperature
     :math:`T_{cp}`.
 
     Parameters
@@ -139,7 +140,8 @@ def CCT_to_xy_CIE_D(CCT: ArrayLike) -> NDArrayFloat:
     Raises
     ------
     ValueError
-        If the correlated colour temperature is not in appropriate domain.
+        If the correlated colour temperature is not in the appropriate
+        domain.
 
     References
     ----------

--- a/colour/temperature/hernandez1999.py
+++ b/colour/temperature/hernandez1999.py
@@ -2,14 +2,14 @@
 Hernandez-Andres, Lee and Romero (1999) Correlated Colour Temperature
 =====================================================================
 
-Define the *Hernandez-Andres et al. (1999)* correlated colour temperature
-:math:`T_{cp}` computations objects:
+Define *Hernandez-Andres et al. (1999)* correlated colour temperature
+:math:`T_{cp}` computation objects.
 
--   :func:`colour.temperature.xy_to_CCT_Hernandez1999`: Correlated colour
-    temperature :math:`T_{cp}` computation of specified *CIE xy* chromaticity
+-   :func:`colour.temperature.xy_to_CCT_Hernandez1999`: Compute correlated
+    colour temperature :math:`T_{cp}` from specified *CIE xy* chromaticity
     coordinates using *Hernandez-Andres, Lee and Romero (1999)* method.
--   :func:`colour.temperature.CCT_to_xy_Hernandez1999`: *CIE xy* chromaticity
-    coordinates computation of specified correlated colour temperature
+-   :func:`colour.temperature.CCT_to_xy_Hernandez1999`: Compute *CIE xy*
+    chromaticity coordinates from specified correlated colour temperature
     :math:`T_{cp}` using *Hernandez-Andres, Lee and Romero (1999)* method.
 
 References
@@ -50,9 +50,9 @@ __all__ = [
 
 def xy_to_CCT_Hernandez1999(xy: ArrayLike) -> NDArrayFloat:
     """
-    Compute the correlated colour temperature :math:`T_{cp}` from specified
-    *CIE xy* chromaticity coordinates using *Hernandez-Andres et al. (1999)*
-    method.
+    Compute the correlated colour temperature :math:`T_{cp}` from the
+    specified *CIE xy* chromaticity coordinates using
+    *Hernandez-Andres et al. (1999)* method.
 
     Parameters
     ----------
@@ -104,8 +104,9 @@ def CCT_to_xy_Hernandez1999(
     CCT: ArrayLike, optimisation_kwargs: dict | None = None
 ) -> NDArrayFloat:
     """
-    Compute the *CIE xy* chromaticity coordinates from specified correlated colour
-    temperature :math:`T_{cp}` using *Hernandez-Andres et al. (1999)* method.
+    Compute the *CIE xy* chromaticity coordinates from the specified
+    correlated colour temperature :math:`T_{cp}` using
+    *Hernandez-Andres et al. (1999)* method.
 
     Parameters
     ----------
@@ -121,13 +122,14 @@ def CCT_to_xy_Hernandez1999(
 
     Warnings
     --------
-    *Hernandez-Andres et al. (1999)* method for computing *CIE xy* chromaticity
-    coordinates from given correlated colour temperature is not a bijective
-    function and might produce unexpected results. It is given for consistency
-    with other correlated colour temperature computation methods but should be
-    avoided for practical applications. The current implementation relies on
-    optimisation using :func:`scipy.optimize.minimize` definition and thus has
-    reduced precision and poor performance.
+    *Hernandez-Andres et al. (1999)* method for computing *CIE xy*
+    chromaticity coordinates from the specified correlated colour temperature
+    is not a bijective function and might produce unexpected results. It is
+    provided for consistency with other correlated colour temperature
+    computation methods but should be avoided for practical applications. The
+    current implementation relies on optimisation using
+    :func:`scipy.optimize.minimize` definition and thus has reduced precision
+    and poor performance.
 
     References
     ----------

--- a/colour/temperature/kang2002.py
+++ b/colour/temperature/kang2002.py
@@ -3,14 +3,15 @@ Kang, Moon, Hong, Lee, Cho and Kim (2002) Correlated Colour Temperature
 =======================================================================
 
 Define the *Kang et al. (2002)* correlated colour temperature :math:`T_{cp}`
-computations objects:
+computation objects.
 
--   :func:`colour.temperature.xy_to_CCT_Kang2002`: Correlated colour
-    temperature :math:`T_{cp}` of given *CIE xy* chromaticity coordinates
-    computation  using *Kang, Moon, Hong, Lee, Cho and Kim (2002)* method.
--   :func:`colour.temperature.CCT_to_xy_Kang2002`: *CIE xy* chromaticity
-    coordinates computation of given correlated colour temperature
-    :math:`T_{cp}` using *Kang, Moon, Hong, Lee, Cho and Kim (2002)* method.
+-   :func:`colour.temperature.xy_to_CCT_Kang2002`: Compute correlated colour
+    temperature :math:`T_{cp}` from specified *CIE xy* chromaticity
+    coordinates using the *Kang, Moon, Hong, Lee, Cho and Kim (2002)* method.
+-   :func:`colour.temperature.CCT_to_xy_Kang2002`: Compute *CIE xy*
+    chromaticity coordinates from specified correlated colour temperature
+    :math:`T_{cp}` using the *Kang, Moon, Hong, Lee, Cho and Kim (2002)*
+    method.
 
 References
 ----------
@@ -48,8 +49,9 @@ def xy_to_CCT_Kang2002(
     xy: ArrayLike, optimisation_kwargs: dict | None = None
 ) -> NDArrayFloat:
     """
-    Compute the correlated colour temperature :math:`T_{cp}` from specified
-    *CIE xy* chromaticity coordinates using *Kang et al. (2002)* method.
+    Compute the correlated colour temperature :math:`T_{cp}` from the
+    specified *CIE xy* chromaticity coordinates using *Kang et al. (2002)*
+    method.
 
     Parameters
     ----------
@@ -65,11 +67,12 @@ def xy_to_CCT_Kang2002(
 
     Warnings
     --------
-    *Kang et al. (2002)* does not give an analytical inverse transformation to
-    compute the correlated colour temperature :math:`T_{cp}` from given
-    *CIE xy* chromaticity coordinates, the current implementation relies on
-    optimisation using :func:`scipy.optimize.minimize` definition and thus has
-    reduced precision and poor performance.
+    The *Kang et al. (2002)* method does not provide an analytical inverse
+    transformation to compute the correlated colour temperature
+    :math:`T_{cp}` from the specified *CIE xy* chromaticity coordinates.
+    The current implementation relies on optimisation using
+    :func:`scipy.optimize.minimize` definition and thus has reduced
+    precision and poor performance.
 
     References
     ----------
@@ -119,8 +122,9 @@ def xy_to_CCT_Kang2002(
 
 def CCT_to_xy_Kang2002(CCT: ArrayLike) -> NDArrayFloat:
     """
-    Compute the *CIE xy* chromaticity coordinates from specified correlated colour
-    temperature :math:`T_{cp}` using *Kang et al. (2002)* method.
+    Compute the *CIE xy* chromaticity coordinates from the specified
+    correlated colour temperature :math:`T_{cp}` using *Kang et al. (2002)*
+    method.
 
     Parameters
     ----------

--- a/colour/temperature/krystek1985.py
+++ b/colour/temperature/krystek1985.py
@@ -3,14 +3,14 @@ Krystek (1985) Correlated Colour Temperature
 ============================================
 
 Define the *Krystek (1985)* correlated colour temperature :math:`T_{cp}`
-computations objects:
+computation objects.
 
--   :func:`colour.temperature.uv_to_CCT_Krystek1985`: Correlated colour
-    temperature :math:`T_{cp}` computation of given *CIE UCS* colourspace *uv*
-    chromaticity coordinates using *Krystek (1985)* method.
--   :func:`colour.temperature.CCT_to_uv_Krystek1985`: *CIE UCS* colourspace
-    *uv* chromaticity coordinates computation of given correlated colour
-    temperature :math:`T_{cp}` using *Krystek (1985)* method.
+-   :func:`colour.temperature.uv_to_CCT_Krystek1985`: Compute correlated
+    colour temperature :math:`T_{cp}` from specified *CIE UCS* colourspace
+    *uv* chromaticity coordinates using the *Krystek (1985)* method.
+-   :func:`colour.temperature.CCT_to_uv_Krystek1985`: Compute *CIE UCS*
+    colourspace *uv* chromaticity coordinates from specified correlated
+    colour temperature :math:`T_{cp}` using the *Krystek (1985)* method.
 
 References
 ----------
@@ -48,9 +48,9 @@ def uv_to_CCT_Krystek1985(
     uv: ArrayLike, optimisation_kwargs: dict | None = None
 ) -> NDArrayFloat:
     """
-    Compute the correlated colour temperature :math:`T_{cp}` from specified
-    *CIE UCS* colourspace *uv* chromaticity coordinates using *Krystek (1985)*
-    method.
+    Compute the correlated colour temperature :math:`T_{cp}` from the
+    specified *CIE UCS* colourspace *uv* chromaticity coordinates using
+    *Krystek (1985)* method.
 
     Parameters
     ----------
@@ -66,16 +66,18 @@ def uv_to_CCT_Krystek1985(
 
     Warnings
     --------
-    *Krystek (1985)* does not give an analytical inverse transformation to
-    compute the correlated colour temperature :math:`T_{cp}` from given
-    *CIE UCS* colourspace *uv* chromaticity coordinates, the current
-    implementation relies on optimisation using :func:`scipy.optimize.minimize`
-    definition and thus has reduced precision and poor performance.
+    *Krystek (1985)* does not provide an analytical inverse transformation
+    to compute the correlated colour temperature :math:`T_{cp}` from the
+    specified *CIE UCS* colourspace *uv* chromaticity coordinates. The
+    current implementation relies on optimisation using
+    :func:`scipy.optimize.minimize` definition and thus has reduced
+    precision and poor performance.
 
     Notes
     -----
-    -   *Krystek (1985)* method computations are valid for correlated colour
-        temperature :math:`T_{cp}` normalised to domain [1000, 15000].
+    -   *Krystek (1985)* method computations are valid for correlated
+        colour temperature :math:`T_{cp}` normalised to domain
+        [1000, 15000].
 
     References
     ----------
@@ -125,8 +127,9 @@ def uv_to_CCT_Krystek1985(
 
 def CCT_to_uv_Krystek1985(CCT: ArrayLike) -> NDArrayFloat:
     """
-    Compute the *CIE UCS* colourspace *uv* chromaticity coordinates from specified
-    correlated colour temperature :math:`T_{cp}` using *Krystek (1985)* method.
+    Compute the *CIE UCS* colourspace *uv* chromaticity coordinates from the
+    specified correlated colour temperature :math:`T_{cp}` using the
+    *Krystek (1985)* method.
 
     Parameters
     ----------

--- a/colour/temperature/mccamy1992.py
+++ b/colour/temperature/mccamy1992.py
@@ -3,14 +3,14 @@ McCamy (1992) Correlated Colour Temperature
 ===========================================
 
 Define the *McCamy (1992)* correlated colour temperature :math:`T_{cp}`
-computations objects:
+computation objects.
 
--   :func:`colour.temperature.xy_to_CCT_McCamy1992`: Correlated colour
-    temperature :math:`T_{cp}` computation of given *CIE xy* chromaticity
-    coordinates using *McCamy (1992)* method.
--   :func:`colour.temperature.xy_to_CCT_McCamy1992`: *CIE xy* chromaticity
-    coordinates computation of given correlated colour temperature
-    :math:`T_{cp}` using *McCamy (1992)* method.
+-   :func:`colour.temperature.xy_to_CCT_McCamy1992`: Compute correlated
+    colour temperature :math:`T_{cp}` from specified *CIE xy* chromaticity
+    coordinates using the *McCamy (1992)* method.
+-   :func:`colour.temperature.CCT_to_xy_McCamy1992`: Compute *CIE xy*
+    chromaticity coordinates from specified correlated colour temperature
+    :math:`T_{cp}` using the *McCamy (1992)* method.
 
 References
 ----------
@@ -48,8 +48,9 @@ __all__ = [
 
 def xy_to_CCT_McCamy1992(xy: ArrayLike) -> NDArrayFloat:
     """
-    Compute the correlated colour temperature :math:`T_{cp}` from specified
-    *CIE xy* chromaticity coordinates using *McCamy (1992)* method.
+    Compute the correlated colour temperature :math:`T_{cp}` from the
+    specified *CIE xy* chromaticity coordinates using the *McCamy (1992)*
+    method.
 
     Parameters
     ----------
@@ -87,8 +88,9 @@ def CCT_to_xy_McCamy1992(
     CCT: ArrayLike, optimisation_kwargs: dict | None = None
 ) -> NDArrayFloat:
     """
-    Compute the *CIE xy* chromaticity coordinates from specified correlated colour
-    temperature :math:`T_{cp}` using *McCamy (1992)* method.
+    Compute the *CIE xy* chromaticity coordinates from the specified
+    correlated colour temperature :math:`T_{cp}` using the *McCamy (1992)*
+    method.
 
     Parameters
     ----------
@@ -104,13 +106,14 @@ def CCT_to_xy_McCamy1992(
 
     Warnings
     --------
-    *McCamy (1992)* method for computing *CIE xy* chromaticity coordinates
-    from given correlated colour temperature is not a bijective function and
-    might produce unexpected results. It is given for consistency with other
-    correlated colour temperature computation methods but should be avoided
-    for practical applications. The current implementation relies on
-    optimisation using :func:`scipy.optimize.minimize` definition and thus has
-    reduced precision and poor performance.
+    The *McCamy (1992)* method for computing *CIE xy* chromaticity coordinates
+    from the specified correlated colour temperature is not a bijective
+    function and might produce unexpected results. It is provided for
+    consistency with other correlated colour temperature computation methods
+    but should be avoided for practical applications. The current
+    implementation relies on optimisation using
+    :func:`scipy.optimize.minimize` definition and thus has reduced precision
+    and poor performance.
 
     References
     ----------

--- a/colour/temperature/ohno2013.py
+++ b/colour/temperature/ohno2013.py
@@ -3,15 +3,16 @@ Ohno (2013) Correlated Colour Temperature
 =========================================
 
 Define the *Ohno (2013)* correlated colour temperature :math:`T_{cp}`
-computations objects:
+computation objects.
 
--   :func:`colour.temperature.uv_to_CCT_Ohno2013`: Correlated colour
-    temperature :math:`T_{cp}` and :math:`\\Delta_{uv}` computation of given
-    *CIE UCS* colourspace *uv* chromaticity coordinates using *Ohno (2013)*
-    method.
--   :func:`colour.temperature.CCT_to_uv_Ohno2013`: *CIE UCS* colourspace *uv*
-    chromaticity coordinates computation of given correlated colour temperature
-    :math:`T_{cp}`, :math:`\\Delta_{uv}` using *Ohno (2013)* method.
+-   :func:`colour.temperature.uv_to_CCT_Ohno2013`: Compute correlated colour
+    temperature :math:`T_{cp}` and :math:`\\Delta_{uv}` from specified
+    *CIE UCS* colourspace *uv* chromaticity coordinates using the
+    *Ohno (2013)* method.
+-   :func:`colour.temperature.CCT_to_uv_Ohno2013`: Compute *CIE UCS*
+    colourspace *uv* chromaticity coordinates from specified correlated
+    colour temperature :math:`T_{cp}` and :math:`\\Delta_{uv}` using the
+    *Ohno (2013)* method.
 
 References
 ----------
@@ -78,9 +79,9 @@ def planckian_table(
     spacing: float,
 ) -> NDArrayFloat:
     """
-    Generate a planckian table from specified *CIE UCS* colourspace *uv*
-    chromaticity coordinates, colour matching functions and temperature range
-    using *Ohno (2013)* method.
+    Generate a planckian table from the specified *CIE UCS* colourspace
+    *uv* chromaticity coordinates, colour matching functions, and
+    temperature range using the *Ohno (2013)* method.
 
     Parameters
     ----------
@@ -91,8 +92,12 @@ def planckian_table(
     end
         Temperature range end in kelvin degrees.
     spacing
-        The spacing between values expressed as a multiplier. Must be greater
-        than 1.
+        Spacing between values of the underlying Planckian table expressed
+        as a multiplier. Default to 1.001. The closer to 1.0, the higher
+        the precision of the returned colour temperature :math:`T_{cp}` and
+        :math:`\\Delta_{uv}`. A value of 1.01 provides a good balance
+        between performance and accuracy. The ``spacing`` value must be
+        greater than 1.
 
     Returns
     -------
@@ -154,9 +159,8 @@ def uv_to_CCT_Ohno2013(
 ) -> NDArrayFloat:
     """
     Compute the correlated colour temperature :math:`T_{cp}` and
-    :math:`\\Delta_{uv}` from specified *CIE UCS* colourspace *uv* chromaticity
-    coordinates, colour matching functions and temperature range using
-    *Ohno (2013)* method.
+    :math:`\\Delta_{uv}` from the specified *CIE UCS* colourspace *uv*
+    chromaticity coordinates using the *Ohno (2013)* method.
 
     Parameters
     ----------
@@ -170,11 +174,12 @@ def uv_to_CCT_Ohno2013(
     end
         Temperature range end in kelvin degrees, default to 100000.
     spacing
-        Spacing between values of the underlying planckian table expressed as a
-        multiplier. Default to 1.001. The closer to 1.0, the higher the
-        precision of the returned colour temperature :math:`T_{cp}` and
-        :math:`\\Delta_{uv}`. 1.01 provides a good balance between performance
-        and accuracy. ``spacing`` value must be greater than 1.
+        Spacing between values of the underlying Planckian table expressed
+        as a multiplier. Default to 1.001. The closer to 1.0, the higher
+        the precision of the returned colour temperature :math:`T_{cp}` and
+        :math:`\\Delta_{uv}`. A value of 1.01 provides a good balance
+        between performance and accuracy. The ``spacing`` value must be
+        greater than 1.
 
     Returns
     -------
@@ -279,9 +284,10 @@ def CCT_to_uv_Ohno2013(
     CCT_D_uv: ArrayLike, cmfs: MultiSpectralDistributions | None = None
 ) -> NDArrayFloat:
     """
-    Compute the *CIE UCS* colourspace *uv* chromaticity coordinates from specified
-    correlated colour temperature :math:`T_{cp}`, :math:`\\Delta_{uv}` and
-    colour matching functions using *Ohno (2013)* method.
+    Compute the *CIE UCS* colourspace *uv* chromaticity coordinates from
+    the specified correlated colour temperature :math:`T_{cp}`,
+    :math:`\\Delta_{uv}` and colour matching functions using
+    *Ohno (2013)* method.
 
     Parameters
     ----------
@@ -346,26 +352,32 @@ def XYZ_to_CCT_Ohno2013(
 ) -> NDArrayFloat:
     """
     Compute the correlated colour temperature :math:`T_{cp}` and
-    :math:`\\Delta_{uv}` from specified *CIE XYZ* tristimulus values, colour
-    matching functions and temperature range using *Ohno (2013)* method.
+    :math:`\\Delta_{uv}` from the specified *CIE XYZ* tristimulus values
+    using the *Ohno (2013)* method.
+
+    The method computes the correlated colour temperature by finding the
+    closest point on the Planckian locus to the specified chromaticity
+    coordinates using an optimised search algorithm with configurable
+    precision through the spacing parameter.
 
     Parameters
     ----------
     XYZ
-        *XYZ* colourspace *uv* chromaticity coordinates.
+        *CIE XYZ* tristimulus values.
     cmfs
         Standard observer colour matching functions, default to the
         *CIE 1931 2 Degree Standard Observer*.
     start
-        Temperature range start in kelvin degrees, default to 1000.
+        Temperature range start in kelvins, default to 1000.
     end
-        Temperature range end in kelvin degrees, default to 100000.
+        Temperature range end in kelvins, default to 100000.
     spacing
-        Spacing between values of the underlying planckian table expressed as a
-        multiplier. Default to 1.001. The closer to 1.0, the higher the
-        precision of the returned colour temperature :math:`T_{cp}` and
-        :math:`\\Delta_{uv}`. 1.01 provides a good balance between performance
-        and accuracy. ``spacing`` value must be greater than 1.
+        Spacing between values of the underlying Planckian table expressed
+        as a multiplier. Default to 1.001. The closer to 1.0, the higher
+        the precision of the returned colour temperature :math:`T_{cp}` and
+        :math:`\\Delta_{uv}`. A value of 1.01 provides a good balance
+        between performance and accuracy. The ``spacing`` value must be
+        greater than 1.
 
     Returns
     -------
@@ -396,9 +408,9 @@ def CCT_to_XYZ_Ohno2013(
     CCT_D_uv: ArrayLike, cmfs: MultiSpectralDistributions | None = None
 ) -> NDArrayFloat:
     """
-    Compute the *CIE XYZ* tristimulus values from specified correlated colour
-    temperature :math:`T_{cp}`, :math:`\\Delta_{uv}` and colour matching
-    functions using *Ohno (2013)* method.
+    Compute the *CIE XYZ* tristimulus values from the specified correlated
+    colour temperature :math:`T_{cp}` and :math:`\\Delta_{uv}` using the
+    *Ohno (2013)* method.
 
     Parameters
     ----------
@@ -411,7 +423,7 @@ def CCT_to_XYZ_Ohno2013(
     Returns
     -------
     :class:`numpy.ndarray`
-        *CIE UCS* colourspace *uv* chromaticity coordinates.
+        *CIE XYZ* tristimulus values.
 
     Examples
     --------

--- a/colour/temperature/planck1900.py
+++ b/colour/temperature/planck1900.py
@@ -3,7 +3,8 @@ Blackbody - Planck (1900) - Correlated Colour Temperature
 =========================================================
 
 Define the *Planck (1900)* correlated colour temperature :math:`T_{cp}`
-computations objects based on the spectral radiance of a planckian radiator:
+computation objects based on the spectral radiance of a planckian
+radiator:
 
 -   :func:`colour.temperature.uv_to_CCT_Planck1900`
 -   :func:`colour.temperature.CCT_to_uv_Planck1900`
@@ -54,9 +55,9 @@ def uv_to_CCT_Planck1900(
     optimisation_kwargs: dict | None = None,
 ) -> NDArrayFloat:
     """
-    Compute the correlated colour temperature :math:`T_{cp}` of a blackbody from
-    specified *CIE UCS* colourspace *uv* chromaticity coordinates and colour
-    matching functions.
+    Compute the correlated colour temperature :math:`T_{cp}` of a blackbody
+    from specified *CIE UCS* colourspace *uv* chromaticity coordinates using
+    colour matching functions.
 
     Parameters
     ----------
@@ -76,8 +77,8 @@ def uv_to_CCT_Planck1900(
     Warnings
     --------
     The current implementation relies on optimisation using
-    :func:`scipy.optimize.minimize` definition and thus has reduced precision
-    and poor performance.
+    :func:`scipy.optimize.minimize` definition and thus has reduced
+    precision and poor performance.
 
     References
     ----------
@@ -131,15 +132,15 @@ def CCT_to_uv_Planck1900(
     CCT: ArrayLike, cmfs: MultiSpectralDistributions | None = None
 ) -> NDArrayFloat:
     """
-    Compute the *CIE UCS* colourspace *uv* chromaticity coordinates from specified
-    correlated colour temperature :math:`T_{cp}` and colour matching functions
-    using the spectral radiance of a blackbody at the specified thermodynamic
-    temperature.
+    Compute the *CIE UCS* colourspace *uv* chromaticity coordinates from the
+    specified correlated colour temperature :math:`T_{cp}` and colour
+    matching functions using the spectral radiance of a blackbody at the
+    specified thermodynamic temperature.
 
     Parameters
     ----------
     CCT
-        Colour temperature :math:`T_{cp}`.
+        Correlated colour temperature :math:`T_{cp}`.
     cmfs
         Standard observer colour matching functions, default to the
         *CIE 1931 2 Degree Standard Observer*.

--- a/colour/temperature/robertson1968.py
+++ b/colour/temperature/robertson1968.py
@@ -3,20 +3,20 @@ Robertson (1968) Correlated Colour Temperature
 ==============================================
 
 Define the *Robertson (1968)* correlated colour temperature :math:`T_{cp}`
-computations objects:
+computation objects.
 
--   :func:`colour.temperature.mired_to_CCT`: Micro reciprocal degree to
-    correlated colour temperature :math:`T_{cp}` computation.
--   :func:`colour.temperature.CCT_to_mired`: Correlated colour
-    temperature :math:`T_{cp}` to micro reciprocal degree computation.
--   :func:`colour.temperature.uv_to_CCT_Robertson1968`: Correlated colour
-    temperature :math:`T_{cp}` and :math:`\\Delta_{uv}` computation of given
-    *CIE UCS* colourspace *uv* chromaticity coordinates using *Robertson
-    (1968)* method.
--   :func:`colour.temperature.CCT_to_uv_Robertson1968`: *CIE UCS* colourspace
-    *uv* chromaticity coordinates computation of given correlated colour
-    temperature :math:`T_{cp}` and :math:`\\Delta_{uv}` using *Robertson
-    (1968)* method.
+-   :func:`colour.temperature.mired_to_CCT`: Convert micro reciprocal
+    degrees to correlated colour temperature :math:`T_{cp}`.
+-   :func:`colour.temperature.CCT_to_mired`: Convert correlated colour
+    temperature :math:`T_{cp}` to micro reciprocal degrees.
+-   :func:`colour.temperature.uv_to_CCT_Robertson1968`: Compute correlated
+    colour temperature :math:`T_{cp}` and :math:`\\Delta_{uv}` from
+    specified *CIE UCS* colourspace *uv* chromaticity coordinates using
+    the *Robertson (1968)* method.
+-   :func:`colour.temperature.CCT_to_uv_Robertson1968`: Compute *CIE UCS*
+    colourspace *uv* chromaticity coordinates from specified correlated
+    colour temperature :math:`T_{cp}` and :math:`\\Delta_{uv}` using the
+    *Robertson (1968)* method.
 
 References
 ----------
@@ -126,7 +126,7 @@ References
 @dataclass
 class ISOTemperatureLine_Specification_Robertson1968:
     """
-    Define the data for a *Roberston (1968)* iso-temperature line.
+    Define a data structure for a *Robertson (1968)* iso-temperature line.
 
     Parameters
     ----------
@@ -154,13 +154,13 @@ ISOTEMPERATURE_LINES_ROBERTSON1968: list = [
 
 def mired_to_CCT(mired: ArrayLike) -> NDArrayFloat:
     """
-    Convert specified micro reciprocal degree to correlated colour temperature
-    :math:`T_{cp}`.
+    Convert specified micro reciprocal degree (mired) to correlated colour
+    temperature :math:`T_{cp}`.
 
     Parameters
     ----------
     mired
-         Micro reciprocal degree (mired).
+         Micro reciprocal degree.
 
     Returns
     -------
@@ -187,12 +187,12 @@ def CCT_to_mired(CCT: ArrayLike) -> NDArrayFloat:
     Parameters
     ----------
     CCT
-         Correlated colour temperature :math:`T_{cp}`.
+        Correlated colour temperature :math:`T_{cp}`.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Micro reciprocal degree (mired).
+        Micro reciprocal degree.
 
     Examples
     --------
@@ -209,8 +209,8 @@ def CCT_to_mired(CCT: ArrayLike) -> NDArrayFloat:
 def _uv_to_CCT_Robertson1968(uv: ArrayLike) -> NDArrayFloat:
     """
     Compute the correlated colour temperature :math:`T_{cp}` and
-    :math:`\\Delta_{uv}` from specified *CIE UCS* colourspace *uv* chromaticity
-    coordinates using *Roberston (1968)* method.
+    :math:`\\Delta_{uv}` from the specified *CIE UCS* colourspace *uv*
+    chromaticity coordinates using the *Robertson (1968)* method.
 
     Parameters
     ----------
@@ -277,8 +277,8 @@ def _uv_to_CCT_Robertson1968(uv: ArrayLike) -> NDArrayFloat:
 def uv_to_CCT_Robertson1968(uv: ArrayLike) -> NDArrayFloat:
     """
     Compute the correlated colour temperature :math:`T_{cp}` and
-    :math:`\\Delta_{uv}` from specified *CIE UCS* colourspace *uv* chromaticity
-    coordinates using *Roberston (1968)* method.
+    :math:`\\Delta_{uv}` from the specified *CIE UCS* colourspace *uv*
+    chromaticity coordinates using *Robertson (1968)* method.
 
     Parameters
     ----------
@@ -310,9 +310,9 @@ def uv_to_CCT_Robertson1968(uv: ArrayLike) -> NDArrayFloat:
 
 def _CCT_to_uv_Robertson1968(CCT_D_uv: ArrayLike) -> NDArrayFloat:
     """
-    Compute the *CIE UCS* colourspace *uv* chromaticity coordinates from specified
-    correlated colour temperature :math:`T_{cp}` and :math:`\\Delta_{uv}` using
-    *Roberston (1968)* method.
+    Compute the *CIE UCS* colourspace *uv* chromaticity coordinates from
+    the specified correlated colour temperature :math:`T_{cp}` and
+    :math:`\\Delta_{uv}` using *Robertson (1968)* method.
 
     Parameters
     ----------
@@ -370,9 +370,9 @@ def _CCT_to_uv_Robertson1968(CCT_D_uv: ArrayLike) -> NDArrayFloat:
 
 def CCT_to_uv_Robertson1968(CCT_D_uv: ArrayLike) -> NDArrayFloat:
     """
-    Compute the *CIE UCS* colourspace *uv* chromaticity coordinates from specified
-    correlated colour temperature :math:`T_{cp}` and :math:`\\Delta_{uv}` using
-    *Roberston (1968)* method.
+    Return the *CIE UCS* colourspace *uv* chromaticity coordinates from the
+    specified correlated colour temperature :math:`T_{cp}` and
+    :math:`\\Delta_{uv}` using *Robertson (1968)* method.
 
     Parameters
     ----------

--- a/colour/utilities/__init__.py
+++ b/colour/utilities/__init__.py
@@ -309,7 +309,7 @@ class utilities(ModuleAPI):
 
 # v0.4.5
 API_CHANGES: dict = {
-    "ObjectRemoved": [  # pyright: ignore
+    "ObjectRemoved": [
         "colour.utilities.is_string",
     ]
 }

--- a/colour/utilities/__init__.py
+++ b/colour/utilities/__init__.py
@@ -299,10 +299,10 @@ __all__ += [
 # ---                API Changes and Deprecation Management                ---#
 # ----------------------------------------------------------------------------#
 class utilities(ModuleAPI):
-    """Class acting like the *utilities* module."""
+    """Define a class acting like the *utilities* module."""
 
     def __getattr__(self, attribute: str) -> Any:
-        """Retrieve the value from the specified attribute."""
+        """Return the value from the specified attribute."""
 
         return super().__getattr__(attribute)
 

--- a/colour/utilities/array.py
+++ b/colour/utilities/array.py
@@ -2,7 +2,7 @@
 Array Utilities
 ===============
 
-Array utilities objects.
+Provide utilities for array manipulation and computational operations.
 
 References
 ----------
@@ -121,8 +121,11 @@ __all__ = [
 
 class MixinDataclassFields:
     """
-    A mixin providing fields introspection for the :class:`dataclass`-like
-    class fields.
+    Provide fields introspection for :class:`dataclass`-like classes.
+
+    This mixin extends dataclass functionality to enable introspection
+    capabilities, allowing programmatic access to field metadata and
+    properties.
 
     Attributes
     ----------
@@ -132,12 +135,12 @@ class MixinDataclassFields:
     @property
     def fields(self) -> tuple:
         """
-        Getter property for the fields of the :class:`dataclass`-like class.
+        Getter for the fields of the :class:`dataclass`-like class.
 
         Returns
         -------
         :class:`tuple`
-           Tuple of :class:`dataclass`-like class fields.
+            :class:`dataclass`-like class fields.
         """
 
         return fields(self)  # pyright: ignore
@@ -145,8 +148,11 @@ class MixinDataclassFields:
 
 class MixinDataclassIterable(MixinDataclassFields):
     """
-    A mixin providing iteration capabilities over the :class:`dataclass`-like
-    class fields.
+    Provide iteration capabilities over :class:`dataclass`-like classes.
+
+    This mixin extends dataclass functionality to enable dictionary-like
+    iteration over fields, allowing access to field names, values, and
+    name-value pairs through standard iteration protocols.
 
     Attributes
     ----------
@@ -160,8 +166,8 @@ class MixinDataclassIterable(MixinDataclassFields):
 
     Notes
     -----
-    -   The :class:`colour.utilities.MixinDataclassIterable` class inherits the
-        methods from the following class:
+    -   The :class:`colour.utilities.MixinDataclassIterable` class inherits
+        the methods from the following class:
 
         -   :class:`colour.utilities.MixinDataclassFields`
     """
@@ -169,13 +175,13 @@ class MixinDataclassIterable(MixinDataclassFields):
     @property
     def keys(self) -> tuple:
         """
-        Getter property for the :class:`dataclass`-like class keys, i.e., the
-        field names.
+        Getter for the :class:`dataclass`-like class keys, i.e., the field
+        names.
 
         Returns
         -------
         :class:`tuple`
-           :class:`dataclass`-like class keys.
+            :class:`dataclass`-like class keys.
         """
 
         return tuple(field for field, _value in self)
@@ -183,13 +189,12 @@ class MixinDataclassIterable(MixinDataclassFields):
     @property
     def values(self) -> tuple:
         """
-        Getter property for the :class:`dataclass`-like class values, i.e., the
-        field values.
+        Getter for the :class:`dataclass`-like class field values.
 
         Returns
         -------
         :class:`tuple`
-           :class:`dataclass`-like class values.
+            :class:`dataclass`-like class field values.
         """
 
         return tuple(value for _field, value in self)
@@ -197,25 +202,25 @@ class MixinDataclassIterable(MixinDataclassFields):
     @property
     def items(self) -> tuple:
         """
-        Getter property for the :class:`dataclass`-like class items, i.e., the
-        field names and values.
+        Getter for the :class:`dataclass`-like class items, i.e., the field
+        names and values.
 
         Returns
         -------
         :class:`tuple`
-           :class:`dataclass`-like class items.
+            :class:`dataclass`-like class items.
         """
 
         return tuple((field, value) for field, value in self)
 
     def __iter__(self) -> Generator:
         """
-        Return a generator for the :class:`dataclass`-like class fields.
+        Yield the :class:`dataclass`-like class fields.
 
         Yields
         ------
         Generator
-           :class:`dataclass`-like class field generator.
+            :class:`dataclass`-like class field generator.
         """
 
         yield from {
@@ -225,8 +230,11 @@ class MixinDataclassIterable(MixinDataclassFields):
 
 class MixinDataclassArray(MixinDataclassIterable):
     """
-    A mixin providing conversion methods for :class:`dataclass`-like class
-    conversion to :class:`numpy.ndarray` class.
+    Provide conversion methods for :class:`dataclass`-like classes to
+    :class:`numpy.ndarray` objects.
+
+    This mixin extends dataclass functionality to enable seamless conversion
+    to NumPy arrays, facilitating numerical operations on structured data.
 
     Methods
     -------
@@ -234,8 +242,8 @@ class MixinDataclassArray(MixinDataclassIterable):
 
     Notes
     -----
-    -   The :class:`colour.utilities.MixinDataclassArray` class inherits the
-        methods from the following classes:
+    -   The :class:`colour.utilities.MixinDataclassArray` class
+        inherits the methods from the following classes:
 
         -   :class:`colour.utilities.MixinDataclassIterable`
         -   :class:`colour.utilities.MixinDataclassFields`
@@ -254,8 +262,8 @@ class MixinDataclassArray(MixinDataclassIterable):
         Parameters
         ----------
         dtype
-            :class:`numpy.dtype` to use for conversion to `np.ndarray`, default
-            to the :class:`numpy.dtype` defined by
+            :class:`numpy.dtype` to use for conversion to `np.ndarray`,
+            default to the :class:`numpy.dtype` defined by
             :attr:`colour.constant.DTYPE_FLOAT_DEFAULT` attribute.
         copy
             Whether to return a copy of the underlying data, will always be
@@ -264,7 +272,8 @@ class MixinDataclassArray(MixinDataclassIterable):
         Returns
         -------
         :class:`numpy.ndarray`
-            :class:`dataclass`-like class converted to :class:`numpy.ndarray`.
+            :class:`dataclass`-like class converted to
+            :class:`numpy.ndarray`.
         """
 
         dtype = optional(dtype, DTYPE_FLOAT_DEFAULT)
@@ -286,8 +295,11 @@ class MixinDataclassArray(MixinDataclassIterable):
 
 class MixinDataclassArithmetic(MixinDataclassArray):
     """
-    A mixin providing mathematical operations for :class:`dataclass`-like
-    class.
+    Provide mathematical operations for :class:`dataclass`-like classes.
+
+    This mixin extends dataclass functionality to enable arithmetic
+    operations, facilitating mathematical computations on dataclass instances
+    containing array-like data.
 
     Methods
     -------
@@ -481,7 +493,8 @@ class MixinDataclassArithmetic(MixinDataclassArray):
         Returns
         -------
         :class:`dataclass`
-            In-place variable exponentiated :class:`dataclass`-like class.
+            In-place variable exponentiated :class:`dataclass`-like
+            class.
         """
 
         return self.arithmetical_operation(a, "**", True)
@@ -490,8 +503,8 @@ class MixinDataclassArithmetic(MixinDataclassArray):
         self, a: Any, operation: str, in_place: bool = False
     ) -> Dataclass:
         """
-        Perform specified arithmetical operation with :math:`a` operand on the
-        :class:`dataclass`-like class.
+        Perform the specified arithmetical operation with the :math:`a`
+        operand on the :class:`dataclass`-like class.
 
         Parameters
         ----------
@@ -505,7 +518,7 @@ class MixinDataclassArithmetic(MixinDataclassArray):
         Returns
         -------
         :class:`dataclass`
-            :class:`dataclass`-like class with arithmetical operation
+            :class:`dataclass`-like class with the arithmetical operation
             performed.
         """
 
@@ -550,8 +563,8 @@ def as_array(
     dtype: Type[DType] | None = None,
 ) -> NDArray:
     """
-    Convert specified variable :math:`a` to :class:`numpy.ndarray` using
-    specified :class:`numpy.dtype`.
+    Convert the specified variable :math:`a` to :class:`numpy.ndarray` using
+    the specified :class:`numpy.dtype`.
 
     Parameters
     ----------
@@ -595,9 +608,12 @@ def as_int(
 ) -> DTypeInt | NDArrayInt: ...
 def as_int(a: ArrayLike, dtype: Type[DTypeInt] | None = None) -> DTypeInt | NDArrayInt:
     """
-    Attempt to convert specified variable :math:`a` to :class:`numpy.integer`
-    using specified :class:`numpy.dtype`. If variable :math:`a` is not a scalar or
-    0-dimensional, it is converted to :class:`numpy.ndarray`.
+    Convert the specified variable :math:`a` to :class:`numpy.integer` using
+    the specified :class:`numpy.dtype`.
+
+    The function converts variable :math:`a` to an integer type. If variable
+    :math:`a` is not a scalar or 0-dimensional array, it is converted to
+    :class:`numpy.ndarray`.
 
     Parameters
     ----------
@@ -646,9 +662,11 @@ def as_float(
     a: ArrayLike, dtype: Type[DTypeFloat] | None = None
 ) -> DTypeFloat | NDArrayFloat:
     """
-    Attempt to convert specified variable :math:`a` to :class:`numpy.floating`
-    using specified :class:`numpy.dtype`. If variable :math:`a` is not a scalar or
-    0-dimensional, it is converted to :class:`numpy.ndarray`.
+    Convert the specified variable :math:`a` to :class:`numpy.floating` using
+    the specified :class:`numpy.dtype`.
+
+    If variable :math:`a` is not a scalar or 0-dimensional, it is converted
+    to :class:`numpy.ndarray`.
 
     Parameters
     ----------
@@ -692,8 +710,8 @@ def as_float(
 
 def as_int_array(a: ArrayLike, dtype: Type[DTypeInt] | None = None) -> NDArrayInt:
     """
-    Convert specified variable :math:`a` to :class:`numpy.ndarray` using
-    specified :class:`numpy.dtype`.
+    Convert the specified variable :math:`a` to :class:`numpy.ndarray` using
+    the specified integer :class:`numpy.dtype`.
 
     Parameters
     ----------
@@ -707,7 +725,7 @@ def as_int_array(a: ArrayLike, dtype: Type[DTypeInt] | None = None) -> NDArrayIn
     Returns
     -------
     :class:`numpy.ndarray`
-        Variable :math:`a` converted to :class:`numpy.ndarray`.
+        Variable :math:`a` converted to integer :class:`numpy.ndarray`.
 
     Examples
     --------
@@ -724,22 +742,23 @@ def as_int_array(a: ArrayLike, dtype: Type[DTypeInt] | None = None) -> NDArrayIn
 
 def as_float_array(a: ArrayLike, dtype: Type[DTypeFloat] | None = None) -> NDArrayFloat:
     """
-    Convert specified variable :math:`a` to :class:`numpy.ndarray` using
-    specified :class:`numpy.dtype`.
+    Convert the specified variable :math:`a` to :class:`numpy.ndarray` using
+    the specified floating-point :class:`numpy.dtype`.
 
     Parameters
     ----------
     a
         Variable :math:`a` to convert.
     dtype
-        :class:`numpy.dtype` to use for conversion, default to the
-        :class:`numpy.dtype` defined by the
+        Floating-point :class:`numpy.dtype` to use for conversion, default
+        to the :class:`numpy.dtype` defined by the
         :attr:`colour.constant.DTYPE_FLOAT_DEFAULT` attribute.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Variable :math:`a` converted to :class:`numpy.ndarray`.
+        Variable :math:`a` converted to floating-point
+        :class:`numpy.ndarray`.
 
     Examples
     --------
@@ -756,9 +775,8 @@ def as_float_array(a: ArrayLike, dtype: Type[DTypeFloat] | None = None) -> NDArr
 
 def as_int_scalar(a: ArrayLike, dtype: Type[DTypeInt] | None = None) -> int:
     """
-    Convert specified :math:`a` variable to :class:`numpy.integer` using
-    specified
-    :class:`numpy.dtype`.
+    Convert the specified variable :math:`a` to :class:`numpy.integer` using
+    the specified :class:`numpy.dtype`.
 
     Parameters
     ----------
@@ -772,7 +790,7 @@ def as_int_scalar(a: ArrayLike, dtype: Type[DTypeInt] | None = None) -> int:
     Returns
     -------
     :class:`int`
-        :math:`a` variable converted to :class:`numpy.integer`.
+        Variable :math:`a` converted to :class:`numpy.integer`.
 
     Warnings
     --------
@@ -795,9 +813,8 @@ def as_int_scalar(a: ArrayLike, dtype: Type[DTypeInt] | None = None) -> int:
 
 def as_float_scalar(a: ArrayLike, dtype: Type[DTypeFloat] | None = None) -> float:
     """
-    Convert specified :math:`a` variable to :class:`numpy.floating` using
-    specified
-    :class:`numpy.dtype`.
+    Convert the specified variable :math:`a` to :class:`numpy.floating` using
+    the specified :class:`numpy.dtype`.
 
     Parameters
     ----------
@@ -811,7 +828,7 @@ def as_float_scalar(a: ArrayLike, dtype: Type[DTypeFloat] | None = None) -> floa
     Returns
     -------
     :class:`float`
-        :math:`a` variable converted to :class:`numpy.floating`.
+        Variable :math:`a` converted to :class:`numpy.floating`.
 
     Warnings
     --------
@@ -836,28 +853,28 @@ def set_default_int_dtype(
     dtype: Type[DTypeInt] = DTYPE_INT_DEFAULT,
 ) -> None:
     """
-    Set *Colour* default :class:`numpy.integer` precision by setting
-    :attr:`colour.constant.DTYPE_INT_DEFAULT` attribute with specified
+    Set the *Colour* default :class:`numpy.integer` precision by setting
+    :attr:`colour.constant.DTYPE_INT_DEFAULT` attribute with the specified
     :class:`numpy.dtype` wherever the attribute is imported.
 
     Parameters
     ----------
     dtype
-        :class:`numpy.dtype` to set :attr:`colour.constant.DTYPE_INT_DEFAULT`
-        with.
+        :class:`numpy.dtype` to set
+        :attr:`colour.constant.DTYPE_INT_DEFAULT` with.
 
     Notes
     -----
-    -   It is possible to define the int precision at import time by setting
-        the *COLOUR_SCIENCE__DEFAULT_INT_DTYPE* environment variable, for
-        example `set COLOUR_SCIENCE__DEFAULT_INT_DTYPE=int32`.
+    -   It is possible to define the integer precision at import time by
+        setting the *COLOUR_SCIENCE__DEFAULT_INT_DTYPE* environment
+        variable, for example `set COLOUR_SCIENCE__DEFAULT_INT_DTYPE=int32`.
 
     Warnings
     --------
     This definition is mostly given for consistency purposes with
-    :func:`colour.utilities.set_default_float_dtype` definition but contrary to the
-    latter, changing *integer* precision will almost certainly completely break
-    *Colour*. With great power comes great responsibility.
+    :func:`colour.utilities.set_default_float_dtype` definition but contrary
+    to the latter, changing *integer* precision will almost certainly
+    completely break *Colour*. With great power comes great responsibility.
 
     Examples
     --------
@@ -886,29 +903,32 @@ def set_default_float_dtype(
     dtype: Type[DTypeFloat] = DTYPE_FLOAT_DEFAULT,
 ) -> None:
     """
-    Set *Colour* default :class:`numpy.floating` precision by setting
-    :attr:`colour.constant.DTYPE_FLOAT_DEFAULT` attribute with specified
-    :class:`numpy.dtype` wherever the attribute is imported.
+    Set the *Colour* default :class:`numpy.floating` precision by setting
+    :attr:`colour.constant.DTYPE_FLOAT_DEFAULT` attribute with the
+    specified :class:`numpy.dtype` wherever the attribute is imported.
 
     Parameters
     ----------
     dtype
-        :class:`numpy.dtype` to set :attr:`colour.constant.DTYPE_FLOAT_DEFAULT`
-        with.
-
-    Warnings
-    --------
-    Changing *float* precision might result in various *Colour* functionality
-    breaking entirely: https://github.com/numpy/numpy/issues/6860. With great
-    power comes great responsibility.
+        :class:`numpy.dtype` to set
+        :attr:`colour.constant.DTYPE_FLOAT_DEFAULT` with.
 
     Notes
     -----
     -   It is possible to define the *float* precision at import time by
-        setting the *COLOUR_SCIENCE__DEFAULT_FLOAT_DTYPE* environment variable,
-        for example `set COLOUR_SCIENCE__DEFAULT_FLOAT_DTYPE=float32`.
-    -   Some definition returning a single-scalar ndarray might not honour the
-        specified *float* precision: https://github.com/numpy/numpy/issues/16353
+        setting the *COLOUR_SCIENCE__DEFAULT_FLOAT_DTYPE* environment
+        variable, for example
+        `set COLOUR_SCIENCE__DEFAULT_FLOAT_DTYPE=float32`.
+    -   Some definition returning a single-scalar ndarray might not
+        honour the specified *float* precision:
+        https://github.com/numpy/numpy/issues/16353
+
+    Warnings
+    --------
+    Changing *float* precision might result in various *Colour*
+    functionality breaking entirely:
+    https://github.com/numpy/numpy/issues/6860. With great power comes
+    great responsibility.
 
     Examples
     --------
@@ -944,16 +964,17 @@ _DOMAIN_RANGE_SCALE
 
 def get_domain_range_scale() -> Literal["ignore", "reference", "1", "100"] | str:
     """
-    Return the current *Colour* domain-range scale. The following scales are
-    available:
+    Return the current *Colour* domain-range scale.
 
-    -   **'Reference'**, the default *Colour* domain-range scale which varies
-        depending on the referenced algorithm, e.g., [0, 1], [0, 10], [0, 100],
-        [0, 255], etc...
-    -   **'1'**, a domain-range scale normalised to [0, 1], it is important to
-        acknowledge that this is a soft normalisation and it is possible to
-        use negative out of gamut values or high dynamic range data exceeding
-        1.
+    The following scales are available:
+
+    -   **'Reference'**, the default *Colour* domain-range scale which
+        varies depending on the referenced algorithm, e.g., [0, 1],
+        [0, 10], [0, 100], [0, 255], etc...
+    -   **'1'**, a domain-range scale normalised to [0, 1], it is
+        important to acknowledge that this is a soft normalisation
+        and it is possible to use negative out of gamut values or
+        high dynamic range data exceeding 1.
 
     Returns
     -------
@@ -962,8 +983,8 @@ def get_domain_range_scale() -> Literal["ignore", "reference", "1", "100"] | str
 
     Warnings
     --------
-    -   The **'Ignore'** and **'100'** domain-range scales are for internal
-        usage only!
+    -   The **'Ignore'** and **'100'** domain-range scales are for
+        internal usage only!
     """
 
     return _DOMAIN_RANGE_SCALE
@@ -975,16 +996,17 @@ def set_domain_range_scale(
     ) = "reference",
 ) -> None:
     """
-    Set the current *Colour* domain-range scale. The following scales are
-    available:
+    Set the current *Colour* domain-range scale.
 
-    -   **'Reference'**, the default *Colour* domain-range scale which varies
-        depending on the referenced algorithm, e.g., [0, 1], [0, 10], [0, 100],
-        [0, 255], etc...
-    -   **'1'**, a domain-range scale normalised to [0, 1], it is important to
-        acknowledge that this is a soft normalisation and it is possible to
-        use negative out of gamut values or high dynamic range data exceeding
-        1.
+    The following scales are available:
+
+    -   **'Reference'**, the default *Colour* domain-range scale which
+        varies depending on the referenced algorithm, e.g., [0, 1],
+        [0, 10], [0, 100], [0, 255], etc...
+    -   **'1'**, a domain-range scale normalised to [0, 1], it is
+        important to acknowledge that this is a soft normalisation and it
+        is possible to use negative out of gamut values or high dynamic
+        range data exceeding 1.
 
     Parameters
     ----------
@@ -993,8 +1015,8 @@ def set_domain_range_scale(
 
     Warnings
     --------
-    -   The **'Ignore'** and **'100'** domain-range scales are for internal
-        usage only!
+    -   The **'Ignore'** and **'100'** domain-range scales are for
+        internal usage only!
     """
 
     global _DOMAIN_RANGE_SCALE  # noqa: PLW0603
@@ -1008,18 +1030,18 @@ def set_domain_range_scale(
 
 class domain_range_scale:
     """
-    Define context manager and decorator temporarily setting *Colour*
+    Define a context manager and decorator to temporarily set the *Colour*
     domain-range scale.
 
     The following scales are available:
 
-    -   **'Reference'**, the default *Colour* domain-range scale which varies
-        depending on the referenced algorithm, e.g., [0, 1], [0, 10], [0, 100],
-        [0, 255], etc...
-    -   **'1'**, a domain-range scale normalised to [0, 1], it is important to
-        acknowledge that this is a soft normalisation and it is possible to
-        use negative out of gamut values or high dynamic range data exceeding
-        1.
+    -   **'Reference'**, the default *Colour* domain-range scale which
+        varies depending on the referenced algorithm, e.g., [0, 1],
+        [0, 10], [0, 100], [0, 255], etc...
+    -   **'1'**, a domain-range scale normalised to [0, 1], it is
+        important to acknowledge that this is a soft normalisation and it
+        is possible to use negative out of gamut values or high dynamic
+        range data exceeding 1.
 
     Parameters
     ----------
@@ -1028,8 +1050,8 @@ class domain_range_scale:
 
     Warnings
     --------
-    -   The **'Ignore'** and **'100'** domain-range scales are for internal
-        usage only!
+    -   The **'Ignore'** and **'100'** domain-range scales are for
+        internal usage only!
 
     Examples
     --------
@@ -1078,12 +1100,17 @@ class domain_range_scale:
         return self
 
     def __exit__(self, *args: Any) -> None:
-        """Set the previous domain-range scale upon exiting the context manager."""
+        """
+        Restore the previous domain-range scale upon exiting the context
+        manager.
+        """
 
         set_domain_range_scale(self._previous_scale)
 
     def __call__(self, function: Callable) -> Any:
-        """Call the wrapped definition."""
+        """
+        Call the wrapped definition with domain-range scale management.
+        """
 
         @functools.wraps(function)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
@@ -1099,23 +1126,24 @@ def to_domain_1(
     dtype: Type[DTypeFloat] | None = None,
 ) -> NDArray:
     """
-    Scale specified array :math:`a` to domain **'1'**. The behaviour is as
-    follows:
+    Scale the specified array :math:`a` to domain **'1'**.
+
+    The behaviour is as follows:
 
     -   If *Colour* domain-range scale is **'Reference'** or **'1'**, the
-        definition is almost entirely by-passed and will conveniently convert
-        array :math:`a` to :class:`np.ndarray`.
+        definition is almost entirely by-passed and will conveniently
+        convert array :math:`a` to :class:`np.ndarray`.
     -   If *Colour* domain-range scale is **'100'** (currently unsupported
-        private value only used for unit tests), array :math:`a` is divided by
-        ``scale_factor``, typically 100.
+        private value only used for unit tests), array :math:`a` is divided
+        by ``scale_factor``, typically 100.
 
     Parameters
     ----------
     a
         Array :math:`a` to scale to domain **'1'**.
     scale_factor
-        Scale factor, usually *numeric* but can be a :class:`numpy.ndarray` if
-        some axis need different scaling to be brought to domain **'1'**.
+        Scale factor, usually *numeric* but can be a :class:`numpy.ndarray`
+        if some axes need different scaling to be brought to domain **'1'**.
     dtype
         Data type used for the conversion to :class:`np.ndarray`.
 
@@ -1161,12 +1189,14 @@ def to_domain_10(
     dtype: Type[DTypeFloat] | None = None,
 ) -> NDArray:
     """
-    Scale specified array :math:`a` to domain **'10'**, used by
-    *Munsell Renotation System*. The behaviour is as follows:
+    Scale the specified array :math:`a` to domain **'10'**, used by the
+    *Munsell Renotation System*.
 
-    -   If *Colour* domain-range scale is **'Reference'**, the
-        definition is almost entirely by-passed and will conveniently convert
-        array :math:`a` to :class:`np.ndarray`.
+    The behaviour is as follows:
+
+    -   If *Colour* domain-range scale is **'Reference'**, the definition
+        is almost entirely by-passed and will conveniently convert array
+        :math:`a` to :class:`np.ndarray`.
     -   If *Colour* domain-range scale is **'1'**, array :math:`a` is
         multiplied by ``scale_factor``, typically 10.
     -   If *Colour* domain-range scale is **'100'** (currently unsupported
@@ -1178,8 +1208,9 @@ def to_domain_10(
     a
         Array :math:`a` to scale to domain **'10'**.
     scale_factor
-        Scale factor, usually *numeric* but can be a :class:`numpy.ndarray` if
-        some axis need different scaling to be brought to domain **'10'**.
+        Scale factor, usually *numeric* but can be a :class:`numpy.ndarray`
+        if some axes need different scaling to be brought to domain
+        **'10'**.
     dtype
         Data type used for the conversion to :class:`np.ndarray`.
 
@@ -1228,13 +1259,14 @@ def to_domain_100(
     dtype: Type[DTypeFloat] | None = None,
 ) -> NDArray:
     """
-    Scale specified array :math:`a` to domain **'100'**. The behaviour is as
-    follows:
+    Scale the specified array :math:`a` to domain **'100'**.
+
+    The behaviour is as follows:
 
     -   If *Colour* domain-range scale is **'Reference'** or **'100'**
         (currently unsupported private value only used for unit tests), the
-        definition is almost entirely by-passed and will conveniently convert
-        array :math:`a` to :class:`np.ndarray`.
+        definition is almost entirely by-passed and will conveniently
+        convert array :math:`a` to :class:`np.ndarray`.
     -   If *Colour* domain-range scale is **'1'**, array :math:`a` is
         multiplied by ``scale_factor``, typically 100.
 
@@ -1243,8 +1275,9 @@ def to_domain_100(
     a
         Array :math:`a` to scale to domain **'100'**.
     scale_factor
-        Scale factor, usually *numeric* but can be a :class:`numpy.ndarray` if
-        some axis need different scaling to be brought to domain **'100'**.
+        Scale factor, usually *numeric* but can be a :class:`numpy.ndarray`
+        if some axes need different scaling to be brought to domain
+        **'100'**.
     dtype
         Data type used for the conversion to :class:`np.ndarray`.
 
@@ -1290,12 +1323,13 @@ def to_domain_degrees(
     dtype: Type[DTypeFloat] | None = None,
 ) -> NDArray:
     """
-    Scale specified array :math:`a` to degrees domain. The behaviour is as
-    follows:
+    Scale the specified array :math:`a` to degrees domain.
 
-    -   If *Colour* domain-range scale is **'Reference'**, the
-        definition is almost entirely by-passed and will conveniently convert
-        array :math:`a` to :class:`np.ndarray`.
+    The behaviour is as follows:
+
+    -   If *Colour* domain-range scale is **'Reference'**, the definition
+        is almost entirely by-passed and will conveniently convert array
+        :math:`a` to :class:`np.ndarray`.
     -   If *Colour* domain-range scale is **'1'**, array :math:`a` is
         multiplied by ``scale_factor``, typically 360.
     -   If *Colour* domain-range scale is **'100'** (currently unsupported
@@ -1307,8 +1341,8 @@ def to_domain_degrees(
     a
         Array :math:`a` to scale to degrees domain.
     scale_factor
-        Scale factor, usually *numeric* but can be a :class:`numpy.ndarray` if
-        some axis need different scaling to be brought to degrees domain.
+        Scale factor, usually *numeric* but can be a :class:`numpy.ndarray`
+        if some axes need different scaling to be brought to degrees domain.
     dtype
         Data type used for the conversion to :class:`np.ndarray`.
 
@@ -1357,11 +1391,13 @@ def to_domain_int(
     dtype: Type[DTypeFloat] | None = None,
 ) -> NDArray:
     """
-    Scale specified array :math:`a` to int domain. The behaviour is as follows:
+    Scale the specified array :math:`a` to integer domain.
 
-    -   If *Colour* domain-range scale is **'Reference'**, the
-        definition is almost entirely by-passed and will conveniently convert
-        array :math:`a` to :class:`np.ndarray`.
+    The behaviour is as follows:
+
+    -   If *Colour* domain-range scale is **'Reference'**, the definition
+        is almost entirely by-passed and will conveniently convert array
+        :math:`a` to :class:`np.ndarray`.
     -   If *Colour* domain-range scale is **'1'**, array :math:`a` is
         multiplied by :math:`2^{bit\\_depth} - 1`.
     -   If *Colour* domain-range scale is **'100'** (currently unsupported
@@ -1371,22 +1407,22 @@ def to_domain_int(
     Parameters
     ----------
     a
-        Array :math:`a` to scale to int domain.
+        Array :math:`a` to scale to integer domain.
     bit_depth
         Bit-depth, usually *int* but can be a :class:`numpy.ndarray` if
-        some axis need different scaling to be brought to int domain.
+        some axis need different scaling to be brought to integer domain.
     dtype
         Data type used for the conversion to :class:`np.ndarray`.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Array :math:`a` scaled to int domain.
+        Array :math:`a` scaled to integer domain.
 
     Notes
     -----
-    -   To avoid precision issues and rounding, the scaling is performed on
-        *float* numbers.
+    -   To avoid precision issues and rounding, the scaling is performed
+        on *float* numbers.
 
     Examples
     --------
@@ -1429,22 +1465,24 @@ def from_range_1(
     dtype: Type[DTypeFloat] | None = None,
 ) -> NDArray:
     """
-    Scale specified array :math:`a` from range **'1'**. The behaviour is as
-    follows:
+    Scale the specified array :math:`a` from range **'1'**.
+
+    The behaviour is as follows:
 
     -   If *Colour* domain-range scale is **'Reference'** or **'1'**, the
         definition is entirely by-passed.
     -   If *Colour* domain-range scale is **'100'** (currently unsupported
-        private value only used for unit tests), array :math:`a` is multiplied
-        by ``scale_factor``, typically 100.
+        private value only used for unit tests), array :math:`a` is
+        multiplied by ``scale_factor``, typically 100.
 
     Parameters
     ----------
     a
         Array :math:`a` to scale from range **'1'**.
     scale_factor
-        Scale factor, usually *numeric* but can be a :class:`numpy.ndarray` if
-        some axis need different scaling to be brought from range **'1'**.
+        Scale factor, usually *numeric* but can be a :class:`numpy.ndarray`
+        if some axis need different scaling to be brought from range
+        **'1'**.
     dtype
         Data type used for the conversion to :class:`np.ndarray`.
 
@@ -1455,8 +1493,8 @@ def from_range_1(
 
     Warnings
     --------
-    The scale conversion of variable :math:`a` happens in-place, i.e., :math:`a`
-    will be mutated!
+    The scale conversion of variable :math:`a` happens in-place, i.e.,
+    :math:`a` will be mutated!
 
     Examples
     --------
@@ -1495,11 +1533,13 @@ def from_range_10(
     dtype: Type[DTypeFloat] | None = None,
 ) -> NDArray:
     """
-    Scale specified array :math:`a` from range **'10'**, used by
-    *Munsell Renotation System*. The behaviour is as follows:
+    Scale the specified array :math:`a` from range **'10'**, used by the
+    *Munsell Renotation System*.
 
-    -   If *Colour* domain-range scale is **'Reference'**, the
-        definition is entirely by-passed.
+    The behaviour is as follows:
+
+    -   If *Colour* domain-range scale is **'Reference'**, the definition
+        is entirely by-passed.
     -   If *Colour* domain-range scale is **'1'**, array :math:`a` is
         divided by ``scale_factor``, typically 10.
     -   If *Colour* domain-range scale is **'100'** (currently unsupported
@@ -1511,8 +1551,9 @@ def from_range_10(
     a
         Array :math:`a` to scale from range **'10'**.
     scale_factor
-        Scale factor, usually *numeric* but can be a :class:`numpy.ndarray` if
-        some axis need different scaling to be brought from range **'10'**.
+        Scale factor, usually *numeric* but can be a
+        :class:`numpy.ndarray` if some axis need different scaling to be
+        brought from range **'10'**.
     dtype
         Data type used for the conversion to :class:`np.ndarray`.
 
@@ -1523,8 +1564,8 @@ def from_range_10(
 
     Warnings
     --------
-    The scale conversion of variable :math:`a` happens in-place, i.e., :math:`a`
-    will be mutated!
+    The scale conversion of variable :math:`a` happens in-place, i.e.,
+    :math:`a` will be mutated!
 
     Examples
     --------
@@ -1566,8 +1607,9 @@ def from_range_100(
     dtype: Type[DTypeFloat] | None = None,
 ) -> NDArray:
     """
-    Scale specified array :math:`a` from range **'100'**. The behaviour is as
-    follows:
+    Scale the specified array :math:`a` from range **'100'**.
+
+    The behaviour is as follows:
 
     -   If *Colour* domain-range scale is **'Reference'** or **'100'**
         (currently unsupported private value only used for unit tests), the
@@ -1580,10 +1622,11 @@ def from_range_100(
     a
         Array :math:`a` to scale from range **'100'**.
     scale_factor
-        Scale factor, usually *numeric* but can be a :class:`numpy.ndarray` if
-        some axis need different scaling to be brought from range **'100'**.
+        Scale factor, usually *numeric* but can be a :class:`numpy.ndarray`
+        if some axes require different scaling to be brought from range
+        **'100'**.
     dtype
-        Data type used for the conversion to :class:`np.ndarray`.
+        Data type used for the conversion to :class:`numpy.ndarray`.
 
     Returns
     -------
@@ -1592,8 +1635,8 @@ def from_range_100(
 
     Warnings
     --------
-    The scale conversion of variable :math:`a` happens in-place, i.e., :math:`a`
-    will be mutated!
+    The scale conversion of variable :math:`a` happens in-place, i.e.,
+    :math:`a` will be mutated!
 
     Examples
     --------
@@ -1632,11 +1675,12 @@ def from_range_degrees(
     dtype: Type[DTypeFloat] | None = None,
 ) -> NDArray:
     """
-    Scale specified array :math:`a` from degrees range. The behaviour is as
-    follows:
+    Scale the specified array :math:`a` from degrees range.
 
-    -   If *Colour* domain-range scale is **'Reference'**, the
-        definition is entirely by-passed.
+    The behaviour is as follows:
+
+    -   If *Colour* domain-range scale is **'Reference'**, the definition
+        is entirely by-passed.
     -   If *Colour* domain-range scale is **'1'**, array :math:`a` is
         divided by ``scale_factor``, typically 360.
     -   If *Colour* domain-range scale is **'100'** (currently unsupported
@@ -1648,10 +1692,11 @@ def from_range_degrees(
     a
         Array :math:`a` to scale from degrees range.
     scale_factor
-        Scale factor, usually *numeric* but can be a :class:`numpy.ndarray` if
-        some axis need different scaling to be brought from degrees range.
+        Scale factor, usually *numeric* but can be a
+        :class:`numpy.ndarray` if some axes need different scaling to be
+        brought from degrees range.
     dtype
-        Data type used for the conversion to :class:`np.ndarray`.
+        Data type used for the conversion to :class:`numpy.ndarray`.
 
     Returns
     -------
@@ -1660,8 +1705,8 @@ def from_range_degrees(
 
     Warnings
     --------
-    The scale conversion of variable :math:`a` happens in-place, i.e., :math:`a`
-    will be mutated!
+    The scale conversion of variable :math:`a` happens in-place, i.e.,
+    :math:`a` will be mutated!
 
     Examples
     --------
@@ -1703,35 +1748,39 @@ def from_range_int(
     dtype: Type[DTypeFloat] | None = None,
 ) -> NDArray:
     """
-    Scale specified array :math:`a` from int range. The behaviour is as follows:
+    Scale the specified array :math:`a` from integer range.
 
-    -   If *Colour* domain-range scale is **'Reference'**, the
-        definition is entirely by-passed.
-    -   If *Colour* domain-range scale is **'1'**, array :math:`a` is converted
-        to :class:`np.ndarray` and divided by :math:`2^{bit\\_depth} - 1`.
+    The behaviour is as follows:
+
+    -   If *Colour* domain-range scale is **'Reference'**, the definition
+        is entirely by-passed.
+    -   If *Colour* domain-range scale is **'1'**, array :math:`a` is
+        converted to :class:`np.ndarray` and divided by
+        :math:`2^{bit\\_depth} - 1`.
     -   If *Colour* domain-range scale is **'100'** (currently unsupported
-        private value only used for unit tests), array :math:`a` is converted
-        to :class:`np.ndarray` and divided by :math:`2^{bit\\_depth} - 1`.
+        private value only used for unit tests), array :math:`a` is
+        converted to :class:`np.ndarray` and divided by
+        :math:`2^{bit\\_depth} - 1`.
 
     Parameters
     ----------
     a
-        Array :math:`a` to scale from int range.
+        Array :math:`a` to scale from integer range.
     bit_depth
         Bit-depth, usually *int* but can be a :class:`numpy.ndarray` if
-        some axis need different scaling to be brought from int range.
+        some axes need different scaling to be brought from integer range.
     dtype
         Data type used for the conversion to :class:`np.ndarray`.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Array :math:`a` scaled from int range.
+        Array :math:`a` scaled from integer range.
 
     Warnings
     --------
-    The scale conversion of variable :math:`a` happens in-place, i.e., :math:`a`
-    will be mutated!
+    The scale conversion of variable :math:`a` happens in-place, i.e.,
+    :math:`a` will be mutated!
 
     Notes
     -----
@@ -1782,9 +1831,11 @@ Global variable storing the current *Colour* state for
 
 def is_ndarray_copy_enabled() -> bool:
     """
-    Return whether *Colour* :class:`numpy.ndarray` copy is enabled: Various API
-    objects return a copy of their internal :class:`numpy.ndarray` for safety
-    purposes but this can be a slow operation impacting performance.
+    Determine whether *Colour* :class:`numpy.ndarray` copy is enabled.
+
+    Various API objects return a copy of their internal
+    :class:`numpy.ndarray` for safety purposes, but this can be a slow
+    operation impacting performance.
 
     Returns
     -------
@@ -1806,7 +1857,7 @@ def is_ndarray_copy_enabled() -> bool:
 
 def set_ndarray_copy_enable(enable: bool) -> None:
     """
-    Set *Colour* :class:`numpy.ndarray` copy enabled state.
+    Set the *Colour* :class:`numpy.ndarray` copy enabled state.
 
     Parameters
     ----------
@@ -1830,7 +1881,7 @@ def set_ndarray_copy_enable(enable: bool) -> None:
 
 class ndarray_copy_enable:
     """
-    Define a context manager and decorator temporarily setting *Colour*
+    Define a context manager and decorator to temporarily set the *Colour*
     :class:`numpy.ndarray` copy enabled state.
 
     Parameters
@@ -1845,8 +1896,8 @@ class ndarray_copy_enable:
 
     def __enter__(self) -> Self:
         """
-        Set the *Colour* :class:`numpy.ndarray` copy enabled state
-        upon entering the context manager.
+        Set the *Colour* :class:`numpy.ndarray` copy enabled state upon
+        entering the context manager.
         """
 
         set_ndarray_copy_enable(self._enable)
@@ -1855,14 +1906,27 @@ class ndarray_copy_enable:
 
     def __exit__(self, *args: Any) -> None:
         """
-        Set the *Colour* :class:`numpy.ndarray` copy enabled state
-        upon exiting the context manager.
+        Restore the *Colour* :class:`numpy.ndarray` copy enabled state upon
+        exiting the context manager.
         """
 
         set_ndarray_copy_enable(self._previous_state)
 
     def __call__(self, function: Callable) -> Callable:
-        """Call the wrapped definition."""
+        """
+        Decorate and call the specified function with array copy control.
+
+        Parameters
+        ----------
+        function
+            Function to be decorated with array copy state management.
+
+        Returns
+        -------
+        :class:`Callable`
+            Decorated function that executes within the configured array copy
+            state context.
+        """
 
         @functools.wraps(function)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
@@ -1875,9 +1939,11 @@ class ndarray_copy_enable:
 def ndarray_copy(a: NDArray) -> NDArray:
     """
     Return a :class:`numpy.ndarray` copy if the relevant *Colour* state is
-    enabled: Various API objects return a copy of their internal
-    :class:`numpy.ndarray` for safety purposes but this can be a slow operation
-    impacting performance.
+    enabled.
+
+    Various API objects return a copy of their internal
+    :class:`numpy.ndarray` for safety purposes, but this can be a slow
+    operation impacting performance.
 
     Parameters
     ----------
@@ -1906,13 +1972,13 @@ def ndarray_copy(a: NDArray) -> NDArray:
 
 def closest_indexes(a: ArrayLike, b: ArrayLike) -> NDArray:
     """
-    Return the array :math:`a` closest element indexes to the reference array
+    Return the closest element indexes from array :math:`a` to reference array
     :math:`b` elements.
 
     Parameters
     ----------
     a
-        Array :math:`a` to search for the closest element indexes.
+        Array :math:`a` to search for the closest elements.
     b
         Reference array :math:`b`.
 
@@ -1947,13 +2013,13 @@ def closest_indexes(a: ArrayLike, b: ArrayLike) -> NDArray:
 
 def closest(a: ArrayLike, b: ArrayLike) -> NDArray:
     """
-    Return the closest array :math:`a` elements to the reference array
+    Return the closest array :math:`a` elements to reference array
     :math:`b` elements.
 
     Parameters
     ----------
     a
-        Array :math:`a` to search for the closest element.
+        Array :math:`a` to search for the closest elements.
     b
         Reference array :math:`b`.
 
@@ -1992,15 +2058,15 @@ _CACHE_DISTRIBUTION_INTERVAL: dict = CACHE_REGISTRY.register_cache(
 
 def interval(distribution: ArrayLike, unique: bool = True) -> NDArray:
     """
-    Return the interval size of specified distribution.
+    Return the interval size of the specified distribution.
 
     Parameters
     ----------
     distribution
-        Distribution to retrieve the interval.
+        Distribution to retrieve the interval from.
     unique
-        Whether to return unique intervals if  the distribution is
-        non-uniformly spaced or the complete intervals
+        Whether to return unique intervals if the distribution is
+        non-uniformly spaced or the complete intervals.
 
     Returns
     -------
@@ -2054,17 +2120,17 @@ def interval(distribution: ArrayLike, unique: bool = True) -> NDArray:
 
 def is_uniform(distribution: ArrayLike) -> bool:
     """
-    Return whether specified distribution is uniform.
+    Determine whether the specified distribution is uniform.
 
     Parameters
     ----------
     distribution
-        Distribution to check the uniformity of.
+        Distribution to check for uniformity.
 
     Returns
     -------
     :class:`bool`
-        Whether distribution uniform.
+        Whether the distribution is uniform.
 
     Examples
     --------
@@ -2086,15 +2152,15 @@ def is_uniform(distribution: ArrayLike) -> bool:
 
 def in_array(a: ArrayLike, b: ArrayLike, tolerance: Real = EPSILON) -> NDArray:
     """
-    Return whether each element of the array :math:`a` is also present in the
-    array :math:`b` within specified tolerance.
+    Determine whether each element of array :math:`a` is present in array
+    :math:`b` within the specified tolerance.
 
     Parameters
     ----------
     a
         Array :math:`a` to test the elements from.
     b
-        The array :math:`b` against which to test the elements of array
+        Array :math:`b` against which to test the elements of array
         :math:`a`.
     tolerance
         Tolerance value.
@@ -2102,9 +2168,9 @@ def in_array(a: ArrayLike, b: ArrayLike, tolerance: Real = EPSILON) -> NDArray:
     Returns
     -------
     :class:`numpy.ndarray`
-        A bool array with array :math:`a` shape describing whether an
-        element of array :math:`a` is present in array :math:`b` within specified
-        tolerance.
+        Boolean array with array :math:`a` shape indicating whether each
+        element of array :math:`a` is present in array :math:`b` within the
+        specified tolerance.
 
     References
     ----------
@@ -2133,10 +2199,10 @@ def tstack(
     dtype: Type[DTypeBoolean] | Type[DTypeReal] | None = None,
 ) -> NDArray:
     """
-    Stack specified array of arrays :math:`a` along the last axis (tail) to
-    produce a stacked array.
+    Stack the specified array of arrays :math:`a` along the last axis (tail)
+    to produce a stacked array.
 
-    It is used to stack an array of arrays produced by the
+    Used to stack an array of arrays produced by the
     :func:`colour.utilities.tsplit` definition.
 
     Parameters
@@ -2145,8 +2211,8 @@ def tstack(
         Array of arrays :math:`a` to stack along the last axis.
     dtype
         :class:`numpy.dtype` to use for initial conversion to
-        :class:`numpy.ndarray`, default to the :class:`numpy.dtype` defined by
-        :attr:`colour.constant.DTYPE_FLOAT_DEFAULT` attribute.
+        :class:`numpy.ndarray`, default to the :class:`numpy.dtype` defined
+        by :attr:`colour.constant.DTYPE_FLOAT_DEFAULT` attribute.
 
     Returns
     -------
@@ -2196,11 +2262,11 @@ def tsplit(
     dtype: Type[DTypeBoolean] | Type[DTypeReal] | None = None,
 ) -> NDArray:
     """
-    Split specified stacked array :math:`a` along the last axis (tail) to produce
-    an array of arrays.
+    Split the specified stacked array :math:`a` along the last axis (tail)
+    to produce an array of arrays.
 
-    It is used to split a stacked array produced by the
-    :func:`colour.utilities.tstack` definition.
+    Used to split a stacked array produced by the :func:`colour.utilities.tstack`
+    definition.
 
     Parameters
     ----------
@@ -2208,8 +2274,8 @@ def tsplit(
         Stacked array :math:`a` to split.
     dtype
         :class:`numpy.dtype` to use for initial conversion to
-        :class:`numpy.ndarray`, default to the :class:`numpy.dtype` defined by
-        :attr:`colour.constant.DTYPE_FLOAT_DEFAULT` attribute.
+        :class:`numpy.ndarray`, default to the :class:`numpy.dtype` defined
+        by :attr:`colour.constant.DTYPE_FLOAT_DEFAULT` attribute.
 
     Returns
     -------
@@ -2255,12 +2321,12 @@ def tsplit(
 
 def row_as_diagonal(a: ArrayLike) -> NDArray:
     """
-    Return the rows of specified array :math:`a` as diagonal matrices.
+    Return the rows of the specified array :math:`a` as diagonal matrices.
 
     Parameters
     ----------
     a
-        Array :math:`a` to returns the rows of as diagonal matrices.
+        Array :math:`a` to return the rows of as diagonal matrices.
 
     Returns
     -------
@@ -2318,7 +2384,7 @@ def orient(
     ) = "Ignore",
 ) -> NDArray:
     """
-    Orient specified array :math:`a` according to specified orientation.
+    Orient the specified array :math:`a` using the specified orientation.
 
     Parameters
     ----------
@@ -2379,17 +2445,17 @@ def orient(
 
 def centroid(a: ArrayLike) -> NDArrayInt:
     """
-    Return the centroid indexes of specified array :math:`a`.
+    Return the centroid indexes of the specified array :math:`a`.
 
     Parameters
     ----------
     a
-        Array :math:`a` to returns the centroid indexes of.
+        Array :math:`a` to return the centroid indexes of.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Array :math:`a` centroid indexes.
+        Centroid indexes of array :math:`a`.
 
     Examples
     --------
@@ -2426,7 +2492,8 @@ def fill_nan(
     default: Real = 0,
 ) -> NDArray:
     """
-    Fill specified array :math:`a` NaN values according to specified method.
+    Fill the NaN values in the specified array :math:`a` using the specified
+    method.
 
     Parameters
     ----------
@@ -2441,7 +2508,7 @@ def fill_nan(
     Returns
     -------
     :class:`numpy.ndarray`
-        NaNs filled array :math:`a`.
+        NaN-filled array :math:`a`.
 
     Examples
     --------
@@ -2467,17 +2534,17 @@ def fill_nan(
 
 def has_only_nan(a: ArrayLike) -> bool:
     """
-    Return whether specified array :math:`a` contains only NaN values.
+    Return whether the specified array :math:`a` contains only *NaN* values.
 
     Parameters
     ----------
     a
-        Array :math:`a` to check whether it contains only NaN values.
+        Array :math:`a` to check whether it contains only *NaN* values.
 
     Returns
     -------
     :class:`bool`
-        Whether array :math:`a` contains only NaN values.
+        Whether array :math:`a` contains only *NaN* values.
 
     Examples
     --------
@@ -2499,8 +2566,8 @@ def has_only_nan(a: ArrayLike) -> bool:
 @contextmanager
 def ndarray_write(a: ArrayLike) -> Generator:
     """
-    Define a context manager setting specified array :math:`a` writeable to
-    operate one and then read-only.
+    Define a context manager that temporarily sets the specified array
+    :math:`a` to writeable for operations, then restores it to read-only.
 
     Parameters
     ----------
@@ -2510,7 +2577,7 @@ def ndarray_write(a: ArrayLike) -> Generator:
     Yields
     ------
     Generator
-        Array :math:`a` operated.
+        Array :math:`a` made temporarily writeable.
 
     Examples
     --------
@@ -2540,6 +2607,8 @@ def zeros(
     order: Literal["C", "F"] = "C",
 ) -> NDArray:
     """
+    Create an array of zeros with the active dtype.
+
     Wrap :func:`np.zeros` definition to create an array with the active
     :class:`numpy.dtype` defined by the
     :attr:`colour.constant.DTYPE_FLOAT_DEFAULT` attribute.
@@ -2553,13 +2622,14 @@ def zeros(
         :class:`numpy.dtype` defined by the
         :attr:`colour.constant.DTYPE_FLOAT_DEFAULT` attribute.
     order
-        Whether to store multi-dimensional data in row-major (C-style) or
-        column-major (Fortran-style) order in memory.
+        Whether to store multi-dimensional data in row-major
+        (C-style) or column-major (Fortran-style) order in memory.
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Array of specified shape and :class:`numpy.dtype`, filled with zeros.
+        Array of the specified shape and :class:`numpy.dtype`, filled
+        with zeros.
 
     Examples
     --------
@@ -2578,6 +2648,8 @@ def ones(
     order: Literal["C", "F"] = "C",
 ) -> NDArray:
     """
+    Create an array of ones with the active dtype.
+
     Wrap :func:`np.ones` definition to create an array with the active
     :class:`numpy.dtype` defined by the
     :attr:`colour.constant.DTYPE_FLOAT_DEFAULT` attribute.
@@ -2597,7 +2669,7 @@ def ones(
     Returns
     -------
     :class:`numpy.ndarray`
-        Array of specified shape and type, filled with ones.
+        Array of the specified shape and :class:`numpy.dtype`, filled with ones.
 
     Examples
     --------
@@ -2617,8 +2689,11 @@ def full(
     order: Literal["C", "F"] = "C",
 ) -> NDArray:
     """
-    Wrap :func:`np.full` definition to create an array with the active type
-    defined by the:attr:`colour.constant.DTYPE_FLOAT_DEFAULT` attribute.
+    Create an array of the specified value with the active dtype.
+
+    Wrap :func:`np.full` definition to create an array with the active
+    :class:`numpy.dtype` defined by the
+    :attr:`colour.constant.DTYPE_FLOAT_DEFAULT` attribute.
 
     Parameters
     ----------
@@ -2637,12 +2712,13 @@ def full(
     Returns
     -------
     :class:`numpy.ndarray`
-        Array of specified shape and :class:`numpy.dtype`, filled with specified value.
+        Array of the specified shape and :class:`numpy.dtype`, filled with
+        the specified value.
 
     Examples
     --------
-    >>> ones(3)
-    array([ 1.,  1.,  1.])
+    >>> full(3, 2.5)
+    array([ 2.5,  2.5,  2.5])
     """
 
     dtype = optional(dtype, DTYPE_FLOAT_DEFAULT)
@@ -2652,17 +2728,18 @@ def full(
 
 def index_along_last_axis(a: ArrayLike, indexes: ArrayLike) -> NDArray:
     """
-    Reduce the dimension of array :math:`a` by one, by using an array of
-    indexes to pick elements off the last axis.
+    Reduce the dimension of array :math:`a` by one, using an array of
+    indexes to select elements from the last axis.
 
     Parameters
     ----------
     a
         Array :math:`a` to be indexed.
     indexes
-        *integer* array with the same shape as `a` but with one dimension
-        fewer, containing indices to the last dimension of `a`. All elements
-        must be numbers between `0` and `m` - 1.
+        *Integer* array with the same shape as :math:`a` but with one
+        dimension fewer, containing indices to the last dimension of
+        :math:`a`. All elements must be numbers between 0 and
+        :math:`m - 1`.
 
     Returns
     -------
@@ -2675,7 +2752,7 @@ def index_along_last_axis(a: ArrayLike, indexes: ArrayLike) -> NDArray:
         If the array :math:`a` and ``indexes`` have incompatible shapes.
     :class:`IndexError`
         If ``indexes`` has elements outside of the allowed range of 0 to
-        `m` - 1 or if it's not an *integer* array.
+        :math:`m - 1` or if it is not an *integer* array.
 
     Examples
     --------
@@ -2747,7 +2824,7 @@ def index_along_last_axis(a: ArrayLike, indexes: ArrayLike) -> NDArray:
 
 def format_array_as_row(a: ArrayLike, decimals: int = 7, separator: str = " ") -> str:
     """
-    Format specified array :math:`a` as a row.
+    Format the specified array :math:`a` as a row.
 
     Parameters
     ----------

--- a/colour/utilities/array.py
+++ b/colour/utilities/array.py
@@ -537,11 +537,11 @@ class MixinDataclassArithmetic(MixinDataclassArray):
 
 # NOTE : The following messages are pre-generated for performance reasons.
 _ASSERTION_MESSAGE_DTYPE_INT = (
-    f'"dtype" must be one of the following types: "{DTypeInt.__args__}"'  # pyright: ignore
+    f'"dtype" must be one of the following types: "{DTypeInt.__args__}"'
 )
 
 _ASSERTION_MESSAGE_DTYPE_FLOAT = (
-    f'"dtype" must be one of the following types: "{DTypeFloat.__args__}"'  # pyright: ignore
+    f'"dtype" must be one of the following types: "{DTypeFloat.__args__}"'
 )
 
 
@@ -625,10 +625,7 @@ def as_int(a: ArrayLike, dtype: Type[DTypeInt] | None = None) -> DTypeInt | NDAr
 
     dtype = optional(dtype, DTYPE_INT_DEFAULT)
 
-    attest(
-        dtype in DTypeInt.__args__,  # pyright: ignore
-        _ASSERTION_MESSAGE_DTYPE_INT,
-    )
+    attest(dtype in DTypeInt.__args__, _ASSERTION_MESSAGE_DTYPE_INT)
 
     return dtype(a)  # pyright: ignore
 
@@ -679,10 +676,7 @@ def as_float(
 
     dtype = optional(dtype, DTYPE_FLOAT_DEFAULT)
 
-    attest(
-        dtype in DTypeFloat.__args__,  # pyright: ignore
-        _ASSERTION_MESSAGE_DTYPE_FLOAT,
-    )
+    attest(dtype in DTypeFloat.__args__, _ASSERTION_MESSAGE_DTYPE_FLOAT)
 
     # NOTE: "np.float64" reduces dimensionality:
     # >>> np.int64(np.array([[1]]))
@@ -723,10 +717,7 @@ def as_int_array(a: ArrayLike, dtype: Type[DTypeInt] | None = None) -> NDArrayIn
 
     dtype = optional(dtype, DTYPE_INT_DEFAULT)
 
-    attest(
-        dtype in DTypeInt.__args__,  # pyright: ignore
-        _ASSERTION_MESSAGE_DTYPE_INT,
-    )
+    attest(dtype in DTypeInt.__args__, _ASSERTION_MESSAGE_DTYPE_INT)
 
     return as_array(a, dtype)
 
@@ -758,10 +749,7 @@ def as_float_array(a: ArrayLike, dtype: Type[DTypeFloat] | None = None) -> NDArr
 
     dtype = optional(dtype, DTYPE_FLOAT_DEFAULT)
 
-    attest(
-        dtype in DTypeFloat.__args__,  # pyright: ignore
-        _ASSERTION_MESSAGE_DTYPE_FLOAT,
-    )
+    attest(dtype in DTypeFloat.__args__, _ASSERTION_MESSAGE_DTYPE_FLOAT)
 
     return as_array(a, dtype)
 

--- a/colour/utilities/callback.py
+++ b/colour/utilities/callback.py
@@ -2,7 +2,7 @@
 Callback Management
 ===================
 
-Callback management objects.
+Provide callback management functionality for event-driven systems.
 """
 
 from __future__ import annotations
@@ -30,14 +30,17 @@ __all__ = [
 @dataclass
 class Callback:
     """
-    Define a callback.
+    Represent a named callback with its associated callable function.
+
+    This dataclass encapsulates a callback's identifying name and its
+    callable function for use in event-driven callback systems.
 
     Parameters
     ----------
     name
-        Callback name.
+        Callback identifier used for registration and management.
     function
-        Callback callable.
+        Callable object to execute when the callback is triggered.
     """
 
     name: str
@@ -46,7 +49,11 @@ class Callback:
 
 class MixinCallback:
     """
-    A mixin providing support for callbacks.
+    Provide callback support for attribute changes in classes.
+
+    This mixin extends class functionality to enable callback registration,
+    allowing automatic invocation when specified attributes are modified.
+    Callbacks can transform or validate attribute values before they are set.
 
     Attributes
     ----------
@@ -83,24 +90,26 @@ class MixinCallback:
     @property
     def callbacks(self) -> defaultdict[str, List[Callback]]:
         """
-        Getter property for the callbacks.
+        Getter for the event callbacks dictionary.
 
         Returns
         -------
         :class:`defaultdict`
-            Callbacks.
+            Dictionary mapping event names to lists of callback functions.
+            Each key represents an event identifier, and each value contains
+            the registered callbacks for that event.
         """
 
         return self._callbacks
 
     def __setattr__(self, name: str, value: Any) -> None:
         """
-        Set specified value to the attribute with specified name.
+        Set the specified value to the attribute with the specified name.
 
         Parameters
         ----------
-        attribute
-            Attribute to set the value of.
+        name
+            Name of the attribute to set.
         value
             Value to set the attribute with.
         """
@@ -113,7 +122,8 @@ class MixinCallback:
 
     def register_callback(self, attribute: str, name: str, function: Callable) -> None:
         """
-        Register the callback with specified name for specified attribute.
+        Register a callback with the specified name for the specified
+        attribute.
 
         Parameters
         ----------
@@ -130,7 +140,6 @@ class MixinCallback:
         ...     def __init__(self):
         ...         super().__init__()
         ...         self.attribute_a = "a"
-        ...
         >>> with_callback = WithCallback()
         >>> with_callback.register_callback(
         ...     "attribute_a", "callback", lambda *args: None
@@ -144,7 +153,8 @@ class MixinCallback:
 
     def unregister_callback(self, attribute: str, name: str) -> None:
         """
-        Unregister the callback with specified name for specified attribute.
+        Unregister the callback with the specified name for the specified
+        attribute.
 
         Parameters
         ----------
@@ -159,7 +169,6 @@ class MixinCallback:
         ...     def __init__(self):
         ...         super().__init__()
         ...         self.attribute_a = "a"
-        ...
         >>> with_callback = WithCallback()
         >>> with_callback.register_callback(
         ...     "attribute_a", "callback", lambda s, n, v: v

--- a/colour/utilities/common.py
+++ b/colour/utilities/common.py
@@ -2,7 +2,7 @@
 Common Utilities
 ================
 
-Common utilities objects that don't fall in any specific category.
+Provide common utility objects that don't fall in any specific category.
 
 References
 ----------
@@ -98,7 +98,12 @@ Global variable storing the current *Colour* caching enabled state.
 
 def is_caching_enabled() -> bool:
     """
-    Return whether *Colour* caching is enabled.
+    Determine whether *Colour* caching is enabled.
+
+    The caching state is controlled by the global
+    *COLOUR_SCIENCE__DISABLE_CACHING* environment variable and can be
+    temporarily modified using the :func:`set_caching_enable` function or the
+    :class:`caching_enable` context manager.
 
     Returns
     -------
@@ -120,7 +125,7 @@ def is_caching_enabled() -> bool:
 
 def set_caching_enable(enable: bool) -> None:
     """
-    Set *Colour* caching enabled state.
+    Set the *Colour* caching enabled state.
 
     Parameters
     ----------
@@ -144,8 +149,8 @@ def set_caching_enable(enable: bool) -> None:
 
 class caching_enable:
     """
-    Define a context manager and decorator temporarily setting *Colour* caching
-    enabled state.
+    Define a context manager and decorator to temporarily set the *Colour*
+    caching enabled state.
 
     Parameters
     ----------
@@ -159,8 +164,7 @@ class caching_enable:
 
     def __enter__(self) -> Self:
         """
-        Set the *Colour* caching enabled state upon entering the context
-        manager.
+        Enter the caching context and set the *Colour* caching state.
         """
 
         set_caching_enable(self._enable)
@@ -169,14 +173,16 @@ class caching_enable:
 
     def __exit__(self, *args: Any) -> None:
         """
-        Set the *Colour* caching enabled state upon exiting the context
-        manager.
+        Exit the caching context manager and restore the previous *Colour*
+        caching state.
         """
 
         set_caching_enable(self._previous_state)
 
     def __call__(self, function: Callable) -> Callable:
-        """Call the wrapped definition."""
+        """
+        Decorate and call the specified function with caching control.
+        """
 
         @functools.wraps(function)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
@@ -188,7 +194,11 @@ class caching_enable:
 
 class CacheRegistry:
     """
-    A registry for mapping-based caches.
+    Provide a registry for managing mapping-based caches.
+
+    The registry maintains a collection of named caches that can be
+    registered, cleared, and unregistered. Each cache operates as a
+    dictionary-like mapping for storing key-value pairs.
 
     Attributes
     ----------
@@ -229,12 +239,12 @@ class CacheRegistry:
     @property
     def registry(self) -> dict:
         """
-        Getter property for the cache registry.
+        Getter for the cache registry.
 
         Returns
         -------
         :class:`dict`
-            Cache registry.
+            Cache registry containing cached computation results.
         """
 
         return self._registry
@@ -258,7 +268,7 @@ class CacheRegistry:
 
     def register_cache(self, name: str) -> dict:
         """
-        Register a new cache with specified name in the registry.
+        Register a new cache with the specified name in the registry.
 
         Parameters
         ----------
@@ -288,7 +298,7 @@ class CacheRegistry:
 
     def unregister_cache(self, name: str) -> None:
         """
-        Unregister cache with specified name in the registry.
+        Unregister the cache with the specified name from the registry.
 
         Parameters
         ----------
@@ -322,7 +332,7 @@ class CacheRegistry:
 
     def clear_cache(self, name: str) -> None:
         """
-        Clear the cache with specified name.
+        Clear the cache with the specified name.
 
         Parameters
         ----------
@@ -345,7 +355,7 @@ class CacheRegistry:
 
     def clear_all_caches(self) -> None:
         """
-        Clear all the caches in the registry.
+        Clear all caches in the registry.
 
         Examples
         --------
@@ -375,16 +385,18 @@ processes.
 
 def handle_numpy_errors(**kwargs: Any) -> Callable:
     """
-    Decorate a function to handle *Numpy* errors.
+    Handle *Numpy* errors through function decoration.
 
     Other Parameters
     ----------------
     kwargs
-        Keywords arguments.
+        Keyword arguments passed to :func:`numpy.seterr` to control
+        error handling behaviour.
 
     Returns
     -------
     Callable
+        Decorated function with specified *Numpy* error handling.
 
     References
     ----------
@@ -434,6 +446,8 @@ def ignore_python_warnings(function: Callable) -> Callable:
     Returns
     -------
     Callable
+        Decorated function that suppresses *Python* warnings during
+        execution.
 
     Examples
     --------
@@ -457,7 +471,7 @@ def ignore_python_warnings(function: Callable) -> Callable:
 
 def attest(condition: bool | DTypeBoolean, message: str = "") -> None:
     """
-    Provide the `assert` statement functionality without being disabled by
+    Provide the ``assert`` statement functionality without being disabled by
     optimised Python execution.
 
     Parameters
@@ -474,7 +488,7 @@ def attest(condition: bool | DTypeBoolean, message: str = "") -> None:
 
 def batch(sequence: Sequence, k: int | Literal[3] = 3) -> Generator:
     """
-    Generate batches from specified sequence.
+    Generate batches from the specified sequence.
 
     Parameters
     ----------
@@ -504,7 +518,7 @@ _MULTIPROCESSING_ENABLED: bool = True
 
 class disable_multiprocessing:
     """
-    Define a context manager and decorator to temporarily disabling *Colour*
+    Define a context manager and decorator to temporarily disable *Colour*
     multiprocessing state.
     """
 
@@ -531,7 +545,9 @@ class disable_multiprocessing:
         _MULTIPROCESSING_ENABLED = True
 
     def __call__(self, function: Callable) -> Callable:
-        """Call the wrapped definition."""
+        """
+        Execute the decorated function with optional multiprocessing support.
+        """
 
         @functools.wraps(function)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
@@ -545,15 +561,15 @@ class disable_multiprocessing:
 
 def _initializer(kwargs: Any) -> None:
     """
-    Initialize a multiprocessing pool.
+    Initialize a multiprocessing pool worker process.
 
-    It is used to ensure that processes on *Windows* inherit correctly from the
-    current domain-range scale.
+    Ensure that worker processes on *Windows* correctly inherit the current
+    domain-range scale configuration from the parent process.
 
     Parameters
     ----------
     kwargs
-        Initialisation arguments.
+        Initialization arguments for configuring the worker process state.
     """
 
     # NOTE: No coverage information is available as this code is executed in
@@ -578,19 +594,20 @@ def _initializer(kwargs: Any) -> None:
 @contextmanager
 def multiprocessing_pool(*args: Any, **kwargs: Any) -> Generator:
     """
-    Define a context manager providing a multiprocessing pool.
+    Provide a context manager for a multiprocessing pool.
 
     Other Parameters
     ----------------
     args
-        Arguments.
+        Arguments passed to the multiprocessing pool constructor.
     kwargs
-        Keywords arguments.
+        Keyword arguments passed to the multiprocessing pool
+        constructor.
 
     Yields
     ------
     Generator
-        Multiprocessing pool.
+        Multiprocessing pool context manager.
 
     Examples
     --------
@@ -627,7 +644,7 @@ def multiprocessing_pool(*args: Any, **kwargs: Any) -> Generator:
             iterable: Sequence,
             chunksize: int | None = None,  # noqa: ARG002
         ) -> list[Any]:
-            """Apply specified function to each element of specified iterable."""
+            """Apply specified function to each element of the specified iterable."""
 
             return [func(a) for a in iterable]
 
@@ -661,17 +678,17 @@ def multiprocessing_pool(*args: Any, **kwargs: Any) -> Generator:
 
 def is_iterable(a: Any) -> bool:
     """
-    Determine whether specified variable :math:`a` is iterable.
+    Determine whether the specified variable :math:`a` is iterable.
 
     Parameters
     ----------
     a
-        Variable :math:`a` to check the iterability.
+        Variable :math:`a` to check for iterability.
 
     Returns
     -------
     :class:`bool`
-        Whether variable :math:`a` is iterable.
+        Whether the variable :math:`a` is iterable.
 
     Examples
     --------
@@ -686,8 +703,8 @@ def is_iterable(a: Any) -> bool:
 
 def is_numeric(a: Any) -> bool:
     """
-    Determine whether specified variable :math:`a` is a :class:`Real`-like
-    variable.
+    Determine whether the specified variable :math:`a` is a
+    :class:`Real`-like variable.
 
     Parameters
     ----------
@@ -735,8 +752,8 @@ def is_numeric(a: Any) -> bool:
 
 def is_integer(a: Any) -> bool:
     """
-    Return whether specified variable :math:`a` is an :class:`numpy.integer`-like
-    variable under specified threshold.
+    Determine whether the specified variable :math:`a` is an
+    :class:`numpy.integer`-like variable under the specified threshold.
 
     Parameters
     ----------
@@ -746,7 +763,8 @@ def is_integer(a: Any) -> bool:
     Returns
     -------
     :class:`bool`
-        Whether variable :math:`a` is an :class:`numpy.integer`-like variable.
+        Whether variable :math:`a` is an :class:`numpy.integer`-like
+        variable.
 
     Notes
     -----
@@ -766,19 +784,22 @@ def is_integer(a: Any) -> bool:
 
 def is_sibling(element: Any, mapping: Mapping) -> bool:
     """
-    Return whether specified element type is present in specified mapping types.
+    Determine whether the type of the specified element is present in the
+    specified mapping types.
 
     Parameters
     ----------
     element
-        Element to check whether its type is present in the mapping types.
+        Element to check whether its type is present in the mapping
+        types.
     mapping
-        Mapping types.
+        Mapping types to check against.
 
     Returns
     -------
     :class:`bool`
-        Whether specified element type is present in specified mapping types.
+        Whether the type of the specified element is present in the
+        specified mapping types.
     """
 
     return isinstance(element, tuple({type(element) for element in mapping.values()}))
@@ -786,22 +807,23 @@ def is_sibling(element: Any, mapping: Mapping) -> bool:
 
 def filter_kwargs(function: Callable, **kwargs: Any) -> dict:
     """
-    Filter keyword arguments incompatible with the specified function signature.
+    Filter keyword arguments incompatible with the specified function
+    signature.
 
     Parameters
     ----------
     function
-        Callable to filter the incompatible keyword arguments.
+        Callable to filter the incompatible keyword arguments against.
 
     Other Parameters
     ----------------
     kwargs
-        Keywords arguments.
+        Keyword arguments to be filtered.
 
     Returns
     -------
     dict
-        Filtered keyword arguments.
+        Filtered keyword arguments compatible with the function signature.
 
     Examples
     --------
@@ -834,27 +856,27 @@ def filter_kwargs(function: Callable, **kwargs: Any) -> dict:
 
 def filter_mapping(mapping: Mapping, names: str | Sequence[str]) -> dict:
     """
-    Filter specified mapping with specified names.
+    Filter the specified mapping with specified names.
 
     Parameters
     ----------
     mapping
         Mapping to filter.
     names
-        Name for specified mapping elements or a list of names.
+        Name for the mapping elements to filter or a sequence of names.
 
     Returns
     -------
     dict
-        Filtered mapping elements.
+        Filtered mapping containing only the specified elements.
 
     Notes
     -----
-    -   If the mapping passed is a :class:`colour.utilities.CanonicalMapping`
-        class instance, then the lower, slugified and canonical keys are also
+    -   If the mapping is a :class:`colour.utilities.CanonicalMapping`
+        instance, then the lower, slugified and canonical keys are also
         used for matching.
-    -   To honour the filterers ordering, the return value is a :class:`dict`
-        class instance.
+    -   To honour the filterers ordering, the return value is a
+        :class:`dict` instance.
 
     Examples
     --------
@@ -872,14 +894,14 @@ def filter_mapping(mapping: Mapping, names: str | Sequence[str]) -> dict:
 
     def filter_mapping_with_name(mapping: Mapping, name: str) -> dict:
         """
-        Filter specified mapping with specified name.
+        Filter specified mapping with the specified name.
 
         Parameters
         ----------
         mapping
             Mapping to filter.
         name
-            Name for specified mapping elements.
+            Name for the specified mapping elements.
 
         Returns
         -------
@@ -912,16 +934,17 @@ def filter_mapping(mapping: Mapping, names: str | Sequence[str]) -> dict:
 
 def first_item(a: Iterable) -> Any:
     """
-    Return the first item of specified iterable.
+    Return the first item from the specified iterable.
 
     Parameters
     ----------
     a
-        Iterable to get the first item from.
+        Iterable to retrieve the first item from.
 
     Returns
     -------
     :class:`object`
+        First item from the iterable.
 
     Raises
     ------
@@ -948,12 +971,12 @@ def copy_definition(definition: Callable, name: str | None = None) -> Callable:
     definition
         Definition to be copied.
     name
-        Optional definition copy name.
+        Optional name for the definition copy.
 
     Returns
     -------
     Callable
-        Definition copy.
+        Copy of the specified definition.
     """
 
     copy = types.FunctionType(
@@ -976,8 +999,8 @@ def validate_method(
     as_lowercase: bool = True,
 ) -> str:
     """
-    Validate whether specified method exists in the specified valid methods and
-    optionally returns the method lower cased.
+    Validate whether the specified method exists in the specified valid
+    methods and optionally return the method lower cased.
 
     Parameters
     ----------
@@ -1022,7 +1045,7 @@ T = TypeVar("T")
 
 def optional(value: T | None, default: T) -> T:
     """
-    Handle optional argument value by providing a default value.
+    Return the specified value or a default if the value is *None*.
 
     Parameters
     ----------
@@ -1052,11 +1075,12 @@ def optional(value: T | None, default: T) -> T:
 
 def slugify(object_: Any, allow_unicode: bool = False) -> str:
     """
-    Generate a *SEO* friendly and human-readable slug from specified object.
+    Generate a *SEO* friendly and human-readable slug from the specified
+    object.
 
     Convert to ASCII if ``allow_unicode`` is *False*. Convert spaces or
-    repeated dashes to single dashes. Remove characters that aren't
-    alphanumerics, underscores, or hyphens. Convert to lowercase. Also strip
+    repeated dashes to single dashes. Remove characters that are not
+    alphanumerics, underscores, or hyphens. Convert to lowercase. Strip
     leading and trailing whitespace, dashes, and underscores.
 
     Parameters
@@ -1115,15 +1139,15 @@ if is_xxhash_installed():
             seed: int = 0,  # noqa: ARG001
         ) -> int:
             """
-            Generate an integer digest for specified argument using *xxhash* if
-            available or falling back to :func:`hash` if not.
+            Generate an integer digest for the specified argument using
+            *xxhash* if available, otherwise fall back to :func:`hash`.
 
             Parameters
             ----------
             args
-                Argument to generate the int digest of.
+                Argument to generate the integer digest of.
             seed
-                Seed used to alter result predictably.
+                Seed used to alter the result predictably.
 
             Returns
             -------

--- a/colour/utilities/deprecation.py
+++ b/colour/utilities/deprecation.py
@@ -2,7 +2,7 @@
 Deprecation Utilities
 =====================
 
-Various deprecation management related objects.
+Define deprecation management utilities for the Colour library.
 """
 
 from __future__ import annotations
@@ -46,14 +46,14 @@ __all__ = [
 @dataclass(frozen=True)
 class ObjectRenamed(MixinDataclassIterable):
     """
-    A class used for an object that has been renamed.
+    Represent an object that has been renamed in the API.
 
     Parameters
     ----------
     name
-        Object name that changed.
+        Object name that has been changed.
     new_name
-        Object new name.
+        New object name.
     """
 
     name: str
@@ -75,7 +75,7 @@ class ObjectRenamed(MixinDataclassIterable):
 @dataclass(frozen=True)
 class ObjectRemoved(MixinDataclassIterable):
     """
-    A class used for an object that has been removed.
+    Represent an object that has been removed from the API.
 
     Parameters
     ----------
@@ -101,15 +101,14 @@ class ObjectRemoved(MixinDataclassIterable):
 @dataclass(frozen=True)
 class ObjectFutureRename(MixinDataclassIterable):
     """
-    A class used for future object name deprecation, i.e., object name will
-    change in a future release.
+    Represent an object that will be renamed in a future release.
 
     Parameters
     ----------
     name
         Object name that will change in a future release.
     new_name
-        Object future release name.
+        New object name.
     """
 
     name: str
@@ -117,7 +116,7 @@ class ObjectFutureRename(MixinDataclassIterable):
 
     def __str__(self) -> str:
         """
-        Return a formatted string representation of the deprecation type.
+        Return a formatted string representation of the class.
 
         Returns
         -------
@@ -134,7 +133,7 @@ class ObjectFutureRename(MixinDataclassIterable):
 @dataclass(frozen=True)
 class ObjectFutureRemove(MixinDataclassIterable):
     """
-    A class used for future object removal.
+    Represent an object that will be removed in a future release.
 
     Parameters
     ----------
@@ -146,7 +145,7 @@ class ObjectFutureRemove(MixinDataclassIterable):
 
     def __str__(self) -> str:
         """
-        Return a formatted string representation of the deprecation type.
+        Return a formatted string representation of the class.
 
         Returns
         -------
@@ -163,15 +162,15 @@ class ObjectFutureRemove(MixinDataclassIterable):
 @dataclass(frozen=True)
 class ObjectFutureAccessChange(MixinDataclassIterable):
     """
-    A class used for future object access deprecation, i.e., object access will
-    change in a future release.
+    Represent an object whose access pattern will change in a future
+    release.
 
     Parameters
     ----------
     access
         Object access that will change in a future release.
     new_access
-        Object future release access.
+        New object access pattern.
     """
 
     access: str
@@ -179,7 +178,7 @@ class ObjectFutureAccessChange(MixinDataclassIterable):
 
     def __str__(self) -> str:
         """
-        Return a formatted string representation of the deprecation type.
+        Return a formatted string representation of the class.
 
         Returns
         -------
@@ -196,20 +195,20 @@ class ObjectFutureAccessChange(MixinDataclassIterable):
 @dataclass(frozen=True)
 class ObjectFutureAccessRemove(MixinDataclassIterable):
     """
-    A class used for future object access removal, i.e., object access will
+    Represent an object whose access will be removed in a future release.
     be removed in a future release.
 
     Parameters
     ----------
     name
-        Object name whose access will removed in a future release.
+        Object name whose access will be removed in a future release.
     """
 
     name: str
 
     def __str__(self) -> str:
         """
-        Return a formatted string representation of the deprecation type.
+        Return a formatted string representation of the class.
 
         Returns
         -------
@@ -223,14 +222,14 @@ class ObjectFutureAccessRemove(MixinDataclassIterable):
 @dataclass(frozen=True)
 class ArgumentRenamed(MixinDataclassIterable):
     """
-    A class used for an argument that has been renamed.
+    Represent an argument that has been renamed in the API.
 
     Parameters
     ----------
     name
-        Argument name that changed.
+        Argument name that has been changed.
     new_name
-        Argument new name.
+        New argument name.
     """
 
     name: str
@@ -252,7 +251,7 @@ class ArgumentRenamed(MixinDataclassIterable):
 @dataclass(frozen=True)
 class ArgumentRemoved(MixinDataclassIterable):
     """
-    A class used for an argument that has been removed.
+    Represent an argument that has been removed from the API.
 
     Parameters
     ----------
@@ -278,7 +277,7 @@ class ArgumentRemoved(MixinDataclassIterable):
 @dataclass(frozen=True)
 class ArgumentFutureRename(MixinDataclassIterable):
     """
-    A class used for future argument name deprecation, i.e., argument name will
+    Represent an argument that will be renamed in a future release.
     change in a future release.
 
     Parameters
@@ -286,7 +285,7 @@ class ArgumentFutureRename(MixinDataclassIterable):
     name
         Argument name that will change in a future release.
     new_name
-        Argument future release name.
+        New argument name.
     """
 
     name: str
@@ -294,7 +293,7 @@ class ArgumentFutureRename(MixinDataclassIterable):
 
     def __str__(self) -> str:
         """
-        Return a formatted string representation of the deprecation type.
+        Return a formatted string representation of the class.
 
         Returns
         -------
@@ -311,7 +310,7 @@ class ArgumentFutureRename(MixinDataclassIterable):
 @dataclass(frozen=True)
 class ArgumentFutureRemove(MixinDataclassIterable):
     """
-    A class used for future argument removal.
+    Represent an argument that will be removed in a future release.
 
     Parameters
     ----------
@@ -323,7 +322,7 @@ class ArgumentFutureRemove(MixinDataclassIterable):
 
     def __str__(self) -> str:
         """
-        Return a formatted string representation of the deprecation type.
+        Return a formatted string representation of the class.
 
         Returns
         -------
@@ -339,13 +338,13 @@ class ArgumentFutureRemove(MixinDataclassIterable):
 
 class ModuleAPI:
     """
-    Define a class that allows customisation of module attributes access with
-    deprecation management.
+    Define a class enabling customisation of module attribute access with
+    built-in deprecation management functionality.
 
     Parameters
     ----------
     module
-        Module to customise attributes access.
+        Module for which to customise attribute access behaviour.
 
     Methods
     -------
@@ -366,7 +365,7 @@ class ModuleAPI:
 
     def __getattr__(self, attribute: str) -> Any:
         """
-        Return specified attribute value while handling deprecation.
+        Return the specified attribute value while handling deprecation.
 
         Parameters
         ----------
@@ -420,13 +419,13 @@ class ModuleAPI:
 
 def get_attribute(attribute: str) -> Any:
     """
-    Return specified attribute value.
+    Retrieve the value of the specified attribute from its namespace.
 
     Parameters
     ----------
     attribute
-        Attribute to retrieve, ``attribute`` must have a namespace module, e.g.,
-        *colour.models.oetf_inverse_BT2020*.
+        Attribute to retrieve, ``attribute`` must have a namespace
+        module, e.g., *colour.models.oetf_inverse_BT2020*.
 
     Returns
     -------
@@ -455,7 +454,7 @@ def get_attribute(attribute: str) -> Any:
 
 def build_API_changes(changes: dict) -> dict:
     """
-    Build the effective API changes for a desired API changes mapping.
+    Build effective API changes from specified API changes mapping.
 
     Parameters
     ----------
@@ -532,22 +531,24 @@ name='module.object_6_access')}
 
 def handle_arguments_deprecation(changes: dict, **kwargs: Any) -> dict:
     """
-    Handle arguments deprecation according to desired API changes mapping.
+    Handle argument deprecation according to the specified API changes
+    mapping.
 
     Parameters
     ----------
     changes
-        Dictionary of desired API changes.
+        Dictionary of specified API changes defining how arguments should
+        be handled during deprecation.
 
     Other Parameters
     ----------------
     kwargs
-        Keywords arguments to handle.
+        Keyword arguments to process for deprecation handling.
 
     Returns
     -------
     :class:`dict`
-        Handled keywords arguments.
+        Processed keyword arguments with deprecation rules applied.
 
     Examples
     --------

--- a/colour/utilities/documentation.py
+++ b/colour/utilities/documentation.py
@@ -2,7 +2,7 @@
 Documentation
 =============
 
-Documentation related objects.
+Define objects and utilities for documentation generation and processing.
 """
 
 from __future__ import annotations
@@ -28,44 +28,44 @@ __all__ = [
 
 class DocstringDict(dict):
     """
-    A :class:`dict` sub-class that allows settings a docstring to :class:`dict`
-    instances.
+    Define a :class:`dict` sub-class that allows docstring attachment to
+    :class:`dict` instances.
     """
 
 
 class DocstringFloat(float):
     """
-    A :class:`float` sub-class that allows settings a docstring to
+    Define a :class:`float` sub-class that allows docstring attachment to
     :class:`float` instances.
     """
 
 
 class DocstringInt(int):
     """
-    A :class:`numpy.integer` sub-class that allows settings a docstring to
-    :class:`numpy.integer` instances.
+    Define an :class:`int` sub-class that allows docstring attachment to
+    :class:`int` instances.
     """
 
 
 class DocstringText(str):  # noqa: SLOT000
     """
-    A :class:`str` sub-class that allows settings a docstring to
+    Define a :class:`str` sub-class that allows docstring attachment to
     :class:`str` instances.
     """
 
 
 class DocstringTuple(tuple):  # noqa: SLOT001
     """
-    A :class:`tuple` sub-class that allows settings a docstring to
+    Define a :class:`tuple` sub-class that allows docstring attachment to
     :class:`tuple` instances.
     """
 
 
 def is_documentation_building() -> bool:
     """
-    Return whether the documentation is being built by checking whether the
+    Determine whether the documentation is being built by checking for the
     *READTHEDOCS* or *COLOUR_SCIENCE__DOCUMENTATION_BUILD* environment
-    variables are defined, their value is not accounted for.
+    variables.
 
     Returns
     -------

--- a/colour/utilities/metrics.py
+++ b/colour/utilities/metrics.py
@@ -2,7 +2,7 @@
 Metrics
 =======
 
-Define various metrics:
+Define various metrics for evaluating signal quality and comparing data:
 
 -   :func:`colour.utilities.metric_mse`
 -   :func:`colour.utilities.metric_psnr`
@@ -53,8 +53,8 @@ def metric_mse(
     axis: int | Tuple[int] | None = None,
 ) -> NDArrayFloat:
     """
-    Compute the mean squared error (MSE) or mean squared deviation (MSD)
-    between specified variables :math:`a` and :math:`b`.
+    Compute the mean squared error (MSE) between the specified arrays
+    :math:`a` and :math:`b`.
 
     Parameters
     ----------
@@ -64,9 +64,9 @@ def metric_mse(
         Variable :math:`b`.
     axis
         Axis or axes along which the means are computed. The default is to
-        compute the mean of the flattened array.
-        If this is a tuple of ints, a mean is performed over multiple axes,
-        instead of a single axis or all the axes as before.
+        compute the mean of the flattened array. If this is a tuple of
+        integers, a mean is performed over multiple axes instead of a
+        single axis or all the axes as before.
 
     Returns
     -------
@@ -95,22 +95,22 @@ def metric_psnr(
     axis: int | Tuple[int] | None = None,
 ) -> NDArrayFloat:
     """
-    Compute the peak signal-to-noise ratio (PSNR) between specified variables
-    :math:`a` and :math:`b`.
+    Compute the peak signal-to-noise ratio (PSNR) between the specified
+    arrays :math:`a` and :math:`b`.
 
     Parameters
     ----------
     a
-        Variable :math:`a`.
+        Array :math:`a`.
     b
-        Variable :math:`b`.
+        Array :math:`b`.
     max_a
-        Maximum possible pixel value of the :math:`a` variable.
+        Maximum possible value of the array :math:`a`.
     axis
-        Axis or axes along which the means are computed. The default is to
-        compute the mean of the flattened array.
-        If this is a tuple of ints, a mean is performed over multiple axes,
-        instead of a single axis or all the axes as before.
+        Axis or axes along which the means are computed. The default is
+        to compute the mean of the flattened array. If this is a tuple
+        of integers, a mean is performed over multiple axes, instead of
+        a single axis or all the axes as before.
 
     Returns
     -------

--- a/colour/utilities/network.py
+++ b/colour/utilities/network.py
@@ -2,27 +2,27 @@
 Network
 =======
 
-Various node-graph / network related classes:
+Node-graph and network infrastructure for computational workflows.
 
--   :class:`colour.utilities.TreeNode`: A basic node object supporting creation
-    of basic node trees.
--   :class:`colour.utilities.Port`: An object that can be added either as an
-    input or output port.
--   :class:`colour.utilities.PortMode`: A node with support for input and
+-   :class:`colour.utilities.TreeNode`: Basic node object supporting
+    creation of hierarchical node trees.
+-   :class:`colour.utilities.Port`: Object that can be added as either an
+    input or output port for data flow.
+-   :class:`colour.utilities.PortMode`: Node with support for input and
     output ports.
--   :class:`colour.utilities.PortGraph`: A graph for nodes with input and
-    output ports.
--   :class:`colour.utilities.ExecutionPort`: An object for nodes
-    supporting execution input and output ports.
--   :class:`colour.utilities.ExecutionNode`: A node with builtin input and
+-   :class:`colour.utilities.PortGraph`: Graph structure for nodes with
+    input and output ports.
+-   :class:`colour.utilities.ExecutionPort`: Object for nodes supporting
+    execution input and output ports.
+-   :class:`colour.utilities.ExecutionNode`: Node with built-in input and
     output execution ports.
--   :class:`colour.utilities.ControlFlowNode`: A node inherited by control flow
-    nodes.
--   :class:`colour.utilities.For`: A node performing for loops in the
+-   :class:`colour.utilities.ControlFlowNode`: Base node inherited by
+    control flow nodes.
+-   :class:`colour.utilities.For`: Node performing for loops in the
     node-graph.
--   :class:`colour.utilities.ParallelForThread`: A node performing for loops in
-    parallel in the node-graph using threads.
--   :class:`colour.utilities.ParallelForMultiprocess`: A node performing for
+-   :class:`colour.utilities.ParallelForThread`: Node performing for loops
+    in parallel in the node-graph using threads.
+-   :class:`colour.utilities.ParallelForMultiprocess`: Node performing for
     loops in parallel in the node-graph using multiprocessing.
 """
 
@@ -75,7 +75,8 @@ __all__ = [
 
 class TreeNode:
     """
-    Basic node supporting the creation of basic node trees.
+    Define a basic node supporting the creation of hierarchical node
+    trees.
 
     Parameters
     ----------
@@ -86,7 +87,7 @@ class TreeNode:
     children
         Children of the node.
     data
-        The data belonging to this node.
+        Data belonging to this node.
 
     Attributes
     ----------
@@ -138,7 +139,7 @@ class TreeNode:
 
     def __new__(cls, *args: Any, **kwargs: Any) -> Self:  # noqa: ARG004
         """
-        Return a new instance of the :class:`colour.utilities.Node` class.
+        Return a new instance of the :class:`colour.utilities.TreeNode` class.
 
         Other Parameters
         ----------------
@@ -173,12 +174,12 @@ class TreeNode:
     @property
     def id(self) -> int:
         """
-        Getter property for the node id.
+        Getter for the node identifier.
 
         Returns
         -------
         :class:`int`
-            Node id.
+            Node identifier.
         """
 
         return self._id  # pyright: ignore
@@ -186,12 +187,12 @@ class TreeNode:
     @property
     def name(self) -> str:
         """
-        Getter and setter property for the name.
+        Getter and setter for the node name.
 
         Parameters
         ----------
         value
-            Value to set the name with.
+            Value to set the node name with.
 
         Returns
         -------
@@ -215,7 +216,7 @@ class TreeNode:
     @property
     def parent(self) -> Self | None:
         """
-        Getter and setter property for the node parent.
+        Getter and setter for the node parent.
 
         Parameters
         ----------
@@ -224,7 +225,7 @@ class TreeNode:
 
         Returns
         -------
-        :class:`Node` or :py:data:`None`
+        :class:`TreeNode` or :py:data:`None`
             Node parent.
         """
 
@@ -250,7 +251,7 @@ class TreeNode:
     @property
     def children(self) -> List[Self]:
         """
-        Getter and setter property for the node children.
+        Getter and setter for the node children.
 
         Parameters
         ----------
@@ -291,12 +292,12 @@ class TreeNode:
     @property
     def root(self) -> Self:
         """
-        Getter property for the node tree.
+        Getter for the root node of the tree hierarchy.
 
         Returns
         -------
         :class:`TreeNode`
-            Node root.
+            Root node of the tree.
         """
 
         if self.is_root():
@@ -307,12 +308,13 @@ class TreeNode:
     @property
     def leaves(self) -> Generator:
         """
-        Getter property for the node leaves.
+        Getter for all leaf nodes in the hierarchy.
 
-        Yields
-        ------
+        Returns
+        -------
         Generator
-            Node leaves.
+            Generator yielding all leaf nodes (nodes without children) in
+            the hierarchy.
         """
 
         if self.is_leaf():
@@ -323,12 +325,13 @@ class TreeNode:
     @property
     def siblings(self) -> Generator:
         """
-        Getter property for the node siblings.
+        Getter for the sibling nodes at the same hierarchical level.
 
         Returns
         -------
         Generator
-            Node siblings.
+            Generator yielding sibling nodes that share the same parent
+            node in the hierarchy.
         """
 
         if self.parent is None:
@@ -339,12 +342,17 @@ class TreeNode:
     @property
     def data(self) -> Any:
         """
-        Getter property for the node data.
+        Getter and setter for the node data.
+
+        Parameters
+        ----------
+        value
+            Data to assign to the node.
 
         Returns
         -------
         :class:`object`
-            Node data.
+            Data stored in the node.
         """
 
         return self._data
@@ -361,7 +369,7 @@ class TreeNode:
 
         Returns
         -------
-        :class`str`
+        :class:`str`
             Formatted string representation.
         """
 
@@ -381,7 +389,7 @@ class TreeNode:
 
     def is_root(self) -> bool:
         """
-        Return whether the node is a root node.
+        Determine whether the node is a root node.
 
         Returns
         -------
@@ -403,7 +411,7 @@ class TreeNode:
 
     def is_inner(self) -> bool:
         """
-        Return whether the node is an inner node.
+        Determine whether the node is an inner node.
 
         Returns
         -------
@@ -425,7 +433,7 @@ class TreeNode:
 
     def is_leaf(self) -> bool:
         """
-        Return whether the node is a leaf node.
+        Determine whether the node is a leaf node.
 
         Returns
         -------
@@ -447,8 +455,8 @@ class TreeNode:
 
     def walk_hierarchy(self, ascendants: bool = False) -> Generator:
         """
-        Return a generator used to walk into :class:`colour.utilities.Node`
-        tree.
+        Generate a generator to walk the :class:`colour.utilities.TreeNode`
+        tree hierarchy.
 
         Parameters
         ----------
@@ -496,17 +504,17 @@ class TreeNode:
 
     def render(self, tab_level: int = 0) -> str:
         """
-        Render the current node and its children as a string.
+        Render the node and its children as a formatted tree string.
 
         Parameters
         ----------
         tab_level
-            Initial indentation level
+            Initial indentation level for the tree structure.
 
         Returns
         -------
         :class:`str`
-            Rendered node tree.
+            Formatted tree representation of the node hierarchy.
 
         Examples
         --------
@@ -539,9 +547,9 @@ class TreeNode:
 
 class Port(MixinLogging):
     """
-    Object that can be added either as an input or output port,
-    i.e., a pin, to a :class:`colour.utilities.PortNode` class and connected to
-    another input or output port.
+    Define a port object that serves as an input or output port (i.e., a
+    pin) for a :class:`colour.utilities.PortNode` class and connects to
+    other input or output ports.
 
     Parameters
     ----------
@@ -550,7 +558,7 @@ class Port(MixinLogging):
     value
         Initial value to set the port with.
     description
-        Port description
+        Port description.
     node
         Node to add the port to.
 
@@ -606,7 +614,7 @@ class Port(MixinLogging):
     @property
     def name(self) -> str:
         """
-        Getter and setter property for the port name.
+        Getter and setter for the port name.
 
         Parameters
         ----------
@@ -635,7 +643,7 @@ class Port(MixinLogging):
     @property
     def value(self) -> Any:
         """
-        Getter and setter property for the port value.
+        Getter and setter for the port value.
 
         Parameters
         ----------
@@ -695,7 +703,7 @@ class Port(MixinLogging):
     @property
     def description(self) -> str:
         """
-        Getter and setter property for the port description.
+        Getter and setter for the port description.
 
         Parameters
         ----------
@@ -725,7 +733,12 @@ class Port(MixinLogging):
     @property
     def node(self) -> PortNode | None:
         """
-        Getter property for the port node.
+        Getter and setter for the port node.
+
+        Parameters
+        ----------
+        value : PortNode or None
+            Port node to set.
 
         Returns
         -------
@@ -749,12 +762,13 @@ class Port(MixinLogging):
     @property
     def connections(self) -> Dict[Port, None]:
         """
-        Getter property for the port connections.
+        Getter for the port connections.
 
         Returns
         -------
         :class:`dict`
-            Port connections.
+            Port connections mapping each :class:`Port` instance to
+            ``None``.
         """
 
         return self._connections
@@ -766,7 +780,7 @@ class Port(MixinLogging):
         Returns
         -------
         :class:`str`
-            Formatted string representation of the port.
+            Formatted string representation.
 
         Examples
         --------
@@ -793,7 +807,7 @@ class Port(MixinLogging):
 
     def is_input_port(self) -> bool:
         """
-        Return whether the port is an input port.
+        Determine whether the port is an input port.
 
         Returns
         -------
@@ -816,7 +830,7 @@ class Port(MixinLogging):
 
     def is_output_port(self) -> bool:
         """
-        Return whether the port is an output port.
+        Determine whether the port is an output port.
 
         Returns
         -------
@@ -839,7 +853,7 @@ class Port(MixinLogging):
 
     def connect(self, port: Port) -> None:
         """
-        Connect the port to the other specified port.
+        Connect this port to the specified port.
 
         Parameters
         ----------
@@ -849,8 +863,8 @@ class Port(MixinLogging):
         Raises
         ------
         ValueError
-            if an attempt is made to connect an input port to multiple output
-            ports.
+            If an attempt is made to connect an input port to multiple
+            output ports.
 
         Examples
         --------
@@ -876,7 +890,7 @@ class Port(MixinLogging):
 
     def disconnect(self, port: Port) -> None:
         """
-        Disconnect the port from the other specified port.
+        Disconnect from the specified port.
 
         Parameters
         ----------
@@ -908,13 +922,14 @@ class Port(MixinLogging):
 
     def to_graphviz(self) -> str:
         """
-        Return a string representation for visualisation of the port with
+        Generate a string representation for port visualisation with
         *Graphviz*.
 
         Returns
         -------
         :class:`str`
-            String representation for visualisation of the port with *Graphviz*.
+            String representation for visualisation of the port with
+            *Graphviz*.
 
         Examples
         --------
@@ -927,7 +942,7 @@ class Port(MixinLogging):
 
 class PortNode(TreeNode, MixinLogging):
     """
-    Node with support for input and output ports.
+    Define a node with support for input and output ports.
 
     Other Parameters
     ----------------
@@ -999,12 +1014,13 @@ class PortNode(TreeNode, MixinLogging):
     @property
     def input_ports(self) -> Dict[str, Port]:
         """
-        Getter property for the input ports.
+        Getter for the input ports of the node.
 
         Returns
         -------
         :class:`dict`
-            Input ports.
+            Dictionary mapping port names to their corresponding input port
+            instances.
         """
 
         return self._input_ports
@@ -1012,12 +1028,13 @@ class PortNode(TreeNode, MixinLogging):
     @property
     def output_ports(self) -> Dict[str, Port]:
         """
-        Getter property for the output ports.
+        Getter for the output ports of the node.
 
         Returns
         -------
         :class:`dict`
-            Output ports.
+            Mapping of output port names to their corresponding :class:`Port`
+            instances.
         """
 
         return self._output_ports
@@ -1025,17 +1042,17 @@ class PortNode(TreeNode, MixinLogging):
     @property
     def dirty(self) -> bool:
         """
-        Getter and setter property for the node dirty state.
+        Getter and setter for the node's dirty state.
 
         Parameters
         ----------
         value
-            Value to set the node dirty state.
+            Value to set the node dirty state with.
 
         Returns
         -------
         :class:`bool`
-            Whether the node is dirty.
+            Whether the node is in a dirty state.
         """
 
         return self._dirty
@@ -1056,14 +1073,17 @@ class PortNode(TreeNode, MixinLogging):
         self,
     ) -> Tuple[Dict[Tuple[Port, Port], None], Dict[Tuple[Port, Port], None]]:
         """
-        Return the edges of the node.
+        Getter for the edges of the node.
 
-        Each edge represent a port and one of its connections.
+        Retrieve the edges representing ports and their connections. Each
+        edge corresponds to a port and one of its connections within the
+        node structure.
 
         Returns
         -------
         :class:`tuple`
-            Edges of the node as a tuple of input and output edge dictionaries.
+            Edges of the node as a tuple of input and output edge
+            dictionaries.
         """
 
         # TODO: Consider using ordered set.
@@ -1083,7 +1103,7 @@ class PortNode(TreeNode, MixinLogging):
     @property
     def description(self) -> str:
         """
-        Getter and setter property for the node description.
+        Getter and setter for the node description.
 
         Parameters
         ----------
@@ -1125,7 +1145,7 @@ class PortNode(TreeNode, MixinLogging):
         name
             Name of the input port.
         value
-            Value of the input port
+            Value of the input port.
         description
             Description of the input port.
         port_type
@@ -1152,17 +1172,17 @@ class PortNode(TreeNode, MixinLogging):
         name: str,
     ) -> Port:
         """
-        Remove the input port with specified name from the node.
+        Remove the input port with the specified name from the node.
 
         Parameters
         ----------
         name
-            Name of the input port.
+            Name of the input port to remove.
 
         Returns
         -------
         :class:`colour.utilities.Port`
-            Input port.
+            Removed input port.
 
         Examples
         --------
@@ -1192,14 +1212,14 @@ class PortNode(TreeNode, MixinLogging):
         port_type: Type[Port] = Port,
     ) -> Port:
         """
-        Add an output port with specified name and value to the node.
+        Add an output port with the specified name and value to the node.
 
         Parameters
         ----------
         name
             Name of the output port.
         value
-            Value of the output port
+            Value of the output port.
         description
             Description of the output port.
         port_type
@@ -1226,17 +1246,17 @@ class PortNode(TreeNode, MixinLogging):
         name: str,
     ) -> Port:
         """
-        Remove the output port with specified name from the node.
+        Remove the output port with the specified name from the node.
 
         Parameters
         ----------
         name
-            Name of the output port.
+            Name of the output port to remove.
 
         Returns
         -------
         :class:`colour.utilities.Port`
-            Output port.
+            Removed output port.
 
         Examples
         --------
@@ -1260,7 +1280,7 @@ class PortNode(TreeNode, MixinLogging):
 
     def get_input(self, name: str) -> Any:
         """
-        Return the value of the input port with specified name.
+        Return the value of the input port with the specified name.
 
         Parameters
         ----------
@@ -1269,7 +1289,7 @@ class PortNode(TreeNode, MixinLogging):
 
         Returns
         -------
-        :class:`object`:
+        :class:`object`
             Value of the input port.
 
         Raises
@@ -1294,19 +1314,20 @@ class PortNode(TreeNode, MixinLogging):
 
     def set_input(self, name: str, value: Any) -> None:
         """
-        Set the value of the input port with specified name.
+        Set the value of an input port with the specified name.
 
         Parameters
         ----------
         name
-            Name of the input port.
+            Name of the input port to set.
         value
-            Value of the input port
+            Value to assign to the input port.
 
         Raises
         ------
         AssertionError
-            If the input port is not a member of the node input ports.
+            If the specified input port is not a member of the node's
+            input ports.
 
         Examples
         --------
@@ -1327,7 +1348,7 @@ class PortNode(TreeNode, MixinLogging):
 
     def get_output(self, name: str) -> Any:
         """
-        Return the value of the output port with specified name.
+        Return the value of the output port with the specified name.
 
         Parameters
         ----------
@@ -1336,13 +1357,14 @@ class PortNode(TreeNode, MixinLogging):
 
         Returns
         -------
-        :class:`object`:
+        :class:`object`
             Value of the output port.
 
         Raises
         ------
         AssertionError
-            If the output port is not a member of the node output ports.
+            If the output port is not a member of the node output
+            ports.
 
         Examples
         --------
@@ -1361,14 +1383,14 @@ class PortNode(TreeNode, MixinLogging):
 
     def set_output(self, name: str, value: Any) -> None:
         """
-        Set the value of the output port with specified name.
+        Set the value of the output port with the specified name.
 
         Parameters
         ----------
         name
             Name of the output port.
         value
-            Value of the output port
+            Value to assign to the output port.
 
         Raises
         ------
@@ -1399,16 +1421,18 @@ class PortNode(TreeNode, MixinLogging):
         target_port: str,
     ) -> None:
         """
-        Connect the specified source port to specified node target port.
+        Connect the specified source port to the specified target port of
+        another node.
 
         The source port can be an input port but the target port must be
-        an output port and conversely, if the source port is an output port, the
-        target port must be an input port.
+        an output port and conversely, if the source port is an output
+        port, the target port must be an input port.
 
         Parameters
         ----------
         source_port
-            Source port of the node to connect to the other node target port.
+            Source port of the node to connect to the other node target
+            port.
         target_node
             Target node that the target port is the member of.
         target_port
@@ -1441,20 +1465,23 @@ class PortNode(TreeNode, MixinLogging):
         target_port: str,
     ) -> None:
         """
-        Disconnect the specified source port from specified node target port.
+        Disconnect the specified source port from the specified target node
+        port.
 
-        The source port can be an input port but the target port must be
-        an output port and conversely, if the source port is an output port, the
-        target port must be an input port.
+        The source port can be an input port but the target port must be an
+        output port and conversely, if the source port is an output port,
+        the target port must be an input port.
 
         Parameters
         ----------
         source_port
-            Source port of the node to disconnect from the other node target port.
+            Source port of the node to disconnect from the other node target
+            port.
         target_node
             Target node that the target port is the member of.
         target_port
-            Target port from the target node to disconnect the source port from.
+            Target port from the target node to disconnect the source port
+            from.
 
         Examples
         --------
@@ -1483,8 +1510,8 @@ class PortNode(TreeNode, MixinLogging):
         """
         Process the node, must be reimplemented by sub-classes.
 
-        This definition is responsible to set the dirty state of the node
-        according to processing outcome.
+        This definition is responsible for setting the dirty state of the
+        node according to the processing outcome.
 
         Examples
         --------
@@ -1522,13 +1549,14 @@ class PortNode(TreeNode, MixinLogging):
 
     def to_graphviz(self) -> str:
         """
-        Return a string representation for visualisation of the node with
+        Generate a string representation for node visualisation with
         *Graphviz*.
 
         Returns
         -------
         :class:`str`
-            String representation for visualisation of the node with *Graphviz*.
+            String representation for visualisation of the node with
+            *Graphviz*.
 
         Examples
         --------
@@ -1552,14 +1580,15 @@ class PortNode(TreeNode, MixinLogging):
 
 class PortGraph(PortNode):
     """
-    Node-graph for :class:`colour.utilities.PortNode` class instances.
+    Define a node-graph for :class:`colour.utilities.PortNode` class
+    instances.
 
     Parameters
     ----------
     name
         Name of the node-graph.
     description
-        Port description
+        Description of the node-graph's purpose or functionality.
 
     Attributes
     ----------
@@ -1625,12 +1654,13 @@ class PortGraph(PortNode):
     @property
     def nodes(self) -> Dict[str, PortNode]:
         """
-        Getter property for the node-graph nodes.
+        Getter for the node-graph nodes.
 
         Returns
         -------
         :class:`dict`
-            Node-graph nodes.
+            Node-graph nodes as a mapping from node identifiers to their
+            corresponding :class:`PortNode` instances.
         """
 
         return self._nodes
@@ -1641,7 +1671,7 @@ class PortGraph(PortNode):
 
         Returns
         -------
-        :class`str`
+        :class:`str`
             Formatted string representation.
         """
 
@@ -1658,7 +1688,7 @@ class PortGraph(PortNode):
 
         Raises
         ------
-        AsssertionError
+        AssertionError
             If the node is not a :class:`colour.utilities.PortNode` class
             instance.
 
@@ -1678,7 +1708,7 @@ class PortGraph(PortNode):
 <...PortNode object at 0x...>}
         """
 
-        attest(isinstance(node, PortNode), f'"{node}" is not a "Node" instance!')
+        attest(isinstance(node, PortNode), f'"{node}" is not a "PortNode" instance!')
 
         attest(
             node.name not in self._nodes, f'"{node}" is already a member of the graph!'
@@ -1690,7 +1720,7 @@ class PortGraph(PortNode):
 
     def remove_node(self, node: PortNode) -> None:
         """
-        Remove specified node from the node-graph.
+        Remove the specified node from the node-graph.
 
         The node input and output ports will be disconnected from all their
         connections.
@@ -1723,7 +1753,7 @@ class PortGraph(PortNode):
         {}
         """
 
-        attest(isinstance(node, PortNode), f'"{node}" is not a "Node" instance!')
+        attest(isinstance(node, PortNode), f'"{node}" is not a "PortNode" instance!')
 
         attest(
             node.name in self._nodes,
@@ -1745,16 +1775,17 @@ class PortGraph(PortNode):
     @required("NetworkX")
     def walk_ports(self) -> Generator:
         """
-        Return a generator used to walk into the node-graph.
+        Return a generator to walk the node-graph in topological order.
 
-        The node is walked according to a topological sorted order. A
-        topological sort is a non-unique permutation of the nodes of a directed
-        graph such that an edge from :math:`u` to :math:`v` implies that
-        :math:`u` appears before :math:`v` in the topological sort order.
-        This ordering is valid only if the graph has no directed cycles.
+        Walk the node according to topologically sorted order. A topological
+        sort is a non-unique permutation of the nodes of a directed graph
+        such that an edge from :math:`u` to :math:`v` implies that :math:`u`
+        appears before :math:`v` in the topological sort order. This ordering
+        is valid only if the graph has no directed cycles.
 
-        To walk the node-graph, an *NetworkX* graph is constructed by
-        connecting the ports together and in turn connecting them to the nodes.
+        To walk the node-graph, a *NetworkX* graph is constructed by
+        connecting the ports together and in turn connecting them to the
+        nodes.
 
         Yields
         ------
@@ -1849,8 +1880,8 @@ class PortGraph(PortNode):
 
     def process(self, **kwargs: Dict) -> None:
         """
-        Process the node-graph by walking it and calling the
-        :func:`colour.utilities.PortNode.process` method.
+        Process the node-graph by traversing it and executing the
+        :func:`colour.utilities.PortNode.process` method for each node.
 
         Other Parameters
         ----------------
@@ -1926,7 +1957,7 @@ class PortGraph(PortNode):
     @required("Pydot")
     def to_graphviz(self) -> Dot:  # noqa: F821  # pyright: ignore
         """
-        Return a visualisation node-graph for *Graphviz*.
+        Generate a node-graph visualisation for *Graphviz*.
 
         Returns
         -------
@@ -1959,7 +1990,7 @@ class PortGraph(PortNode):
         graphs = [node for node in self.walk_ports() if isinstance(node, PortGraph)]
 
         def is_graph_member(node: PortNode) -> bool:
-            """Return whether the specified node is member of a graph."""
+            """Determine whether the specified node is member of a graph."""
 
             return any(node in graph.nodes.values() for graph in graphs)
 
@@ -1994,14 +2025,18 @@ class PortGraph(PortNode):
 
 class ExecutionPort(Port):
     """
-    Special port for nodes supporting execution input and output
-    ports.
+    Define a specialised port for execution flow control in node graphs.
+
+    Attributes
+    ----------
+    value
+        Port value accessor for execution state transmission.
     """
 
     @property
     def value(self) -> Any:
         """
-        Getter and setter property for the port value.
+        Getter and setter for the port value.
 
         Parameters
         ----------
@@ -2021,7 +2056,8 @@ class ExecutionPort(Port):
 
 class ExecutionNode(PortNode):
     """
-    Special node with execution input and output ports.
+    Define a specialised node that manages execution flow through
+    dedicated input and output ports.
     """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -2036,7 +2072,9 @@ class ExecutionNode(PortNode):
 
 
 class ControlFlowNode(ExecutionNode):
-    """Class inherited by control flow nodes."""
+    """
+    Define a base class for control flow nodes in computational graphs.
+    """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
@@ -2044,25 +2082,26 @@ class ControlFlowNode(ExecutionNode):
 
 class For(ControlFlowNode):
     """
-    ``for`` loop node.
+    Define a ``for`` loop node for iterating over arrays.
 
-    The node loops over the input port ``array``, sets the ``index`` and
-    ``element`` output ports at each iteration and call the
-    :meth:`colour.utilities.ExecutionNode.process` method of the object
-    connected to the ``loop_output`` output port.
+    The node iterates over the input port ``array``, setting the
+    ``index`` and ``element`` output ports at each iteration and calling
+    the :meth:`colour.utilities.ExecutionNode.process` method of the
+    object connected to the ``loop_output`` output port.
 
-    Upon completion, the :meth:`colour.utilities.ExecutionNode.process` method
-    of the object connected to the ``execution_output`` output port is called.
+    Upon completion, the :meth:`colour.utilities.ExecutionNode.process`
+    method of the object connected to the ``execution_output`` output
+    port is called.
 
     Notes
     -----
-    -   The :class:`colour.utilities.For` loop node does not currently call
-        more than the two aforementioned
-        :meth:`colour.utilities.ExecutionNode.process` methods, if a series of
-        nodes is attached to the `loop_output`` or ``execution_output`` output
-        ports, only the left-most node will be processed. To circumvent this
-        limitation, it is recommended to use a
-        :class:`colour.utilities.PortGraph` class instance.
+    -   The :class:`colour.utilities.For` loop node does not currently
+        call more than the two aforementioned
+        :meth:`colour.utilities.ExecutionNode.process` methods, if a
+        series of nodes is attached to the ``loop_output`` or
+        ``execution_output`` output ports, only the left-most node will
+        be processed. To circumvent this limitation, it is recommended
+        to use a :class:`colour.utilities.PortGraph` class instance.
     """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -2074,9 +2113,7 @@ class For(ControlFlowNode):
         self.add_output_port("loop_output", None, "Port for loop Output", ExecutionPort)
 
     def process(self) -> None:
-        """
-        Process the ``for`` loop node.
-        """
+        """Process the *for* loop node execution."""
 
         connection = next(iter(self.output_ports["loop_output"].connections), None)
         if connection is None:
@@ -2117,13 +2154,18 @@ _THREADING_LOCK = threading.Lock()
 
 def _task_thread(args: Sequence) -> tuple[int, Any]:
     """
-    Define the default task for the
+    Execute the default task for the
     :class:`colour.utilities.ParallelForThread` loop node.
 
     Parameters
     ----------
     args
-        Processing arguments.
+        Processing arguments for the parallel thread task.
+
+    Returns
+    -------
+    :class:`tuple`
+        Index and result pair from the executed task.
     """
 
     i, element, sub_graph, node = args
@@ -2141,8 +2183,8 @@ def _task_thread(args: Sequence) -> tuple[int, Any]:
 
 class ThreadPoolExecutorManager:
     """
-    Singleton class managing our
-    :class:`concurrent.futures.ThreadPoolExecutor` class instance.
+    Define a singleton :class:`concurrent.futures.ThreadPoolExecutor`
+    manager.
 
     Attributes
     ----------
@@ -2161,8 +2203,8 @@ class ThreadPoolExecutorManager:
         max_workers: int | None = None,
     ) -> concurrent.futures.ThreadPoolExecutor:
         """
-        Return the :class:`concurrent.futures.ThreadPoolExecutor` class instance or
-        create it if not existing.
+        Return the :class:`concurrent.futures.ThreadPoolExecutor` class
+        instance or create it if not existing.
 
         Parameters
         ----------
@@ -2172,6 +2214,7 @@ class ThreadPoolExecutorManager:
         Returns
         -------
         :class:`concurrent.futures.ThreadPoolExecutor`
+            Thread pool executor instance.
 
         Notes
         -----
@@ -2190,7 +2233,8 @@ class ThreadPoolExecutorManager:
     @staticmethod
     def shutdown_executor() -> None:
         """
-        Shutdown the :class:`concurrent.futures.ThreadPoolExecutor` class instance.
+        Shut down the :class:`concurrent.futures.ThreadPoolExecutor` class
+        instance.
         """
 
         if ThreadPoolExecutorManager.ThreadPoolExecutor is not None:
@@ -2200,31 +2244,33 @@ class ThreadPoolExecutorManager:
 
 class ParallelForThread(ControlFlowNode):
     """
-    Advanced ``for`` loop node distributing the work across multiple
-    threads.
+    Define an advanced ``for`` loop node that distributes work across
+    multiple threads for parallel execution.
 
-    Each generated task receives one ``index`` and ``element`` output ports
-    value. The tasks are then executed by a
-    :class:`concurrent.futures.ThreadPoolExecutor` class instance, the futures
-    result are then collected, sorted and the ``results`` output port value is
-    set with them.
+    Each generated task receives one ``index`` and ``element`` output port
+    value. The tasks are executed by a
+    :class:`concurrent.futures.ThreadPoolExecutor` class instance. The
+    futures results are collected, sorted, and assigned to the ``results``
+    output port.
 
-    Upon completion, the :meth:`colour.utilities.ExecutionNode.process` method
-    of the object connected to the ``execution_output`` output port is called.
+    Upon completion, the :meth:`colour.utilities.ExecutionNode.process`
+    method of the object connected to the ``execution_output`` output port
+    is called.
 
     Notes
     -----
     -   The :class:`colour.utilities.ParallelForThread` loop node does not
         currently call more than the two aforementioned
-        :meth:`colour.utilities.ExecutionNode.process` methods, if a series of
-        nodes is attached to the `loop_output`` or ``execution_output`` output
-        ports, only the left-most node will be processed. To circumvent this
-        limitation, it is recommended to use a
+        :meth:`colour.utilities.ExecutionNode.process` methods. If a series
+        of nodes is attached to the ``loop_output`` or ``execution_output``
+        output ports, only the left-most node will be processed. To
+        circumvent this limitation, it is recommended to use a
         :class:`colour.utilities.PortGraph` class instance.
-    -   As the graph being processed is shared across the threads, a lock must
-        be taken in the task callable. This might nullify any speed gains for
-        heavy processing tasks, in such eventuality, it is recommended to use
-        the :class:`colour.utilities.ParallelForMultiprocess` loop node
+    -   As the graph being processed is shared across the threads, a lock
+        must be taken in the task callable. This might nullify any speed
+        gains for heavy processing tasks. In such eventuality, it is
+        recommended to use the
+        :class:`colour.utilities.ParallelForMultiprocess` loop node
         instead.
     """
 
@@ -2241,7 +2287,7 @@ class ParallelForThread(ControlFlowNode):
 
     def process(self) -> None:
         """
-        Process the ``for`` loop node.
+        Process the parallel loop node execution.
         """
 
         connection = next(iter(self.output_ports["loop_output"].connections), None)
@@ -2292,13 +2338,18 @@ class ParallelForThread(ControlFlowNode):
 
 def _task_multiprocess(args: Sequence) -> tuple[int, Any]:
     """
-    Define the default task for the
-    :class:`colour.utilities.ParallelForMultiprocess` loop node.
+    Execute the default processing task for
+    :class:`colour.utilities.ParallelForMultiprocess` loop node instances.
 
     Parameters
     ----------
     args
-        Processing arguments.
+        Processing arguments for the parallel execution task.
+
+    Returns
+    -------
+    :class:`tuple`
+        Tuple containing the task index and computed result.
     """
 
     i, element, sub_graph, node = args
@@ -2315,8 +2366,8 @@ def _task_multiprocess(args: Sequence) -> tuple[int, Any]:
 
 class ProcessPoolExecutorManager:
     """
-    Singleton class managing our
-    :class:`concurrent.futures.ProcessPoolExecutor` class instance.
+    Define a singleton :class:`concurrent.futures.ProcessPoolExecutor`
+    manager for parallel processing.
 
     Attributes
     ----------
@@ -2335,22 +2386,24 @@ class ProcessPoolExecutorManager:
         max_workers: int | None = None,
     ) -> concurrent.futures.ProcessPoolExecutor:
         """
-        Return the :class:`concurrent.futures.ProcessPoolExecutor` class instance or
-        create it if not existing.
+        Return the :class:`concurrent.futures.ProcessPoolExecutor` class
+        instance or create it if not existing.
 
         Parameters
         ----------
         max_workers
-            Maximum worker count.
+            Maximum number of worker processes. If ``None``, it will
+            default to the number of processors on the machine.
 
         Returns
         -------
         :class:`concurrent.futures.ProcessPoolExecutor`
+            Process pool executor instance for parallel execution.
 
         Notes
         -----
         The :class:`concurrent.futures.ProcessPoolExecutor` class instance is
-        automatically shutdown on process exit.
+        automatically shut down on process exit.
         """
 
         if ProcessPoolExecutorManager.ProcessPoolExecutor is None:
@@ -2367,7 +2420,8 @@ class ProcessPoolExecutorManager:
     @staticmethod
     def shutdown_executor() -> None:
         """
-        Shutdown the :class:`concurrent.futures.ProcessPoolExecutor` class instance.
+        Shut down the :class:`concurrent.futures.ProcessPoolExecutor` class
+        instance.
         """
 
         if ProcessPoolExecutorManager.ProcessPoolExecutor is not None:
@@ -2377,26 +2431,25 @@ class ProcessPoolExecutorManager:
 
 class ParallelForMultiprocess(ControlFlowNode):
     """
-    Advanced ``for`` loop node distributing the work across multiple
-    processes.
+    Define a parallel ``for`` loop node that distributes operations across
+    multiple processes.
 
-    Each generated task receives one ``index`` and ``element`` output ports
-    value. The tasks are then executed by a
-    :class:`multiprocessing.Pool` class instance, the results are then
-    collected, sorted and the ``results`` output port value is set with them.
+    Distribute iteration work by assigning each task one ``index`` and
+    ``element`` output port value. Execute tasks using a
+    :class:`multiprocessing.Pool` instance, then collect, sort, and assign
+    results to the ``results`` output port.
 
-    Upon completion, the :meth:`colour.utilities.ExecutionNode.process` method
-    of the object connected to the ``execution_output`` output port is called.
+    Upon completion, invoke the :meth:`colour.utilities.ExecutionNode.process`
+    method of the object connected to the ``execution_output`` output port.
 
     Notes
     -----
-    -   The :class:`colour.utilities.ParallelForMultiprocess` loop node does
-        not currently call more than the two aforementioned
-        :meth:`colour.utilities.ExecutionNode.process` methods, if a series of
-        nodes is attached to the `loop_output`` or ``execution_output``
-        output ports, only the left-most node will be processed. To circumvent
-        this limitation, it is recommended to use a
-        :class:`colour.utilities.PortGraph` class instance.
+    -   The :class:`colour.utilities.ParallelForMultiprocess` loop node
+        currently invokes only the two aforementioned
+        :meth:`colour.utilities.ExecutionNode.process` methods. When a series
+        of nodes connects to the ``loop_output`` or ``execution_output``
+        output ports, only the left-most node processes. To circumvent this
+        limitation, use a :class:`colour.utilities.PortGraph` class instance.
     """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -2412,7 +2465,7 @@ class ParallelForMultiprocess(ControlFlowNode):
 
     def process(self) -> None:
         """
-        Process the ``for`` loop node.
+        Process the ``for`` loop node execution.
         """
 
         connection = next(iter(self.output_ports["loop_output"].connections), None)

--- a/colour/utilities/requirements.py
+++ b/colour/utilities/requirements.py
@@ -2,7 +2,7 @@
 Requirements Utilities
 ======================
 
-Requirements utilities objects.
+Define utilities for checking the availability of optional dependencies.
 """
 
 from __future__ import annotations
@@ -47,7 +47,7 @@ __all__ = [
 
 def is_ctlrender_installed(raise_exception: bool = False) -> bool:
     """
-    Return whether *ctlrender* is installed and available.
+    Determine whether *ctlrender* is installed and available.
 
     Parameters
     ----------
@@ -91,7 +91,7 @@ def is_ctlrender_installed(raise_exception: bool = False) -> bool:
 
 def is_imageio_installed(raise_exception: bool = False) -> bool:
     """
-    Return whether *Imageio* is installed and available.
+    Determine whether *Imageio* is installed and available.
 
     Parameters
     ----------
@@ -128,7 +128,7 @@ def is_imageio_installed(raise_exception: bool = False) -> bool:
 
 def is_openimageio_installed(raise_exception: bool = False) -> bool:
     """
-    Return whether *OpenImageIO* is installed and available.
+    Determine whether *OpenImageIO* is installed and available.
 
     Parameters
     ----------
@@ -165,7 +165,7 @@ def is_openimageio_installed(raise_exception: bool = False) -> bool:
 
 def is_matplotlib_installed(raise_exception: bool = False) -> bool:
     """
-    Return whether *Matplotlib* is installed and available.
+    Determine whether *Matplotlib* is installed and available.
 
     Parameters
     ----------
@@ -202,7 +202,7 @@ def is_matplotlib_installed(raise_exception: bool = False) -> bool:
 
 def is_networkx_installed(raise_exception: bool = False) -> bool:
     """
-    Return whether *NetworkX* is installed and available.
+    Determine whether *NetworkX* is installed and available.
 
     Parameters
     ----------
@@ -240,7 +240,7 @@ def is_networkx_installed(raise_exception: bool = False) -> bool:
 
 def is_opencolorio_installed(raise_exception: bool = False) -> bool:
     """
-    Return whether *OpenColorIO* is installed and available.
+    Determine whether *OpenColorIO* is installed and available.
 
     Parameters
     ----------
@@ -277,7 +277,7 @@ def is_opencolorio_installed(raise_exception: bool = False) -> bool:
 
 def is_pandas_installed(raise_exception: bool = False) -> bool:
     """
-    Return whether *Pandas* is installed and available.
+    Determine whether *Pandas* is installed and available.
 
     Parameters
     ----------
@@ -314,8 +314,9 @@ def is_pandas_installed(raise_exception: bool = False) -> bool:
 
 def is_pydot_installed(raise_exception: bool = False) -> bool:
     """
-    Return whether *Pydot* is installed and available. The presence of
-    *Graphviz* will also be tested.
+    Determine whether *Pydot* is installed and available.
+
+    The presence of *Graphviz* will also be tested.
 
     Parameters
     ----------
@@ -364,7 +365,7 @@ def is_pydot_installed(raise_exception: bool = False) -> bool:
 
 def is_tqdm_installed(raise_exception: bool = False) -> bool:
     """
-    Return whether *tqdm* is installed and available.
+    Determine whether *tqdm* is installed and available.
 
     Parameters
     ----------
@@ -401,7 +402,7 @@ def is_tqdm_installed(raise_exception: bool = False) -> bool:
 
 def is_trimesh_installed(raise_exception: bool = False) -> bool:
     """
-    Return whether *Trimesh* is installed and available.
+    Determine whether *Trimesh* is installed and available.
 
     Parameters
     ----------
@@ -438,7 +439,7 @@ def is_trimesh_installed(raise_exception: bool = False) -> bool:
 
 def is_xxhash_installed(raise_exception: bool = False) -> bool:
     """
-    Return whether *xxhash* is installed and available.
+    Determine whether *xxhash* is installed and available.
 
     Parameters
     ----------
@@ -509,17 +510,18 @@ def required(
     ],
 ) -> Callable:
     """
-    Decorate a function to check whether various ancillary package requirements
-    are satisfied.
+    Check whether specified ancillary package requirements are satisfied
+    and decorate the function accordingly.
 
     Other Parameters
     ----------------
     requirements
-        Requirements to check whether they are satisfied.
+        Package requirements to check for satisfaction.
 
     Returns
     -------
     Callable
+        Decorated function that validates package availability.
     """
 
     def wrapper(function: Callable) -> Callable:

--- a/colour/utilities/structures.py
+++ b/colour/utilities/structures.py
@@ -2,17 +2,17 @@
 Data Structures
 ===============
 
-Various data structures classes:
+Provide various data structure classes for flexible data manipulation.
 
 -   :class:`colour.utilities.Structure`: An object similar to C/C++ structured
     type.
 -   :class:`colour.utilities.Lookup`: A :class:`dict` sub-class acting as a
     lookup to retrieve keys by values.
 -   :class:`colour.utilities.CanonicalMapping`: A delimiter and
-    case-insensitive :class:`dict`-like object allowing values retrieving from
+    case-insensitive :class:`dict`-like object allowing values retrieval from
     keys while ignoring the key case.
 -   :class:`colour.utilities.LazyCanonicalMapping`: Another delimiter and
-    case-insensitive mapping allowing lazy values retrieving from keys while
+    case-insensitive mapping allowing lazy values retrieval from keys while
     ignoring the key case.
 
 References
@@ -58,8 +58,13 @@ __all__ = [
 
 class Structure(dict):
     """
-    :class:`dict`-like object allowing to access key values using dot
-    syntax.
+    Represent a :class:`dict`-like structure that enables access to key
+    values through dot notation syntax.
+
+    This class extends the built-in :class:`dict` to provide
+    attribute-style access to dictionary items, allowing both traditional
+    dictionary access patterns and object-oriented dot notation for
+    improved code readability and convenience.
 
     Other Parameters
     ----------------
@@ -97,7 +102,7 @@ class Structure(dict):
 
     def __setattr__(self, name: str, value: Any) -> None:
         """
-        Assign specified value to the attribute with specified name.
+        Assign the specified value to the attribute with the specified name.
 
         Parameters
         ----------
@@ -111,7 +116,7 @@ class Structure(dict):
 
     def __delattr__(self, name: str) -> None:
         """
-        Delete the attribute with specified name.
+        Delete the attribute with the specified name.
 
         Parameters
         ----------
@@ -123,7 +128,8 @@ class Structure(dict):
 
     def __dir__(self) -> Iterable:
         """
-        Return a list of valid attributes for the :class:`dict`-like object.
+        Return the list of valid attributes for the :class:`dict`-like
+        object.
 
         Returns
         -------
@@ -135,7 +141,7 @@ class Structure(dict):
 
     def __getattr__(self, name: str) -> Any:
         """
-        Return the value from the attribute with specified name.
+        Return the value from the attribute with the specified name.
 
         Parameters
         ----------
@@ -145,6 +151,7 @@ class Structure(dict):
         Returns
         -------
         :class:`object`
+            Value of the specified attribute.
 
         Raises
         ------
@@ -165,7 +172,13 @@ class Structure(dict):
 
 class Lookup(dict):
     """
-    Extend :class:`dict` type to provide a lookup by value(s).
+    Represent a :class:`dict`-like object that provides lookup functionality by
+    value(s).
+
+    This class extends the built-in :class:`dict` to provide reverse lookup
+    capabilities for dictionary values, enabling retrieval of keys based on
+    their associated values. Support both single and multiple key retrieval
+    for matching values.
 
     Methods
     -------
@@ -188,7 +201,7 @@ class Lookup(dict):
 
     def keys_from_value(self, value: Any) -> list:
         """
-        Get the keys associated with specified value.
+        Return the keys associated with the specified value.
 
         Parameters
         ----------
@@ -198,7 +211,7 @@ class Lookup(dict):
         Returns
         -------
         :class:`list`
-            Keys associated with specified value.
+            Keys associated with the specified value.
         """
 
         keys = []
@@ -217,7 +230,7 @@ class Lookup(dict):
 
     def first_key_from_value(self, value: Any) -> Any:
         """
-        Get the first key associated with specified value.
+        Return the first key associated with the specified value.
 
         Parameters
         ----------
@@ -227,7 +240,7 @@ class Lookup(dict):
         Returns
         -------
         :class:`object`
-            First key associated with specified value.
+            First key associated with the specified value.
         """
 
         return self.keys_from_value(value)[0]
@@ -235,21 +248,23 @@ class Lookup(dict):
 
 class CanonicalMapping(MutableMapping):
     """
-    Implement a delimiter and case-insensitive :class:`dict`-like object with
-    support for slugs, i.e., *SEO* friendly and human-readable version of the
-    keys but also canonical keys, i.e., slugified keys without delimiters.
+    Represent a delimiter and case-insensitive :class:`dict`-like object
+    supporting both slug keys (*SEO*-friendly, human-readable versions with
+    delimiters) and canonical keys (slugified keys without delimiters).
 
-    The item keys are expected to be :class:`str`-like objects thus supporting
-    the :meth:`str.lower` method. Setting items is done by using the specified
-    keys. Retrieving or deleting an item and testing whether an item exist is
-    done by transforming the item's key in a sequence as follows:
+    This class extends :class:`MutableMapping` to provide flexible key
+    matching that accepts various transformations of the original key while
+    maintaining the original key structure for storage. Item keys must be
+    :class:`str`-like objects supporting the :meth:`str.lower` method. Set
+    items using the specified original keys. Retrieve, delete, or test item
+    existence by transforming the query key through the following sequence:
 
     -   *Original Key*
     -   *Lowercase Key*
     -   *Slugified Key*
     -   *Canonical Key*
 
-    For example, given the ``McCamy 1992`` key:
+    For example, using the ``McCamy 1992`` key:
 
     -   *Original Key* : ``McCamy 1992``
     -   *Lowercase Key* : ``mccamy 1992``
@@ -312,13 +327,13 @@ class CanonicalMapping(MutableMapping):
     @property
     def data(self) -> dict:
         """
-        Getter property for the delimiter and case-insensitive
-        :class:`dict`-like object data.
+        Getter for the delimiter and case-insensitive :class:`dict`-like
+        object data.
 
         Returns
         -------
         :class:`dict`
-            Data.
+            Internal data storage.
         """
 
         return self._data
@@ -345,8 +360,8 @@ class CanonicalMapping(MutableMapping):
 
     def __setitem__(self, item: str | Any, value: Any) -> None:
         """
-        Set specified item with specified value in the delimiter and case-insensitive
-        :class:`dict`-like object.
+        Set the specified item with the specified value in the delimiter and
+        case-insensitive :class:`dict`-like object.
 
         Parameters
         ----------
@@ -362,8 +377,8 @@ class CanonicalMapping(MutableMapping):
 
     def __getitem__(self, item: str | Any) -> Any:
         """
-        Return the value of specified item from the delimiter and case-insensitive
-        :class:`dict`-like object.
+        Return the value of the specified item from the delimiter and
+        case-insensitive :class:`dict`-like object.
 
         Parameters
         ----------
@@ -407,7 +422,7 @@ class CanonicalMapping(MutableMapping):
 
     def __delitem__(self, item: str | Any) -> None:
         """
-        Delete specified item from the delimiter and case-insensitive
+        Delete the specified item from the delimiter and case-insensitive
         :class:`dict`-like object.
 
         Parameters
@@ -418,8 +433,8 @@ class CanonicalMapping(MutableMapping):
 
         Notes
         -----
-        -   The item can be deleted by using either its lower-case, slugified
-            or canonical variant.
+        -   The item can be deleted by using either its lower-case,
+            slugified or canonical variant.
         """
 
         try:
@@ -452,24 +467,24 @@ class CanonicalMapping(MutableMapping):
     def __contains__(self, item: str | Any) -> bool:
         """
         Return whether the delimiter and case-insensitive :class:`dict`-like
-        object contains specified item.
+        object contains the specified item.
 
         Parameters
         ----------
         item
-            Item to find whether it is in the delimiter and case-insensitive
+            Item to check for presence in the delimiter and case-insensitive
             :class:`dict`-like object.
 
         Returns
         -------
         :class:`bool`
-            Whether specified item is in the delimiter and case-insensitive
-            :class:`dict`-like object.
+            Whether the specified item exists in the delimiter and
+            case-insensitive :class:`dict`-like object.
 
         Notes
         -----
-        -   The item presence can be checked by using either its lower-case,
-            slugified or canonical variant.
+        -   Item presence can be checked using its lower-case, slugified, or
+            canonical variant.
         """
 
         return bool(
@@ -502,12 +517,12 @@ class CanonicalMapping(MutableMapping):
 
     def __len__(self) -> int:
         """
-        Return the items count.
+        Return the item count of the container.
 
         Returns
         -------
         :class:`int`
-            Items count.
+            Item count.
         """
 
         return len(self._data)
@@ -516,20 +531,20 @@ class CanonicalMapping(MutableMapping):
 
     def __eq__(self, other: object) -> bool:
         """
-        Return whether the delimiter and case-insensitive :class:`dict`-like
-        object is equal to specified other object.
+        Test whether the delimiter and case-insensitive :class:`dict`-like
+        object equals the specified object.
 
         Parameters
         ----------
         other
-            Object to test whether it is equal to the delimiter and
-            case-insensitive :class:`dict`-like object
+            Object to test for equality with the delimiter and
+            case-insensitive :class:`dict`-like object.
 
         Returns
         -------
         :class:`bool`
-            Whether specified object is equal to the delimiter and case-insensitive
-            :class:`dict`-like object.
+            Whether the specified object equals the delimiter and
+            case-insensitive :class:`dict`-like object.
         """
 
         if isinstance(other, Mapping):
@@ -546,19 +561,19 @@ class CanonicalMapping(MutableMapping):
 
     def __ne__(self, other: object) -> bool:
         """
-        Return whether the delimiter and case-insensitive :class:`dict`-like
-        object is not equal to specified other object.
+        Test whether the delimiter and case-insensitive
+        :class:`dict`-like object is not equal to the specified other object.
 
         Parameters
         ----------
         other
             Object to test whether it is not equal to the delimiter and
-            case-insensitive :class:`dict`-like object
+            case-insensitive :class:`dict`-like object.
 
         Returns
         -------
         :class:`bool`
-            Whether specified object is not equal to the delimiter and
+            Whether the specified object is not equal to the delimiter and
             case-insensitive :class:`dict`-like object.
         """
 
@@ -567,11 +582,12 @@ class CanonicalMapping(MutableMapping):
     @staticmethod
     def _collision_warning(keys: list) -> None:
         """
-        Issue a runtime warning when specified keys are colliding.
+        Issue a runtime warning for colliding keys.
 
         Parameters
         ----------
         keys
+            Keys to check for collisions.
         """
 
         from colour.utilities import usage_warning  # noqa: PLC0415
@@ -583,8 +599,8 @@ class CanonicalMapping(MutableMapping):
 
     def copy(self) -> CanonicalMapping:
         """
-        Return a copy of the delimiter and case-insensitive :class:`dict`-like
-        object.
+        Return a copy of the delimiter and case-insensitive
+        :class:`dict`-like object.
 
         Returns
         -------
@@ -593,8 +609,8 @@ class CanonicalMapping(MutableMapping):
 
         Warnings
         --------
-        -   The :class:`CanonicalMapping` class copy returned is a
-            *copy* of the object not a *deepcopy*!
+        -   The :class:`CanonicalMapping` class copy returned is a *copy* of
+            the object not a *deepcopy*!
         """
 
         return CanonicalMapping(dict(**self._data))
@@ -607,7 +623,7 @@ class CanonicalMapping(MutableMapping):
         Yields
         ------
         Generator
-            Item generator.
+            Lower-case key generator.
         """
 
         lower_keys = [str(key).lower() for key in self._data]
@@ -631,8 +647,8 @@ class CanonicalMapping(MutableMapping):
 
     def slugified_keys(self) -> Generator:
         """
-        Iterate over the slugified keys of the delimiter and case-insensitive
-        :class:`dict`-like object.
+        Iterate over the slugified keys of the delimiter and
+        case-insensitive :class:`dict`-like object.
 
         Yields
         ------
@@ -650,8 +666,8 @@ class CanonicalMapping(MutableMapping):
 
     def slugified_items(self) -> Generator:
         """
-        Iterate over the slugified items of the delimiter and case-insensitive
-        :class:`dict`-like object.
+        Iterate over the slugified items of the delimiter and
+        case-insensitive :class:`dict`-like object.
 
         Yields
         ------
@@ -663,8 +679,8 @@ class CanonicalMapping(MutableMapping):
 
     def canonical_keys(self) -> Generator:
         """
-        Iterate over the canonical keys of the delimiter and case-insensitive
-        :class:`dict`-like object.
+        Iterate over the canonical keys of the delimiter and
+        case-insensitive :class:`dict`-like object.
 
         Yields
         ------
@@ -694,12 +710,13 @@ class CanonicalMapping(MutableMapping):
 
 class LazyCanonicalMapping(CanonicalMapping):
     """
-    Implement a lazy delimiter and case-insensitive :class:`dict`-like object
-    inheriting from :class:`colour.utilities.CanonicalMapping` class.
+    Represent a lazy delimiter and case-insensitive :class:`dict`-like object
+    inheriting from :class:`colour.utilities.CanonicalMapping`.
 
-    The lazy retrieval is performed as follows: If the value is a callable,
-    then it is evaluated and its return value is stored in place of the current
-    value.
+    This class extends :class:`CanonicalMapping` with lazy evaluation
+    capabilities. When a value is a callable, it is automatically evaluated
+    upon first access and its return value is cached, replacing the original
+    callable for subsequent retrievals.
 
     Parameters
     ----------
@@ -731,7 +748,7 @@ class LazyCanonicalMapping(CanonicalMapping):
 
     def __getitem__(self, item: str | Any) -> Any:
         """
-        Return the value of specified item from the lazy delimiter and
+        Return the value of the specified item from the lazy delimiter and
         case-insensitive :class:`dict`-like object.
 
         Parameters

--- a/colour/utilities/tests/test_deprecated.py
+++ b/colour/utilities/tests/test_deprecated.py
@@ -16,7 +16,7 @@ class deprecated(ModuleAPI):
     """Define a class acting like the *deprecated* module."""
 
     def __getattr__(self, attribute: str) -> Any:
-        """Return the value from the attribute with specified name."""
+        """Return the value from the attribute with the specified name."""
 
         return super().__getattr__(attribute)
 

--- a/colour/utilities/verbose.py
+++ b/colour/utilities/verbose.py
@@ -802,7 +802,7 @@ def describe_environment(
     try:  # pragma: no cover
         output = subprocess.check_output(
             ["git", "describe"],  # noqa: S607
-            cwd=colour.__path__[0],  # pyright: ignore
+            cwd=colour.__path__[0],
             stderr=subprocess.STDOUT,
         ).strip()
         version = output.decode("utf-8")

--- a/colour/utilities/verbose.py
+++ b/colour/utilities/verbose.py
@@ -2,7 +2,7 @@
 Verbose
 =======
 
-Verbose related objects.
+Define verbose output, logging, and warning management utilities.
 """
 
 from __future__ import annotations
@@ -76,7 +76,10 @@ LOGGER = logging.getLogger(__name__)
 
 class MixinLogging:
     """
-    A mixin providing a convenient logging method.
+    Provide logging capabilities through mixin inheritance.
+
+    This mixin extends class functionality to enable structured logging,
+    allowing consistent logging behaviour across the codebase.
 
     Attributes
     ----------
@@ -107,7 +110,7 @@ class MixinLogging:
         ] = "info",
     ) -> None:
         """
-        Log specified message using specified verbosity level.
+        Log the specified message using the specified verbosity level.
 
         Parameters
         ----------
@@ -126,25 +129,33 @@ class MixinLogging:
 
 class ColourWarning(Warning):
     """
-    Base class of *Colour* warnings.
+    Define the base class for *Colour* warnings.
 
-    It is a subclass of the :class:`Warning` class.
+    This class serves as the foundational warning type for the *Colour*
+    library, inheriting from the standard :class:`Warning` class to provide
+    consistent warning behaviour across the library.
     """
 
 
 class ColourUsageWarning(Warning):
     """
-    Base class of *Colour* usage warnings.
+    Define the base class for *Colour* usage warnings.
 
-    It is a subclass of the :class:`colour.utilities.ColourWarning` class.
+    This class serves as the foundation for all usage-related warnings in the
+    *Colour* library, providing a consistent interface for alerting users to
+    non-critical issues during runtime operations. It is a subclass of the
+    :class:`colour.utilities.ColourWarning` class.
     """
 
 
 class ColourRuntimeWarning(Warning):
     """
-    Base class of *Colour* runtime warnings.
+    Define the base class for *Colour* runtime warnings.
 
-    It is a subclass of the :class:`colour.utilities.ColourWarning` class.
+    This class serves as the foundation for all runtime warnings in the
+    *Colour* library, providing a consistent interface for alerting users to
+    runtime issues. It is a subclass of the
+    :class:`colour.utilities.ColourWarning` class.
     """
 
 
@@ -155,18 +166,18 @@ def message_box(
     print_callable: Callable = print,
 ) -> None:
     """
-    Print a message inside a box.
+    Print a message inside a formatted box.
 
     Parameters
     ----------
     message
-        Message to print.
+        Message to print inside the box.
     width
-        Message box width.
+        Width of the message box in characters.
     padding
-        Padding on each side of the message.
+        Number of spaces for padding on each side of the message.
     print_callable
-        Callable used to print the message box.
+        Callable used to print the formatted message box.
 
     Examples
     --------
@@ -236,12 +247,12 @@ def show_warning(
     line: str | None = None,
 ) -> None:
     """
-    Alternative :func:`warnings.showwarning` definition that allows traceback
-    printing.
+    Display a warning message with enhanced formatting that enables
+    traceback printing.
 
-    This definition is expected to be used by setting the
-    *COLOUR_SCIENCE__COLOUR__SHOW_WARNINGS_WITH_TRACEBACK* environment variable
-    prior to importing *colour*.
+    This definition is activated by setting the
+    *COLOUR_SCIENCE__COLOUR__SHOW_WARNINGS_WITH_TRACEBACK* environment
+    variable before importing *colour*.
 
     Parameters
     ----------
@@ -250,9 +261,11 @@ def show_warning(
     category
         :class:`Warning` sub-class.
     filename
-        File path to read the line at ``lineno`` from if ``line`` is None.
+        File path to read the line at ``lineno`` from if ``line`` is
+        None.
     lineno
-        Line number to read the line at in ``filename`` if ``line`` is None.
+        Line number to read the line at in ``filename`` if ``line`` is
+        None.
     file
         :class:`file` object to write the warning to, defaults to
         :attr:`sys.stderr` attribute.
@@ -261,11 +274,12 @@ def show_warning(
 
     Notes
     -----
-    -   Setting the *COLOUR_SCIENCE__COLOUR__SHOW_WARNINGS_WITH_TRACEBACK*
-        environment variable will result in the :func:`warnings.showwarning`
-        definition to be replaced with the
-        :func:`colour.utilities.show_warning` definition and thus providing
-        complete traceback from the point where the warning occurred.
+    -   Setting the
+        *COLOUR_SCIENCE__COLOUR__SHOW_WARNINGS_WITH_TRACEBACK*
+        environment variable replaces the :func:`warnings.showwarning`
+        definition with the :func:`colour.utilities.show_warning`
+        definition, providing complete traceback from the point where
+        the warning occurred.
     """
 
     frame_range = (1, None)
@@ -311,9 +325,10 @@ def warning(*args: Any, **kwargs: Any) -> None:
     Other Parameters
     ----------------
     args
-        Arguments.
+        Warning message and optional arguments for message formatting.
     kwargs
-        Keywords arguments.
+        Keyword arguments for controlling warning behaviour, including
+        category, stacklevel, and source filtering options.
 
     Examples
     --------
@@ -332,13 +347,13 @@ def runtime_warning(*args: Any, **kwargs: Any) -> None:
     Other Parameters
     ----------------
     args
-        Arguments.
+        Warning message and optional arguments for message formatting.
     kwargs
-        Keywords arguments.
+        Keyword arguments for controlling warning behaviour.
 
     Examples
     --------
-    >>> usage_warning("This is a runtime warning!")  # doctest: +SKIP
+    >>> runtime_warning("This is a runtime warning!")  # doctest: +SKIP
     """
 
     kwargs["category"] = ColourRuntimeWarning
@@ -353,9 +368,9 @@ def usage_warning(*args: Any, **kwargs: Any) -> None:
     Other Parameters
     ----------------
     args
-        Arguments.
+        Warning message and optional arguments for message formatting.
     kwargs
-        Keywords arguments.
+        Keyword arguments for controlling warning behaviour.
 
     Examples
     --------
@@ -374,7 +389,7 @@ def filter_warnings(
     python_warnings: bool | LiteralWarning | None = None,
 ) -> None:
     """
-    Filter *Colour* and also optionally overall Python warnings.
+    Filter *Colour* and optionally overall Python warnings.
 
     The possible values for all the actions, i.e., each argument, are as
     follows:
@@ -392,16 +407,17 @@ def filter_warnings(
     Parameters
     ----------
     colour_runtime_warnings
-        Whether to filter *Colour* runtime warnings according to the action
-        value.
+        Whether to filter *Colour* runtime warnings using the specified
+        action value.
     colour_usage_warnings
-        Whether to filter *Colour* usage warnings according to the action
-        value.
+        Whether to filter *Colour* usage warnings using the specified
+        action value.
     colour_warnings
-        Whether to filter *Colour* warnings, this also filters *Colour* usage
-        and runtime warnings according to the action value.
+        Whether to filter *Colour* warnings, this also filters *Colour*
+        usage and runtime warnings using the specified action value.
     python_warnings
-        Whether to filter *Python* warnings according to the action value.
+        Whether to filter *Python* warnings using the specified action
+        value.
 
     Examples
     --------
@@ -453,19 +469,20 @@ def filter_warnings(
 
 def as_bool(a: str) -> bool:
     """
-    Convert specified string to bool.
+    Convert the specified string to a boolean value.
 
     The following string values evaluate to *True*: "1", "On", and "True".
+    All other string values evaluate to *False*.
 
     Parameters
     ----------
     a
-        String to convert to bool.
+        String to convert to boolean.
 
     Returns
     -------
     :class:`bool`
-        Whether the specified string is *True*.
+        Boolean representation of the specified string.
 
     Examples
     --------
@@ -529,8 +546,8 @@ def suppress_warnings(
     python_warnings: bool | LiteralWarning | None = None,
 ) -> Generator:
     """
-    Context manager filtering *Colour* and also optionally overall
-    Python warnings.
+    Suppress *Colour* and optionally overall Python warnings within a
+    context.
 
     The possible values for all the actions, i.e., each argument, are as
     follows:
@@ -548,16 +565,18 @@ def suppress_warnings(
     Parameters
     ----------
     colour_runtime_warnings
-        Whether to filter *Colour* runtime warnings according to the action
-        value.
+        Whether to filter *Colour* runtime warnings according to the
+        specified action value.
     colour_usage_warnings
-        Whether to filter *Colour* usage warnings according to the action
-        value.
+        Whether to filter *Colour* usage warnings according to the
+        specified action value.
     colour_warnings
-        Whether to filter *Colour* warnings, this also filters *Colour* usage
-        and runtime warnings according to the action value.
+        Whether to filter *Colour* warnings, this also filters *Colour*
+        usage and runtime warnings according to the specified action
+        value.
     python_warnings
-        Whether to filter *Python* warnings  according to the action value.
+        Whether to filter *Python* warnings according to the specified
+        action value.
     """
 
     filters = warnings.filters
@@ -579,8 +598,7 @@ def suppress_warnings(
 
 class suppress_stdout:
     """
-    Context manager and decorator temporarily suppressing standard
-    output.
+    Define a context manager and decorator to temporarily suppress standard output.
 
     Examples
     --------
@@ -591,7 +609,9 @@ class suppress_stdout:
     """
 
     def __enter__(self) -> Self:
-        """Redirect the standard output upon entering the context manager."""
+        """
+        Redirect standard output to null device upon context manager entry.
+        """
 
         self._stdout = sys.stdout
         sys.stdout = open(os.devnull, "w")
@@ -599,13 +619,15 @@ class suppress_stdout:
         return self
 
     def __exit__(self, *args: Any) -> None:
-        """Restore the standard output upon exiting the context manager."""
+        """
+        Restore standard output upon context manager exit.
+        """
 
         sys.stdout.close()
         sys.stdout = self._stdout
 
     def __call__(self, function: Callable) -> Callable:  # pragma: no cover
-        """Call the wrapped definition."""
+        """Call the wrapped definition with suppressed output."""
 
         @functools.wraps(function)
         def wrapper(*args: Any, **kwargs: Any) -> Callable:
@@ -618,15 +640,15 @@ class suppress_stdout:
 @contextmanager
 def numpy_print_options(*args: Any, **kwargs: Any) -> Generator:
     """
-    Context manager implementing context changes to *Numpy* print
-    behaviour.
+    Implement a context manager for temporarily modifying *NumPy* array
+    print options.
 
     Other Parameters
     ----------------
     args
-        Arguments.
+        Positional arguments passed to :func:`numpy.set_printoptions`.
     kwargs
-        Keywords arguments.
+        Keyword arguments passed to :func:`numpy.set_printoptions`.
 
     Examples
     --------
@@ -682,8 +704,8 @@ def describe_environment(
     **kwargs: Any,
 ) -> defaultdict:
     """
-    Describe *Colour* running environment, i.e., interpreter, runtime and
-    development packages.
+    Describe the *Colour* runtime environment, including interpreter details
+    and package versions.
 
     Parameters
     ----------
@@ -943,25 +965,27 @@ def multiline_str(
     separator: str = " : ",
 ) -> str:
     """
-    Return a formatted string representation of the specified object.
+    Generate a formatted multi-line string representation of the specified
+    object.
 
     Parameters
     ----------
     object_
-        Object to format.
+        Object to format into a string representation.
     attributes
-        Attributes to format.
+        Attributes to format, provided as a list of dictionaries with
+        formatting specifications.
     header_underline
-        Underline character to use for a header.
+        Underline character to use for header sections.
     section_underline
-        Underline character to use for a section.
+        Underline character to use for subsections.
     separator
         Separator to use when formatting the attributes and their values.
 
     Returns
     -------
     :class:`str`
-        Formatted string representation.
+        Formatted multi-line string representation.
 
     Examples
     --------
@@ -1088,7 +1112,7 @@ def multiline_repr(
     reduce_array_representation: bool = True,
 ) -> str:
     """
-    Return an (almost) evaluable string representation of the specified object.
+    Generate an evaluable string representation of the specified object.
 
     Parameters
     ----------
@@ -1101,7 +1125,7 @@ def multiline_repr(
 
     Returns
     -------
-    :class`str`
+    :class:`str`
         (Almost) evaluable string representation.
 
     Examples

--- a/colour/volume/macadam_limits.py
+++ b/colour/volume/macadam_limits.py
@@ -2,7 +2,7 @@
 Optimal Colour Stimuli - MacAdam Limits
 =======================================
 
-Objects related to *Optimal Colour Stimuli* computations.
+Define objects for computing *Optimal Colour Stimuli* and *MacAdam Limits*.
 """
 
 from __future__ import annotations
@@ -45,8 +45,8 @@ def _XYZ_optimal_colour_stimuli(
     illuminant: Literal["A", "C", "D65"] | str = "D65",
 ) -> NDArrayFloat:
     """
-    Return specified illuminant *Optimal Colour Stimuli* in *CIE XYZ* tristimulus
-    values and caches it if not existing.
+    Return the *Optimal Colour Stimuli* for the specified illuminant in
+    *CIE XYZ* tristimulus values and cache it if not existing.
 
     Parameters
     ----------
@@ -56,7 +56,7 @@ def _XYZ_optimal_colour_stimuli(
     Returns
     -------
     :class:`numpy.ndarray`
-        Illuminant *Optimal Colour Stimuli*.
+        *Optimal Colour Stimuli* for the specified illuminant.
     """
 
     illuminant = validate_method(
@@ -85,8 +85,8 @@ def is_within_macadam_limits(
     tolerance: float = 100 * EPSILON,
 ) -> NDArrayFloat:
     """
-    Return whether specified *CIE xyY* colourspace array is within MacAdam limits
-    of specified illuminant.
+    Determine whether the specified *CIE xyY* colourspace array are within
+    the MacAdam limits of the specified illuminant.
 
     Parameters
     ----------
@@ -100,7 +100,8 @@ def is_within_macadam_limits(
     Returns
     -------
     :class:`numpy.ndarray`
-        Whether specified *CIE xyY* colourspace array is within MacAdam limits.
+        Boolean array indicating whether the specified *CIE xyY*
+        colourspace array is within MacAdam limits.
 
     Notes
     -----

--- a/colour/volume/mesh.py
+++ b/colour/volume/mesh.py
@@ -2,7 +2,9 @@
 Mesh Volume Computation Helpers
 ===============================
 
-Helper objects related to volume computations.
+Define helper objects for computing volumes of three-dimensional meshes
+and polyhedra using Delaunay triangulation and related computational
+geometry methods.
 """
 
 from __future__ import annotations
@@ -34,8 +36,8 @@ def is_within_mesh_volume(
     points: ArrayLike, mesh: ArrayLike, tolerance: float = 100 * EPSILON
 ) -> NDArrayFloat:
     """
-    Return whether specified points are within specified mesh volume using Delaunay
-    triangulation.
+    Determine whether the specified points are within the volume defined by a mesh
+    using Delaunay triangulation.
 
     Parameters
     ----------
@@ -49,7 +51,8 @@ def is_within_mesh_volume(
     Returns
     -------
     :class:`numpy.ndarray`
-        Whether specified points are within specified mesh volume.
+        Boolean array indicating whether specified points are within
+        specified mesh volume.
 
     Examples
     --------

--- a/colour/volume/pointer_gamut.py
+++ b/colour/volume/pointer_gamut.py
@@ -2,7 +2,7 @@
 Pointer's Gamut Volume Computations
 ===================================
 
-Objects related to *Pointer's Gamut* volume computations.
+Define objects and computations for *Pointer's Gamut* volume analysis.
 """
 
 from __future__ import annotations
@@ -38,8 +38,8 @@ def is_within_pointer_gamut(
     XYZ: ArrayLike, tolerance: float = 100 * EPSILON
 ) -> NDArrayFloat:
     """
-    Return whether specified *CIE XYZ* tristimulus values are within Pointer's
-    Gamut volume.
+    Determine whether the specified *CIE XYZ* tristimulus values are within
+    Pointer's Gamut volume.
 
     Parameters
     ----------
@@ -51,8 +51,8 @@ def is_within_pointer_gamut(
     Returns
     -------
     :class:`numpy.ndarray`
-        Whether specified *CIE XYZ* tristimulus values are within Pointer's Gamut
-        volume.
+        Boolean array indicating whether specified *CIE XYZ* tristimulus
+        values are within Pointer's Gamut volume.
 
     Notes
     -----

--- a/colour/volume/rgb.py
+++ b/colour/volume/rgb.py
@@ -2,7 +2,7 @@
 RGB Colourspace Volume Computation
 ==================================
 
-Various RGB colourspace volume computation objects:
+Define RGB colourspace volume computation functionality.
 
 -   :func:`colour.RGB_colourspace_limits`
 -   :func:`colour.RGB_colourspace_volume_MonteCarlo`
@@ -59,13 +59,14 @@ __all__ = [
 
 def _wrapper_RGB_colourspace_volume_MonteCarlo(arguments: tuple) -> int:
     """
-    Call the :func:`colour.volume.rgb.sample_RGB_colourspace_volume_MonteCarlo`
-    definition with multiple arguments.
+    Wrap the
+    :func:`colour.volume.rgb.sample_RGB_colourspace_volume_MonteCarlo`
+    function for parallel processing with multiple arguments.
 
     Parameters
     ----------
     arguments
-        Arguments.
+        Arguments to pass to the wrapped function.
 
     Returns
     -------
@@ -90,7 +91,7 @@ def sample_RGB_colourspace_volume_MonteCarlo(
     random_state: np.random.RandomState | None = None,
 ) -> int:
     """
-    Randomly sample the *CIE L\\*a\\*b\\** colourspace volume and returns the
+    Randomly sample the *CIE L\\*a\\*b\\** colourspace volume and return the
     ratio of samples within the specified *RGB* colourspace volume.
 
     Parameters
@@ -119,10 +120,10 @@ def sample_RGB_colourspace_volume_MonteCarlo(
 
     Notes
     -----
-    -   The doctest is assuming that :func:`np.random.RandomState` definition
-        will return the same sequence no matter which *OS* or *Python*
-        version is used. There is however no formal promise about the *prng*
-        sequence reproducibility of either *Python* or *Numpy*
+    -   The doctest is assuming that :func:`np.random.RandomState`
+        definition will return the same sequence no matter which *OS* or
+        *Python* version is used. There is however no formal promise about
+        the *prng* sequence reproducibility of either *Python* or *Numpy*
         implementations: Laurent. (2012). Reproducibility of python
         pseudo-random numbers across systems and versions? Retrieved January
         20, 2015, from http://stackoverflow.com/questions/8786084/\
@@ -152,8 +153,8 @@ reproducibility-of-python-pseudo-random-numbers-across-systems-and-versions
 
 def RGB_colourspace_limits(colourspace: RGB_Colourspace) -> NDArrayFloat:
     """
-    Compute specified *RGB* colourspace volume limits in *CIE L\\*a\\*b\\**
-    colourspace.
+    Compute the specified *RGB* colourspace volume limits in
+    *CIE L\\*a\\*b\\** colourspace.
 
     Parameters
     ----------
@@ -167,11 +168,11 @@ def RGB_colourspace_limits(colourspace: RGB_Colourspace) -> NDArrayFloat:
 
     Notes
     -----
-    The limits are computed for the specified *RGB* colourspace illuminant. This is
-    important to account for, if the intent is to compare various *RGB*
-    colourspaces together. In this instance, they must be chromatically adapted
-    to the same illuminant before-hand.
-    See :meth:`colour.RGB_Colourspace.chromatically_adapt` method for more
+    The limits are computed for the specified *RGB* colourspace illuminant.
+    This is important to account for if the intent is to compare various
+    *RGB* colourspaces together. In this instance, they must be
+    chromatically adapted to the same illuminant beforehand. See
+    :meth:`colour.RGB_Colourspace.chromatically_adapt` method for more
     information.
 
     Examples
@@ -212,27 +213,28 @@ def RGB_colourspace_volume_MonteCarlo(
     random_state: np.random.RandomState | None = None,
 ) -> float:
     """
-    Perform specified *RGB* colourspace volume computation using *Monte Carlo*
-    method and multiprocessing.
+    Compute the specified *RGB* colourspace volume using the *Monte Carlo*
+    method with multiprocessing.
 
     Parameters
     ----------
-    colourspace\
+    colourspace
         *RGB* colourspace to compute the volume of.
-    samples\
+    samples
         Sample count.
-    limits\
-        *CIE L\\*a\\*b\\** colourspace volume.
-    illuminant_Lab\
-        *CIE L\\*a\\*b\\** colourspace *illuminant* chromaticity coordinates.
-    chromatic_adaptation_transform\
+    limits
+        *CIE L\\*a\\*b\\** colourspace volume boundaries.
+    illuminant_Lab
+        *CIE L\\*a\\*b\\** colourspace *illuminant* chromaticity
+        coordinates.
+    chromatic_adaptation_transform
         *Chromatic adaptation* method.
-    random_generator\
+    random_generator
         Random triplet generator providing the random samples within the
         *CIE L\\*a\\*b\\** colourspace volume.
-    random_state\
-        Mersenne Twister pseudo-random number generator to use in the random
-        number generator.
+    random_state
+        Mersenne Twister pseudo-random number generator to use in the
+        random number generator.
 
     Returns
     -------
@@ -241,10 +243,10 @@ def RGB_colourspace_volume_MonteCarlo(
 
     Notes
     -----
-    -   The doctest is assuming that :func:`np.random.RandomState` definition
-        will return the same sequence no matter which *OS* or *Python*
-        version is used. There is however no formal promise about the *prng*
-        sequence reproducibility of either *Python* or *Numpy*
+    -   The doctest is assuming that :func:`np.random.RandomState`
+        definition will return the same sequence no matter which *OS* or
+        *Python* version is used. There is however no formal promise about
+        the *prng* sequence reproducibility of either *Python* or *Numpy*
         implementations: Laurent. (2012). Reproducibility of python
         pseudo-random numbers across systems and versions? Retrieved January
         20, 2015, from http://stackoverflow.com/questions/8786084/\
@@ -296,7 +298,8 @@ def RGB_colourspace_volume_coverage_MonteCarlo(
     random_state: np.random.RandomState | None = None,
 ) -> float:
     """
-    Return specified *RGB* colourspace percentage coverage of an arbitrary volume.
+    Compute the specified *RGB* colourspace percentage coverage of an
+    arbitrary volume.
 
     Parameters
     ----------
@@ -309,8 +312,8 @@ def RGB_colourspace_volume_coverage_MonteCarlo(
     random_generator
         Random triplet generator providing the random samples.
     random_state
-        Mersenne Twister pseudo-random number generator to use in the random
-        number generator.
+        Mersenne Twister pseudo-random number generator to use in the
+        random number generator.
 
     Returns
     -------
@@ -347,20 +350,21 @@ def RGB_colourspace_pointer_gamut_coverage_MonteCarlo(
     random_state: np.random.RandomState | None = None,
 ) -> float:
     """
-    Return specified *RGB* colourspace percentage coverage of Pointer's Gamut
-    volume using *Monte Carlo* method.
+    Compute the specified *RGB* colourspace percentage coverage of
+    *Pointer's Gamut* volume using the *Monte Carlo* method.
 
     Parameters
     ----------
     colourspace
-        *RGB* colourspace to compute the *Pointer's Gamut* coverage percentage.
+        *RGB* colourspace to compute the *Pointer's Gamut* coverage
+        percentage.
     samples
         Sample count.
     random_generator
         Random triplet generator providing the random samples.
     random_state
-        Mersenne Twister pseudo-random number generator to use in the random
-        number generator.
+        Mersenne Twister pseudo-random number generator to use in the
+        random number generator.
 
     Returns
     -------
@@ -393,8 +397,8 @@ def RGB_colourspace_visible_spectrum_coverage_MonteCarlo(
     random_state: np.random.RandomState | None = None,
 ) -> float:
     """
-    Return specified *RGB* colourspace percentage coverage of visible spectrum
-    volume using *Monte Carlo* method.
+    Compute the specified *RGB* colourspace percentage coverage of the visible
+    spectrum volume using the *Monte Carlo* method.
 
     Parameters
     ----------

--- a/colour/volume/spectrum.py
+++ b/colour/volume/spectrum.py
@@ -1,9 +1,9 @@
 """
-Rösch-MacAdam colour solid - Visible Spectrum Volume Computations
+Rösch-MacAdam Colour Solid - Visible Spectrum Volume Computations
 =================================================================
 
-Objects related to *Rösch-MacAdam* colour solid, visible spectrum
-volume computations.
+Define objects for computing and analyzing the *Rösch-MacAdam* colour
+solid and visible spectrum volume boundaries.
 
 References
 ----------
@@ -82,8 +82,8 @@ def generate_pulse_waves(
     filter_jagged_pulses: bool = False,
 ) -> NDArrayFloat:
     """
-    Generate the pulse waves of specified number of bins necessary to totally
-    stimulate the colour matching functions and produce the *Rösch-MacAdam*
+    Generate pulse waves of the specified number of bins necessary to fully
+    stimulate the colour matching functions and produce the *Rösch-MacAdam*
     colour solid.
 
     Assuming 5 bins, a first set of SPDs would be as follows::
@@ -117,16 +117,17 @@ def generate_pulse_waves(
     bins
         Number of bins of the pulse waves.
     pulse_order
-        Method for ordering the pulse waves. *Bins* is the default order, with
-        *Pulse Wave Width* ordering, instead of iterating over the pulse wave
-        widths first, iteration occurs over the bins, producing blocks of pulse
-        waves with increasing width.
+        Method for ordering the pulse waves. *Bins* is the default order,
+        with *Pulse Wave Width* ordering, instead of iterating over the
+        pulse wave widths first, iteration occurs over the bins, producing
+        blocks of pulse waves with increasing width.
     filter_jagged_pulses
         Whether to filter jagged pulses. When ``pulse_order`` is set to
-        *Pulse Wave Width*, the pulses are ordered by increasing width. Because
-        of the discrete nature of the underlying signal, the resulting pulses
-        will be jagged. For example assuming 5 bins, the center block with
-        the two extreme values added would be as follows::
+        *Pulse Wave Width*, the pulses are ordered by increasing width.
+        Because of the discrete nature of the underlying signal, the
+        resulting pulses will be jagged. For example assuming 5 bins, the
+        center block with the two extreme values added would be as
+        follows::
 
             0 0 0 0 0
             0 0 1 0 0
@@ -135,9 +136,10 @@ def generate_pulse_waves(
             0 1 1 1 1 <--
             1 1 1 1 1
 
-        Setting the ``filter_jagged_pulses`` parameter to `True` will result
-        in the removal of the two marked pulse waves above thus avoiding jagged
-        lines when plotting and having to resort to excessive ``bins`` values.
+        Setting the ``filter_jagged_pulses`` parameter to `True` will
+        result in the removal of the two marked pulse waves above thus
+        avoiding jagged lines when plotting and having to resort to
+        excessive ``bins`` values.
 
     Returns
     -------
@@ -146,7 +148,8 @@ def generate_pulse_waves(
 
     References
     ----------
-    :cite:`Lindbloom2015`, :cite:`Mansencal2018`, :cite:`Martinez-Verdu2007`
+    :cite:`Lindbloom2015`, :cite:`Mansencal2018`,
+    :cite:`Martinez-Verdu2007`
 
     Examples
     --------
@@ -251,9 +254,10 @@ def XYZ_outer_surface(
     **kwargs: Any,
 ) -> NDArrayFloat:
     """
-    Generate the *Rösch-MacAdam* colour solid, i.e., *CIE XYZ* colourspace
-    outer surface, for specified colour matching functions using multi-spectral
-    conversion of pulse waves to *CIE XYZ* tristimulus values.
+    Generate the *Rösch-MacAdam* colour solid, i.e., *CIE XYZ*
+    colourspace outer surface, for the specified colour matching functions
+    using multi-spectral conversion of pulse waves to *CIE XYZ*
+    tristimulus values.
 
     Parameters
     ----------
@@ -263,17 +267,18 @@ def XYZ_outer_surface(
     illuminant
         Illuminant spectral distribution, default to *CIE Illuminant E*.
     point_order
-        Method for ordering the underlying pulse waves used to generate the
-        *Rösch-MacAdam* colour solid. *Bins* is the default order, with
-        *Pulse Wave Width* ordering, instead of iterating over the pulse wave
-        widths first, iteration occurs over the bins, producing blocks of pulse
-        waves with increasing width.
+        Method for ordering the underlying pulse waves used to generate
+        the *Rösch-MacAdam* colour solid. *Bins* is the default order,
+        with *Pulse Wave Width* ordering, instead of iterating over the
+        pulse wave widths first, iteration occurs over the bins,
+        producing blocks of pulse waves with increasing width.
     filter_jagged_points
-        Whether to filter the underlying jagged pulses. When ``point_order`` is
-        set to *Pulse Wave Width*, the pulses are ordered by increasing width.
-        Because of the discrete nature of the underlying signal, the resulting
-        pulses will be jagged. For example assuming 5 bins, the center block
-        with the two extreme values added would be as follows::
+        Whether to filter the underlying jagged pulses. When
+        ``point_order`` is set to *Pulse Wave Width*, the pulses are
+        ordered by increasing width. Because of the discrete nature of the
+        underlying signal, the resulting pulses will be jagged. For
+        example assuming 5 bins, the center block with the two extreme
+        values added would be as follows::
 
             0 0 0 0 0
             0 0 1 0 0
@@ -282,9 +287,10 @@ def XYZ_outer_surface(
             0 1 1 1 1 <--
             1 1 1 1 1
 
-        Setting the ``filter_jagged_points`` parameter to `True` will result
-        in the removal of the two marked pulse waves above thus avoiding jagged
-        lines when plotting and having to resort to excessive ``bins`` values.
+        Setting the ``filter_jagged_points`` parameter to `True` will
+        result in the removal of the two marked pulse waves above thus
+        avoiding jagged lines when plotting and having to resort to
+        excessive ``bins`` values.
 
     Other Parameters
     ----------------
@@ -295,12 +301,13 @@ def XYZ_outer_surface(
     Returns
     -------
     :class:`numpy.ndarray`
-        *Rösch-MacAdam* colour solid, *CIE XYZ* outer surface tristimulus
-        values.
+        *Rösch-MacAdam* colour solid, *CIE XYZ* outer surface
+        tristimulus values.
 
     References
     ----------
-    :cite:`Lindbloom2015`, :cite:`Mansencal2018`, :cite:`Martinez-Verdu2007`
+    :cite:`Lindbloom2015`, :cite:`Mansencal2018`,
+    :cite:`Martinez-Verdu2007`
 
     Examples
     --------
@@ -391,9 +398,9 @@ def is_within_visible_spectrum(
     **kwargs: Any,
 ) -> NDArrayFloat:
     """
-    Return whether specified *CIE XYZ* tristimulus values are within the visible
-    spectrum volume, i.e., *Rösch-MacAdam* colour solid, for specified colour
-    matching functions and illuminant.
+    Determine whether the specified *CIE XYZ* tristimulus values are within the
+    visible spectrum volume (*Rösch-MacAdam* colour solid) for the specified
+    colour matching functions and illuminant.
 
     Parameters
     ----------
@@ -416,8 +423,8 @@ def is_within_visible_spectrum(
     Returns
     -------
     :class:`numpy.ndarray`
-        Are *CIE XYZ* tristimulus values within the visible spectrum volume,
-        i.e., *Rösch-MacAdam* colour solid.
+        Boolean array indicating whether *CIE XYZ* tristimulus values are
+        within the visible spectrum volume (*Rösch-MacAdam* colour solid).
 
     Notes
     -----

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,7 @@ reportMissingImports = false
 reportMissingModuleSource = false
 reportUnboundVariable = false
 reportUnnecessaryCast = true
-reportUnnecessaryTypeIgnorComment = true
+reportUnnecessaryTypeIgnoreComment = true
 reportUnsupportedDunderAll = false
 reportUnusedExpression = false
 

--- a/utilities/generate_plots.py
+++ b/utilities/generate_plots.py
@@ -470,7 +470,7 @@ def generate_documentation_plots(output_directory: str) -> None:
 
     arguments["filename"] = os.path.join(output_directory, "Plotting_Plot_Image.png")
     path = os.path.join(
-        colour.__path__[0],  # pyright: ignore
+        colour.__path__[0],
         "examples",
         "plotting",
         "resources",
@@ -802,12 +802,7 @@ def generate_documentation_plots(output_directory: str) -> None:
     light_source = light_source.copy().align(SpectralShape(360, 830, 1))
     cqs_i = colour_quality_scale(illuminant, additional_data=True)
     cqs_l = colour_quality_scale(light_source, additional_data=True)
-    plt.close(
-        plot_colour_quality_bars(
-            [cqs_i, cqs_l],  # pyright: ignore
-            **arguments,  # pyright: ignore
-        )[0]
-    )
+    plt.close(plot_colour_quality_bars([cqs_i, cqs_l], **arguments)[0])
 
     arguments["filename"] = os.path.join(
         output_directory,


### PR DESCRIPTION
<!--
Thank you for taking the time to create this pull request. If it is the first
time you are contributing to a colour-science repository, a contributing guide
is available to guide the process: https://www.colour-science.org/contributing/.
-->

# Summary

This PR performs a second pass of docstrings improvements using https://github.com/colour-science/colour-science.meta/blob/master/.claude/scripts/docstring_processor.py and a gazillion of extra polishing passes.

# Preflight

<!-- Please mark any checkboxes that do not apply to this pull request as [N/A]. -->

**Code Style and Quality**

- [ ] Unit tests have been implemented and passed.
- [ ] Pyright static checking has been run and passed.
- [ ] Pre-commit hooks have been run and passed.
- [ ] New transformations have been added to the _Automatic Colour Conversion Graph_.
- [ ] New transformations have been exported to the relevant namespaces, e.g. `colour`, `colour.models`.

<!-- The unit tests can be invoked with `uv run invoke tests` -->
<!-- Pyright can be started with `uv run pyright --threads --skipunannotated` -->

**Documentation**

- [ ] New features are documented along with examples if relevant.
- [ ] The documentation is [Sphinx](https://www.sphinx-doc.org/en/master/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant.

<!--
Thank you again!
-->
