### PR TITLE
PR: Fix return type of `_1_2_3` in `models.rgb.cylindrical.HCL_to_RGB`

### DIFF
--- a/colour/models/rgb/cylindrical.py
+++ b/colour/models/rgb/cylindrical.py
@@ -56,7 +56,7 @@ import numpy as np
 from colour.algebra import sdiv, sdiv_mode
 
 if typing.TYPE_CHECKING:
-    from colour.hints import Domain1, NDArrayFloat, Range1
+    from colour.hints import Domain1, NDArrayBoolean, NDArrayFloat, Range1
 
 from colour.hints import ArrayLike, cast
 from colour.utilities import as_float_array, from_range_1, to_domain_1, tsplit, tstack
@@ -520,7 +520,7 @@ def HCL_to_RGB(HCL: Domain1, gamma: float = 3, Y_0: float = 100) -> Range1:
     r_n60 = np.radians(-60)
     r_n120 = np.radians(-120)
 
-    def _1_2_3(a: ArrayLike) -> NDArrayFloat:
+    def _1_2_3(a: ArrayLike) -> NDArrayBoolean:
         """Tail-stack specified :math:`a` array as a *bool* dtype."""
 
         return tstack(cast("ArrayLike", [a, a, a]), dtype=np.bool_)


### PR DESCRIPTION
<!--
Thank you for taking the time to create this pull request. If it is the first
time you are contributing to a colour-science repository, a contributing guide
is available to guide the process: https://www.colour-science.org/contributing/.
-->

# Summary

In https://github.com/numpy/numpy/pull/30246 mypy_primer reported a new error related to `numpy.select`, which turned out to be a true positive, so I figured I might as well fix it.

# Preflight

<!-- Please mark any checkboxes that do not apply to this pull request as [N/A]. -->

**Code Style and Quality**

- [ ] Unit tests have been implemented and passed.
- [ ] Pyright static checking has been run and passed.
- [ ] Pre-commit hooks have been run and passed.
- [ ] New transformations have been added to the _Automatic Colour Conversion Graph_.
- [ ] New transformations have been exported to the relevant namespaces, e.g. `colour`, `colour.models`.

<!-- The unit tests can be invoked with `uv run invoke tests` -->
<!-- Pyright can be started with `uv run pyright --threads --skipunannotated` -->

**Documentation**

- [ ] New features are documented along with examples if relevant.
- [ ] The documentation is [Sphinx](https://www.sphinx-doc.org/en/master/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant.

<!--
Thank you again!
-->
