### PR TITLE
PR: Implement support for *Python* 3.14, drop support for *Python* 3.10.

### DIFF
--- a/.github/workflows/continuous-integration-quality-unit-tests.yml
+++ b/.github/workflows/continuous-integration-quality-unit-tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: ["3.10", 3.11, 3.12, 3.13]
+        python-version: [3.11, 3.12, 3.13, 3.14]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
     rev: 1.19.1
     hooks:
       - id: blacken-docs
-        language_version: python3.10
+        language_version: python3.11
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: "v4.0.0-alpha.8"
     hooks:

--- a/colour/algebra/tests/test_interpolation.py
+++ b/colour/algebra/tests/test_interpolation.py
@@ -1306,7 +1306,7 @@ class TestLinearInterpolator:
             try:
                 linear_interpolator = LinearInterpolator(case, case)
                 linear_interpolator(case[0])
-            except ValueError:  # noqa: PERF203
+            except ValueError:
                 pass
 
 
@@ -1400,7 +1400,7 @@ class TestSpragueInterpolator:
             try:
                 sprague_interpolator = SpragueInterpolator(case, case)
                 sprague_interpolator(case[0])  # pragma: no cover
-            except AssertionError:  # noqa: PERF203
+            except AssertionError:
                 pass
 
 
@@ -1615,7 +1615,7 @@ default` property.
             try:
                 null_interpolator = NullInterpolator(case, case)
                 null_interpolator(case[0])
-            except ValueError:  # noqa: PERF203
+            except ValueError:
                 pass
 
 

--- a/colour/hints/__init__.py
+++ b/colour/hints/__init__.py
@@ -25,6 +25,7 @@ from typing import (  # noqa: UP035
     NewType,
     NoReturn,
     Protocol,
+    Self,
     Set,
     SupportsIndex,
     TextIO,
@@ -40,7 +41,6 @@ from typing import (  # noqa: UP035
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
-from typing_extensions import Self
 
 __author__ = "Colour Developers"
 __copyright__ = "Copyright 2013 Colour Developers"

--- a/colour/io/uprtek_sekonic.py
+++ b/colour/io/uprtek_sekonic.py
@@ -420,7 +420,7 @@ class SpectralDistribution_UPRTek(SpectralDistribution_IESTM2714):
                             self._metadata[attribute] = method(
                                 value  # pyright: ignore
                             )
-                        except (TypeError, ValueError):  # noqa: PERF203
+                        except (TypeError, ValueError):
                             self._metadata[attribute] = value
                         else:
                             break

--- a/colour/models/tests/test_cam02_ucs.py
+++ b/colour/models/tests/test_cam02_ucs.py
@@ -557,5 +557,5 @@ class TestUCS_Luo2006_to_XYZ:
         for case in cases:
             try:
                 UCS_Luo2006_to_XYZ(case, COEFFICIENTS_UCS_LUO2006["CAM02-LCD"])
-            except ValueError as error:  # noqa: PERF203
+            except ValueError as error:
                 attest("CAM_Specification_CIECAM02" in str(error))

--- a/colour/utilities/verbose.py
+++ b/colour/utilities/verbose.py
@@ -909,7 +909,7 @@ def describe_environment(
                 package = mapping.get(package, package)  # noqa: PLW2901
 
                 environment["Development"][package] = version
-            except Exception:  # pragma: no cover  # noqa: BLE001, PERF203, S112
+            except Exception:  # pragma: no cover  # noqa: BLE001, S112
                 continue
 
         environment["Development"].update(ANCILLARY_DEVELOPMENT_PACKAGES)
@@ -922,7 +922,7 @@ def describe_environment(
                 package = mapping.get(package, package)  # noqa: PLW2901
 
                 environment["Extras"][package] = version
-            except Exception:  # pragma: no cover  # noqa: BLE001, PERF203, S112
+            except Exception:  # pragma: no cover  # noqa: BLE001, S112
                 continue
 
         environment["Extras"].update(ANCILLARY_EXTRAS_PACKAGES)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "colour-science"
 version = "0.4.6"
 description = "Colour Science for Python"
 readme = "README.rst"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.11,<3.15"
 authors = [
     { name = "Colour Developers", email = "colour-developers@colour-science.org" },
 ]
@@ -54,7 +54,7 @@ optional = [
     "imageio>=2,<3",
     "matplotlib>=3.9",
     "networkx>=3.3,<4",
-    "opencolorio>=2,<3",
+    "opencolorio>=2,<3; python_version < '3.14'",
     "openimageio>=3,<4",
     "pandas>=2.2,<3",
     "pydot>=3,<4",
@@ -150,7 +150,7 @@ filterwarnings = [
 ]
 
 [tool.ruff]
-target-version = "py310"
+target-version = "py311"
 line-length = 88
 select = ["ALL"]
 ignore = [


### PR DESCRIPTION
<!--
Thank you for taking the time to create this pull request. If it is the first
time you are contributing to a colour-science repository, a contributing guide
is available to guide the process: https://www.colour-science.org/contributing/.
-->

# Summary

This PR implements support for *Python* 3.14, drop support for *Python* 3.10.

# Preflight

<!-- Please mark any checkboxes that do not apply to this pull request as [N/A]. -->

**Code Style and Quality**

- [x] Unit tests have been implemented and passed.
- [x] Pyright static checking has been run and passed.
- [x] Pre-commit hooks have been run and passed.
- [N/A] New transformations have been added to the _Automatic Colour Conversion Graph_.
- [N/A] New transformations have been exported to the relevant namespaces, e.g. `colour`, `colour.models`.

<!-- The unit tests can be invoked with `uv run invoke tests` -->
<!-- Pyright can be started with `uv run pyright --threads --skipunannotated` -->

**Documentation**

- [x] New features are documented along with examples if relevant.
- [x] The documentation is [Sphinx](https://www.sphinx-doc.org/en/master/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant.

<!--
Thank you again!
-->
