### PR TITLE
PR: Vectorise *Robertson (1968)* Correlated Colour Temperature Computation

### DIFF
--- a/BIBLIOGRAPHY.bib
+++ b/BIBLIOGRAPHY.bib
@@ -1,7 +1,7 @@
 @article{Abasi2020a,
   title = {Distance Metrics for Very Large Color Differences},
   author = {Abasi, Saeedeh and Amani Tehran, Mohammad and Fairchild, Mark D.},
-  year = {2020},
+  year = 2020,
   month = apr,
   journal = {Color Research \& Application},
   volume = {45},
@@ -18,7 +18,7 @@
 @article{Abebe2017,
   title = {Perceptual {{Lightness Modeling}} for {{High-Dynamic-Range Imaging}}},
   author = {Abebe, Mekides Assefa and Pouli, Tania and Larabi, Mohamed-Chaker and Reinhard, Erik},
-  year = {2017},
+  year = 2017,
   month = jul,
   journal = {ACM Transactions on Applied Perception},
   volume = {15},
@@ -33,26 +33,14 @@
 @misc{AdobeSystems2005a,
   title = {Adobe {{RGB}} (1998) {{Color Image Encoding}}},
   author = {{Adobe Systems}},
-  year = {2005},
+  year = 2005,
   file = {/Users/kelsolaar/Zotero/storage/Y9MJZ34N/Adobe Systems - 2005 - Adobe RGB (1998) Color Image Encoding.pdf}
-}
-
-@misc{AdobeSystems2013,
-  title = {Adobe {{DNG Software Development Kit}} ({{SDK}}) - 1.3.0.0 - Dng\_sdk\_1\_3/Dng\_sdk/Source/Dng\_temperature.Cpp::Dng\_temperature::{{Set}}\_xy\_coord},
-  author = {{Adobe Systems}},
-  year = {2013}
-}
-
-@misc{AdobeSystems2013a,
-  title = {Adobe {{DNG Software Development Kit}} ({{SDK}}) - 1.3.0.0 - Dng\_sdk\_1\_3/Dng\_sdk/Source/Dng\_temperature.Cpp::Dng\_temperature::Xy\_coord},
-  author = {{Adobe Systems}},
-  year = {2013}
 }
 
 @misc{AdobeSystems2013b,
   title = {Cube {{LUT Specification}}},
   author = {{Adobe Systems}},
-  year = {2013},
+  year = 2013,
   keywords = {Iridas,look-up table,specification},
   file = {/Users/kelsolaar/Zotero/storage/LLPBPADA/Adobe Systems - 2013 - Cube LUT Specification.pdf}
 }
@@ -60,7 +48,7 @@
 @misc{ANSI2003a,
   title = {Specification of {{ROMM RGB}}},
   author = {{ANSI}},
-  year = {2003},
+  year = 2003,
   pages = {1--2},
   file = {/Users/kelsolaar/Zotero/storage/HKFYZ5YF/ANSI - 2003 - Specification of ROMM RGB.pdf}
 }
@@ -68,7 +56,7 @@
 @book{ANSI2018,
   title = {{{ANSI}}/{{IES TM-30-18}} - {{IES Method}} for {{Evaluating Light Source Color Rendition}}},
   author = {{ANSI} and {IES Color Committee}},
-  year = {2018},
+  year = 2018,
   publisher = {ANSI/IES},
   isbn = {978-0-87995-379-9},
   annotation = {thomas.mansencal@gmail.com},
@@ -78,7 +66,7 @@
 @misc{AppleInc.2019,
   title = {{{displayP3}}},
   author = {{Apple Inc.}},
-  year = {2019},
+  year = 2019,
   urldate = {2019-12-18},
   howpublished = {https://developer.apple.com/documentation/coregraphics/cgcolorspace/1408916-displayp3}
 }
@@ -86,7 +74,7 @@
 @misc{AppleInc.2023,
   title = {Apple {{Log Profile White Paper}}},
   author = {{Apple Inc.}},
-  year = {2023},
+  year = 2023,
   langid = {english},
   file = {/Users/kelsolaar/Zotero/storage/E3QYPTPS/2023 - Apple Log Profile White Paper.pdf}
 }
@@ -94,21 +82,21 @@
 @misc{ARRI2012a,
   title = {{{ALEXA}} - {{Log C Curve}} - {{Usage}} in {{VFX}}},
   author = {{ARRI}},
-  year = {2012},
+  year = 2012,
   file = {/Users/kelsolaar/Zotero/storage/JIDE329W/ARRI - 2012 - ALEXA - Log C Curve - Usage in VFX.pdf}
 }
 
 @misc{AssociationofRadioIndustriesandBusinesses2015a,
   title = {Essential {{Parameter Values}} for the {{Extended Image Dynamic Range Television}} ({{EIDRTV}}) {{System}} for {{Programme Production}}},
   author = {{Association of Radio Industries and Businesses}},
-  year = {2015},
+  year = 2015,
   file = {/Users/kelsolaar/Zotero/storage/UK6PZDJ4/Association of Radio Industries and Businesses - 2015 - Essential Parameter Values for the Extended Image Dynamic Range Television (EIDR.pdf}
 }
 
 @misc{ASTMInternational1989a,
   title = {{{ASTM D1535-89}} - {{Standard Practice}} for {{Specifying Color}} by the {{Munsell System}}},
   author = {{ASTM International}},
-  year = {1989},
+  year = 1989,
   pages = {1--29},
   urldate = {2014-09-25},
   keywords = {color,D1535,Munsell,Munsell color order system,Munsell notation},
@@ -118,7 +106,7 @@
 @misc{ASTMInternational2007,
   title = {{{ASTM D2244-07}} - {{Standard Practice}} for {{Calculation}} of {{Color Tolerances}} and {{Color Differences}} from {{Instrumentally Measured Color Coordinates}}},
   author = {{ASTM International}},
-  year = {2007},
+  year = 2007,
   volume = {i},
   pages = {1--10},
   doi = {10.1520/D2244-16},
@@ -128,14 +116,14 @@
 @misc{ASTMInternational2008a,
   title = {{{ASTM D1535-08e1}} - {{Standard Practice}} for {{Specifying Color}} by the {{Munsell System}}},
   author = {{ASTM International}},
-  year = {2008},
+  year = 2008,
   doi = {10.1520/D1535-08E01}
 }
 
 @misc{ASTMInternational2011a,
   title = {{{ASTM E2022-11}} - {{Standard Practice}} for {{Calculation}} of {{Weighting Factors}} for {{Tristimulus Integration}}},
   author = {{ASTM International}},
-  year = {2011},
+  year = 2011,
   pages = {1--10},
   doi = {10.1520/E2022-11},
   abstract = {This standard is issued under the fixed designation E2022; the number immediately following the designation indicates the year of original adoption or, in the case of revision, the year of last revision. A number in parentheses indicates the year of last reapproval. A superscript epsilon) indicates an editorial change since the last revision or reapproval.},
@@ -145,7 +133,7 @@
 @misc{ASTMInternational2015,
   title = {{{ASTM E313-15e1}} - {{Standard Practice}} for {{Calculating Yellowness}} and {{Whiteness Indices}} from {{Instrumentally Measured Color Coordinates}}},
   author = {{ASTM International}},
-  year = {2015},
+  year = 2015,
   doi = {10.1520/E0313-20},
   file = {/Users/kelsolaar/Zotero/storage/WXZIPWTS/ASTM International - ASTM E313-15e1 - Standard Practice for Calculating.pdf}
 }
@@ -153,7 +141,7 @@
 @misc{ASTMInternational2015b,
   title = {{{ASTM E308-15}} - {{Standard Practice}} for {{Computing}} the {{Colors}} of {{Objects}} by {{Using}} the {{CIE System}}},
   author = {{ASTM International}},
-  year = {2015},
+  year = 2015,
   pages = {1--47},
   doi = {10.1520/E0308-15},
   file = {/Users/kelsolaar/Zotero/storage/6NCHYYI5/ASTM International - 2015 - ASTM E308-15 - Standard Practice for Computing the Colors of Objects by Using the CIE System.pdf}
@@ -162,14 +150,14 @@
 @misc{ASWFColorInteropForum2024,
   title = {Color {{Space Encodings}} for {{Texture Assets}} and {{CG Rendering}}},
   author = {{ASWF Color Interop Forum}},
-  year = {2024},
+  year = 2024,
   month = oct
 }
 
 @misc{BabelColor2012b,
   title = {The {{ColorChecker}} (since 1976!)},
   author = {{BabelColor}},
-  year = {2012},
+  year = 2012,
   urldate = {2014-09-26},
   howpublished = {http://www.babelcolor.com/main\_level/ColorChecker.htm}
 }
@@ -177,14 +165,14 @@
 @misc{BabelColor2012c,
   title = {{{ColorChecker RGB}} and Spectra},
   author = {{BabelColor}},
-  year = {2012},
+  year = 2012,
   file = {/Users/kelsolaar/Zotero/storage/BASARME2/BabelColor - 2012 - ColorChecker RGB and spectra.xls}
 }
 
 @book{Barten1999,
   title = {Contrast {{Sensitivity}} of the {{Human Eye}} and {{Its Effects}} on {{Image Quality}}},
   author = {Barten, Peter G.},
-  year = {1999},
+  year = 1999,
   month = dec,
   number = {1999},
   publisher = {SPIE},
@@ -200,7 +188,7 @@
   booktitle = {Proceedings of {{SPIE}}},
   author = {Barten, Peter G. J.},
   editor = {Miyake, Yoichi and Rasmussen, D. Rene},
-  year = {2003},
+  year = 2003,
   month = dec,
   volume = {5294},
   pages = {231--238},
@@ -214,7 +202,7 @@
 @article{Bianco2010a,
   title = {Two New von {{Kries}} Based Chromatic Adaptation Transforms Found by Numerical Optimization},
   author = {Bianco, S. and Schettini, R.},
-  year = {2010},
+  year = 2010,
   month = jun,
   journal = {Color Research \& Application},
   volume = {35},
@@ -229,14 +217,14 @@
 @misc{BlackmagicDesign2020,
   title = {{{DaVinci Wide Gamut}} - {{DaVinci Resolve Studio}} 17 {{Public Beta}} 1},
   author = {{Blackmagic Design}},
-  year = {2020},
+  year = 2020,
   month = nov
 }
 
 @misc{BlackmagicDesign2020a,
   title = {Wide {{Gamut Intermediate DaVinci Resolve}}},
   author = {{Blackmagic Design}},
-  year = {2020},
+  year = 2020,
   urldate = {2020-12-12},
   file = {/Users/kelsolaar/Zotero/storage/QRUMYRLW/Blackmagic Design - 2020 - Wide Gamut Intermediate DaVinci Resolve.pdf}
 }
@@ -244,14 +232,14 @@
 @misc{BlackmagicDesign2021,
   title = {Blackmagic {{Generation}} 5 {{Color Science}}},
   author = {{Blackmagic Design}},
-  year = {2021},
+  year = 2021,
   file = {/Users/kelsolaar/Zotero/storage/UHWCNCMJ/Blackmagic Design - 2021 - Blackmagic Generation 5 Color Science.pdf}
 }
 
 @article{Bodhaine1999a,
   title = {On {{Rayleigh Optical Depth Calculations}}},
   author = {Bodhaine, Barry A. and Wood, Norman B. and Dutton, Ellsworth G. and Slusser, James R.},
-  year = {1999},
+  year = 1999,
   month = nov,
   journal = {Journal of Atmospheric and Oceanic Technology},
   volume = {16},
@@ -267,7 +255,7 @@
 @misc{Borer2017a,
   title = {Private {{Discussion}} with {{Mansencal}}, {{T}}. and {{Shaw}}, {{N}}.},
   author = {Borer, Tim},
-  year = {2017}
+  year = 2017
 }
 
 @misc{Bourkea,
@@ -287,7 +275,7 @@
 @article{Breneman1987b,
   title = {Corresponding Chromaticities for Different States of Adaptation to Complex Visual Fields},
   author = {Breneman, Edwin J.},
-  year = {1987},
+  year = 1987,
   month = jun,
   journal = {Journal of the Optical Society of America A},
   volume = {4},
@@ -304,7 +292,7 @@
 @article{Brill2008a,
   title = {Repairing Gamut Problems in {{CIECAM02}}: {{A}} Progress Report},
   author = {Brill, Michael H. and Susstrunk, Sabine},
-  year = {2008},
+  year = 2008,
   month = oct,
   journal = {Color Research \& Application},
   volume = {33},
@@ -320,7 +308,7 @@
 @misc{Broadbent2009a,
   title = {Calculation from the {{Original Experimental Data}} of the {{Cie}} 1931 {{RGB Standard Observer Spectral Chromaticity Co-Ordinates}} and {{Color Matching Functions}}.},
   author = {Broadbent, A. D.},
-  year = {2009},
+  year = 2009,
   journal = {Qu{\'e}bec, Canada: D{\'e}partement de g{\'e}nie chimique, {\dots}},
   pages = {1--17},
   urldate = {2014-06-12},
@@ -332,7 +320,7 @@
 @book{Burger2009b,
   title = {Principles of {{Digital Image Processing}}},
   author = {Burger, Wilhelm and Burge, Mark James},
-  year = {2009},
+  year = 2009,
   publisher = {Springer London},
   address = {London},
   doi = {10.1007/978-1-84800-195-4},
@@ -342,7 +330,7 @@
 @article{Byrnes2016,
   title = {Multilayer Optical Calculations},
   author = {Byrnes, Steven J.},
-  year = {2016},
+  year = 2016,
   eprint = {1603.02720},
   pages = {1--20},
   abstract = {When light hits a multilayer planar stack, it is reflected, refracted, and absorbed in a way that can be derived from the Fresnel equations. The analysis is treated in many textbooks, and implemented in many software programs, but certain aspects of it are difficult to find explicitly and consistently worked out in the literature. Here, we derive the formulas underlying the transfer-matrix method of calculating the optical properties of these stacks, including oblique-angle incidence, absorption-vs-position profiles, and ellipsometry parameters. We discuss and explain some strange consequences of the formulas in the situation where the incident and/or final (semi-infinite) medium are absorptive, such as calculating \$T{$>$}1\$ in the absence of gain. We also discuss some implementation details like complex-plane branch cuts. Finally, we derive modified formulas for including one or more "incoherent" layers, i.e. very thick layers in which interference can be neglected. This document was written in conjunction with the "tmm" Python software package, which implements these calculations.},
@@ -360,7 +348,7 @@
 @misc{Canon2014a,
   title = {{{EOS C500 Firmware Update}}},
   author = {{Canon}},
-  year = {2014},
+  year = 2014,
   urldate = {2016-08-27},
   howpublished = {https://www.usa.canon.com/internet/portal/us/home/explore/product-showcases/cameras-and-lenses/cinema-eos-firmware/c500}
 }
@@ -368,7 +356,7 @@
 @misc{Canon2016,
   title = {Input {{Transform Version}} 201612 for {{EOS C300 Mark II}}},
   author = {{Canon}},
-  year = {2016},
+  year = 2016,
   urldate = {2016-08-23},
   howpublished = {https://www.usa.canon.com/internet/portal/us/home/support/details/cameras/cinema-eos/eos-c300-mark-ii}
 }
@@ -376,7 +364,7 @@
 @misc{Canon2020,
   title = {Input {{Transform Version}} 202007 for {{EOS C300 Mark II}}},
   author = {{Canon}},
-  year = {2020},
+  year = 2020,
   urldate = {2023-07-16},
   howpublished = {https://www.usa.canon.com/internet/portal/us/home/support/details/cameras/cinema-eos/eos-c300-mark-ii}
 }
@@ -384,7 +372,7 @@
 @article{Cao2013,
   title = {Comparison of the Performance of Inverse Transformation Methods from {{OSA-UCS}} to {{CIEXYZ}}},
   author = {Cao, Renbo and Trussell, H Joel and Shamey, Renzo},
-  year = {2013},
+  year = 2013,
   month = aug,
   journal = {Journal of the Optical Society of America A},
   volume = {30},
@@ -401,7 +389,7 @@
 @techreport{Carter2018,
   title = {{{CIE}} 015:2018 {{Colorimetry}}, 4th {{Edition}}},
   author = {Carter, E.C. and Schanda, J.D. and Hirschler, R. and Jost, S. and Luo, M.R. and Melgosa, M. and Ohno, Y. and Pointer, M.R. and Rich, D.C. and Vienot, F. and Whitehead, L. and Wold, J.H.},
-  year = {2018},
+  year = 2018,
   month = oct,
   address = {Vienna},
   institution = {International Commission on Illumination},
@@ -413,7 +401,7 @@
 @misc{Castro2014a,
   title = {Numpy: {{Fastest}} Way of Computing Diagonal for Each Row of a 2d Array},
   author = {Castro, Saullo},
-  year = {2014},
+  year = 2014,
   urldate = {2014-08-22},
   howpublished = {http://stackoverflow.com/questions/26511401/numpy-fastest-way-of-computing-diagonal-for-each-row-of-a-2d-array/26517247\#26517247}
 }
@@ -421,7 +409,7 @@
 @article{Centore2012a,
   title = {An Open-Source Inversion Algorithm for the {{Munsell}} Renotation},
   author = {Centore, Paul},
-  year = {2012},
+  year = 2012,
   month = dec,
   journal = {Color Research \& Application},
   volume = {37},
@@ -437,67 +425,67 @@
 @misc{Centore2014k,
   title = {{{MunsellAndKubelkaMunkToolboxApr2014}} - {{MunsellRenotationRoutines}}/{{MunsellHueToASTMHue}}.m},
   author = {Centore, Paul},
-  year = {2014}
+  year = 2014
 }
 
 @misc{Centore2014l,
   title = {{{MunsellAndKubelkaMunkToolboxApr2014}} - {{MunsellSystemRoutines}}/{{LinearVsRadialInterpOnRenotationOvoid}}.m},
   author = {Centore, Paul},
-  year = {2014}
+  year = 2014
 }
 
 @misc{Centore2014m,
   title = {{{MunsellAndKubelkaMunkToolboxApr2014}} - {{MunsellRenotationRoutines}}/{{MunsellToxyY}}.m},
   author = {Centore, Paul},
-  year = {2014}
+  year = 2014
 }
 
 @misc{Centore2014n,
   title = {{{MunsellAndKubelkaMunkToolboxApr2014}} - {{MunsellRenotationRoutines}}/{{FindHueOnRenotationOvoid}}.m},
   author = {Centore, Paul},
-  year = {2014}
+  year = 2014
 }
 
 @misc{Centore2014o,
   title = {{{MunsellAndKubelkaMunkToolboxApr2014}} - {{MunsellSystemRoutines}}/{{BoundingRenotationHues}}.m},
   author = {Centore, Paul},
-  year = {2014}
+  year = 2014
 }
 
 @misc{Centore2014p,
   title = {{{MunsellAndKubelkaMunkToolboxApr2014}} - {{MunsellRenotationRoutines}}/{{xyYtoMunsell}}.m},
   author = {Centore, Paul},
-  year = {2014}
+  year = 2014
 }
 
 @misc{Centore2014q,
   title = {{{MunsellAndKubelkaMunkToolboxApr2014}} - {{MunsellRenotationRoutines}}/{{MunsellToxyForIntegerMunsellValue}}.m},
   author = {Centore, Paul},
-  year = {2014}
+  year = 2014
 }
 
 @misc{Centore2014r,
   title = {{{MunsellAndKubelkaMunkToolboxApr2014}} - {{MunsellRenotationRoutines}}/{{MaxChromaForExtrapolatedRenotation}}.m},
   author = {Centore, Paul},
-  year = {2014}
+  year = 2014
 }
 
 @misc{Centore2014s,
   title = {{{MunsellAndKubelkaMunkToolboxApr2014}} - {{MunsellRenotationRoutines}}/{{MunsellHueToChromDiagHueAngle}}.m},
   author = {Centore, Paul},
-  year = {2014}
+  year = 2014
 }
 
 @misc{Centore2014t,
   title = {{{MunsellAndKubelkaMunkToolboxApr2014}} - {{MunsellRenotationRoutines}}/{{ChromDiagHueAngleToMunsellHue}}.m},
   author = {Centore, Paul},
-  year = {2014}
+  year = 2014
 }
 
 @misc{Centore2014u,
   title = {{{MunsellAndKubelkaMunkToolboxApr2014}} - {{GeneralRoutines}}/{{CIELABtoApproxMunsellSpec}}.m},
   author = {Centore, Paul},
-  year = {2014}
+  year = 2014
 }
 
 @misc{Centorea,
@@ -510,7 +498,7 @@
 @misc{Chamberlain2015,
   title = {{{LUT}} Documentation (to Create from Another Program)},
   author = {Chamberlain, Peter},
-  year = {2015},
+  year = 2015,
   urldate = {2018-08-23},
   howpublished = {https://forum.blackmagicdesign.com/viewtopic.php?f=21\&t=40284\#p232952}
 }
@@ -518,7 +506,7 @@
 @article{Cheung2004,
   title = {A Comparative Study of the Characterisation of Colour Cameras by Means of Neural Networks and Polynomial Transforms},
   author = {Cheung, Vien and Westland, Stephen and Connah, David and Ripamonti, Caterina},
-  year = {2004},
+  year = 2004,
   journal = {Coloration Technology},
   volume = {120},
   number = {1},
@@ -532,7 +520,7 @@
 @misc{CIE2024,
   title = {Spectral Radiance Factors of Test-Colour Sample \#15 of the {{Japanese}} Skin Complexion, 5nm Wavelength Steps},
   author = {{CIE}},
-  year = {2024},
+  year = 2024,
   publisher = {International Commission on Illumination (CIE)},
   doi = {10.25039/CIE.DS.7chm7z5h},
   urldate = {2025-03-17},
@@ -542,7 +530,7 @@
 @misc{CIEce,
   title = {{{CIE}} 15:2004 {{Tables Data}}},
   author = {{CIE}},
-  year = {2004},
+  year = 2004,
   file = {/Users/kelsolaar/Zotero/storage/R95FLNMC/CIE - 2004 - CIE 152004 Tables Data.xls}
 }
 
@@ -555,7 +543,7 @@
 @book{CIEDivision12022,
   title = {{{CIE}} 248:2022 {{The CIE}} 2016 {{Colour Appearance Model}} for {{Colour Management Systems}}: {{CIECAM16}}},
   author = {{CIE Division 1} and {CIE Division 8}},
-  year = {2022},
+  year = 2022,
   publisher = {Commission Internationale de l'Eclairage},
   isbn = {978-3-902842-94-7},
   file = {/Users/kelsolaar/Zotero/storage/5LMUJ936/CIE Division 1Division 8 - 2022 - CIE 2482022 The CIE 2016 Colour Appearance Model .pdf}
@@ -564,7 +552,7 @@
 @book{CIETC1-321994b,
   title = {{{CIE}} 109-1994 {{A Method}} of {{Predicting Corresponding Colours}} under {{Different Chromatic}} and {{Illuminance Adaptations}}},
   author = {{CIE TC 1-32}},
-  year = {1994},
+  year = 1994,
   publisher = {Commission Internationale de l'Eclairage},
   isbn = {978-3-900734-51-0},
   file = {/Users/kelsolaar/Zotero/storage/MFXWLR4T/CIE TC 1-32 - 1994 - CIE 109-1994 A Method of Predicting Corresponding Colours under Different Chromatic and Illuminance Adaptations.pdf}
@@ -573,7 +561,7 @@
 @book{CIETC1-362006a,
   title = {{{CIE}} 170-1:2006 {{Fundamental Chromaticity Diagram}} with {{Physiological Axes}} - {{Part}} 1},
   author = {{CIE TC 1-36}},
-  year = {2006},
+  year = 2006,
   publisher = {Commission Internationale de l'Eclairage},
   isbn = {978-3-901906-46-6},
   file = {/Users/kelsolaar/Zotero/storage/8KV64XHT/CIE TC 1-36 - 2006 - CIE 170-12006 Fundamental Chromaticity Diagram with Physiological Axes - Part 1.pdf}
@@ -583,7 +571,7 @@
   title = {9. {{INTERPOLATION}}},
   booktitle = {{{CIE}} 167:2005 {{Recommended Practice}} for {{Tabulating Spectral Data}} for {{Use}} in {{Colour Computations}}},
   author = {{CIE TC 1-38}},
-  year = {2005},
+  year = 2005,
   pages = {14--19},
   isbn = {978-3-901906-41-1}
 }
@@ -592,7 +580,7 @@
   title = {9.2.4 {{Method}} of Interpolation for Uniformly Spaced Independent Variable},
   booktitle = {{{CIE}} 167:2005 {{Recommended Practice}} for {{Tabulating Spectral Data}} for {{Use}} in {{Colour Computations}}},
   author = {{CIE TC 1-38}},
-  year = {2005},
+  year = 2005,
   pages = {1--27},
   isbn = {978-3-901906-41-1}
 }
@@ -601,7 +589,7 @@
   title = {{{EXTRAPOLATION}}},
   booktitle = {{{CIE}} 167:2005 {{Recommended Practice}} for {{Tabulating Spectral Data}} for {{Use}} in {{Colour Computations}}},
   author = {{CIE TC 1-38}},
-  year = {2005},
+  year = 2005,
   pages = {19--20},
   isbn = {978-3-901906-41-1}
 }
@@ -610,7 +598,7 @@
   title = {Table {{V}}. {{Values}} of the c-Coefficients of {{Equ}}.s 6 and 7.},
   booktitle = {{{CIE}} 167:2005 {{Recommended Practice}} for {{Tabulating Spectral Data}} for {{Use}} in {{Colour Computations}}},
   author = {{CIE TC 1-38}},
-  year = {2005},
+  year = 2005,
   pages = {19},
   isbn = {978-3-901906-41-1}
 }
@@ -619,7 +607,7 @@
   title = {{{EXPLANATORY COMMENTS}} - 5},
   booktitle = {{{CIE}} 015:2004 {{Colorimetry}}, 3rd {{Edition}}},
   author = {{CIE TC 1-48}},
-  year = {2004},
+  year = 2004,
   pages = {68--68},
   isbn = {978-3-901906-33-6}
 }
@@ -627,7 +615,7 @@
 @book{CIETC1-482004h,
   title = {{{CIE}} 015:2004 {{Colorimetry}}, 3rd {{Edition}}},
   author = {{CIE TC 1-48}},
-  year = {2004},
+  year = 2004,
   journal = {CIE 015:2004 Colorimetry, 3rd Edition},
   publisher = {Commission Internationale de l'Eclairage},
   isbn = {978-3-901906-33-6},
@@ -638,7 +626,7 @@
   title = {{{APPENDIX E}}. {{INFORMATION ON THE USE OF PLANCK}}'{{S EQUATION FOR STANDARD AIR}}},
   booktitle = {{{CIE}} 015:2004 {{Colorimetry}}, 3rd {{Edition}}},
   author = {{CIE TC 1-48}},
-  year = {2004},
+  year = 2004,
   pages = {77--82},
   isbn = {978-3-901906-33-6},
   file = {/Users/kelsolaar/Zotero/storage/6J5GE7WN/CIE TC 1-48 - 2004 - APPENDIX E. INFORMATION ON THE USE OF PLANCK'S EQUATION FOR STANDARD AIR.pdf}
@@ -648,7 +636,7 @@
   title = {{{CIE}} 1976 Uniform Chromaticity Scale Diagram ({{UCS}} Diagram)},
   booktitle = {{{CIE}} 015:2004 {{Colorimetry}}, 3rd {{Edition}}},
   author = {{CIE TC 1-48}},
-  year = {2004},
+  year = 2004,
   pages = {24},
   isbn = {978-3-901906-33-6}
 }
@@ -657,7 +645,7 @@
   title = {The Evaluation of Whiteness},
   booktitle = {{{CIE}} 015:2004 {{Colorimetry}}, 3rd {{Edition}}},
   author = {{CIE TC 1-48}},
-  year = {2004},
+  year = 2004,
   pages = {24},
   isbn = {978-3-901906-33-6}
 }
@@ -666,7 +654,7 @@
   title = {Extrapolation},
   booktitle = {{{CIE}} 015:2004 {{Colorimetry}}, 3rd {{Edition}}},
   author = {{CIE TC 1-48}},
-  year = {2004},
+  year = 2004,
   pages = {24},
   isbn = {978-3-901906-33-6}
 }
@@ -675,7 +663,7 @@
   title = {{{CIE}} 1976 Uniform Colour Spaces},
   booktitle = {{{CIE}} 015:2004 {{Colorimetry}}, 3rd {{Edition}}},
   author = {{CIE TC 1-48}},
-  year = {2004},
+  year = 2004,
   pages = {24},
   isbn = {978-3-901906-33-6}
 }
@@ -684,7 +672,7 @@
   title = {3.1 {{Recommendations}} Concerning Standard Physical Data of Illuminants},
   booktitle = {{{CIE}} 015:2004 {{Colorimetry}}, 3rd {{Edition}}},
   author = {{CIE TC 1-48}},
-  year = {2004},
+  year = 2004,
   pages = {12--13},
   isbn = {978-3-901906-33-6}
 }
@@ -693,7 +681,7 @@
   title = {9.1 {{Dominant}} Wavelength and Purity},
   booktitle = {{{CIE}} 015:2004 {{Colorimetry}}, 3rd {{Edition}}},
   author = {{CIE TC 1-48}},
-  year = {2004},
+  year = 2004,
   pages = {32--33},
   isbn = {978-3-901906-33-6}
 }
@@ -701,7 +689,7 @@
 @book{CIETC1-902017,
   title = {{CIE 2017 colour fidelity index for accurate scientific use}},
   author = {{CIE TC 1-90}},
-  year = {2017},
+  year = 2017,
   series = {{Technical report / CIE}},
   number = {224},
   publisher = {CIE Central Bureau},
@@ -736,7 +724,7 @@
 @misc{Cooper2022,
   title = {{{ARRI LogC4 Logarithmic Color Space SPECIFICATION}}},
   author = {Cooper, Sean and Brendel, Harald},
-  year = {2022},
+  year = 2022,
   urldate = {2022-10-24},
   file = {/Users/kelsolaar/Zotero/storage/GKDQLNEX/Cooper and Brendel - 2022 - ARRI LogC4 Logarithmic Color Space SPECIFICATION.pdf}
 }
@@ -749,7 +737,7 @@
 @article{Cowan2004,
   title = {Contrast {{Sensitivity Experiment}} to {{Determine}} the {{Bit Depth}} for {{Digital Cinema}}},
   author = {Cowan, Matthew and Kennel, Glenn and Maier, Thomas and Walker, Brad},
-  year = {2004},
+  year = 2004,
   month = sep,
   journal = {SMPTE Motion Imaging Journal},
   volume = {113},
@@ -765,7 +753,7 @@
   ids = {Cui2002a},
   title = {Uniform Colour Spaces Based on the {{DIN99}} Colour-Difference Formula},
   author = {Cui, G. and Luo, M. R. and Rigg, B. and Roesler, G. and Witt, K.},
-  year = {2002},
+  year = 2002,
   journal = {Color Research \& Application},
   volume = {27},
   number = {4},
@@ -818,7 +806,7 @@
 @misc{CVRLu,
   title = {Cone {{Fundamentals}}},
   author = {Stockman, Andrew and Sharpe, Lindsay T.},
-  year = {2000},
+  year = 2000,
   urldate = {2014-06-23},
   howpublished = {http://www.cvrl.org/cones.htm}
 }
@@ -840,7 +828,7 @@
 @article{Darrodi2015a,
   title = {Reference Data Set for Camera Spectral Sensitivity Estimation},
   author = {Darrodi, Maryam Mohammadzadeh and Finlayson, Graham and Goodman, Teresa and Mackiewicz, Michal},
-  year = {2015},
+  year = 2015,
   month = mar,
   journal = {Journal of the Optical Society of America A},
   volume = {32},
@@ -854,7 +842,7 @@
 @article{David2015,
   title = {Development of the {{IES}} Method for Evaluating the Color Rendition of Light Sources},
   author = {David, Aurelien and Fini, Paul T. and Houser, Kevin W. and Ohno, Yoshi and Royer, Michael P. and Smet, Kevin A. G. and Wei, Minchen and Whitehead, Lorne},
-  year = {2015},
+  year = 2015,
   month = jun,
   journal = {Optics Express},
   volume = {23},
@@ -871,7 +859,7 @@
 @article{Davis2010a,
   title = {Color Quality Scale},
   author = {Davis, Wendy and Ohno, Yoshiro},
-  year = {2010},
+  year = 2010,
   month = mar,
   journal = {Optical Engineering},
   volume = {49},
@@ -887,21 +875,21 @@
 @misc{DigitalCinemaInitiatives2007b,
   title = {Digital {{Cinema System Specification}} - {{Version}} 1.1},
   author = {{Digital Cinema Initiatives}},
-  year = {2007},
+  year = 2007,
   file = {/Users/kelsolaar/Zotero/storage/WSI7QRSL/Digital Cinema Initiatives - 2007 - Digital Cinema System Specification - Version 1.1.pdf}
 }
 
 @misc{DjangoSoftwareFoundation2022,
   title = {Slugify},
   author = {{Django Software Foundation}},
-  year = {2022},
+  year = 2022,
   urldate = {2022-06-01}
 }
 
 @misc{DJI2017,
   title = {White {{Paper}} on {{D-Log}} and {{D-Gamut}} of {{DJI Cinema Color System}}},
   author = {{Dji}},
-  year = {2017},
+  year = 2017,
   pages = {1--5},
   file = {/Users/kelsolaar/Zotero/storage/KHLE47UN/Dji - 2017 - White Paper on D-Log and D-Gamut of DJI Cinema Color System.pdf}
 }
@@ -909,14 +897,14 @@
 @misc{Dolby2016a,
   title = {{{WHAT IS ICTCP}}? - {{INTRODUCTION}}},
   author = {{Dolby}},
-  year = {2016},
+  year = 2016,
   file = {/Users/kelsolaar/Zotero/storage/TNDLN3NF/Dolby - 2016 - WHAT IS ICTCP - INTRODUCTION.pdf}
 }
 
 @misc{Dyer2017,
   title = {{{RAW}} to {{ACES}}},
   author = {Dyer, Scott and Forsythe, Alexander and Irons, Jonathon and Mansencal, Thomas and Zhu, Miaoqi},
-  year = {2017}
+  year = 2017
 }
 
 @misc{EasyRGBh,
@@ -980,7 +968,7 @@
   booktitle = {Proc. {{SPIE}} 3300, {{Color Imaging}}: {{Device-Independent Color}}, {{Color Hardcopy}}, and {{Graphic Arts III}}, (2 {{January}} 1998)},
   author = {Ebner, Fritz and Fairchild, Mark D.},
   editor = {Beretta, Giordano B. and Eschbach, Reiner},
-  year = {1998},
+  year = 1998,
   month = jan,
   pages = {107--117},
   doi = {10.1117/12.298269},
@@ -1005,20 +993,20 @@
 @misc{EuropeanBroadcastingUnion1975,
   title = {{{EBU Tech}} 3213 - {{EBU Standard}} for {{Chromaticity Tolerances}} for {{Studio Monitors}}},
   author = {{European Broadcasting Union}},
-  year = {1975},
+  year = 1975,
   month = aug
 }
 
 @misc{EuropeanColorInitiative2002a,
   title = {{{ECI RGB}} V2},
   author = {{European Color Initiative}},
-  year = {2002}
+  year = 2002
 }
 
 @article{Fairchild1991a,
   title = {Formulation and Testing of an Incomplete-Chromatic-Adaptation Model},
   author = {Fairchild, Mark D.},
-  year = {1991},
+  year = 1991,
   month = aug,
   journal = {Color Research \& Application},
   volume = {16},
@@ -1034,7 +1022,7 @@
 @article{Fairchild1996a,
   title = {Refinement of the {{RLAB}} Color Space},
   author = {Fairchild, Mark D.},
-  year = {1996},
+  year = 1996,
   month = oct,
   journal = {Color Research \& Application},
   volume = {21},
@@ -1050,7 +1038,7 @@
 @misc{Fairchild1998b,
   title = {Colorimetric {{Characterization}} of {{The Apple Studio Display}} (Flat Panel {{LCD}})},
   author = {Fairchild, M. and Wyble, D.},
-  year = {1998},
+  year = 1998,
   pages = {22},
   abstract = {The colorimetric characterization of a flat-panel LCD monitor, the Apple Studio Display, using traditional CRT characterization techniques was evaluated. The results showed that the display performed up to the manufacturer's specifications in terms of luminance and contrast. However, the traditional CRT gain-offset-gamma (GOG) model for characterization was inadequate and a model with one-dimensional lookup tables followed by a 3x3 matrix was developed. The LUT model performed excellently with average CIE94 color differences between measured and predicted colors of approximately 1.0.},
   file = {/Users/kelsolaar/Zotero/storage/IZFF4EKD/Fairchild, Wyble - 1998 - Colorimetric Characterization of The Apple Studio Display (flat panel LCD).pdf}
@@ -1060,7 +1048,7 @@
   title = {{{CIECAM02}}},
   booktitle = {Color {{Appearance Models}}},
   author = {Fairchild, Mark D.},
-  year = {2004},
+  year = 2004,
   edition = {2},
   pages = {289--301},
   publisher = {Wiley},
@@ -1072,7 +1060,7 @@
   title = {Hdr-{{CIELAB}} and Hdr-{{IPT}}: {{Simple Models}} for {{Describing}} the {{Color}} of {{High-Dynamic-Range}} and {{Wide-Color-Gamut Images}}},
   booktitle = {Proc. of {{Color}} and {{Imaging Conference}}},
   author = {Fairchild, Mark D. and Wyble, David R.},
-  year = {2010},
+  year = 2010,
   pages = {322--326},
   issn = {21669635},
   isbn = {978-1-62993-215-6},
@@ -1085,7 +1073,7 @@
   booktitle = {Proc. {{SPIE}} 7867, {{Image Quality}} and {{System Performance VIII}}},
   author = {Fairchild, Mark D and Chen, Ping-hsu},
   editor = {Farnand, Susan P. and Gaykema, Frans},
-  year = {2011},
+  year = 2011,
   month = jan,
   pages = {78670O},
   doi = {10.1117/12.872075},
@@ -1097,7 +1085,7 @@
   title = {The {{Nayatani}} et al. {{Model}}},
   booktitle = {Color {{Appearance Models}}},
   author = {Fairchild, Mark D.},
-  year = {2013},
+  year = 2013,
   edition = {3},
   pages = {4810--5085},
   publisher = {Wiley},
@@ -1108,7 +1096,7 @@
   title = {{{FAIRCHILD}}'{{S}} 1990 {{MODEL}}},
   booktitle = {Color {{Appearance Models}}},
   author = {Fairchild, Mark D.},
-  year = {2013},
+  year = 2013,
   edition = {3},
   pages = {4418--4495},
   publisher = {Wiley},
@@ -1119,7 +1107,7 @@
   title = {Chromatic {{Adaptation Models}}},
   booktitle = {Color {{Appearance Models}}},
   author = {Fairchild, Mark D.},
-  year = {2013},
+  year = 2013,
   edition = {3},
   pages = {4179--4252},
   publisher = {Wiley},
@@ -1130,7 +1118,7 @@
   title = {The {{Hunt Model}}},
   booktitle = {Color {{Appearance Models}}},
   author = {Fairchild, Mark D.},
-  year = {2013},
+  year = 2013,
   edition = {3},
   pages = {5094--5556},
   publisher = {Wiley},
@@ -1141,7 +1129,7 @@
   title = {{{ATD Model}}},
   booktitle = {Color {{Appearance Models}}},
   author = {Fairchild, Mark D.},
-  year = {2013},
+  year = 2013,
   edition = {3},
   pages = {5852--5991},
   publisher = {Wiley},
@@ -1152,7 +1140,7 @@
   title = {The {{RLAB Model}}},
   booktitle = {Color {{Appearance Models}}},
   author = {Fairchild, Mark D.},
-  year = {2013},
+  year = 2013,
   edition = {3},
   pages = {5563--5824},
   publisher = {Wiley},
@@ -1163,7 +1151,7 @@
   title = {{{LLAB Model}}},
   booktitle = {Color {{Appearance Models}}},
   author = {Fairchild, Mark D.},
-  year = {2013},
+  year = 2013,
   edition = {3},
   pages = {6025--6178},
   publisher = {Wiley},
@@ -1174,7 +1162,7 @@
   title = {{{IPT Colourspace}}},
   booktitle = {Color {{Appearance Models}}},
   author = {Fairchild, Mark D.},
-  year = {2013},
+  year = 2013,
   edition = {3},
   pages = {6197--6223},
   publisher = {Wiley},
@@ -1185,7 +1173,7 @@
   title = {Von {{Kries}} 2020: {{Evolution}} of Degree of Chromatic Adaptation},
   shorttitle = {Von {{Kries}} 2020},
   author = {Fairchild, Mark D.},
-  year = {2020},
+  year = 2020,
   month = nov,
   journal = {Color and Imaging Conference},
   volume = {28},
@@ -1202,7 +1190,7 @@
 @misc{Fairchild2022,
   title = {Private {{Discussion}} with {{Mansencal}}, {{T}}.},
   author = {Fairchild, Mark D and Hellwig, Luke},
-  year = {2022}
+  year = 2022
 }
 
 @misc{Fairchildb,
@@ -1213,7 +1201,7 @@
 @article{Fairman1985b,
   title = {The Calculation of Weight Factors for Tristimulus Integration},
   author = {Fairman, Hugh S.},
-  year = {1985},
+  year = 1985,
   journal = {Color Research \& Application},
   volume = {10},
   number = {4},
@@ -1226,7 +1214,7 @@
 @article{Fairman1997,
   title = {How the {{CIE}} 1931 Color-Matching Functions Were Derived from {{Wright-Guild}} Data},
   author = {Fairman, Hugh S. and Brill, Michael H. and Hemmendinger, Henry},
-  year = {1997},
+  year = 1997,
   month = feb,
   journal = {Color Research \& Application},
   volume = {22},
@@ -1243,28 +1231,28 @@
 @misc{FFmpegDevelopers2022,
   title = {{{FFmpeg}}::{{AVColorPrimaries}}},
   author = {{FFmpeg Developers}},
-  year = {2022},
+  year = 2022,
   month = aug
 }
 
 @misc{FFmpegDevelopers2022a,
   title = {{{FFmpeg}}::{{AVColorTransferCharacteristic}}},
   author = {{FFmpeg Developers}},
-  year = {2022},
+  year = 2022,
   month = aug
 }
 
 @misc{FFmpegDevelopers2022b,
   title = {{{FFmpeg}}::{{AVColorSpace}}},
   author = {{FFmpeg Developers}},
-  year = {2022},
+  year = 2022,
   month = aug
 }
 
 @article{Fichet2021,
   title = {An {{OpenEXR Layout}} for {{Spectral Images}}},
   author = {Fichet, A and Pacanowski, R and Wilkie, A},
-  year = {2021},
+  year = 2021,
   journal = {Journal of Computer Graphics Techniques},
   volume = {10},
   number = {3},
@@ -1277,7 +1265,7 @@
 @misc{FiLMiCInc2017,
   title = {{{FiLMiC Pro}} - {{User Manual}} v6 - {{Revision}} 1},
   author = {{FiLMiC Inc}},
-  year = {2017},
+  year = 2017,
   pages = {1--46},
   file = {/Users/kelsolaar/Zotero/storage/SCXMQ6YV/FiLMiC Inc - 2017 - FiLMiC Pro - User Manual v6 - Revision 1.pdf}
 }
@@ -1285,7 +1273,7 @@
 @article{Finlayson2015,
   title = {Color {{Correction Using Root-Polynomial Regression}}},
   author = {Finlayson, Graham D. and MacKiewicz, Michal and Hurlbert, Anya},
-  year = {2015},
+  year = 2015,
   month = may,
   journal = {IEEE Transactions on Image Processing},
   volume = {24},
@@ -1302,13 +1290,13 @@
 @misc{Forsythe2018,
   title = {Private {{Discussion}} with {{Mansencal}}, {{T}}},
   author = {Forsythe, Alex},
-  year = {2018}
+  year = 2018
 }
 
 @misc{Frohlich2017,
   title = {Encoding High Dynamic Range and Wide Color Gamut Imagery},
   author = {Fr{\"o}hlich, Jan},
-  year = {2017},
+  year = 2017,
   publisher = {Universit{\"a}t Stuttgart},
   urldate = {2021-08-07},
   abstract = {In dieser Dissertation wird ein szenischer Bewegtbilddatensatz mit erweitertem Dynamikumfang (High Dynamic Range, HDR) und gro{\ss}em Farbumfang (Wide Color Gamut, WCG) eingef{\"u}hrt und es werden Modelle zur Kodierung von HDR und WCG Bildern vorgestellt. Die objektive und visuelle Evaluation neuer HDR und WCG Bildverarbeitungsalgorithmen, Kompressionsverfahren und Bildwiedergabeger{\"a}te erfordert einen Referenzdatensatz hoher Qualit{\"a}t. Daher wird ein neuer HDR- und WCG-Video-Datensatz mit einem Dynamikumfang von bis zu 18 fotografischen Blenden eingef{\"u}hrt. Er enth{\"a}lt inszenierte und dokumentarische Szenen. Die einzelnen Szenen sind konzipiert um eine Herausforderung f{\"u}r Tone Mapping Operatoren, Gamut Mapping Algorithmen, Kompressionscodecs und HDR und WCG Bildanzeigeger{\"a}te darzustellen. Die Szenen sind mit professionellem Licht, Maske und Filmausstattung aufgenommen. Um einen cinematischen Bildeindruck zu erhalten, werden digitale Filmkameras mit `Super-35 mm' Sensorgr{\"o}{\ss}e verwendet. Der zus{\"a}tzliche Informationsgehalt von HDR- und WCG-Videosignalen erfordert im Vergleich zu Signalen mit herk{\"o}mmlichem Dynamikumfang eine neue und effizientere Signalkodierung. Ein Farbraum f{\"u}r HDR und WCG Video sollte nicht nur effizient quantisieren, sondern wegen der unterschiedlichen Monitoreigenschaften auf der Empf{\"a}ngerseite auch f{\"u}r die Dynamik- und Farbumfangsanpassung geeignet sein. Bisher wurden Methoden f{\"u}r die Quantisierung von HDR Luminanzsignalen vorgeschlagen. Es fehlt jedoch noch ein entsprechendes Modell f{\"u}r Farbdifferenzsignale. Es werden daher zwei neue Farbr{\"a}ume eingef{\"u}hrt, die sich sowohl f{\"u}r die effiziente Kodierung von HDR und WCG Signalen als auch f{\"u}r die Dynamik- und Farbumfangsanpassung eignen. Diese Farbr{\"a}ume werden mit existierenden HDR und WCG Farbsignalkodierungen des aktuellen Stands der Technik verglichen. Die vorgestellten Kodierungsschemata erlauben es, HDR- und WCG-Video mittels drei Farbkan{\"a}len mit 12 Bits tonaler Aufl{\"o}sung zu quantisieren, ohne dass Quantisierungsartefakte sichtbar werden. W{\"a}hrend die Speicherung und {\"U}bertragung von HDR und WCG Video mit 12-Bit Farbtiefe pro Kanal angestrebt wird, unterst{\"u}tzen aktuell verbreitete Dateiformate, Videoschnittstellen und Kompressionscodecs oft nur niedrigere Bittiefen. Um diese existierende Infrastruktur f{\"u}r die HDR Video{\"u}bertragung und -speicherung nutzen zu k{\"o}nnen, wird ein neues bildinhaltsabh{\"a}ngiges Quantisierungsschema eingef{\"u}hrt. Diese Quantisierungsmethode nutzt Bildeigenschaften wie Rauschen und Textur um die ben{\"o}tigte tonale Aufl{\"o}sung f{\"u}r die visuell verlustlose Quantisierung zu sch{\"a}tzen. Die vorgestellte Methode erlaubt es HDR Video mit einer Bittiefe von 10 Bits ohne sichtbare Unterschiede zum Original zu quantisieren und kommt mit weniger Rechenkraft im Vergleich zu aktuellen HDR Bilddifferenzmetriken aus.},
@@ -1321,7 +1309,7 @@
 @misc{Fujifilm2022,
   title = {F-{{Log Data Sheet Ver}}.1.1},
   author = {{Fujifilm}},
-  year = {2022},
+  year = 2022,
   pages = {1--4},
   file = {/Users/kelsolaar/Zotero/storage/738GHAVF/Fujifilm - 2022 - F-Log Data Sheet Ver.1.1.pdf;/Users/kelsolaar/Zotero/storage/VWE47E88/Fujifilm - 2016 - F-Log Data Sheet Ver.1.0.pdf}
 }
@@ -1329,7 +1317,7 @@
 @misc{Fujifilm2022a,
   title = {F-{{Log2 Data Sheet Ver}}.1.0},
   author = {{Fujifilm}},
-  year = {2022},
+  year = 2022,
   pages = {1--4},
   file = {/Users/kelsolaar/Zotero/storage/7S8MSN7N/Fujifilm - 2022 - F-Log2 Data Sheet Ver.1.0.pdf}
 }
@@ -1337,7 +1325,7 @@
 @misc{Fujifilm2024,
   title = {F-{{Log2 C Data Sheet Ver}}.1.0},
   author = {{Fujifilm}},
-  year = {2024},
+  year = 2024,
   urldate = {2024-12-08},
   file = {/Users/kelsolaar/Zotero/storage/M63D257M/Fujifilm - 2024 - F-Log2 C Data Sheet Ver.1.0.pdf}
 }
@@ -1353,7 +1341,7 @@
 @article{Garcia2007,
   title = {Measurement of the Relationship between Perceived and Computed Color Differences},
   author = {Garc{\'i}a, Pedro A. and Huertas, Rafael and Melgosa, Manuel and Cui, Guihua},
-  year = {2007},
+  year = 2007,
   month = jul,
   journal = {Journal of the Optical Society of America A},
   volume = {24},
@@ -1369,7 +1357,7 @@
 @article{Glasser1958a,
   title = {Cube-{{Root Color Coordinate System}}},
   author = {Glasser, L. G. and McKinney, A. H. and Reilly, C. D. and Schnelle, P. D.},
-  year = {1958},
+  year = 1958,
   month = oct,
   journal = {Journal of the Optical Society of America},
   volume = {48},
@@ -1385,7 +1373,7 @@
 @misc{GoPro2016a,
   title = {Gopro.Py},
   author = {{GoPro} and Duiker, Haarm-Pieter and Mansencal, Thomas},
-  year = {2016},
+  year = 2016,
   urldate = {2017-04-12},
   howpublished = {https://github.com/hpd/OpenColorIO-Configs/blob/master/aces\_1.0.3/python/aces\_ocio/colorspaces/gopro.py}
 }
@@ -1395,7 +1383,7 @@
   booktitle = {Proc. {{SPIE}} 2414, {{Device-Independent Color Imaging II}}},
   author = {Guth, S. Lee},
   editor = {Walowit, Eric},
-  year = {1995},
+  year = 1995,
   month = apr,
   volume = {2414},
   pages = {12--26},
@@ -1409,7 +1397,7 @@
 @misc{Halir1998,
   title = {Numerically {{Stable Direct Least Squares Fitting Of Ellipses}}},
   author = {Halir, Radim and Flusser, Jan},
-  year = {1998},
+  year = 1998,
   pages = {1--8},
   doi = {10.1.1.1.7559},
   keywords = {eigenvectors,ellipses,fitting,least squares},
@@ -1421,7 +1409,7 @@
   booktitle = {Image {{Analysis}}},
   author = {Hanbury, Allan},
   editor = {Bigun, Josef and Gustavsson, Tomas},
-  year = {2003},
+  year = 2003,
   pages = {804--811},
   publisher = {Springer Berlin Heidelberg},
   address = {Berlin, Heidelberg},
@@ -1432,7 +1420,7 @@
 @article{Hellwig2020,
   title = {Using {{Gaussian Spectra}} to {{Derive}} a {{Hue-linear Color Space}}},
   author = {Hellwig, Luke and Fairchild, Mark D.},
-  year = {2020},
+  year = 2020,
   journal = {Journal of Perceptual Imaging},
   issn = {2575-8144},
   doi = {10.2352/J.Percept.Imaging.2020.3.2.020401},
@@ -1446,7 +1434,7 @@
   title = {Brightness, Lightness, Colorfulness, and Chroma in {{{\textsc{CIECAM02}}}} and {{{\textsc{CAM16}}}}},
   shorttitle = {Brightness, Lightness, Colorfulness, and Chroma In},
   author = {Hellwig, Luke and Fairchild, Mark D.},
-  year = {2022},
+  year = 2022,
   month = mar,
   journal = {Color Research \& Application},
   pages = {col.22792},
@@ -1462,7 +1450,7 @@
   title = {Extending {{CIECAM02}} and {{CAM16}} for the {{Helmholtz}}--{{Kohlrausch}} Effect},
   shorttitle = {Extending},
   author = {Hellwig, Luke and Stolitzka, Dale and Fairchild, Mark D.},
-  year = {2022},
+  year = 2022,
   month = jun,
   journal = {Color Research \& Application},
   pages = {col.22793},
@@ -1476,7 +1464,7 @@
 @article{Hernandez-Andres1999a,
   title = {Calculating Correlated Color Temperatures across the Entire Gamut of Daylight and Skylight Chromaticities},
   author = {{Hern{\'a}ndez-Andr{\'e}s}, Javier and Lee, Raymond L. and Romero, Javier},
-  year = {1999},
+  year = 1999,
   month = sep,
   journal = {Applied Optics},
   volume = {38},
@@ -1492,7 +1480,7 @@
 @misc{Hewlett-PackardDevelopmentCompany2009a,
   title = {Understanding the {{HP DreamColor LP2480zx DCI-P3 Emulation Color Space}}},
   author = {{Hewlett-Packard Development Company}},
-  year = {2009},
+  year = 2009,
   pages = {1--3},
   file = {/Users/kelsolaar/Zotero/storage/UV8ZBEJ9/Hewlett-Packard Development Company - 2009 - Understanding the HP DreamColor LP2480zx DCI-P3 Emulation Color Space.pdf}
 }
@@ -1505,13 +1493,13 @@
 @misc{Houston2015a,
   title = {Private {{Discussion}} with {{Mansencal}}, {{T}}.},
   author = {Houston, Jim},
-  year = {2015}
+  year = 2015
 }
 
 @article{Huang2015,
   title = {Power Functions Improving the Performance of Color-Difference Formulas},
   author = {Huang, Min and Cui, Guihua and Melgosa, Manuel and {S{\'a}nchez-Mara{\~n}{\'o}n}, Manuel and Li, Changjun and Luo, M. Ronnier and Liu, Haoxue},
-  year = {2015},
+  year = 2015,
   journal = {Optical Society of America},
   volume = {23},
   number = {1},
@@ -1524,7 +1512,7 @@
 @article{Hung1995,
   title = {Determination of Constant {{Hue Loci}} for a {{CRT}} Gamut and Their Predictions Using Color Appearance Spaces},
   author = {Hung, Po-Chieh and Berns, Roy S.},
-  year = {1995},
+  year = 1995,
   month = oct,
   journal = {Color Research \& Application},
   volume = {20},
@@ -1539,7 +1527,7 @@
 @book{Hunt2004b,
   title = {The {{Reproduction}} of {{Colour}}},
   author = {Hunt, R.W.G.},
-  year = {2004},
+  year = 2004,
   month = sep,
   edition = {6},
   publisher = {John Wiley \& Sons, Ltd},
@@ -1553,14 +1541,14 @@
 @misc{HunterLab2008b,
   title = {Hunter {{L}},a,b {{Color Scale}}},
   author = {{HunterLab}},
-  year = {2008},
+  year = 2008,
   file = {/Users/kelsolaar/Zotero/storage/QCSVFR4Y/HunterLab - 2008 - Hunter L,a,b Color Scale.pdf}
 }
 
 @misc{HunterLab2008c,
   title = {Illuminant {{Factors}} in {{Universal Software}} and {{EasyMatch Coatings}}},
   author = {{HunterLab}},
-  year = {2008},
+  year = 2008,
   keywords = {ASTM illuminant},
   file = {/Users/kelsolaar/Zotero/storage/69THKHD4/HunterLab - 2008 - Illuminant Factors in Universal Software and EasyMatch Coatings.pdf}
 }
@@ -1568,7 +1556,7 @@
 @misc{HunterLab2012a,
   title = {Hunter {{Rd}},a,b {{Color Scale}} - {{History}} and {{Application}}},
   author = {{HunterLab}},
-  year = {2012},
+  year = 2012,
   keywords = {a rd,b rd,hunter rd,opponent color scale,rd a b,rdab},
   file = {/Users/kelsolaar/Zotero/storage/IDWM4ZS7/HunterLab - 2012 - Hunter Rd,a,b Color Scale – History and Application.pdf}
 }
@@ -1596,7 +1584,7 @@
 @book{IESComputerCommittee2014a,
   title = {{{IES Standard Format}} for the {{Electronic Transfer}} of {{Spectral Data Electronic Transfer}} of {{Spectral Data}}},
   author = {{IES Computer Committee} and {TM-27-14 Working Group}},
-  year = {2014},
+  year = 2014,
   publisher = {Illuminating Engineering Society},
   isbn = {978-0-87995-295-2},
   file = {/Users/kelsolaar/Zotero/storage/X8T6H9FS/IES Computer Committee, TM-27-14 Working Group - 2014 - IES Standard Format for the Electronic Transfer of Spectral Data Electronic Tran.pdf}
@@ -1605,13 +1593,13 @@
 @misc{ImageEngineering2017,
   title = {{{TE226 V2}} Data Sheet},
   author = {{Image Engineering}},
-  year = {2017}
+  year = 2017
 }
 
 @misc{InternationalColorConsortium2010,
   title = {Specification {{ICC}}.1:2010 ({{Profile}} Version 4.3.0.0)},
   author = {{International Color Consortium}},
-  year = {2010},
+  year = 2010,
   pages = {1--130},
   file = {/Users/kelsolaar/Zotero/storage/HJPQMS5T/International Color Consortium - 2010 - Specification ICC.12010.pdf}
 }
@@ -1619,7 +1607,7 @@
 @misc{InternationalElectrotechnicalCommission1999a,
   title = {{{IEC}} 61966-2-1:1999 - {{Multimedia}} Systems and Equipment - {{Colour}} Measurement and Management - {{Part}} 2-1: {{Colour}} Management - {{Default RGB}} Colour Space - {{sRGB}}},
   author = {{International Electrotechnical Commission}},
-  year = {1999},
+  year = 1999,
   pages = {51},
   file = {/Users/kelsolaar/Zotero/storage/CHHY5VTL/International Electrotechnical Commission - 1999 - IEC 61966-2-11999 - Multimedia systems and equipment - Colour measurement and managem.pdf;/Users/kelsolaar/Zotero/storage/ETN7B9LR/iec61966-2-1-amd1 ed1.0 en.pdf;/Users/kelsolaar/Zotero/storage/NXEIX9SZ/iec61966-2-1 ed1.0 b.pdf}
 }
@@ -1627,49 +1615,49 @@
 @misc{InternationalOrganizationforStandardization2002,
   title = {{{INTERNATIONAL STANDARD ISO}} 7589-2002 - {{Photography}} - {{Illuminants}} for Sensitometry - {{Specifications}} for Daylight, Incandescent Tungsten and Printer},
   author = {{International Organization for Standardization}},
-  year = {2002},
+  year = 2002,
   file = {/Users/kelsolaar/Zotero/storage/AP7R4ZUK/ISO - 2002 - INTERNATIONAL STANDARD 7589-2002 - Photography - Illuminants for sensitometry - Specifications for daylight, incandescent t.pdf}
 }
 
 @misc{InternationalOrganizationforStandardization2012,
   title = {{{INTERNATIONAL STANDARD ISO}} 17321-1 - {{Graphic}} Technology and Photography - {{Colour}} Characterisation of Digital Still Cameras ({{DSCs}}) - {{Part}} 1: {{Stimuli}}, Metrology and Test Procedures},
   author = {{International Organization for Standardization}},
-  year = {2012},
+  year = 2012,
   file = {/Users/kelsolaar/Zotero/storage/2G448HML/tabula-ISO 17321-1-2012.zip;/Users/kelsolaar/Zotero/storage/5U9QAXM3/International Organization for Standardization - 2012 - INTERNATIONAL STANDARD ISO 17321-1 - Graphic techn.pdf}
 }
 
 @misc{InternationalOrganizationforStandardization2013,
   title = {{{INTERNATIONAL STANDARD ISO}}/{{IEC}} 23001-8 - {{Information}} Technology - {{MPEG}} Systems Technologies - {{Part}} 8: {{Coding-independent}} Code Points},
   author = {{International Organization for Standardization}},
-  year = {2013},
+  year = 2013,
   file = {/Users/kelsolaar/Zotero/storage/625YTALW/International Organization for Standardization - 2013 - INTERNATIONAL STANDARD ISOIEC 23001-8 - Informati.pdf}
 }
 
 @misc{InternationalOrganizationforStandardization2020,
   title = {{{INTERNATIONAL STANDARD ISO}}/{{IEC}} 14496-10 - {{Information}} Technology - {{Coding}} of Audio-Visual Objects - {{Part}} 10: {{Advanced}} Video Coding},
   author = {{International Organization for Standardization}},
-  year = {2020},
+  year = 2020,
   file = {/Users/kelsolaar/Zotero/storage/EWFPAHUM/International Organization for Standardization - 2020 - INTERNATIONAL STANDARD ISOIEC 14496-10 - Informat.pdf}
 }
 
 @misc{InternationalOrganizationforStandardization2021,
   title = {{{INTERNATIONAL STANDARD ISO}}/{{IEC}} 23091-2 - {{Information}} Technology - {{Coding-}} Independent Code Points - {{Part}} 2: {{Video}}},
   author = {{International Organization for Standardization}},
-  year = {2021},
+  year = 2021,
   file = {/Users/kelsolaar/Zotero/storage/L2F8CBGK/International Organization for Standardization - 2021 - INTERNATIONAL STANDARD ISOIEC 23091-2 - Informati.pdf}
 }
 
 @misc{InternationalTelecommunicationUnion1998,
   title = {Recommendation {{ITU-R BT}}.1361 - {{Worldwide}} Unified Colorimetry and Related Characteristics of Future Television and Imaging Systems},
   author = {{International Telecommunication Union}},
-  year = {1998},
+  year = 1998,
   pages = {1--32}
 }
 
 @misc{InternationalTelecommunicationUnion1998a,
   title = {Recommendation {{ITU-R BT}}.470-6 - {{CONVENTIONAL TELEVISION SYSTEMS}}},
   author = {{International Telecommunication Union}},
-  year = {1998},
+  year = 1998,
   pages = {1--36},
   file = {/Users/kelsolaar/Zotero/storage/3D28CU78/International Telecommunication Union - 1998 - Recommendation ITU-R BT.470-6 - CONVENTIONAL TELEVISION SYSTEMS.pdf}
 }
@@ -1677,28 +1665,28 @@
 @misc{InternationalTelecommunicationUnion2011e,
   title = {Recommendation {{ITU-T T}}.871 - {{Information}} Technology - {{Digital}} Compression and Coding of Continuous-Tone Still Images: {{JPEG File Interchange Format}} ({{JFIF}})},
   author = {{International Telecommunication Union}},
-  year = {2011},
+  year = 2011,
   file = {/Users/kelsolaar/Zotero/storage/82WBLIX8/International Telecommunication Union - 2011 - Recommendation ITU-T T.871 - Information technology – Digital compression and coding of.pdf}
 }
 
 @misc{InternationalTelecommunicationUnion2011f,
   title = {Recommendation {{ITU-R BT}}.601-7 - {{Studio}} Encoding Parameters of Digital Television for Standard 4:3 and Wide-Screen 16:9 Aspect Ratios},
   author = {{International Telecommunication Union}},
-  year = {2011},
+  year = 2011,
   file = {/Users/kelsolaar/Zotero/storage/B4D8LX8W/International Telecommunication Union - 2011 - Recommendation ITU-R BT.601-7 - Studio encoding parameters of digital television for stan.pdf}
 }
 
 @misc{InternationalTelecommunicationUnion2011h,
   title = {Recommendation {{ITU-R BT}}.1886 - {{Reference}} Electro-Optical Transfer Function for Flat Panel Displays Used in {{HDTV}} Studio Production {{BT Series Broadcasting}} Service},
   author = {{International Telecommunication Union}},
-  year = {2011},
+  year = 2011,
   file = {/Users/kelsolaar/Zotero/storage/D39N696V/International Telecommunication Union - 2011 - Recommendation ITU-R BT.1886 - Reference electro-optical transfer function for flat panel.pdf}
 }
 
 @misc{InternationalTelecommunicationUnion2015,
   title = {Report {{ITU-R BT}}.2246-4 - {{The}} Present State of Ultra-High Definition Television {{BT Series Broadcasting}} Service},
   author = {{International Telecommunication Union}},
-  year = {2015},
+  year = 2015,
   volume = {5},
   pages = {1--92},
   file = {/Users/kelsolaar/Zotero/storage/EGF7LGRS/International Telecommunication Union - 2015 - Report ITU-R BT.2246-4 - The present state of ultra-high definition television BT Series.pdf}
@@ -1707,7 +1695,7 @@
 @misc{InternationalTelecommunicationUnion2015h,
   title = {Recommendation {{ITU-R BT}}.2020 - {{Parameter}} Values for Ultra-High Definition Television Systems for Production and International Programme Exchange},
   author = {{International Telecommunication Union}},
-  year = {2015},
+  year = 2015,
   pages = {1--8},
   abstract = {The role of the Radiocommunication Sector is to ensure the rational, equitable, efficient and economical use of the radio-frequency spectrum by all radiocommunication services, including satellite services, and carry out studies without limit of frequency range on the basis of which Recommendations are adopted. The regulatory and policy functions of the Radiocommunication Sector are performed by World and Regional Radiocommunication Conferences and Radiocommunication Assemblies supported by Study Groups},
   file = {/Users/kelsolaar/Zotero/storage/XI25M4LV/International Telecommunication Union - 2015 - Recommendation ITU-R BT.2020 - Parameter values for ultra-high definition television syst.pdf}
@@ -1716,7 +1704,7 @@
 @misc{InternationalTelecommunicationUnion2015i,
   title = {Recommendation {{ITU-R BT}}.709-6 - {{Parameter}} Values for the {{HDTV}} Standards for Production and International Programme Exchange {{BT Series Broadcasting}} Service},
   author = {{International Telecommunication Union}},
-  year = {2015},
+  year = 2015,
   pages = {1--32},
   file = {/Users/kelsolaar/Zotero/storage/QRF7G7KP/International Telecommunication Union - 2015 - Recommendation ITU-R BT.709-6 - Parameter values for the HDTV standards for production an.pdf}
 }
@@ -1724,21 +1712,21 @@
 @misc{InternationalTelecommunicationUnion2017,
   title = {Recommendation {{ITU-R BT}}.2100-1 - {{Image}} Parameter Values for High Dynamic Range Television for Use in Production and International Programme Exchange},
   author = {{International Telecommunication Union}},
-  year = {2017},
+  year = 2017,
   file = {/Users/kelsolaar/Zotero/storage/WN4WGATP/International Telecommunication Union - 2017 - Recommendation ITU-R BT.2100-1 - Image parameter values for high dynamic range television.pdf}
 }
 
 @misc{InternationalTelecommunicationUnion2018,
   title = {Recommendation {{ITU-R BT}}.2100-2 - {{Image}} Parameter Values for High Dynamic Range Television for Use in Production and International Programme Exchange},
   author = {{International Telecommunication Union}},
-  year = {2018},
+  year = 2018,
   file = {/Users/kelsolaar/Zotero/storage/KUDHJGXI/International Telecommunication Union - 2018 - Recommendation ITU-R BT.2100-2 - Image parameter values for high dynamic range television.pdf}
 }
 
 @misc{InternationalTelecommunicationUnion2019,
   title = {Recommendation {{ITU-R BT}}.2124-0 - {{Objective}} Metric for the Assessment of the Potential Visibility of Colour Differences in Television},
   author = {{International Telecommunication Union}},
-  year = {2019},
+  year = 2019,
   pages = {1--36},
   file = {/Users/kelsolaar/Zotero/storage/TZWUUUFT/International Telecommunication Union - 2019 - Recommendation ITU-R BT.2124-0 - Objective metric .pdf}
 }
@@ -1746,7 +1734,7 @@
 @misc{InternationalTelecommunicationUnion2021,
   title = {Recommendation {{ITU-T H}}.273 - {{Coding-independent}} Code Points for Video Signal Type Identification},
   author = {{International Telecommunication Union}},
-  year = {2021},
+  year = 2021,
   file = {/Users/kelsolaar/Zotero/storage/3BXLP6V5/International Telecommunication Union - 2021 - Recommendation ITU-T H.273 - Coding-independent co.pdf}
 }
 
@@ -1754,7 +1742,7 @@
   ids = {Jakob},
   title = {A {{Low}}-{{Dimensional Function Space}} for {{Efficient Spectral Upsampling}}},
   author = {Jakob, Wenzel and Hanika, Johannes},
-  year = {2019},
+  year = 2019,
   month = may,
   journal = {Computer Graphics Forum},
   volume = {38},
@@ -1771,7 +1759,7 @@
   title = {What Is the Space of Spectral Sensitivity Functions for Digital Color Cameras?},
   booktitle = {2013 {{IEEE Workshop}} on {{Applications}} of {{Computer Vision}} ({{WACV}})},
   author = {Jiang, Jun and Liu, Dengyu and Gu, Jinwei and Susstrunk, Sabine},
-  year = {2013},
+  year = 2013,
   month = jan,
   pages = {168--179},
   publisher = {IEEE},
@@ -1785,7 +1773,7 @@
 @article{Kang2002a,
   title = {Design of Advanced Color: {{Temperature}} Control System for {{HDTV}} Applications},
   author = {Kang, Bongsoon and Moon, Ohak and Hong, Changhee and Lee, Honam and Cho, Bonghwan and Kim, Youngsun},
-  year = {2002},
+  year = 2002,
   journal = {Journal of the Korean Physical Society},
   volume = {41},
   number = {6},
@@ -1798,7 +1786,7 @@
 @misc{Kienzle2011a,
   title = {Refl1d.Numpyerrors - {{Refl1D}} v0.6.19 Documentation},
   author = {Kienzle, Paul and Patel, Nikunj and Krycka, James},
-  year = {2011},
+  year = 2011,
   urldate = {2015-01-30},
   howpublished = {http://www.reflectometry.org/danse/docs/refl1d/\_modules/refl1d/numpyerrors.html}
 }
@@ -1806,7 +1794,7 @@
 @article{Kim2009,
   title = {Modeling {{Human Color Perception}} under {{Extended Luminance Levels}}},
   author = {Kim, Mh and Weyrich, T and Kautz, J},
-  year = {2009},
+  year = 2009,
   journal = {ACM Transactions on Graphics},
   volume = {28},
   number = {3},
@@ -1822,7 +1810,7 @@
 @misc{Kirk2006,
   title = {Truelight {{Software Library}} 2.0},
   author = {Kirk, Richard},
-  year = {2006},
+  year = 2006,
   urldate = {2017-07-08},
   file = {/Users/kelsolaar/Zotero/storage/RAPRQZ32/Kirk - 2006 - Truelight Software Library 2.0.pdf}
 }
@@ -1830,7 +1818,7 @@
 @article{Kirk2019,
   title = {Chromaticity Coordinates for Graphic Arts Based on {{CIE}} 2006 {{LMS}} with Even Spacing of {{Munsell}} Colours},
   author = {Kirk, Richard A.},
-  year = {2019},
+  year = 2019,
   month = oct,
   journal = {Color and Imaging Conference},
   volume = {27},
@@ -1846,7 +1834,7 @@
   title = {{{ProLab}}: Perceptually Uniform Projective Colour Coordinate System},
   shorttitle = {{{ProLab}}},
   author = {Konovalenko, Ivan A. and Smagina, Anna A. and Nikolaev, Dmitry P. and Nikolaev, Petr P.},
-  year = {2021},
+  year = 2021,
   month = jan,
   journal = {arXiv:2012.07653 [cs]},
   eprint = {2012.07653},
@@ -1862,13 +1850,13 @@
 @misc{Konovalenko2021a,
   title = {{{proLab}}\_param.m},
   author = {Konovalenko, Ivan A.},
-  year = {2021}
+  year = 2021
 }
 
 @article{Krystek1985b,
   title = {An Algorithm to Calculate Correlated Colour Temperature},
   author = {Krystek, M},
-  year = {1985},
+  year = 1985,
   journal = {Color Research \& Application},
   volume = {10},
   number = {1},
@@ -1882,7 +1870,7 @@
 @misc{Laurent2012a,
   title = {Reproducibility of Python Pseudo-Random Numbers across Systems and Versions?},
   author = {{Laurent}},
-  year = {2012},
+  year = 2012,
   urldate = {2015-01-20},
   howpublished = {http://stackoverflow.com/questions/8786084/reproducibility-of-python-pseudo-random-numbers-across-systems-and-versions}
 }
@@ -1890,14 +1878,14 @@
 @misc{LeicaCameraAG2022,
   title = {Leica {{L-Log Reference Manual}}},
   author = {{Leica Camera AG}},
-  year = {2022},
+  year = 2022,
   file = {/Users/kelsolaar/Zotero/storage/G44PWG9J/Leica L-Log Reference Manual.pdf}
 }
 
 @article{Li2002a,
   title = {{{CMC}} 2000 Chromatic Adaptation Transform: {{CMCCAT2000}}},
   author = {Li, Changjun and Luo, Ming Ronnier and Rigg, Bryan and Hunt, Robert W. G.},
-  year = {2002},
+  year = 2002,
   month = feb,
   journal = {Color Research \& Application},
   volume = {27},
@@ -1914,14 +1902,14 @@
 @misc{Li2007e,
   title = {The {{Problem}} with {{CAT02}} and {{Its Correction}}},
   author = {Li, Changjun and Perales, Esther and Luo, Ming Ronnier and {Martinez-verdu}, Francisco},
-  year = {2007},
+  year = 2007,
   file = {/Users/kelsolaar/Zotero/storage/AW3KVZ5D/Li et al. - 2007 - The Problem with CAT02 and Its Correction.pdf}
 }
 
 @article{Li2017,
   title = {Comprehensive Color Solutions: {{CAM16}}, {{CAT16}}, and {{CAM16-UCS}}},
   author = {Li, Changjun and Li, Zhiqiang and Wang, Zhifeng and Xu, Yang and Luo, Ming Ronnier and Cui, Guihua and Melgosa, Manuel and Brill, Michael H and Pointer, Michael},
-  year = {2017},
+  year = 2017,
   month = dec,
   journal = {Color Research \& Application},
   volume = {42},
@@ -1936,7 +1924,7 @@
 @article{Li2024,
   title = {Simple Color Appearance Model ({{sCAM}}) Based on Simple Uniform Color Space ({{sUCS}})},
   author = {Li, M. and Luo, M. R.},
-  year = {2024},
+  year = 2024,
   month = jan,
   journal = {Optics Express},
   volume = {32},
@@ -1953,14 +1941,14 @@
 @misc{Li2025,
   title = {One {{Step CAT16 Chromatic Adaptation Transform}}},
   author = {Li, Molin},
-  year = {2025},
+  year = 2025,
   month = jul
 }
 
 @misc{Lindbloom2003c,
   title = {Delta {{E}} ({{CIE}} 1976)},
   author = {Lindbloom, Bruce},
-  year = {2003},
+  year = 2003,
   urldate = {2014-02-24},
   howpublished = {http://brucelindbloom.com/Eqn\_DeltaE\_CIE76.html}
 }
@@ -1968,7 +1956,7 @@
 @misc{Lindbloom2003e,
   title = {{{XYZ}} to {{xyY}}},
   author = {Lindbloom, Bruce},
-  year = {2003},
+  year = 2003,
   urldate = {2014-02-24},
   howpublished = {http://www.brucelindbloom.com/Eqn\_XYZ\_to\_xyY.html}
 }
@@ -1976,7 +1964,7 @@
 @misc{Lindbloom2007a,
   title = {Spectral {{Power Distribution}} of a {{CIE D-Illuminant}}},
   author = {Lindbloom, Bruce},
-  year = {2007},
+  year = 2007,
   urldate = {2014-04-05},
   howpublished = {http://www.brucelindbloom.com/Eqn\_DIlluminant.html}
 }
@@ -1984,7 +1972,7 @@
 @misc{Lindbloom2009d,
   title = {{{xyY}} to {{XYZ}}},
   author = {Lindbloom, Bruce},
-  year = {2009},
+  year = 2009,
   urldate = {2014-02-24},
   howpublished = {http://www.brucelindbloom.com/Eqn\_xyY\_to\_XYZ.html}
 }
@@ -1992,7 +1980,7 @@
 @misc{Lindbloom2009f,
   title = {Delta {{E}} ({{CMC}})},
   author = {Lindbloom, Bruce},
-  year = {2009},
+  year = 2009,
   urldate = {2014-02-24},
   howpublished = {http://brucelindbloom.com/Eqn\_DeltaE\_CMC.html}
 }
@@ -2000,7 +1988,7 @@
 @misc{Lindbloom2009g,
   title = {Chromatic {{Adaptation}}},
   author = {Lindbloom, Bruce},
-  year = {2009},
+  year = 2009,
   urldate = {2014-02-24},
   howpublished = {http://brucelindbloom.com/Eqn\_ChromAdapt.html}
 }
@@ -2008,7 +1996,7 @@
 @misc{Lindbloom2011a,
   title = {Delta {{E}} ({{CIE}} 1994)},
   author = {Lindbloom, Bruce},
-  year = {2011},
+  year = 2011,
   urldate = {2014-02-24},
   howpublished = {http://brucelindbloom.com/Eqn\_DeltaE\_CIE94.html}
 }
@@ -2016,7 +2004,7 @@
 @misc{Lindbloom2014a,
   title = {{{RGB Working Space Information}}},
   author = {Lindbloom, Bruce},
-  year = {2014},
+  year = 2014,
   urldate = {2014-04-11},
   howpublished = {http://www.brucelindbloom.com/WorkingSpaceInfo.html}
 }
@@ -2024,7 +2012,7 @@
 @misc{Lindbloom2015,
   title = {About the {{Lab Gamut}}},
   author = {Lindbloom, Bruce},
-  year = {2015},
+  year = 2015,
   urldate = {2018-08-20},
   howpublished = {http://www.brucelindbloom.com/LabGamutDisplayHelp.html}
 }
@@ -2032,7 +2020,7 @@
 @article{Lu2016c,
   title = {{{ITP Colour Space}} and {{Its Compression Performance}} for {{High Dynamic Range}} and {{Wide Colour Gamut Video Distribution}}},
   author = {Lu, Taoran and Pu, Fangjun and Yin, Peng and Chen, Tao and Husak, Walt and Pytlarz, Jaclyn and Atkins, Robin and Froehlich, Jan and Su, Guan-Ming},
-  year = {2016},
+  year = 2016,
   journal = {ZTE Communications},
   volume = {14},
   number = {1},
@@ -2045,7 +2033,7 @@
 @article{Luo1996b,
   title = {The {{LLAB}} (l:C) Colour Model},
   author = {Luo, Ming Ronnier and Lo, Mei-Chun and Kuo, Wen-Guey},
-  year = {1996},
+  year = 1996,
   month = dec,
   journal = {Color Research \& Application},
   volume = {21},
@@ -2062,14 +2050,14 @@
   title = {Two {{Unsolved Issues}} in {{Colour Management}} - {{Colour Appearance}} and {{Gamut Mapping}}},
   booktitle = {Conference: 5th {{International Conference}} on {{High Technology}}: {{Imaging Science}} and {{Technology}} -- {{Evolution}} \& {{Promise}}},
   author = {Luo, Ming Ronnier and Morovic, J{\'a}n},
-  year = {1996},
+  year = 1996,
   pages = {136--147}
 }
 
 @article{Luo1999,
   title = {Corresponding-Colour Datasets},
   author = {Luo, M. Ronnier and Rhodes, Peter A.},
-  year = {1999},
+  year = 1999,
   month = aug,
   journal = {Color Research \& Application},
   volume = {24},
@@ -2084,7 +2072,7 @@
 @article{Luo2006b,
   title = {Uniform Colour Spaces Based on {{CIECAM02}} Colour Appearance Model},
   author = {Luo, M. Ronnier and Cui, Guihua and Li, Changjun},
-  year = {2006},
+  year = 2006,
   month = aug,
   journal = {Color Research \& Application},
   volume = {31},
@@ -2103,7 +2091,7 @@
   booktitle = {Advanced {{Color Image Processing}} and {{Analysis}}},
   author = {Luo, Ming Ronnier and Li, Changjun},
   editor = {{Fernandez-Maloigne}, Christine},
-  year = {2013},
+  year = 2013,
   pages = {19--58},
   publisher = {Springer New York},
   address = {New York, NY},
@@ -2118,7 +2106,7 @@
   title = {The New Preferred Memory Color ( {{{\textsc{PMC}}}} ) Chart},
   shorttitle = {The New Preferred Memory Color (},
   author = {Luo, Ming Ronnier},
-  year = {2024},
+  year = 2024,
   month = may,
   journal = {Color Research \& Application},
   pages = {col.22940},
@@ -2133,7 +2121,7 @@
 @article{MacAdam1935a,
   title = {Maximum {{Visual Efficiency}} of {{Colored Materials}}},
   author = {MacAdam, David L.},
-  year = {1935},
+  year = 1935,
   month = nov,
   journal = {Journal of the Optical Society of America},
   volume = {25},
@@ -2148,7 +2136,7 @@
 @article{Macadam1942,
   title = {Visual {{Sensitivities}} to {{Color Differences}} in {{Daylight}}},
   author = {Macadam, David L.},
-  year = {1942},
+  year = 1942,
   journal = {Journal of the Optical Society of America},
   volume = {32},
   number = {5},
@@ -2163,7 +2151,7 @@
 @article{Machado2009,
   title = {A {{Physiologically-based Model}} for {{Simulation}} of {{Color Vision Deficiency}}},
   author = {Machado, G.M. and Oliveira, M.M. and Fernandes, L.},
-  year = {2009},
+  year = 2009,
   month = nov,
   journal = {IEEE Transactions on Visualization and Computer Graphics},
   volume = {15},
@@ -2180,7 +2168,7 @@
 @misc{Machado2010a,
   title = {A Model for Simulation of Color Vision Deficiency and a Color Contrast Enhancement Technique for Dichromats.},
   author = {Machado, Gustavo Mello},
-  year = {2010},
+  year = 2010,
   pages = {1--94},
   keywords = {Anomalous Trichromacy,Color Perception,Color Vision Deficiency,Color-Contrast Enhancement,Dichromacy,Models of Color Vision,Recoloring Algorithm,Simulation of Color Vision Deficiency},
   file = {/Users/kelsolaar/Zotero/storage/FH4PP3LV/Machado - 2010 - A model for simulation of color vision deficiency and a color contrast enhancement technique for dichromats.pdf}
@@ -2189,7 +2177,7 @@
 @article{Mallett2019,
   title = {Spectral {{Primary Decomposition}} for {{Rendering}} with {{sRGB Reflectance}}},
   author = {Mallett, Ian and Yuksel, Cem},
-  year = {2019},
+  year = 2019,
   journal = {Eurographics Symposium on Rendering - DL-only and Industry Track},
   pages = {7 pages},
   publisher = {The Eurographics Association},
@@ -2205,14 +2193,14 @@
 @misc{Malvar2003,
   title = {{{YCoCg-R}}: {{A Color Space}} with {{RGB Reversibility}} and {{Low Dynamic Range}}},
   author = {Malvar, Henrique and Sullivan, Gary},
-  year = {2003},
+  year = 2003,
   file = {/Users/kelsolaar/Zotero/storage/3ZQJ76UA/Malvar, Sullivan - 2003 - YCoCg-R A Color Space with RGB Reversibility and Low Dynamic Range.pdf}
 }
 
 @misc{Mansencal2015d,
   title = {{{RED Colourspaces Derivation}}},
   author = {Mansencal, Thomas},
-  year = {2015},
+  year = 2015,
   urldate = {2015-05-20},
   howpublished = {https://www.colour-science.org/posts/red-colourspaces-derivation}
 }
@@ -2220,7 +2208,7 @@
 @misc{Mansencal2018,
   title = {How Is the Visible Gamut Bounded?},
   author = {Mansencal, Thomas},
-  year = {2018},
+  year = 2018,
   urldate = {2018-08-19},
   howpublished = {https://stackoverflow.com/a/48396021/931625}
 }
@@ -2228,7 +2216,7 @@
 @misc{Mansencal2019,
   title = {Colour - {{Datasets}}},
   author = {Mansencal, Thomas},
-  year = {2019},
+  year = 2019,
   doi = {10.5281/zenodo.3362520}
 }
 
@@ -2245,7 +2233,7 @@
 @article{Martinez-Verdu2007,
   title = {Computation and Visualization of the {{MacAdam}} Limits for Any Lightness, Hue Angle, and Light Source},
   author = {{Mart{\'i}nez-Verd{\'u}}, Francisco and Perales, Esther and Chorro, Elisabet and {de Fez}, Dolores and Viqueira, Valent{\'i}n and Gilabert, Eduardo},
-  year = {2007},
+  year = 2007,
   month = jun,
   journal = {Journal of the Optical Society of America A},
   volume = {24},
@@ -2261,14 +2249,14 @@
 @misc{Melgosa2013b,
   title = {{{CIE}} / {{ISO}} New Standard: {{CIEDE2000}}},
   author = {Melgosa, Manuel},
-  year = {2013},
+  year = 2013,
   file = {/Users/kelsolaar/Zotero/storage/GMJRKCQV/Melgosa - 2013 - CIE ISO new standard CIEDE2000.pdf}
 }
 
 @article{Meng2015c,
   title = {Physically {{Meaningful Rendering}} Using {{Tristimulus Colours}}},
   author = {Meng, Johannes and Simon, Florian and Hanika, Johannes and Dachsbacher, Carsten},
-  year = {2015},
+  year = 2015,
   month = jul,
   journal = {Computer Graphics Forum},
   volume = {34},
@@ -2282,7 +2270,7 @@
 @misc{Miller2014a,
   title = {A {{Perceptual EOTF}} for {{Extended Dynamic Range Imagery}}},
   author = {Miller, Scott},
-  year = {2014},
+  year = 2014,
   pages = {1--17},
   file = {/Users/kelsolaar/Zotero/storage/E3D2ZNEY/Miller - 2014 - A Perceptual EOTF for Extended Dynamic Range Imagery.pdf}
 }
@@ -2290,7 +2278,7 @@
 @article{Mokrzycki2011,
   title = {Color Difference {{Delta E}} - {{A}} Survey},
   author = {Mokrzycki, Wojciech and Tatol, Maciej},
-  year = {2011},
+  year = 2011,
   month = apr,
   journal = {Machine Graphics and Vision},
   volume = {20},
@@ -2304,7 +2292,7 @@
 @article{Moroney2003,
   title = {A {{Radial Sampling}} of the {{OSA Uniform Color Scales}}},
   author = {Moroney, Nathan},
-  year = {2003},
+  year = 2003,
   journal = {Color and Imaging Conference},
   volume = {2003},
   number = {1},
@@ -2323,7 +2311,7 @@
 @article{Moroneya,
   title = {The {{CIECAM02}} Color Appearance Model},
   author = {Moroney, Nathan and Fairchild, Mark D. and Hunt, Robert W. G. and Li, Changjun and Luo, Ming Ronnier and Newman, Todd},
-  year = {2002},
+  year = 2002,
   journal = {Color and Imaging Conference},
   number = {1},
   pages = {23--27},
@@ -2335,7 +2323,7 @@
 @article{Morovic2000,
   title = {Calculating Medium and Image Gamut Boundaries for Gamut Mapping},
   author = {Morovi{\v c}, J{\'a}n and Luo, M. Ronnier},
-  year = {2000},
+  year = 2000,
   journal = {Color Research and Application},
   volume = {25},
   number = {6},
@@ -2362,20 +2350,20 @@
 @misc{NationalElectricalManufacturersAssociation2004b,
   title = {Digital {{Imaging}} and {{Communications}} in {{Medicine}} ({{DICOM}}) {{Part}} 14: {{Grayscale Standard Display Function}}},
   author = {{National Electrical Manufacturers Association}},
-  year = {2004},
+  year = 2004,
   file = {/Users/kelsolaar/Zotero/storage/RNJQ44Y2/National Electrical Manufacturers Association - 2004 - Digital Imaging and Communications in Medicine (DICOM) Part 14 Grayscale Standard.pdf}
 }
 
 @misc{Nattress2016a,
   title = {Private {{Discussion}} with {{Shaw}}, {{N}}.},
   author = {Nattress, Graeme},
-  year = {2016}
+  year = 2016
 }
 
 @article{Nayatani1995a,
   title = {Lightness Dependency of Chroma Scales of a Nonlinear Color-Appearance Model and Its Latest Formulation},
   author = {Nayatani, Yoshinobu and Sobagaki, Hiroaki and Yano, Kenjiro Hashimoto Tadashi},
-  year = {1995},
+  year = 1995,
   month = jun,
   journal = {Color Research \& Application},
   volume = {20},
@@ -2391,7 +2379,7 @@
 @article{Nayatani1997,
   title = {Simple Estimation Methods for the {{Helmholtz}}---{{Kohlrausch}} Effect},
   author = {Nayatani, Yoshinobu},
-  year = {1997},
+  year = 1997,
   journal = {Color Research \& Application},
   volume = {22},
   number = {6},
@@ -2409,7 +2397,7 @@
 @article{Newhall1943a,
   title = {Final {{Report}} of the {{OSA Subcommittee}} on the {{Spacing}} of the {{Munsell Colors}}},
   author = {Newhall, Sidney M. and Nickerson, Dorothy and Judd, Deane B.},
-  year = {1943},
+  year = 1943,
   month = jul,
   journal = {Journal of the Optical Society of America},
   volume = {33},
@@ -2425,7 +2413,7 @@
 @misc{Nikon2018,
   title = {N-{{Log Specification Document}} - {{Version}} 1.0.0},
   author = {{Nikon}},
-  year = {2018},
+  year = 2018,
   pages = {1--5},
   urldate = {2019-09-09},
   file = {/Users/kelsolaar/Zotero/storage/B9YHNF6B/Nikon - 2018 - N-Log Specification Document - Version 1.0.0.pdf}
@@ -2434,7 +2422,7 @@
 @article{Ohno2005,
   title = {Spectral Design Considerations for White {{LED}} Color Rendering},
   author = {Ohno, Yoshi},
-  year = {2005},
+  year = 2005,
   journal = {Optical Engineering},
   volume = {44},
   number = {11},
@@ -2449,20 +2437,20 @@
 @misc{Ohno2008a,
   title = {{{NIST CQS}} Simulation},
   author = {Ohno, Yoshiro and Davis, Wendy},
-  year = {2008},
+  year = 2008,
   file = {/Users/kelsolaar/Zotero/storage/C99BIK93/Ohno, Davis - 2008 - NIST CQS simulation 7.4.xls}
 }
 
 @misc{Ohno2013,
   title = {{{NIST CQS}} Simulation},
   author = {Ohno, Yoshiro and Davis, Wendy},
-  year = {2013}
+  year = 2013
 }
 
 @article{Ohno2014a,
   title = {Practical {{Use}} and {{Calculation}} of {{CCT}} and {{Duv}}},
   author = {Ohno, Yoshiro},
-  year = {2014},
+  year = 2014,
   month = jan,
   journal = {LEUKOS},
   volume = {10},
@@ -2478,14 +2466,14 @@
 @misc{Ohta1997a,
   title = {The Basis of Color Reproduction Engineering},
   author = {Ohta, N.},
-  year = {1997}
+  year = 1997
 }
 
 @article{Otsu2018,
   title = {Reproducing {{Spectral Reflectances From Tristimulus Colours}}},
   shorttitle = {Reproducing {{Spectral Reflectances From Tristimulus Colours}}},
   author = {Otsu, H. and Yamamoto, M. and Hachisuka, T.},
-  year = {2018},
+  year = 2018,
   month = sep,
   journal = {Computer Graphics Forum},
   volume = {37},
@@ -2502,7 +2490,7 @@
 @misc{Ottosson2020,
   title = {A Perceptual Color Space for Image Processing},
   author = {Ottosson, Bj{\"o}rn},
-  year = {2020},
+  year = 2020,
   urldate = {2020-12-24},
   howpublished = {https://bottosson.github.io/posts/oklab/}
 }
@@ -2510,7 +2498,7 @@
 @misc{Panasonic2014a,
   title = {{{VARICAM V-Log}}/{{V-Gamut}}},
   author = {{Panasonic}},
-  year = {2014},
+  year = 2014,
   pages = {1--7},
   file = {/Users/kelsolaar/Zotero/storage/V3PP87S3/Panasonic - 2014 - VARICAM V-LogV-Gamut.pdf}
 }
@@ -2518,21 +2506,21 @@
 @misc{PLASANorthAmerica2015,
   title = {{{ANSI E1}}.54 - 2015 - {{PLASA Standard}} for {{Color Communication}} in {{Entertainment Lighting}}},
   author = {{PLASA North America}},
-  year = {2015},
+  year = 2015,
   file = {/Users/kelsolaar/Zotero/storage/YVJ4LPZA/PLASA North America - 2015 - ANSI E1.54 - 2015 - PLASA Standard for Color Commu.pdf}
 }
 
 @misc{Pointer1980a,
   title = {Pointer's {{Gamut Data}}},
   author = {Pointer, Michael R.},
-  year = {1980},
+  year = 1980,
   file = {/Users/kelsolaar/Zotero/storage/ZW4DDJU4/Pointer - 1980 - Pointer's Gamut Data.xls}
 }
 
 @article{Ragoo2021,
   title = {Optimising a {{Euclidean Colour Space Transform}} for {{Colour Order}} and {{Perceptual Uniformity}}},
   author = {Ragoo, Luvin Munish and Farup, Ivar},
-  year = {2021},
+  year = 2021,
   month = nov,
   journal = {Color and Imaging Conference},
   volume = {29},
@@ -2547,14 +2535,14 @@
 @misc{Rakotoarison2017,
   title = {Bunch},
   author = {Rakotoarison, Herilalaina},
-  year = {2017},
+  year = 2017,
   month = mar
 }
 
 @misc{REDDigitalCinema2017,
   title = {White {{Paper}} on {{REDWideGamutRGB}} and {{Log3G10}}},
   author = {{RED Digital Cinema}},
-  year = {2017},
+  year = 2017,
   urldate = {2021-01-16},
   file = {/Users/kelsolaar/Zotero/storage/AZSRMF37/RED Digital Cinema - 2017 - White Paper on REDWideGamutRGB and Log3G10.pdf}
 }
@@ -2562,7 +2550,7 @@
 @misc{RenewableResourceDataCenter2003a,
   title = {Reference {{Solar Spectral Irradiance}}: {{ASTM G-173}}},
   author = {{Renewable Resource Data Center}},
-  year = {2003},
+  year = 2003,
   urldate = {2014-08-23},
   howpublished = {http://rredc.nrel.gov/solar/spectra/am1.5/ASTMG173/ASTMG173.html}
 }
@@ -2584,7 +2572,7 @@
 @article{Safdar2017,
   title = {Perceptually Uniform Color Space for Image Signals Including High Dynamic Range and Wide Gamut},
   author = {Safdar, Muhammad and Cui, Guihua and Kim, Youn Jin and Luo, Ming Ronnier},
-  year = {2017},
+  year = 2017,
   month = jun,
   journal = {Optics Express},
   volume = {25},
@@ -2601,7 +2589,7 @@
   ids = {Safdar2019},
   title = {A {{Colour Appearance Model}} Based on {{J}} z a z b z {{Colour Space}}},
   author = {Safdar, Muhammad and Hardeberg, Jon Y. and Kim, Youn Jin and Luo, Ming Ronnier},
-  year = {2018},
+  year = 2018,
   month = nov,
   journal = {Color and Imaging Conference},
   volume = {2018},
@@ -2617,7 +2605,7 @@
 @article{Safdar2021,
   title = {{{ZCAM}}, a Colour Appearance Model Based on a High Dynamic Range Uniform Colour Space},
   author = {Safdar, Muhammad and Hardeberg, Jon Yngve and Ronnier Luo, Ming},
-  year = {2021},
+  year = 2021,
   month = feb,
   journal = {Optics Express},
   volume = {29},
@@ -2634,21 +2622,21 @@
 @misc{Sarifuddin2005,
   title = {A {{New Perceptually Uniform Color Space}} with {{Associated Color Similarity Measure}} for {{ContentBased Image}} and {{Video Retrieval}}},
   author = {Sarifuddin, Madenda and Missaoui, Rokia},
-  year = {2005},
+  year = 2005,
   file = {/Users/kelsolaar/Zotero/storage/Y8VCE33M/Sarifuddin and Missaoui - 2005 - A New Perceptually Uniform Color Space with Associ.pdf}
 }
 
 @misc{Sarifuddin2005a,
   title = {{{HCL}}: A New {{Color Space}} for a More {{Effective Content-based Image Retrieval}}},
   author = {Sarifuddin, Madenda and Missaoui, Rokia},
-  year = {2005},
+  year = 2005,
   file = {/Users/kelsolaar/Zotero/storage/E38KGE54/Sarifuddin and Missaoui - 2005 - HCL a new Color Space for a more Effective Conten.pdf}
 }
 
 @misc{Sarifuddin2021,
   title = {{{RGB}} to {{HCL}} and {{HCL}} to {{RGB}} Color Conversion},
   author = {Sarifuddin, Madenda},
-  year = {2021}
+  year = 2021
 }
 
 @misc{Sastanina,
@@ -2661,7 +2649,7 @@
 @article{Schiebener1990,
   title = {Refractive Index of Water and Steam as Function of Wavelength, Temperature and Density},
   author = {Schiebener, P. and Straub, J. and Levelt Sengers, J. M. H. and Gallagher, J. S.},
-  year = {1990},
+  year = 1990,
   month = may,
   journal = {Journal of Physical and Chemical Reference Data},
   volume = {19},
@@ -2676,7 +2664,7 @@
 @article{Sharma2005b,
   title = {The {{CIEDE2000}} Color-Difference Formula: {{Implementation}} Notes, Supplementary Test Data, and Mathematical Observations},
   author = {Sharma, Gaurav and Wu, Wencheng and Dalal, Edul N.},
-  year = {2005},
+  year = 2005,
   month = feb,
   journal = {Color Research \& Application},
   volume = {30},
@@ -2693,7 +2681,7 @@
 @misc{Shirley2015a,
   title = {The Prismatic Color Space for Rgb Computations},
   author = {Shirley, Peter and Hart, David},
-  year = {2015},
+  year = 2015,
   pages = {2--7},
   abstract = {In the spirit of the HSV color space, we introduce a simple transform of the RGB color cube into a light/dark dimension and a 2D hue. The hue is a normalized (barycentric) triangle with pure red, green, and blue at the vertices, often called the Maxwell Color Tri- angle. Each cross section of the space is the same barycentric triangle, and the light/dark dimension runs zero to one for each hue so the whole color volume takes the form of a prism. This prismatic space has advantages computationally and intuitively for some common color operations used in computer graphics and image processing.},
   file = {/Users/kelsolaar/Zotero/storage/8C7YKTL6/Shirley, Hart - 2015 - The prismatic color space for rgb computations.pdf}
@@ -2702,13 +2690,13 @@
 @misc{Siragusano2018a,
   title = {Private {{Discussion}} with {{Shaw}}, {{Nick}}.},
   author = {Siragusano, Daniele},
-  year = {2018}
+  year = 2018
 }
 
 @misc{Siragusano2025,
   title = {Private Discussion on Colour-Science {{Discord}} Server.},
   author = {Siragusano, Daniele},
-  year = {2025},
+  year = 2025,
   month = jan
 }
 
@@ -2716,7 +2704,7 @@
   title = {Color Gamut Transform Pairs},
   booktitle = {Proceedings of the 5th Annual Conference on {{Computer}} Graphics and Interactive Techniques - {{SIGGRAPH}} '78},
   author = {Smith, Alvy Ray},
-  year = {1978},
+  year = 1978,
   pages = {12--19},
   publisher = {ACM Press},
   address = {New York, New York, USA},
@@ -2728,7 +2716,7 @@
 @article{Smits1999a,
   title = {An {{RGB-to-Spectrum Conversion}} for {{Reflectances}}},
   author = {Smits, Brian},
-  year = {1999},
+  year = 1999,
   month = jan,
   journal = {Journal of Graphics Tools},
   volume = {4},
@@ -2745,7 +2733,7 @@
 @book{SocietyofMotionPictureandTelevisionEngineers1993a,
   title = {{{RP}} 177:1993 - {{Derivation}} of {{Basic Television Color Equations}}},
   author = {{Society of Motion Picture and Television Engineers}},
-  year = {1993},
+  year = 1993,
   month = jan,
   journal = {RP 177:1993},
   volume = {RP 177:199},
@@ -2759,7 +2747,7 @@
 @misc{SocietyofMotionPictureandTelevisionEngineers1999b,
   title = {{{ANSI}}/{{SMPTE 240M-1995}} - {{Signal Parameters}} - 1125-{{Line High-Definition Production Systems}}},
   author = {{Society of Motion Picture and Television Engineers}},
-  year = {1999},
+  year = 1999,
   pages = {1--7},
   file = {/Users/kelsolaar/Zotero/storage/TZBEIHWT/Society of Motion Picture and Television Engineers - 1999 - ANSISMPTE 240M-1995 - Signal Parameters - 1125-Line High-Definition Producti.pdf}
 }
@@ -2767,7 +2755,7 @@
 @book{SocietyofMotionPictureandTelevisionEngineers2004a,
   title = {{{RP}} 145:2004: {{SMPTE C Color Monitor Colorimetry}}},
   author = {{Society of Motion Picture and Television Engineers}},
-  year = {2004},
+  year = 2004,
   month = jan,
   journal = {RP 145:2004},
   volume = {RP 145:200},
@@ -2781,7 +2769,7 @@
 @misc{SocietyofMotionPictureandTelevisionEngineers2014a,
   title = {{{SMPTE ST}} 2084:2014 - {{Dynamic Range Electro-Optical Transfer Function}} of {{Mastering Reference Displays}}},
   author = {{Society of Motion Picture and Television Engineers}},
-  year = {2014},
+  year = 2014,
   pages = {1--14},
   doi = {10.5594/SMPTE.ST2084.2014},
   abstract = {This standard specifies an EOTF characterizing high-dynamic-range reference displays used primarily for mastering non-broadcast content. This standard also specifies an Inverse-EOTF derived from the EOTF.},
@@ -2791,7 +2779,7 @@
 @misc{SocietyofMotionPictureandTelevisionEngineers2019,
   title = {{{ST}} 428-1:2019 - {{D-Cinema Distribution Master}} --- {{Image Characteristic}}},
   author = {{Society of Motion Picture and Television Engineers}},
-  year = {2019},
+  year = 2019,
   doi = {10.5594/SMPTE.ST428-1.2019},
   file = {/Users/kelsolaar/Zotero/storage/P4KVRVHW/Society of Motion Picture and Television Engineers - 2019 - ST 428-12019 - D-Cinema Distribution Master — Ima.pdf}
 }
@@ -2806,7 +2794,7 @@
 @misc{SonyCorporation2012a,
   title = {S-{{Log2 Technical Paper}}},
   author = {{Sony Corporation}},
-  year = {2012},
+  year = 2012,
   pages = {1--9},
   file = {/Users/kelsolaar/Zotero/storage/A3MRGAEZ/Sony Corporation - 2012 - S-Log2 Technical Paper.pdf}
 }
@@ -2826,19 +2814,19 @@
 @misc{SonyElectronicsCorporation2020,
   title = {{{IDT}}.{{Sony}}.{{Venice}}\_{{SLog3}}\_{{SGamut3}}.Ctl},
   author = {{Sony Electronics Corporation}},
-  year = {2020}
+  year = 2020
 }
 
 @misc{SonyElectronicsCorporation2020a,
   title = {{{IDT}}.{{Sony}}.{{Venice}}\_{{SLog3}}\_{{SGamut3Cine}}.Ctl},
   author = {{Sony Electronics Corporation}},
-  year = {2020}
+  year = 2020
 }
 
 @misc{SonyImageworks2012a,
   title = {Make.Py},
   author = {{Sony Imageworks}},
-  year = {2012},
+  year = 2012,
   pages = {1},
   urldate = {2014-11-27},
   howpublished = {https://github.com/imageworks/OpenColorIO-Configs/blob/master/nuke-default/make.py}
@@ -2847,7 +2835,7 @@
 @misc{Spaulding2000b,
   title = {Reference {{Input}}/{{Output Medium Metric RGB Color Encodings}} ({{RIMM}}/{{ROMM RGB}})},
   author = {Spaulding, K E and Woolfe, G J and Giorgianni, E J},
-  year = {2000},
+  year = 2000,
   pages = {1--8},
   abstract = {A new color encoding specification known as Reference Output Medium Metric RGB (ROMM RGB) is defined. This color encoding is intended to be used for storing, interchanging and manipulating images that exist in a rendered image state without imposing the gamut limitations normally associated with device-specific color spaces. ROMM RGB was designed to provide a large enough color gamut to encompass most common output devices, while simultaneously satisfying a number of other important criteria. It is defined in a way that is tightly linked to the ICC profile connection space (PCS) and is suitable for use as an Adobe PhotoshopTM working color space. A companion color encoding specification, known as Reference Input Medium Metric RGB (RIMM RGB), is also defined. This encoding can be used to represent images in an unrendered scene image state.},
   file = {/Users/kelsolaar/Zotero/storage/HCY4FKUP/Spaulding, Woolfe, Giorgianni - 2000 - Reference InputOutput Medium Metric RGB Color Encodings (RIMMROMM RGB).pdf}
@@ -2856,13 +2844,13 @@
 @misc{Spiker2015a,
   title = {Private {{Discussion}} with {{Mansencal}}, {{T}}.},
   author = {Spiker, Nick},
-  year = {2015}
+  year = 2015
 }
 
 @article{Stearns1988a,
   title = {An Example of a Method for Correcting Radiance Data for {{Bandpass}} Error},
   author = {Stearns, E. I. and Stearns, R. E.},
-  year = {1988},
+  year = 1988,
   month = aug,
   journal = {Color Research \& Application},
   volume = {13},
@@ -2876,7 +2864,7 @@
 @misc{Susstrunk1999a,
   title = {Standard {{RGB Color Spaces}}},
   author = {Susstrunk, Sabine and Buckley, Robert and Swen, Steve},
-  year = {1999},
+  year = 1999,
   abstract = {This paper describes the specifications and usage of standard RGB color spaces promoted today by standard bodies and/or the imaging industry. As in the past, most of the new standard RGB color spaces were developed for specific imaging workflow and applications. They are used as interchange spaces to communicate color and/or as working spaces in imaging applications. Standard color spaces can facilitate color communication: if an image is in `knownRGB,' the user, application, and/or device can unambiguously understand the color of the image, and further color manage from there if necessary. When applied correctly, a standard RGB space can minimize color space conversions in an imaging workflow, improve image reproducibility, and facilitate accountability.{\textbackslash}nThe digital image color workflow is examined with emphasis on when an RGB color space is appropriate, and when to apply color management by profile. An RGB space is ``standard'' because either it is defined in an official standards document (a de jure standard) or it is supported by commonly used tools (a de facto standard). Examples of standard RGB color spaces are ISO RGB, sRGB, ROMM RGB, Adobe RGB 98, Apple RGB, and video RGB spaces (NTSC, EBU, ITU-R BT.709). As there is no one RGB color space that is suitable for all imaging needs, factors to consider when choosing an RGB color space are discussed.},
   keywords = {are becoming a thing,color communication,color image workflow,color management,color spaces,color standards,it is quite common,of the,past,skilled operators manage color,to be scanned by,today for an image},
   file = {/Users/kelsolaar/Zotero/storage/52Y2H29A/Susstrunk, Buckley, Swen - 1999 - Standard RGB Color Spaces.pdf}
@@ -2887,7 +2875,7 @@
   booktitle = {Photonics {{West}} 2001 - {{Electronic Imaging}}},
   author = {Susstrunk, Sabine E. and Holm, Jack M. and Finlayson, Graham D.},
   editor = {Eschbach, Reiner and Marcu, Gabriel G.},
-  year = {2000},
+  year = 2000,
   month = dec,
   volume = {4300},
   pages = {172--183},
@@ -2901,7 +2889,7 @@
 @misc{TheAcademyofMotionPictureArtsandSciences2014q,
   title = {Technical {{Bulletin TB-2014-004}} - {{Informative Notes}} on {{SMPTE ST}} 2065-1 - {{Academy Color Encoding Specification}} ({{ACES}})},
   author = {{The Academy of Motion Picture Arts and Sciences} and {Science and Technology Council} and {Academy Color Encoding System (ACES) Project Subcommittee}},
-  year = {2014},
+  year = 2014,
   pages = {1--40},
   urldate = {2014-12-19},
   file = {/Users/kelsolaar/Zotero/storage/YYCGCTW4/The Academy of Motion Picture Arts and Sciences, Science and Technology Council, Academy Color Encoding System (ACES) Project Subcommi.pdf}
@@ -2910,7 +2898,7 @@
 @misc{TheAcademyofMotionPictureArtsandSciences2014r,
   title = {Technical {{Bulletin TB-2014-012}} - {{Academy Color Encoding System Version}} 1.0 {{Component Names}}},
   author = {{The Academy of Motion Picture Arts and Sciences} and {Science and Technology Council} and {Academy Color Encoding System (ACES) Project Subcommittee}},
-  year = {2014},
+  year = 2014,
   pages = {1--8},
   urldate = {2014-12-19},
   file = {/Users/kelsolaar/Zotero/storage/M5RLPB8S/The Academy of Motion Picture Arts and Sciences, Science and Technology Council, Academy Color Encoding System (ACES) Project Subcom(12).pdf}
@@ -2920,7 +2908,7 @@
   ids = {TheAcademyofMotionPictureArtsandSciences2013b},
   title = {Specification {{S-2013-001}} - {{ACESproxy}}, an {{Integer Log Encoding}} of {{ACES Image Data}}},
   author = {{The Academy of Motion Picture Arts and Sciences} and {Science and Technology Council} and {Academy Color Encoding System (ACES) Project Subcommittee}},
-  year = {2013},
+  year = 2013,
   pages = {1--13},
   urldate = {2014-12-19},
   file = {/Users/kelsolaar/Zotero/storage/ND8LP4GZ/The Academy of Motion Picture Arts and Sciences, Science and Technology Council, Academy Color Encoding System (ACES) Project Subcomm(2).pdf;/Users/kelsolaar/Zotero/storage/R4XCBCWV/The Academy of Motion Picture Arts and Sciences, Science and Technology Council, Academy Color Encoding System (ACES) Project Subcomm(5).pdf}
@@ -2929,7 +2917,7 @@
 @misc{TheAcademyofMotionPictureArtsandSciences2014t,
   title = {Specification {{S-2014-003}} - {{ACEScc}}, {{A Logarithmic Encoding}} of {{ACES Data}} for Use within {{Color Grading Systems}}},
   author = {{The Academy of Motion Picture Arts and Sciences} and {Science and Technology Council} and {Academy Color Encoding System (ACES) Project Subcommittee}},
-  year = {2014},
+  year = 2014,
   pages = {1--12},
   urldate = {2014-12-19},
   file = {/Users/kelsolaar/Zotero/storage/TX3MTN9S/The Academy of Motion Picture Arts and Sciences, Science and Technology Council, Academy Color Encoding System (ACES) Project Subcomm(6).pdf}
@@ -2938,7 +2926,7 @@
 @misc{TheAcademyofMotionPictureArtsandSciences2015b,
   title = {Specification {{S-2014-004}} - {{ACEScg}} - {{A Working Space}} for {{CGI Render}} and {{Compositing}}},
   author = {{The Academy of Motion Picture Arts and Sciences} and {Science {and} Technology Council} and {Academy Color Encoding System (ACES) Project Subcommittee}},
-  year = {2015},
+  year = 2015,
   pages = {1--9},
   urldate = {2015-04-24},
   file = {/Users/kelsolaar/Zotero/storage/LPMBZDM3/The Academy of Motion Picture Arts and Sciences, Science and Technology Council, Academy Color Encoding System (ACES) Project Subcom(13).pdf}
@@ -2947,7 +2935,7 @@
 @misc{TheAcademyofMotionPictureArtsandSciences2015c,
   title = {Procedure {{P-2013-001}} - {{Recommended Procedures}} for the {{Creation}} and {{Use}} of {{Digital Camera System Input Device Transforms}} ({{IDTs}})},
   author = {{The Academy of Motion Picture Arts and Sciences} and {Science and Technology Council} and {Academy Color Encoding System (ACES) Project Subcommittee}},
-  year = {2015},
+  year = 2015,
   pages = {1--29},
   urldate = {2015-04-24},
   file = {/Users/kelsolaar/Zotero/storage/GL22IAAL/The Academy of Motion Picture Arts and Sciences, Science and Technology Council, Academy Color Encoding System (ACES) Project Subcom(17).pdf}
@@ -2956,7 +2944,7 @@
 @misc{TheAcademyofMotionPictureArtsandSciences2016c,
   title = {Specification {{S-2016-001}} - {{ACEScct}}, {{A Quasi-Logarithmic Encoding}} of {{ACES Data}} for Use within {{Color Grading Systems}}},
   author = {{The Academy of Motion Picture Arts and Sciences} and {Science and Technology Council} and {Academy Color Encoding System (ACES) Project}},
-  year = {2016},
+  year = 2016,
   urldate = {2016-10-10},
   howpublished = {http://j.mp/S-2016-001}
 }
@@ -2964,7 +2952,7 @@
 @misc{TheAcademyofMotionPictureArtsandSciences2020,
   title = {Specification {{S-2014-006}} - {{Common LUT Format}} ({{CLF}}) - {{A Common File Format}} for {{Look-Up Tables}}},
   author = {{The Academy of Motion Picture Arts and Sciences} and {Science and Technology Council} and {Academy Color Encoding System (ACES) Project Subcommittee}},
-  year = {2020},
+  year = 2020,
   urldate = {2020-06-24},
   file = {/Users/kelsolaar/Zotero/storage/S4BZYY4H/The Academy of Motion Picture Arts and Sciences et al. - 2020 - Specification S-2014-006 - Common LUT Format (CLF).pdf}
 }
@@ -2972,7 +2960,7 @@
 @misc{TheAcademyofMotionPictureArtsandSciences2020a,
   title = {Academy {{Spectral Similarity Index}} ({{SSI}}): {{Overview}}},
   author = {{The Academy of Motion Picture Arts and Sciences}},
-  year = {2020},
+  year = 2020,
   pages = {1--7},
   urldate = {2023-06-05},
   file = {/Users/kelsolaar/Zotero/storage/T7UU65G8/The Academy of Motion Picture Arts and Sciences - 2020 - Academy Spectral Similarity Index (SSI) Overview.pdf}
@@ -2981,7 +2969,7 @@
 @misc{TheAcademyofMotionPictureArtsandSciences2023,
   title = {{{IDT}}.{{Apple}}.{{AppleLog}}\_{{BT2020}}.Ctl},
   author = {{The Academy of Motion Picture Arts and Sciences}},
-  year = {2023},
+  year = 2023,
   urldate = {2023-12-17}
 }
 
@@ -3009,7 +2997,7 @@
 @misc{Thorpe2012a,
   title = {{{CANON-LOG TRANSFER CHARACTERISTIC}}},
   author = {Thorpe, Larry},
-  year = {2012},
+  year = 2012,
   urldate = {2014-09-25},
   file = {/Users/kelsolaar/Zotero/storage/SN7V3V4I/Thorpe - 2012 - CANON-LOG TRANSFER CHARACTERISTIC.pdf}
 }
@@ -3017,13 +3005,13 @@
 @misc{Trieu2015a,
   title = {Private {{Discussion}} with {{Mansencal}}, {{T}}.},
   author = {Trieu, Tashi},
-  year = {2015}
+  year = 2015
 }
 
 @misc{VincentJ2017,
   title = {Is There Any Numpy Group by Function?},
   author = {{Vincent J}},
-  year = {2017},
+  year = 2017,
   urldate = {2023-06-30},
   howpublished = {https://stackoverflow.com/a/43094244}
 }
@@ -3031,13 +3019,13 @@
 @misc{W3C2022,
   title = {{{CSS Color Module Level}} 3},
   author = {{W3C}},
-  year = {2022}
+  year = 2022
 }
 
 @article{Ward2002,
   title = {Picture {{Perfect RGB Rendering Using Spectral Prefiltering}} and {{Sharp Color Primaries}}},
   author = {Ward, Greg and {Eydelberg-Vileshin}, Elena},
-  year = {2002},
+  year = 2002,
   journal = {Eurographics workshop on Rendering},
   pages = {117--124},
   publisher = {Eurographics Association},
@@ -3050,13 +3038,13 @@
 @misc{Ward2016,
   title = {Private {{Discussion}} with {{Mansencal}}, {{T}}.},
   author = {Ward, Greg},
-  year = {2016}
+  year = 2016
 }
 
 @article{Watson2012,
   title = {A Unified Formula for Light-Adapted Pupil Size},
   author = {Watson, Andrew B. and Yellott, John I.},
-  year = {2012},
+  year = 2012,
   month = sep,
   journal = {Journal of Vision},
   volume = {12},
@@ -3073,7 +3061,7 @@
   title = {Table 8.2},
   booktitle = {Computational {{Colour Science Using MATLAB}}},
   author = {Westland, Stephen and Ripamonti, Caterina},
-  year = {2004},
+  year = 2004,
   month = mar,
   edition = {1},
   pages = {137},
@@ -3088,7 +3076,7 @@
   title = {Correction for {{Spectral Bandpass}}},
   booktitle = {Computational {{Colour Science Using MATLAB}}},
   author = {Westland, Stephen and Ripamonti, Caterina and Cheung, Vien},
-  year = {2012},
+  year = 2012,
   edition = {2},
   pages = {38},
   isbn = {978-0-470-66569-5}
@@ -3098,7 +3086,7 @@
   title = {{{CMCCAT97}}},
   booktitle = {Computational {{Colour Science Using MATLAB}}},
   author = {Westland, Stephen and Ripamonti, Caterina and Cheung, Vien},
-  year = {2012},
+  year = 2012,
   edition = {2},
   pages = {80},
   isbn = {978-0-470-66569-5}
@@ -3108,7 +3096,7 @@
   title = {Interpolation {{Methods}}},
   booktitle = {Computational {{Colour Science Using MATLAB}}},
   author = {Westland, Stephen and Ripamonti, Caterina and Cheung, Vien},
-  year = {2012},
+  year = 2012,
   edition = {2},
   pages = {29--37},
   isbn = {978-0-470-66569-5}
@@ -3118,7 +3106,7 @@
   title = {Extrapolation {{Methods}}},
   booktitle = {Computational {{Colour Science Using MATLAB}}},
   author = {Westland, Stephen and Ripamonti, Caterina and Cheung, Vien},
-  year = {2012},
+  year = 2012,
   edition = {2},
   pages = {38},
   isbn = {978-0-470-66569-5}
@@ -3128,7 +3116,7 @@
   title = {{{CMCCAT2000}}},
   booktitle = {Computational {{Colour Science Using MATLAB}}},
   author = {Westland, Stephen and Ripamonti, Caterina and Cheung, Vien},
-  year = {2012},
+  year = 2012,
   edition = {2},
   pages = {83--86},
   isbn = {978-0-470-66569-5}
@@ -3144,7 +3132,7 @@
 @misc{Wikipedia2001,
   title = {Approximation},
   author = {{Wikipedia}},
-  year = {2001},
+  year = 2001,
   urldate = {2014-06-28},
   howpublished = {http://en.wikipedia.org/wiki/Color\_temperature\#Approximation}
 }
@@ -3152,7 +3140,7 @@
 @misc{Wikipedia2001a,
   title = {Color Temperature},
   author = {{Wikipedia}},
-  year = {2001},
+  year = 2001,
   urldate = {2014-06-28},
   howpublished = {http://en.wikipedia.org/wiki/Color\_temperature}
 }
@@ -3160,7 +3148,7 @@
 @misc{Wikipedia2001b,
   title = {Luminance},
   author = {{Wikipedia}},
-  year = {2001},
+  year = 2001,
   urldate = {2018-02-10},
   howpublished = {https://en.wikipedia.org/wiki/Luminance}
 }
@@ -3168,7 +3156,7 @@
 @misc{Wikipedia2001c,
   title = {Rayleigh Scattering},
   author = {{Wikipedia}},
-  year = {2001},
+  year = 2001,
   urldate = {2014-09-23},
   howpublished = {http://en.wikipedia.org/wiki/Rayleigh\_scattering}
 }
@@ -3176,7 +3164,7 @@
 @misc{Wikipedia2003,
   title = {{{HSL}} and {{HSV}}},
   author = {{Wikipedia}},
-  year = {2003},
+  year = 2003,
   urldate = {2014-09-10},
   howpublished = {http://en.wikipedia.org/wiki/HSL\_and\_HSV}
 }
@@ -3184,7 +3172,7 @@
 @misc{Wikipedia2003a,
   title = {Lagrange Polynomial - {{Definition}}},
   author = {{Wikipedia}},
-  year = {2003},
+  year = 2003,
   urldate = {2016-01-20},
   howpublished = {https://en.wikipedia.org/wiki/Lagrange\_polynomial\#Definition}
 }
@@ -3192,7 +3180,7 @@
 @misc{Wikipedia2003b,
   title = {Luminosity Function},
   author = {{Wikipedia}},
-  year = {2003},
+  year = 2003,
   urldate = {2014-10-20},
   howpublished = {https://en.wikipedia.org/wiki/Luminosity\_function\#Details}
 }
@@ -3200,7 +3188,7 @@
 @misc{Wikipedia2003c,
   title = {Mean Squared Error},
   author = {{Wikipedia}},
-  year = {2003},
+  year = 2003,
   urldate = {2018-03-05},
   howpublished = {https://en.wikipedia.org/wiki/Mean\_squared\_error}
 }
@@ -3208,7 +3196,7 @@
 @misc{Wikipedia2003d,
   title = {Michaelis-{{Menten}} Kinetics},
   author = {{Wikipedia}},
-  year = {2003},
+  year = 2003,
   urldate = {2017-04-29},
   howpublished = {https://en.wikipedia.org/wiki/Michaelis\%E2\%80\%93Menten\_kinetics}
 }
@@ -3216,7 +3204,7 @@
 @misc{Wikipedia2003e,
   title = {Vandermonde Matrix},
   author = {{Wikipedia}},
-  year = {2003},
+  year = 2003,
   urldate = {2018-05-02},
   howpublished = {https://en.wikipedia.org/wiki/Vandermonde\_matrix}
 }
@@ -3224,7 +3212,7 @@
 @misc{Wikipedia2003f,
   title = {Rayleigh--{{Jeans}} Law},
   author = {{Wikipedia}},
-  year = {2003},
+  year = 2003,
   urldate = {2022-02-12},
   howpublished = {https://en.wikipedia.org/wiki/Rayleigh--Jeans\_law}
 }
@@ -3232,7 +3220,7 @@
 @misc{Wikipedia2004,
   title = {Peak Signal-to-Noise Ratio},
   author = {{Wikipedia}},
-  year = {2004},
+  year = 2004,
   urldate = {2018-03-05},
   howpublished = {https://en.wikipedia.org/wiki/Peak\_signal-to-noise\_ratio}
 }
@@ -3240,7 +3228,7 @@
 @misc{Wikipedia2004a,
   title = {Surfaces},
   author = {{Wikipedia}},
-  year = {2004},
+  year = 2004,
   urldate = {2014-09-10},
   howpublished = {http://en.wikipedia.org/wiki/Gamut\#Surfaces}
 }
@@ -3248,7 +3236,7 @@
 @misc{Wikipedia2004b,
   title = {Whiteness},
   author = {{Wikipedia}},
-  year = {2004},
+  year = 2004,
   urldate = {2014-09-17},
   howpublished = {http://en.wikipedia.org/wiki/Whiteness}
 }
@@ -3256,7 +3244,7 @@
 @misc{Wikipedia2004c,
   title = {Wide-Gamut {{RGB}} Color Space},
   author = {{Wikipedia}},
-  year = {2004},
+  year = 2004,
   urldate = {2014-04-13},
   howpublished = {http://en.wikipedia.org/wiki/Wide-gamut\_RGB\_color\_space}
 }
@@ -3264,7 +3252,7 @@
 @misc{Wikipedia2004d,
   title = {{{YCbCr}}},
   author = {{Wikipedia}},
-  year = {2004},
+  year = 2004,
   urldate = {2016-02-29},
   howpublished = {https://en.wikipedia.org/wiki/YCbCr}
 }
@@ -3272,7 +3260,7 @@
 @misc{Wikipedia2005,
   title = {{{CIE}} 1931 Color Space},
   author = {{Wikipedia}},
-  year = {2005},
+  year = 2005,
   urldate = {2014-02-24},
   howpublished = {http://en.wikipedia.org/wiki/CIE\_1931\_color\_space}
 }
@@ -3280,7 +3268,7 @@
 @misc{Wikipedia2005a,
   title = {{{ISO}} 31-11},
   author = {{Wikipedia}},
-  year = {2005},
+  year = 2005,
   urldate = {2016-07-31},
   howpublished = {https://en.wikipedia.org/wiki/ISO\_31-11}
 }
@@ -3288,7 +3276,7 @@
 @misc{Wikipedia2005b,
   title = {Lanczos Resampling},
   author = {{Wikipedia}},
-  year = {2005},
+  year = 2005,
   urldate = {2017-10-14},
   howpublished = {https://en.wikipedia.org/wiki/Lanczos\_resampling}
 }
@@ -3296,7 +3284,7 @@
 @misc{Wikipedia2005c,
   title = {Luminous {{Efficacy}}},
   author = {{Wikipedia}},
-  year = {2005},
+  year = 2005,
   urldate = {2016-04-03},
   howpublished = {https://en.wikipedia.org/wiki/Luminous\_efficacy}
 }
@@ -3304,7 +3292,7 @@
 @misc{Wikipedia2005d,
   title = {Mesopic Weighting Function},
   author = {{Wikipedia}},
-  year = {2005},
+  year = 2005,
   urldate = {2014-06-20},
   howpublished = {http://en.wikipedia.org/wiki/Mesopic\_vision\#Mesopic\_weighting\_function}
 }
@@ -3312,7 +3300,7 @@
 @misc{Wikipedia2006,
   title = {List of Common Coordinate Transformations},
   author = {{Wikipedia}},
-  year = {2006},
+  year = 2006,
   urldate = {2014-07-18},
   howpublished = {http://en.wikipedia.org/wiki/List\_of\_common\_coordinate\_transformations}
 }
@@ -3320,7 +3308,7 @@
 @misc{Wikipedia2006a,
   title = {White Points of Standard Illuminants},
   author = {{Wikipedia}},
-  year = {2006},
+  year = 2006,
   urldate = {2014-02-24},
   howpublished = {http://en.wikipedia.org/wiki/Standard\_illuminant\#White\_points\_of\_standard\_illuminants}
 }
@@ -3328,7 +3316,7 @@
 @misc{Wikipedia2007,
   title = {{{CAT02}}},
   author = {{Wikipedia}},
-  year = {2007},
+  year = 2007,
   urldate = {2014-02-24},
   howpublished = {http://en.wikipedia.org/wiki/CIECAM02\#CAT02}
 }
@@ -3336,7 +3324,7 @@
 @misc{Wikipedia2007a,
   title = {{{CIECAM02}}},
   author = {{Wikipedia}},
-  year = {2007},
+  year = 2007,
   urldate = {2014-08-14},
   howpublished = {http://en.wikipedia.org/wiki/CIECAM02}
 }
@@ -3344,7 +3332,7 @@
 @misc{Wikipedia2007b,
   title = {{{CIELUV}}},
   author = {{Wikipedia}},
-  year = {2007},
+  year = 2007,
   urldate = {2014-02-24},
   howpublished = {http://en.wikipedia.org/wiki/CIELUV}
 }
@@ -3352,7 +3340,7 @@
 @misc{Wikipedia2007c,
   title = {Lightness},
   author = {{Wikipedia}},
-  year = {2007},
+  year = 2007,
   urldate = {2014-04-13},
   howpublished = {http://en.wikipedia.org/wiki/Lightness}
 }
@@ -3360,7 +3348,7 @@
 @misc{Wikipedia2007d,
   title = {The Reverse Transformation},
   author = {{Wikipedia}},
-  year = {2007},
+  year = 2007,
   urldate = {2014-02-24},
   howpublished = {http://en.wikipedia.org/wiki/CIELUV\#The\_reverse\_transformation}
 }
@@ -3368,7 +3356,7 @@
 @misc{Wikipedia2008,
   title = {{{CIE}} 1960 Color Space},
   author = {{Wikipedia}},
-  year = {2008},
+  year = 2008,
   urldate = {2014-02-24},
   howpublished = {http://en.wikipedia.org/wiki/CIE\_1960\_color\_space}
 }
@@ -3376,7 +3364,7 @@
 @misc{Wikipedia2008a,
   title = {{{CIE}} 1964 Color Space},
   author = {{Wikipedia}},
-  year = {2008},
+  year = 2008,
   urldate = {2014-06-10},
   howpublished = {http://en.wikipedia.org/wiki/CIE\_1964\_color\_space}
 }
@@ -3384,7 +3372,7 @@
 @misc{Wikipedia2008b,
   title = {Color Difference},
   author = {{Wikipedia}},
-  year = {2008},
+  year = 2008,
   urldate = {2014-08-29},
   howpublished = {http://en.wikipedia.org/wiki/Color\_difference}
 }
@@ -3392,7 +3380,7 @@
 @misc{Wikipedia2008c,
   title = {Relation to {{CIE XYZ}}},
   author = {{Wikipedia}},
-  year = {2008},
+  year = 2008,
   urldate = {2014-02-24},
   howpublished = {http://en.wikipedia.org/wiki/CIE\_1960\_color\_space\#Relation\_to\_CIE\_XYZ}
 }
@@ -3400,7 +3388,7 @@
 @misc{Wikipedia2015,
   title = {{{HCL}} Color Space},
   author = {{Wikipedia}},
-  year = {2015},
+  year = 2015,
   urldate = {2021-04-04},
   howpublished = {https://en.wikipedia.org/wiki/HCL\_color\_space}
 }
@@ -3408,7 +3396,7 @@
 @misc{Wood2014,
   title = {Making the Same Color Twice - {{A}} Proposed {{PLASA}} Standard for Color Communication},
   author = {Wood, Mike},
-  year = {2014},
+  year = 2014,
   urldate = {2023-08-13},
   file = {/Users/kelsolaar/Zotero/storage/67PALFRL/Wood - 2014 - Making the same color twice- A proposed PLASA stan.pdf}
 }
@@ -3416,7 +3404,7 @@
 @article{Wyszecki1963b,
   title = {Proposal for a {{New Color-Difference Formula}}},
   author = {Wyszecki, G{\"u}nter},
-  year = {1963},
+  year = 1963,
   month = nov,
   journal = {Journal of the Optical Society of America},
   volume = {53},
@@ -3433,7 +3421,7 @@
   title = {Table 2(5.4.1) {{MacAdam Ellipses}} ({{Observer PGN}}) {{Observed}} and {{Calculated}} on the {{Basis}} of a {{Normal Distribution}} of {{Color Matches}} about a {{Color Center}} ({{Silberstein}} and {{MacAdam}}, 1945)},
   booktitle = {Color {{Science}}: {{Concepts}} and {{Methods}}, {{Quantitative Data}} and {{Formulae}}},
   author = {Wyszecki, G{\"u}nther and Stiles, W S},
-  year = {2000},
+  year = 2000,
   pages = {309},
   publisher = {Wiley},
   isbn = {978-0-471-39918-6}
@@ -3443,7 +3431,7 @@
   title = {Equation {{I}}(1.2.1)},
   booktitle = {Color {{Science}}: {{Concepts}} and {{Methods}}, {{Quantitative Data}} and {{Formulae}}},
   author = {Wyszecki, G{\"u}nther and Stiles, W S},
-  year = {2000},
+  year = 2000,
   pages = {8},
   publisher = {Wiley},
   isbn = {978-0-471-39918-6}
@@ -3453,7 +3441,7 @@
   title = {Table {{I}}(6.5.3) {{Whiteness Formulae}} ({{Whiteness Measure Denoted}} by {{W}})},
   booktitle = {Color {{Science}}: {{Concepts}} and {{Methods}}, {{Quantitative Data}} and {{Formulae}}},
   author = {Wyszecki, G{\"u}nther and Stiles, W. S.},
-  year = {2000},
+  year = 2000,
   pages = {837--839},
   publisher = {Wiley},
   isbn = {978-0-471-39918-6}
@@ -3463,7 +3451,7 @@
   title = {Table {{I}}(3.7)},
   booktitle = {Color {{Science}}: {{Concepts}} and {{Methods}}, {{Quantitative Data}} and {{Formulae}}},
   author = {Wyszecki, G{\"u}nther and Stiles, W. S.},
-  year = {2000},
+  year = 2000,
   pages = {776--777},
   publisher = {Wiley},
   isbn = {978-0-471-39918-6}
@@ -3473,7 +3461,7 @@
   title = {{{CIE}} 1976 ({{L}}*u*v*)-{{Space}} and {{Color-Difference Formula}}},
   booktitle = {Color {{Science}}: {{Concepts}} and {{Methods}}, {{Quantitative Data}} and {{Formulae}}},
   author = {Wyszecki, G{\"u}nther and Stiles, W. S.},
-  year = {2000},
+  year = 2000,
   pages = {167},
   publisher = {Wiley},
   isbn = {978-0-471-39918-6}
@@ -3483,7 +3471,7 @@
   title = {The {{CIE}} 1964 {{Standard Observer}}},
   booktitle = {Color {{Science}}: {{Concepts}} and {{Methods}}, {{Quantitative Data}} and {{Formulae}}},
   author = {Wyszecki, G{\"u}nther and Stiles, W. S.},
-  year = {2000},
+  year = 2000,
   pages = {141},
   publisher = {Wiley},
   isbn = {978-0-471-39918-6}
@@ -3493,7 +3481,7 @@
   title = {Integration {{Replaced}} by {{Summation}}},
   booktitle = {Color {{Science}}: {{Concepts}} and {{Methods}}, {{Quantitative Data}} and {{Formulae}}},
   author = {Wyszecki, G{\"u}nther and Stiles, W. S.},
-  year = {2000},
+  year = 2000,
   pages = {158--163},
   publisher = {Wiley},
   isbn = {978-0-471-39918-6}
@@ -3503,7 +3491,7 @@
   title = {Table 1(3.3.3)},
   booktitle = {Color {{Science}}: {{Concepts}} and {{Methods}}, {{Quantitative Data}} and {{Formulae}}},
   author = {Wyszecki, G{\"u}nther and Stiles, W. S.},
-  year = {2000},
+  year = 2000,
   pages = {138--139},
   publisher = {Wiley},
   isbn = {978-0-471-39918-6}
@@ -3513,7 +3501,7 @@
   title = {Table {{II}}(3.7)},
   booktitle = {Color {{Science}}: {{Concepts}} and {{Methods}}, {{Quantitative Data}} and {{Formulae}}},
   author = {Wyszecki, G{\"u}nther and Stiles, W. S.},
-  year = {2000},
+  year = 2000,
   pages = {778--779},
   publisher = {Wiley},
   isbn = {978-0-471-39918-6}
@@ -3523,7 +3511,7 @@
   title = {Standard {{Photometric Observers}}},
   booktitle = {Color {{Science}}: {{Concepts}} and {{Methods}}, {{Quantitative Data}} and {{Formulae}}},
   author = {Wyszecki, G{\"u}nther and Stiles, W. S.},
-  year = {2000},
+  year = 2000,
   pages = {256--259,395},
   publisher = {Wiley},
   isbn = {978-0-471-39918-6}
@@ -3533,7 +3521,7 @@
   title = {Table 1(3.11) {{Isotemperature Lines}}},
   booktitle = {Color {{Science}}: {{Concepts}} and {{Methods}}, {{Quantitative Data}} and {{Formulae}}},
   author = {Wyszecki, G{\"u}nther and Stiles, W. S.},
-  year = {2000},
+  year = 2000,
   pages = {228},
   publisher = {Wiley},
   isbn = {978-0-471-39918-6}
@@ -3543,7 +3531,7 @@
   title = {{{DISTRIBUTION TEMPERATURE}}, {{COLOR TEMPERATURE}}, {{AND CORRELATED COLOR TEMPERATURE}}},
   booktitle = {Color {{Science}}: {{Concepts}} and {{Methods}}, {{Quantitative Data}} and {{Formulae}}},
   author = {Wyszecki, G{\"u}nther and Stiles, W. S.},
-  year = {2000},
+  year = 2000,
   pages = {224--229},
   publisher = {Wiley},
   isbn = {978-0-471-39918-6}
@@ -3553,7 +3541,7 @@
   title = {{{CIE Method}} of {{Calculating D-Illuminants}}},
   booktitle = {Color {{Science}}: {{Concepts}} and {{Methods}}, {{Quantitative Data}} and {{Formulae}}},
   author = {Wyszecki, G{\"u}nther and Stiles, W. S.},
-  year = {2000},
+  year = 2000,
   pages = {145--146},
   publisher = {Wiley},
   isbn = {978-0-471-39918-6}
@@ -3562,14 +3550,14 @@
 @misc{X-Rite2012a,
   title = {Color {{iQC}} and {{Color iMatch Color Calculations Guide}}},
   author = {{X-Rite} and {Pantone}},
-  year = {2012},
+  year = 2012,
   file = {/Users/kelsolaar/Zotero/storage/2F3A6AZ3/X-Rite, Pantone - 2012 - Color iQC and Color iMatch Color Calculations Guide.pdf}
 }
 
 @misc{X-Rite2016,
   title = {New Color Specifications for {{ColorChecker SG}} and {{Classic Charts}}},
   author = {{X-Rite}},
-  year = {2016},
+  year = 2016,
   urldate = {2018-10-29},
   howpublished = {http://xritephoto.com/ph\_product\_overview.aspx?ID=938\&Action=Support\&SupportID=5884\#}
 }
@@ -3577,7 +3565,7 @@
 @misc{Yorke2014a,
   title = {Python: {{Change}} Format of Np.Array or Allow Tolerance in In1d Function},
   author = {Yorke, Rory},
-  year = {2014},
+  year = 2014,
   urldate = {2015-03-27},
   howpublished = {http://stackoverflow.com/a/23521245/931625}
 }
@@ -3585,7 +3573,7 @@
 @article{Zhai2018,
   title = {Study of Chromatic Adaptation via Neutral White Matches on Different Viewing Media},
   author = {Zhai, Qiyan and Luo, Ming R.},
-  year = {2018},
+  year = 2018,
   month = mar,
   journal = {Optics Express},
   volume = {26},
@@ -3601,7 +3589,7 @@
 @article{Zhang2024,
   title = {Xiaomi {{Log Profile White Paper}}},
   author = {Zhang, Junkai and Zhao, Guidong and Liu, Taoyuan and Luan, Ye},
-  year = {2024},
+  year = 2024,
   langid = {english},
   file = {/Users/kelsolaar/Zotero/storage/MNIDL7YC/Zhang et al. - 2024 - Xiaomi Log Profile White Paper.pdf}
 }

--- a/THIRD_PARTY
+++ b/THIRD_PARTY
@@ -1,7 +1,3 @@
-Copyright for portions of project Adobe DNG Software Development Kit (SDK) are
-held by Adobe Systems, 2013 as part of project Adobe DNG SDK and are distributed
-under the DNG SDK License Agreement.
-
 Copyright for portions of project The Munsell and Kubelka-Munk Toolbox are
 held by Paul Centore, 2010-2018 as part of project The Munsell and Kubelka-Munk
 Toolbox and are distributed under the BSD-3-Clause by explicit permission

--- a/colour/temperature/__init__.py
+++ b/colour/temperature/__init__.py
@@ -5,10 +5,6 @@ References
     Development Kit (SDK) - 1.3.0.0 -
     dng_sdk_1_3/dng_sdk/source/dng_temperature.cpp::dng_temperature::\
 Set_xy_coord. https://www.adobe.com/support/downloads/dng/dng_sdk.html
--   :cite:`AdobeSystems2013a` : Adobe Systems. (2013). Adobe DNG Software
-    Development Kit (SDK) - 1.3.0.0 -
-    dng_sdk_1_3/dng_sdk/source/dng_temperature.cpp::dng_temperature::xy_coord.
-    https://www.adobe.com/support/downloads/dng/dng_sdk.html
 -   :cite:`CIETC1-482004i` : CIE TC 1-48. (2004). APPENDIX E. INFORMATION ON
     THE USE OF PLANCK'S EQUATION FOR STANDARD AIR. In CIE 015:2004 Colorimetry,
     3rd Edition (pp. 77-82). ISBN:978-3-901906-33-6
@@ -125,7 +121,7 @@ colour temperature :math:`T_{cp}` computation methods.
 
 References
 ----------
-:cite:`AdobeSystems2013`, :cite:`AdobeSystems2013a`,
+:cite:`AdobeSystems2013`,
 :cite:`CIETC1-482004i`, :cite:`Krystek1985b`, :cite:`Ohno2014a`,
 :cite:`Wyszecki2000y`
 
@@ -186,7 +182,7 @@ def uv_to_CCT(
 
     References
     ----------
-    :cite:`AdobeSystems2013`, :cite:`AdobeSystems2013a`,
+    :cite:`AdobeSystems2013`,
     :cite:`CIETC1-482004i`, :cite:`Krystek1985b`, :cite:`Ohno2014a`,
     :cite:`Wyszecki2000y`
 
@@ -219,7 +215,7 @@ Supported correlated colour temperature :math:`T_{cp}` to *CIE UCS* colourspace
 
 References
 ----------
-:cite:`AdobeSystems2013`, :cite:`AdobeSystems2013a`,
+:cite:`AdobeSystems2013`,
 :cite:`CIETC1-482004i`, :cite:`Krystek1985b`, :cite:`Ohno2014a`,
 :cite:`Wyszecki2000y`
 
@@ -265,7 +261,7 @@ def CCT_to_uv(
 
     References
     ----------
-    :cite:`AdobeSystems2013`, :cite:`AdobeSystems2013a`,
+    :cite:`AdobeSystems2013`,
     :cite:`CIETC1-482004i`, :cite:`Krystek1985b`, :cite:`Ohno2014a`,
     :cite:`Wyszecki2000y`
 

--- a/colour/temperature/robertson1968.py
+++ b/colour/temperature/robertson1968.py
@@ -24,10 +24,6 @@ References
     Development Kit (SDK) - 1.3.0.0 -
     dng_sdk_1_3/dng_sdk/source/dng_temperature.cpp::dng_temperature::\
 Set_xy_coord. https://www.adobe.com/support/downloads/dng/dng_sdk.html
--   :cite:`AdobeSystems2013a` : Adobe Systems. (2013). Adobe DNG Software
-    Development Kit (SDK) - 1.3.0.0 -
-    dng_sdk_1_3/dng_sdk/source/dng_temperature.cpp::dng_temperature::xy_coord.
-    https://www.adobe.com/support/downloads/dng/dng_sdk.html
 -   :cite:`Wyszecki2000x` : Wyszecki, Günther, & Stiles, W. S. (2000). Table
     1(3.11) Isotemperature Lines. In Color Science: Concepts and Methods,
     Quantitative Data and Formulae (p. 228). Wiley. ISBN:978-0-471-39918-6
@@ -206,74 +202,6 @@ def CCT_to_mired(CCT: ArrayLike) -> NDArrayFloat:
         return sdiv(1.0e6, CCT)
 
 
-def _uv_to_CCT_Robertson1968(uv: ArrayLike) -> NDArrayFloat:
-    """
-    Compute the correlated colour temperature :math:`T_{cp}` and
-    :math:`\\Delta_{uv}` from the specified *CIE UCS* colourspace *uv*
-    chromaticity coordinates using the *Robertson (1968)* method.
-
-    Parameters
-    ----------
-    uv
-        *CIE UCS* colourspace *uv* chromaticity coordinates.
-
-    Returns
-    -------
-    :class:`numpy.ndarray`
-        Correlated colour temperature :math:`T_{cp}`, :math:`\\Delta_{uv}`.
-    """
-
-    u, v = tsplit(uv)
-
-    last_dt = last_dv = last_du = 0
-
-    D_uv = 0
-    for i in range(1, 31):
-        wr_ruvt = ISOTEMPERATURE_LINES_ROBERTSON1968[i]
-        wr_ruvt_previous = ISOTEMPERATURE_LINES_ROBERTSON1968[i - 1]
-
-        du = 1
-        dv = wr_ruvt.t
-
-        length = np.hypot(1, dv)
-
-        du /= length
-        dv /= length
-
-        uu = u - wr_ruvt.u
-        vv = v - wr_ruvt.v
-
-        dt = -uu * dv + vv * du
-
-        if dt <= 0 or i == 30:
-            dt = -min(dt, 0)
-
-            f = 0 if i == 1 else dt / (last_dt + dt)
-
-            T = mired_to_CCT(wr_ruvt_previous.r * f + wr_ruvt.r * (1 - f))
-
-            uu = u - (wr_ruvt_previous.u * f + wr_ruvt.u * (1 - f))
-            vv = v - (wr_ruvt_previous.v * f + wr_ruvt.v * (1 - f))
-
-            du = du * (1 - f) + last_du * f
-            dv = dv * (1 - f) + last_dv * f
-
-            length = np.hypot(du, dv)
-
-            du /= length
-            dv /= length
-
-            D_uv = uu * du + vv * dv
-
-            break
-
-        last_dt = dt
-        last_du = du
-        last_dv = dv
-
-    return np.array([T, -D_uv])
-
-
 def uv_to_CCT_Robertson1968(uv: ArrayLike) -> NDArrayFloat:
     """
     Compute the correlated colour temperature :math:`T_{cp}` and
@@ -302,70 +230,65 @@ def uv_to_CCT_Robertson1968(uv: ArrayLike) -> NDArrayFloat:
     """
 
     uv = as_float_array(uv)
+    shape = uv.shape
+    uv = uv.reshape(-1, 2)
 
-    CCT_D_uv = [_uv_to_CCT_Robertson1968(a) for a in np.reshape(uv, (-1, 2))]
+    r_itl, u_itl, v_itl, t_itl = tsplit(
+        np.array(DATA_ISOTEMPERATURE_LINES_ROBERTSON1968)
+    )
 
-    return np.reshape(CCT_D_uv, uv.shape)
+    # Normalized direction vectors
+    length = np.hypot(1.0, t_itl)
+    du_itl = 1.0 / length
+    dv_itl = t_itl / length
 
+    # Vectorized computation for all UV pairs at once
+    u, v = tsplit(uv)
+    u = u[:, np.newaxis]  # Shape (N, 1)
+    v = v[:, np.newaxis]  # Shape (N, 1)
 
-def _CCT_to_uv_Robertson1968(CCT_D_uv: ArrayLike) -> NDArrayFloat:
-    """
-    Compute the *CIE UCS* colourspace *uv* chromaticity coordinates from
-    the specified correlated colour temperature :math:`T_{cp}` and
-    :math:`\\Delta_{uv}` using *Robertson (1968)* method.
+    # Compute distances for all UV pairs against all isotemperature lines
+    # Broadcasting: (N, 1) - (30,) = (N, 30)
+    uu = u - u_itl[1:]  # Shape (N, 30)
+    vv = v - v_itl[1:]  # Shape (N, 30)
+    dt = -uu * dv_itl[1:] + vv * du_itl[1:]  # Shape (N, 30)
 
-    Parameters
-    ----------
-    CCT_D_uv
-        Correlated colour temperature :math:`T_{cp}`, :math:`\\Delta_{uv}`.
+    # Find the first crossing point for each UV pair
+    mask = dt <= 0
+    i = np.where(np.any(mask, axis=1), np.argmax(mask, axis=1) + 1, 30)
 
-    Returns
-    -------
-    :class:`numpy.ndarray`
-        *CIE UCS* colourspace *uv* chromaticity coordinates.
-    """
+    # Interpolation factor
+    idx = np.arange(len(i))
+    dt_current = -np.minimum(dt[idx, i - 1], 0.0)
+    dt_previous = dt[idx, i - 2]
+    f = np.where(
+        i == 1, 0.0, np.where(i > 1, dt_current / (dt_previous + dt_current), 0.0)
+    )
 
-    CCT, D_uv = tsplit(CCT_D_uv)
+    # Interpolate temperature
+    T = mired_to_CCT(r_itl[i - 1] * f + r_itl[i] * (1 - f))
 
-    r = CCT_to_mired(CCT)
+    # Interpolate uv position
+    u_i = u_itl[i - 1] * f + u_itl[i] * (1 - f)
+    v_i = v_itl[i - 1] * f + v_itl[i] * (1 - f)
 
-    u, v = 0, 0
-    for i in range(30):
-        wr_ruvt = ISOTEMPERATURE_LINES_ROBERTSON1968[i]
-        wr_ruvt_next = ISOTEMPERATURE_LINES_ROBERTSON1968[i + 1]
+    # Interpolate direction vectors
+    du_i = du_itl[i] * (1 - f) + du_itl[i - 1] * f
+    dv_i = dv_itl[i] * (1 - f) + dv_itl[i - 1] * f
 
-        if r < wr_ruvt_next.r or i == 29:
-            f = (wr_ruvt_next.r - r) / (wr_ruvt_next.r - wr_ruvt.r)
+    # Normalize interpolated direction
+    length_i = np.hypot(du_i, dv_i)
+    du_i /= length_i
+    dv_i /= length_i
 
-            u = wr_ruvt.u * f + wr_ruvt_next.u * (1 - f)
-            v = wr_ruvt.v * f + wr_ruvt_next.v * (1 - f)
+    # Calculate D_uv
+    uu = u.ravel() - u_i
+    vv = v.ravel() - v_i
+    D_uv = uu * du_i + vv * dv_i
 
-            uu1 = uu2 = 1.0
-            vv1, vv2 = wr_ruvt.t, wr_ruvt_next.t
+    result = np.stack([T, -D_uv], axis=-1)
 
-            length1 = np.hypot(1, vv1)
-            length2 = np.hypot(1, vv2)
-
-            uu1 /= length1
-            vv1 /= length1
-
-            uu2 /= length2
-            vv2 /= length2
-
-            uu3 = uu1 * f + uu2 * (1 - f)
-            vv3 = vv1 * f + vv2 * (1 - f)
-
-            len3 = np.sqrt(uu3 * uu3 + vv3 * vv3)
-
-            uu3 /= len3
-            vv3 /= len3
-
-            u += uu3 * -D_uv
-            v += vv3 * -D_uv
-
-            break
-
-    return np.array([u, v])
+    return result.reshape(shape)
 
 
 def CCT_to_uv_Robertson1968(CCT_D_uv: ArrayLike) -> NDArrayFloat:
@@ -386,7 +309,7 @@ def CCT_to_uv_Robertson1968(CCT_D_uv: ArrayLike) -> NDArrayFloat:
 
     References
     ----------
-    :cite:`AdobeSystems2013a`, :cite:`Wyszecki2000y`
+    :cite:`Wyszecki2000y`
 
     Examples
     --------
@@ -396,7 +319,46 @@ def CCT_to_uv_Robertson1968(CCT_D_uv: ArrayLike) -> NDArrayFloat:
     """
 
     CCT_D_uv = as_float_array(CCT_D_uv)
+    shape = CCT_D_uv.shape
+    CCT_D_uv = CCT_D_uv.reshape(-1, 2)
 
-    uv = [_CCT_to_uv_Robertson1968(a) for a in np.reshape(CCT_D_uv, (-1, 2))]
+    r_itl, u_itl, v_itl, t_itl = tsplit(
+        np.array(DATA_ISOTEMPERATURE_LINES_ROBERTSON1968)
+    )
 
-    return np.reshape(uv, CCT_D_uv.shape)
+    # Precompute normalized direction vectors
+    length = np.hypot(1.0, t_itl)
+    du_itl = 1.0 / length
+    dv_itl = t_itl / length
+
+    # Vectorized computation for all CCT/D_uv pairs at once
+    CCT, D_uv = tsplit(CCT_D_uv)
+    r = CCT_to_mired(CCT)
+
+    # Find the isotemperature range containing r for all values
+    mask = r[:, np.newaxis] < r_itl[1:]
+    i = np.where(np.any(mask, axis=1), np.argmax(mask, axis=1), 29)
+
+    # Interpolation factor
+    f = (r_itl[i + 1] - r) / (r_itl[i + 1] - r_itl[i])
+
+    # Interpolate uv position on Planckian locus
+    u = u_itl[i] * f + u_itl[i + 1] * (1 - f)
+    v = v_itl[i] * f + v_itl[i + 1] * (1 - f)
+
+    # Interpolate direction vectors
+    du_i = du_itl[i] * f + du_itl[i + 1] * (1 - f)
+    dv_i = dv_itl[i] * f + dv_itl[i + 1] * (1 - f)
+
+    # Normalize interpolated direction
+    length_i = np.hypot(du_i, dv_i)
+    du_i /= length_i
+    dv_i /= length_i
+
+    # Offset by D_uv along the isotherm
+    u += du_i * -D_uv
+    v += dv_i * -D_uv
+
+    result = np.stack([u, v], axis=-1)
+
+    return result.reshape(shape)


### PR DESCRIPTION
 <!--
Thank you for taking the time to create this pull request. If it is the first
time you are contributing to a colour-science repository, a contributing guide
is available to guide the process: https://www.colour-science.org/contributing/.
-->

# Summary

This PR vectorises`colour.temperature.uv_to_CCT_Robertson1968` and `colour.temperature.CCT_to_uv_Robertson1968` definitions for 32.78x and 93.61x performance improvement.

The implementation has been verified to reproduce the same values than the non-vectorised version with samples as follows:

  - 50 CCT values: 2,000K to 25,000K
  - 50 D_uv values: -0.100 to +0.100
  - Total: 2,500 samples

# Preflight

<!-- Please mark any checkboxes that do not apply to this pull request as [N/A]. -->

**Code Style and Quality**

- [x] Unit tests have been implemented and passed.
- [x] Pyright static checking has been run and passed.
- [x] Pre-commit hooks have been run and passed.
- [N/A] New transformations have been added to the _Automatic Colour Conversion Graph_.
- [N/A] New transformations have been exported to the relevant namespaces, e.g. `colour`, `colour.models`.

<!-- The unit tests can be invoked with `uv run invoke tests` -->
<!-- Pyright can be started with `uv run pyright --threads --skipunannotated` -->

**Documentation**

- [N/A] New features are documented along with examples if relevant.
- [x] The documentation is [Sphinx](https://www.sphinx-doc.org/en/master/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant.

<!--
Thank you again!
-->
