### PR TITLE
PR: Implement support for multi-spectral distributions in `colour.spectral_similarity_index` definition.

### DIFF
--- a/colour/quality/ssi.py
+++ b/colour/quality/ssi.py
@@ -22,10 +22,17 @@ import numpy as np
 from scipy.ndimage import convolve1d
 
 from colour.algebra import LinearInterpolator, sdiv, sdiv_mode
-from colour.colorimetry import SpectralDistribution, SpectralShape, reshape_sd
+from colour.colorimetry import (
+    MultiSpectralDistributions,
+    SpectralDistribution,
+    SpectralShape,
+    reshape_msds,
+    reshape_sd,
+)
 
 if typing.TYPE_CHECKING:
     from colour.hints import NDArrayFloat
+
 
 from colour.utilities import zeros
 
@@ -50,21 +57,21 @@ _MATRIX_INTEGRATION: NDArrayFloat | None = None
 
 
 def spectral_similarity_index(
-    sd_test: SpectralDistribution,
-    sd_reference: SpectralDistribution,
+    sd_test: SpectralDistribution | MultiSpectralDistributions,
+    sd_reference: SpectralDistribution | MultiSpectralDistributions,
     round_result: bool = True,
 ) -> NDArrayFloat:
     """
     Compute the *Academy Spectral Similarity Index* (SSI) of the specified
-    test spectral distribution with the specified reference spectral
-    distribution.
+    test spectral distribution or multi-spectral distributions with the
+    specified reference spectral distribution or multi-spectral distributions.
 
     Parameters
     ----------
     sd_test
-        Test spectral distribution.
+        Test spectral distribution or multi-spectral distributions.
     sd_reference
-        Reference spectral distribution.
+        Reference spectral distribution or multi-spectral distributions.
     round_result
         Whether to round the result/output. This is particularly useful when
         using SSI in an optimisation routine. Default is *True*.
@@ -72,7 +79,10 @@ def spectral_similarity_index(
     Returns
     -------
     :class:`numpy.ndarray`
-        *Academy Spectral Similarity Index* (SSI).
+        *Academy Spectral Similarity Index* (SSI). When both inputs are
+        :class:`colour.SpectralDistribution` objects, returns a scalar.
+        When either input is a :class:`colour.MultiSpectralDistributions`
+        object, returns an array with one SSI value per spectral distribution.
 
     References
     ----------
@@ -85,6 +95,17 @@ def spectral_similarity_index(
     >>> sd_reference = SDS_ILLUMINANTS["D65"]
     >>> spectral_similarity_index(sd_test, sd_reference)
     94.0
+
+    Computing SSI for multi-spectral distributions:
+
+    >>> from colour.colorimetry import sd_single_led, sds_and_msds_to_msds
+    >>> sd_led_1 = sd_single_led(520, half_spectral_width=45)
+    >>> sd_led_2 = sd_single_led(540, half_spectral_width=55)
+    >>> sd_led_3 = sd_single_led(560, half_spectral_width=50)
+    >>> msds = sds_and_msds_to_msds([sd_led_1, sd_led_2, sd_led_3])
+    >>> sd_reference = sd_single_led(535, half_spectral_width=48)
+    >>> spectral_similarity_index(msds, sd_reference)
+    array([ 52.,  82.,  18.])
     """
 
     global _MATRIX_INTEGRATION  # noqa: PLW0603
@@ -107,53 +128,73 @@ def spectral_similarity_index(
         "extrapolator_kwargs": {"left": 0, "right": 0},
     }
 
-    sd_test = reshape_sd(sd_test, SPECTRAL_SHAPE_SSI, "Align", copy=False, **settings)
-    sd_reference = reshape_sd(
-        sd_reference, SPECTRAL_SHAPE_SSI, "Align", copy=False, **settings
+    sd_test = (
+        reshape_msds(sd_test, SPECTRAL_SHAPE_SSI, "Align", copy=False, **settings)
+        if isinstance(sd_test, MultiSpectralDistributions)
+        else reshape_sd(sd_test, SPECTRAL_SHAPE_SSI, "Align", copy=False, **settings)
+    )
+    sd_reference = (
+        reshape_msds(sd_reference, SPECTRAL_SHAPE_SSI, "Align", copy=False, **settings)
+        if isinstance(sd_reference, MultiSpectralDistributions)
+        else reshape_sd(
+            sd_reference, SPECTRAL_SHAPE_SSI, "Align", copy=False, **settings
+        )
     )
 
     test_i = np.dot(_MATRIX_INTEGRATION, sd_test.values)
     reference_i = np.dot(_MATRIX_INTEGRATION, sd_reference.values)
 
+    if test_i.ndim == 1 and reference_i.ndim == 2:
+        test_i = np.tile(test_i[:, np.newaxis], (1, reference_i.shape[1]))
+    elif test_i.ndim == 2 and reference_i.ndim == 1:
+        reference_i = np.tile(reference_i[:, np.newaxis], (1, test_i.shape[1]))
+
     with sdiv_mode():
-        test_i = sdiv(test_i, np.sum(test_i))
-        reference_i = sdiv(reference_i, np.sum(reference_i))
+        test_i = sdiv(test_i, np.sum(test_i, axis=0, keepdims=True))
+        reference_i = sdiv(reference_i, np.sum(reference_i, axis=0, keepdims=True))
         dr_i = sdiv(test_i - reference_i, reference_i + 1 / 30)
 
-    wdr_i = dr_i * [
-        4 / 15,
-        22 / 45,
-        32 / 45,
-        40 / 45,
-        44 / 45,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        11 / 15,
-        3 / 15,
-    ]
-    c_wdr_i = convolve1d(wdr_i, [0.22, 0.56, 0.22], mode="constant", cval=0)
-    m_v = np.sum(np.square(c_wdr_i))
+    weights = np.array(
+        [
+            4 / 15,
+            22 / 45,
+            32 / 45,
+            40 / 45,
+            44 / 45,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            11 / 15,
+            3 / 15,
+        ]
+    )
+
+    if dr_i.ndim == 2:
+        weights = weights[:, np.newaxis]
+
+    wdr_i = dr_i * weights
+    c_wdr_i = convolve1d(wdr_i, [0.22, 0.56, 0.22], axis=0, mode="constant", cval=0)
+    m_v = np.sum(np.square(c_wdr_i), axis=0)
 
     SSI = 100 - 32 * np.sqrt(m_v)
 

--- a/colour/quality/tests/test_ssi.py
+++ b/colour/quality/tests/test_ssi.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 import numpy as np
 
-from colour.colorimetry import SDS_ILLUMINANTS, SpectralDistribution
+from colour.colorimetry import (
+    SDS_ILLUMINANTS,
+    SpectralDistribution,
+    sd_single_led,
+    sds_and_msds_to_msds,
+)
+from colour.constants import TOLERANCE_ABSOLUTE_TESTS
 from colour.quality import spectral_similarity_index
 
 __author__ = "Colour Developers"
@@ -573,28 +579,51 @@ class TestSpectralSimilarityIndex:
             == 72.0
         )
 
-    def test_spectral_similarity_rounding(self) -> None:
-        """
-        Test :func:`colour.quality.ssi.spectral_similarity_index` for
-        producing continuous values.
-        """
-
-        # Test values were computed at ed2e90
         np.testing.assert_allclose(
             spectral_similarity_index(
                 SDS_ILLUMINANTS["C"],
                 SDS_ILLUMINANTS["D65"],
                 round_result=False,
             ),
-            94.182,
-            atol=0.01,
+            94.182971057336000,
+            atol=TOLERANCE_ABSOLUTE_TESTS,
         )
+
         np.testing.assert_allclose(
             spectral_similarity_index(
                 SpectralDistribution(DATA_HMI),
                 SDS_ILLUMINANTS["D50"],
                 round_result=False,
             ),
-            71.775,
-            atol=0.01,
+            71.775054824255550,
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+        sd_led_1 = sd_single_led(520, half_spectral_width=45)
+        sd_led_2 = sd_single_led(540, half_spectral_width=55)
+        sd_led_3 = sd_single_led(560, half_spectral_width=50)
+
+        msds = sds_and_msds_to_msds([sd_led_1, sd_led_2, sd_led_3])
+        sd_reference = sd_single_led(535, half_spectral_width=48)
+
+        np.testing.assert_array_equal(
+            spectral_similarity_index(msds, msds), [100.0, 100.0, 100.0]
+        )
+
+        np.testing.assert_allclose(
+            spectral_similarity_index(msds, msds, round_result=False),
+            [100.0, 100.0, 100.0],
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+        np.testing.assert_allclose(
+            spectral_similarity_index(msds, sd_reference),
+            [52.0, 82.0, 18.0],
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+        np.testing.assert_allclose(
+            spectral_similarity_index(sd_reference, msds),
+            [50.0, 84.0, 20.0],
+            atol=TOLERANCE_ABSOLUTE_TESTS,
         )


### PR DESCRIPTION
<!--
Thank you for taking the time to create this pull request. If it is the first
time you are contributing to a colour-science repository, a contributing guide
is available to guide the process: https://www.colour-science.org/contributing/.
-->

# Summary

This PR implements support for multi-spectral distributions in `colour.spectral_similarity_index` definition.

It should broadcast:

- sd vs sd
- sd vs msds
- msds vs sd
- msds vs msds (assuming that they are broadcastable)

References #1370.

# Preflight

<!-- Please mark any checkboxes that do not apply to this pull request as [N/A]. -->

**Code Style and Quality**

- [x] Unit tests have been implemented and passed.
- [x] Pyright static checking has been run and passed.
- [x] Pre-commit hooks have been run and passed.
- [N/A] New transformations have been added to the _Automatic Colour Conversion Graph_.
- [N/A] New transformations have been exported to the relevant namespaces, e.g. `colour`, `colour.models`.

<!-- The unit tests can be invoked with `uv run invoke tests` -->
<!-- Pyright can be started with `uv run pyright --threads --skipunannotated` -->

**Documentation**

- [x] New features are documented along with examples if relevant.
- [x] The documentation is [Sphinx](https://www.sphinx-doc.org/en/master/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant.

<!--
Thank you again!
-->
