### PR TITLE
PR: Extend metamerism index with spectral correction.

### DIFF
--- a/colour/colorimetry/__init__.py
+++ b/colour/colorimetry/__init__.py
@@ -62,6 +62,7 @@ from .tristimulus_values import (
     SD_TO_XYZ_METHODS,
     SPECTRAL_SHAPE_ASTME308,
     adjust_tristimulus_weighting_factors_ASTME308,
+    get_tristimulus_weighting_factors_integration,
     handle_spectral_arguments,
     lagrange_coefficients_ASTME2022,
     msds_to_XYZ,
@@ -223,6 +224,7 @@ __all__ += [
     "sd_to_XYZ_ASTME308",
     "sd_to_XYZ_integration",
     "sd_to_XYZ_tristimulus_weighting_factors_ASTME308",
+    "get_tristimulus_weighting_factors_integration",
     "tristimulus_weighting_factors_ASTME2022",
     "wavelength_to_XYZ",
 ]

--- a/colour/colorimetry/tristimulus_values.py
+++ b/colour/colorimetry/tristimulus_values.py
@@ -32,6 +32,10 @@ References
 -   :cite:`ASTMInternational2015b` : ASTM International. (2015). ASTM E308-15 -
     Standard Practice for Computing the Colors of Objects by Using the CIE
     System (pp. 1-47). doi:10.1520/E0308-15
+-   :cite:`InternationalOrganizationforStandardization2024` : International
+    Organization for Standardization. (2024). INTERNATIONAL STANDARD ISO
+    18314-4 - Analytical colorimetry Part 4: Metamerism index for pairs of
+    samples for change of illuminant. https://www.iso.org/standard/85116.html
 -   :cite:`Wyszecki2000bf` : Wyszecki, Günther, & Stiles, W. S. (2000).
     Integration Replaced by Summation. In Color Science: Concepts and Methods,
     Quantitative Data and Formulae (pp. 158-163). Wiley. ISBN:978-0-471-39918-6
@@ -94,6 +98,7 @@ __all__ = [
     "lagrange_coefficients_ASTME2022",
     "tristimulus_weighting_factors_ASTME2022",
     "adjust_tristimulus_weighting_factors_ASTME308",
+    "get_tristimulus_weighting_factors_integration",
     "sd_to_XYZ_integration",
     "sd_to_XYZ_tristimulus_weighting_factors_ASTME308",
     "sd_to_XYZ_ASTME308",
@@ -544,6 +549,99 @@ def adjust_tristimulus_weighting_factors_ASTME308(
     return W[start_index : -end_index or None, ...]
 
 
+def get_tristimulus_weighting_factors_integration(
+    cmfs: MultiSpectralDistributions,
+    illuminant: SpectralDistribution,
+    shape: SpectralShape,
+    k: Real | None = None,
+) -> NDArrayFloat:
+    """
+    Return the tristimulus weighting factors computation method for the
+    integration method.
+
+    Parameters
+    ----------
+    cmfs
+        Standard observer colour matching functions.
+    illuminant
+        Illuminant spectral distribution.
+    shape
+        Shape used to build the table, only the interval is needed.
+    k
+        Normalisation constant :math:`k`. For reflecting or transmitting
+        object colours, :math:`k` is chosen so that :math:`Y = 100` for
+        objects for which the spectral reflectance factor
+        :math:`R(\\lambda)` of the object colour or the spectral
+        transmittance factor :math:`\\tau(\\lambda)` of the object is equal
+        to unity for all wavelengths. For self-luminous objects and
+        illuminants, the constants :math:`k` is usually chosen on the
+        grounds of convenience. If, however, in the CIE 1931 standard
+        colorimetric system, the :math:`Y` value is required to be
+        numerically equal to the absolute value of a photometric quantity,
+        the constant, :math:`k`, must be put equal to the numerical value
+        of :math:`K_m`, the maximum spectral luminous efficacy (which is
+        equal to 683 :math:`lm\\cdot W^{-1}`) and
+        :math:`\\Phi_\\lambda(\\lambda)` must be the spectral concentration
+        of the radiometric quantity corresponding to the photometric
+        quantity required.
+
+    Returns
+    -------
+    :class:`numpy.ndarray`
+        Tristimulus weighting factors table.
+
+    References
+    ----------
+    :cite:`InternationalOrganizationforStandardization2024`
+
+    Examples
+    --------
+    >>> from colour import MSDS_CMFS, SDS_ILLUMINANTS
+    >>> cmfs = MSDS_CMFS["CIE 1931 2 Degree Standard Observer"]
+    >>> illuminant = SDS_ILLUMINANTS["D65"]
+    >>> shape = SpectralShape(400, 700, 20)
+    >>> get_tristimulus_weighting_factors_integration(cmfs, illuminant, shape)
+    ... # doctest: +ELLIPSIS
+    array([[  2.23634421e-01,   6.18862548e-03,   1.06034924e+00],
+           [  2.37101690e+00,   7.05764816e-02,   1.13910441e+01],
+           [  6.89706619e+00,   4.55474108e-01,   3.45974172e+01],
+           [  6.46977575e+00,   1.33489183e+00,   3.71366908e+01],
+           [  2.09370011e+00,   3.04335204e+00,   1.77966720e+01],
+           [  1.01189640e-01,   6.67025585e+00,   5.61705756e+00],
+           [  1.25205375e+00,   1.40502317e+01,   1.54849365e+00],
+           [  5.72562903e+00,   1.88094012e+01,   4.00241975e-01],
+           [  1.12268302e+01,   1.87900691e+01,   7.36495171e-02],
+           [  1.65750211e+01,   1.57374968e+01,   2.98469948e-02],
+           [  1.80544399e+01,   1.07252416e+01,   1.35977706e-02],
+           [  1.41509324e+01,   6.30991383e+00,   3.14667619e-03],
+           [  7.07958281e+00,   2.76607946e+00,   3.16123367e-04],
+           [  2.49792489e+00,   9.24035282e-01,   0.00000000e+00],
+           [  6.91427716e-01,   2.51320744e-01,   0.00000000e+00],
+           [  1.53610085e-01,   5.54714053e-02,   0.00000000e+00]])
+    """
+
+    if cmfs.shape != shape:
+        runtime_warning(f'Aligning "{cmfs.name}" cmfs shape to "{shape}".')
+        cmfs = reshape_msds(cmfs, shape, copy=False)
+
+    if illuminant.shape != shape:
+        runtime_warning(f'Aligning "{illuminant.name}" illuminant shape to "{shape}".')
+        illuminant = reshape_sd(illuminant, shape, copy=False)
+
+    XYZ_b = cmfs.values
+    S = illuminant.values
+
+    d_w = cmfs.shape.interval
+
+    # normalisation constant k from Y = 100 of perfect diffuser
+    with sdiv_mode():
+        k = cast("Real", optional(k, sdiv(100, (np.sum(XYZ_b[..., 1] * S) * d_w))))
+
+    # --- weights matrix A (DIN EN ISO 18314-4, eq. 7-8) ---
+    # A[i, :] = k * S(λ_i) * [x̄(λ_i), ȳ(λ_i), z̄(λ_i)] * Δλ
+    return k * S[..., np.newaxis] * XYZ_b * d_w  # shape: (n, 3)
+
+
 def sd_to_XYZ_integration(
     sd: ArrayLike | SpectralDistribution | MultiSpectralDistributions,
     cmfs: MultiSpectralDistributions | None = None,
@@ -724,16 +822,11 @@ def sd_to_XYZ_integration(
         runtime_warning(f'Aligning "{illuminant.name}" illuminant shape to "{shape}".')
         illuminant = reshape_sd(illuminant, shape, copy=False)
 
-    XYZ_b = cmfs.values
-    S = illuminant.values
     R = np.reshape(R, (-1, wl_c_r))
 
-    d_w = cmfs.shape.interval
+    A = get_tristimulus_weighting_factors_integration(cmfs, illuminant, shape, k)
 
-    with sdiv_mode():
-        k = cast("Real", optional(k, sdiv(100, (np.sum(XYZ_b[..., 1] * S) * d_w))))
-
-    XYZ = k * np.dot(R * S, XYZ_b) * d_w
+    XYZ = np.dot(R, A)
 
     XYZ = from_range_100(np.reshape(XYZ, [*list(shape_R[:-1]), 3]))
 

--- a/colour/difference/__init__.py
+++ b/colour/difference/__init__.py
@@ -66,7 +66,11 @@ from .delta_e import (
 )
 from .din99 import delta_E_DIN99
 from .huang2015 import power_function_Huang2015
-from .metamerism_index import Lab_to_metamerism_index, XYZ_to_metamerism_index
+from .metamerism_index import (
+    Lab_to_metamerism_index,
+    XYZ_to_metamerism_index,
+    sd_to_metamerism_index,
+)
 from .stress import INDEX_STRESS_METHODS, index_stress, index_stress_Garcia2007
 
 __all__ = [
@@ -103,6 +107,7 @@ __all__ += [
 __all__ += [
     "Lab_to_metamerism_index",
     "XYZ_to_metamerism_index",
+    "sd_to_metamerism_index",
 ]
 
 DELTA_E_METHODS: CanonicalMapping = CanonicalMapping(

--- a/colour/difference/metamerism_index.py
+++ b/colour/difference/metamerism_index.py
@@ -17,7 +17,15 @@ References
 
 from __future__ import annotations
 
+from numpy import allclose, identity, linalg
+
 import colour
+from colour.colorimetry import (
+    MultiSpectralDistributions,
+    SpectralDistribution,
+    get_tristimulus_weighting_factors_integration,
+)
+from colour.constants import TOLERANCE_ABSOLUTE_TESTS
 from colour.hints import (  # noqa: TC001
     Any,
     Domain1,
@@ -29,7 +37,9 @@ from colour.hints import (  # noqa: TC001
 from colour.models import XYZ_to_Lab
 from colour.utilities import (
     as_array,
+    attest,
     filter_kwargs,
+    from_range_1,
     validate_method,
 )
 
@@ -43,6 +53,7 @@ __status__ = "Production"
 __all__ = [
     "Lab_to_metamerism_index",
     "XYZ_to_metamerism_index",
+    "sd_to_metamerism_index",
 ]
 
 
@@ -219,7 +230,7 @@ def XYZ_to_metamerism_index(
     ----------------
     illuminant
         {:func:`colour.models.XYZ_to_Lab`},
-        Reference *illuminant* *CIE xy* chromaticity coordinates or *CIE xyY*
+        Test *illuminant* *CIE xy* chromaticity coordinates or *CIE xyY*
         colourspace array for conversion from *CIE XYZ* to *CIE L\\*a\\*b\\**.
     c
         {:func:`colour.difference.delta_E_CMC`},
@@ -296,6 +307,226 @@ def XYZ_to_metamerism_index(
 
     elif correction == "multiplicative":
         XYZ_corr_t = as_array(XYZ_spl_t) * (as_array(XYZ_std_r) / as_array(XYZ_spl_r))
+
+    Lab_std_t = XYZ_to_Lab(XYZ_std_t, **filter_kwargs(XYZ_to_Lab, **kwargs))
+    Lab_corr_t = XYZ_to_Lab(XYZ_corr_t, **filter_kwargs(XYZ_to_Lab, **kwargs))
+
+    return colour.difference.delta_E(
+        Lab_std_t,
+        Lab_corr_t,
+        method=method,
+        **kwargs,
+    )
+
+
+def sd_to_metamerism_index(
+    sd_spl: SpectralDistribution | MultiSpectralDistributions,
+    sd_std: SpectralDistribution | MultiSpectralDistributions,
+    cmfs: MultiSpectralDistributions,
+    illuminant_r: SpectralDistribution,
+    illuminant_t: SpectralDistribution,
+    method: LiteralDeltaEMethod | str = "CIE 2000",
+    **kwargs: Any,
+) -> NDArrayFloat:
+    """
+    Compute the *metamerism index* :math:`M_{t}` from the specified
+    spectral distributions.
+
+    Before computing the *metamerism index*, we apply a spectral correction.
+    The correction aligns the sample spectral distribution to the standard
+    spectral distribution so that under reference illumination there exists
+    no colour different between the two.
+    Afterwards, we compute the corresponding *CIE XYZ* colourspace coordinates
+    under both reference and test illuminants and convert them to
+    *CIE L\\*a\\*b\\** colourspace to compute the *metamerism index*.
+
+    Parameters
+    ----------
+    sd_spl
+        Spectral distribution of the colour sample.
+        If an `ArrayLike` the wavelengths are expected to be in the last axis,
+        e.g., for a spectral array with 77 bins, ``sd`` shape could be (77, )
+        or (1, 77).
+    sd_std
+        Spectral distribution of the colour standard.
+        If an `ArrayLike` the wavelengths are expected to be in the last axis,
+        e.g., for a spectral array with 77 bins, ``sd`` shape could be (77, )
+        or (1, 77).
+    cmfs
+        Standard observer colour matching functions.
+    illuminant_r
+        Illuminant spectral distribution of the reference illuminant.
+    illuminant_t
+        Illuminant spectral distribution of the test illuminant.
+    method
+        Colour-difference method.
+
+    Other Parameters
+    ----------------
+    illuminant
+        {:func:`colour.models.XYZ_to_Lab`},
+        Test *illuminant* *CIE xy* chromaticity coordinates or *CIE xyY*
+        colourspace array for conversion from *CIE XYZ* to *CIE L\\*a\\*b\\**.
+    c
+        {:func:`colour.difference.delta_E_CMC`},
+        *Chroma* weighting factor.
+    l
+        {:func:`colour.difference.delta_E_CMC`},
+        *Lightness* weighting factor.
+    textiles
+        {:func:`colour.difference.delta_E_CIE1994`,
+        :func:`colour.difference.delta_E_CIE2000`,
+        :func:`colour.difference.delta_E_DIN99`},
+        Textiles application specific parametric factors
+        :math:`k_L=2,\\ k_C=k_H=1,\\ k_1=0.048,\\ k_2=0.014,\\ k_E=2,\\ k_{CH}=0.5`
+        weights are used instead of
+        :math:`k_L=k_C=k_H=1,\\ k_1=0.045,\\ k_2=0.015,\\ k_E=k_{CH}=1.0`.
+
+    Returns
+    -------
+    :class:`numpy.ndarray`
+        *Metamerism index* :math:`M_{t}`.
+
+    Notes
+    -----
+    +----------------+-----------------------+-------------------+
+    | **Domain**     | **Scale - Reference** | **Scale - 1**     |
+    +================+=======================+===================+
+    | ``XYZ_spl_t``  | 1                     | 1                 |
+    +----------------+-----------------------+-------------------+
+    | ``XYZ_std_t``  | 1                     | 1                 |
+    +----------------+-----------------------+-------------------+
+    | ``XYZ_spl_r``  | 1                     | 1                 |
+    +----------------+-----------------------+-------------------+
+    | ``XYZ_std_r``  | 1                     | 1                 |
+    +----------------+-----------------------+-------------------+
+
+    References
+    ----------
+    :cite:`InternationalOrganizationforStandardization2024`
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from colour import MSDS_CMFS, SDS_ILLUMINANTS, CCS_ILLUMINANTS
+    >>> from colour.colorimetry import SpectralShape
+    >>> shape = SpectralShape(400, 700, 10)
+    >>> N_spl = np.array(
+    ...     [
+    ...         0.0379,
+    ...         0.0403,
+    ...         0.0415,
+    ...         0.0427,
+    ...         0.045,
+    ...         0.0483,
+    ...         0.0521,
+    ...         0.0572,
+    ...         0.0624,
+    ...         0.0673,
+    ...         0.0777,
+    ...         0.1026,
+    ...         0.1307,
+    ...         0.145,
+    ...         0.1484,
+    ...         0.1455,
+    ...         0.1375,
+    ...         0.1254,
+    ...         0.1099,
+    ...         0.0908,
+    ...         0.0698,
+    ...         0.0526,
+    ...         0.0423,
+    ...         0.0368,
+    ...         0.0331,
+    ...         0.0306,
+    ...         0.0297,
+    ...         0.0311,
+    ...         0.034,
+    ...         0.038,
+    ...         0.0421,
+    ...     ]
+    ... )
+    >>> N_std = np.array(
+    ...     [
+    ...         0.099,
+    ...         0.1244,
+    ...         0.0933,
+    ...         0.0596,
+    ...         0.0405,
+    ...         0.0322,
+    ...         0.0299,
+    ...         0.0316,
+    ...         0.0377,
+    ...         0.0507,
+    ...         0.0681,
+    ...         0.0968,
+    ...         0.1522,
+    ...         0.2014,
+    ...         0.1991,
+    ...         0.159,
+    ...         0.1162,
+    ...         0.0843,
+    ...         0.0655,
+    ...         0.057,
+    ...         0.0553,
+    ...         0.0582,
+    ...         0.0638,
+    ...         0.0716,
+    ...         0.0818,
+    ...         0.0959,
+    ...         0.1131,
+    ...         0.1317,
+    ...         0.149,
+    ...         0.1656,
+    ...         0.1832,
+    ...     ]
+    ... )
+    >>> N_spl = SpectralDistribution(N_spl, shape)
+    >>> N_std = SpectralDistribution(N_std, shape)
+    >>> cmfs = MSDS_CMFS["CIE 1964 10 Degree Standard Observer"]
+    >>> r = SDS_ILLUMINANTS["D65"]
+    >>> t = SDS_ILLUMINANTS["A"]
+    >>> sd_to_metamerism_index(
+    ...     N_spl,
+    ...     N_std,
+    ...     cmfs,
+    ...     r,
+    ...     t,
+    ...     method="CIE 1976",
+    ...     illuminant=colour.CCS_ILLUMINANTS["CIE 1964 10 Degree Standard Observer"][
+    ...         "A"
+    ...     ],
+    ... )  # doctest: +ELLIPSIS
+    3.4766679...
+    """
+
+    attest(
+        sd_spl.shape == sd_std.shape,
+        "`sd_spl` and `sd_std` spectral distributions must have the same shape!",
+    )
+
+    shape = sd_spl.shape
+
+    A = get_tristimulus_weighting_factors_integration(cmfs, illuminant_r, shape=shape)
+    A_t = get_tristimulus_weighting_factors_integration(cmfs, illuminant_t, shape=shape)
+
+    R = A @ linalg.inv(A.T @ A) @ A.T
+
+    sd_corr = R @ sd_std.values + (identity(R.shape[0]) - R) @ sd_spl.values
+    sd_corr = SpectralDistribution(sd_corr, shape)
+
+    XYZ_corr_t = from_range_1((sd_corr.values @ A_t) / 100)
+    XYZ_std_t = from_range_1((sd_std.values @ A_t) / 100)
+    XYZ_corr_r = from_range_1((sd_corr.values @ A) / 100)
+    XYZ_std_r = from_range_1((sd_std.values @ A) / 100)
+
+    # must be equal ! otherwise correction failed !
+    attest(
+        allclose(XYZ_std_r, XYZ_corr_r, atol=TOLERANCE_ABSOLUTE_TESTS),
+        "The corrected sample under reference illuminant must be equal "
+        "to the standard under reference illuminant! Otherwise the correction"
+        "has failed.",
+    )
 
     Lab_std_t = XYZ_to_Lab(XYZ_std_t, **filter_kwargs(XYZ_to_Lab, **kwargs))
     Lab_corr_t = XYZ_to_Lab(XYZ_corr_t, **filter_kwargs(XYZ_to_Lab, **kwargs))

--- a/colour/difference/tests/test_metamerism_index.py
+++ b/colour/difference/tests/test_metamerism_index.py
@@ -4,10 +4,20 @@ from __future__ import annotations
 
 import numpy as np
 
+from colour import (
+    CCS_ILLUMINANTS,
+    MSDS_CMFS,
+    SDS_ILLUMINANTS,
+)
+from colour.colorimetry import (
+    SpectralDistribution,
+    SpectralShape,
+)
 from colour.constants import TOLERANCE_ABSOLUTE_TESTS
 from colour.difference.metamerism_index import (
     Lab_to_metamerism_index,
     XYZ_to_metamerism_index,
+    sd_to_metamerism_index,
 )
 from colour.utilities import domain_range_scale
 
@@ -122,6 +132,138 @@ class TestXYZ_to_Metamerism_Index:
                             XYZ_1 * factor,
                             correction=correction,
                             method=method,
+                        ),
+                        value,
+                        atol=TOLERANCE_ABSOLUTE_TESTS,
+                    )
+
+
+class TestSD_to_Metamerism_Index:
+    """
+    Define :func:`colour.difference.metamerism_index.sd_to_metamerism_index`
+    definition unit tests methods.
+    """
+
+    def test_domain_range_scale_sd_to_metamerism_index(self) -> None:
+        """
+        Test :func:`colour.difference.metamerism_index.sd_to_metamerism_index`
+        definition domain and range scale support.
+        """
+        shape = SpectralShape(400, 700, 10)
+
+        N_spl = np.array(
+            [
+                0.0379,
+                0.0403,
+                0.0415,
+                0.0427,
+                0.045,
+                0.0483,
+                0.0521,
+                0.0572,
+                0.0624,
+                0.0673,
+                0.0777,
+                0.1026,
+                0.1307,
+                0.145,
+                0.1484,
+                0.1455,
+                0.1375,
+                0.1254,
+                0.1099,
+                0.0908,
+                0.0698,
+                0.0526,
+                0.0423,
+                0.0368,
+                0.0331,
+                0.0306,
+                0.0297,
+                0.0311,
+                0.034,
+                0.038,
+                0.0421,
+            ]
+        )
+        N_std = np.array(
+            [
+                0.099,
+                0.1244,
+                0.0933,
+                0.0596,
+                0.0405,
+                0.0322,
+                0.0299,
+                0.0316,
+                0.0377,
+                0.0507,
+                0.0681,
+                0.0968,
+                0.1522,
+                0.2014,
+                0.1991,
+                0.159,
+                0.1162,
+                0.0843,
+                0.0655,
+                0.057,
+                0.0553,
+                0.0582,
+                0.0638,
+                0.0716,
+                0.0818,
+                0.0959,
+                0.1131,
+                0.1317,
+                0.149,
+                0.1656,
+                0.1832,
+            ]
+        )
+
+        N_spl = SpectralDistribution(N_spl, shape)
+        N_std = SpectralDistribution(N_std, shape)
+
+        o = (
+            "CIE 1931 2 Degree Standard Observer",
+            "CIE 1964 10 Degree Standard Observer",
+        )
+        i = ("A", "FL2")
+        m = ("CIE 1976", "CIE 1994", "CIE 2000", "CMC", "DIN99")
+        it = [
+            (
+                observer,
+                illuminant,
+                method,
+                sd_to_metamerism_index(
+                    N_spl,
+                    N_std,
+                    MSDS_CMFS[observer],
+                    SDS_ILLUMINANTS["D65"],
+                    SDS_ILLUMINANTS[illuminant],
+                    method=method,
+                    illuminant=CCS_ILLUMINANTS[observer][illuminant],
+                ),
+            )
+            for observer in o
+            for illuminant in i
+            for method in m
+        ]
+
+        d_r = (("reference", 1), ("1", 1), ("100", 100))
+        for observer, illuminant, method, value in it:
+            for scale, _ in d_r:
+                with domain_range_scale(scale):
+                    np.testing.assert_allclose(
+                        sd_to_metamerism_index(
+                            N_spl,
+                            N_std,
+                            MSDS_CMFS[observer],
+                            SDS_ILLUMINANTS["D65"],
+                            SDS_ILLUMINANTS[illuminant],
+                            method=method,
+                            illuminant=CCS_ILLUMINANTS[observer][illuminant],
                         ),
                         value,
                         atol=TOLERANCE_ABSOLUTE_TESTS,


### PR DESCRIPTION
# Summary

This PR extends previous metamerism implementation (#1374) with spectral correction. One day late for 0.47 release 😵

To achieve this, we need to compute a matrix that contains all integration weights when integrating sd to XYZ. As we are already doing this in function sd_to_XYZ_integration, I was able to extract the relevant part into a new helper function which sd_to_XYZ_integration is now using (same math but slightly different formulation, see image).

(for notation, e.g. R x S means element-wise multiplication, NOT dot product / matrix multiplication)

![IMG_3994](https://github.com/user-attachments/assets/bf5274db-96ba-4132-972a-e0aa628d395d)

# Preflight

**Code Style and Quality**

- [x] Unit tests have been implemented and passed.
- [x] Pyright static checking has been run and passed.
- [x] Pre-commit hooks have been run and passed.
- [x] New transformations have been added to the _Automatic Colour Conversion Graph_.
- [x] New transformations have been exported to the relevant namespaces, e.g. `colour`, `colour.models`.

Following tests failed

TOTAL                                                                          44443   9955    78%
============================= slowest 5 durations =============================
22.91s call     colour/recovery/tests/test_jakob2019.py::TestLUT3D_Jakob2019::test_size
16.24s call     colour/notation/tests/test_munsell.py::TestxyY_to_munsell_specification::test_xyY_to_munsell_specification
6.78s call     colour/utilities/tests/test_network.py::TestParallelForMultiProcess::test_ParallelForMultiProcess
6.66s call     colour/io/luts/lut.py::colour.io.luts.lut.LUT3D.invert
6.33s call     colour/volume/tests/test_rgb.py::TestRGB_colourspaceVisibleSpectrumCoverageMonteCarlo::test_RGB_colourspace_visible_spectrum_coverage_MonteCarlo
=========================== short test summary info ===========================
FAILED colour/io/image.py::colour.io.image.read_image_Imageio
FAILED colour/io/tests/test_image.py::TestWriteImageImageio::test_write_image_Imageio_exr
FAILED colour/io/tests/test_image.py::TestReadImageImageio::test_read_image_Imageio
========== 3 failed, 3683 passed, 17 skipped, 225 warnings in 44.77s ==========

**Documentation**

- [x] New features are documented along with examples if relevant.
- [x] The documentation is [Sphinx](https://www.sphinx-doc.org/en/master/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant.

