### PR TITLE
PR: Implement support for gaussian-based spectral recovery.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1861,7 +1861,7 @@ Reflectance Recovery
 
 .. code-block:: text
 
-    ['Jakob 2019', 'Mallett 2019', 'Meng 2015', 'Otsu 2018', 'Smits 1999']
+    ['Gaussian', 'Jakob 2019', 'Mallett 2019', 'Meng 2015', 'Otsu 2018', 'Smits 1999']
 
 Camera RGB Sensitivities Recovery
 *********************************

--- a/colour/examples/recovery/examples_gaussian.py
+++ b/colour/examples/recovery/examples_gaussian.py
@@ -1,0 +1,47 @@
+"""
+Demonstrate reflectance recovery computations using *Gaussian* basis method.
+
+This module provides examples of reflectance recovery from RGB colourspace
+values using the *Gaussian* basis method with *Smits (1999)* decomposition.
+"""
+
+import numpy as np
+
+import colour
+from colour.recovery.gaussian import XYZ_to_RGB_Gaussian
+from colour.utilities import message_box
+
+message_box('"Gaussian" - Reflectance Recovery Computations')
+
+XYZ = np.array([0.20654008, 0.12197225, 0.05136952])
+RGB = XYZ_to_RGB_Gaussian(XYZ)
+message_box(
+    f'Recovering reflectance using "Gaussian" method from given "XYZ" '
+    f"tristimulus values:\n\n\tXYZ: {XYZ}\n\tRGB: {RGB}"
+)
+sd = colour.recovery.RGB_to_sd_Gaussian(RGB)
+print(sd)
+
+print("\n")
+
+message_box("Round-trip XYZ recovery:")
+XYZ_recovered = colour.sd_to_XYZ(sd) / 100
+print(f"Original XYZ:  {XYZ}")
+print(f"Recovered XYZ: {XYZ_recovered}")
+print(f"Delta: {XYZ_recovered - XYZ}")
+
+print("\n")
+
+message_box("Comparison with Smits (1999) method:")
+sd_smits = colour.recovery.RGB_to_sd_Smits1999(
+    colour.recovery.smits1999.XYZ_to_RGB_Smits1999(XYZ)
+)
+XYZ_smits = colour.sd_to_XYZ(sd_smits.align(colour.SPECTRAL_SHAPE_DEFAULT)) / 100
+print(f"Gaussian error:    {np.sqrt(np.sum((XYZ_recovered - XYZ) ** 2)):.6f}")
+print(f"Smits 1999 error:  {np.sqrt(np.sum((XYZ_smits - XYZ) ** 2)):.6f}")
+
+print("\n")
+
+message_box("Gaussian basis spectra parameters:")
+print(f"Peak wavelengths: {colour.recovery.PEAK_WAVELENGTHS_GAUSSIAN_BASIS}")
+print(f"FWHM: {colour.recovery.FWHM_GAUSSIAN_BASIS}")

--- a/colour/recovery/__init__.py
+++ b/colour/recovery/__init__.py
@@ -35,6 +35,20 @@ from colour.utilities import (
 
 from . import datasets
 from .datasets import *  # noqa: F403
+from .gaussian import (
+    CCS_WHITEPOINT_GAUSSIAN,
+    FWHM_GAUSSIAN_BASIS,
+    PEAK_WAVELENGTHS_GAUSSIAN_BASIS,
+    PRIMARIES_GAUSSIAN,
+    RGB_COLOURSPACE_GAUSSIAN,
+    SDS_GAUSSIAN_BASIS,
+    WHITEPOINT_NAME_GAUSSIAN,
+    RGB_to_sd_Gaussian,
+    XYZ_to_RGB_Gaussian,
+    generate_gaussian_basis,
+    optimise_gaussian_basis_parameters,
+    sd_gaussian_clamped,
+)
 from .jakob2019 import (
     LUT3D_Jakob2019,
     XYZ_to_sd_Jakob2019,
@@ -56,7 +70,7 @@ from .otsu2018 import (
     Tree_Otsu2018,
     XYZ_to_sd_Otsu2018,
 )
-from .smits1999 import RGB_to_sd_Smits1999
+from .smits1999 import RGB_to_sd_Smits1999, sd_from_RGB_Smits1999
 
 __all__ = datasets.__all__
 __all__ += [
@@ -84,10 +98,26 @@ __all__ += [
 ]
 __all__ += [
     "RGB_to_sd_Smits1999",
+    "sd_from_RGB_Smits1999",
+]
+__all__ += [
+    "CCS_WHITEPOINT_GAUSSIAN",
+    "FWHM_GAUSSIAN_BASIS",
+    "PEAK_WAVELENGTHS_GAUSSIAN_BASIS",
+    "PRIMARIES_GAUSSIAN",
+    "RGB_COLOURSPACE_GAUSSIAN",
+    "RGB_to_sd_Gaussian",
+    "SDS_GAUSSIAN_BASIS",
+    "WHITEPOINT_NAME_GAUSSIAN",
+    "XYZ_to_RGB_Gaussian",
+    "generate_gaussian_basis",
+    "optimise_gaussian_basis_parameters",
+    "sd_gaussian_clamped",
 ]
 
 XYZ_TO_SD_METHODS: CanonicalMapping = CanonicalMapping(
     {
+        "Gaussian": RGB_to_sd_Gaussian,
         "Jakob 2019": XYZ_to_sd_Jakob2019,
         "Mallett 2019": RGB_to_sd_Mallett2019,
         "Meng 2015": XYZ_to_sd_Meng2015,
@@ -109,6 +139,7 @@ def XYZ_to_sd(
     XYZ: ArrayLike,
     method: (
         Literal[
+            "Gaussian",
             "Jakob 2019",
             "Mallett 2019",
             "Meng 2015",
@@ -180,9 +211,9 @@ def XYZ_to_sd(
     | ``XYZ``    | 1                     | 1             |
     +------------+-----------------------+---------------+
 
-    -   *Smits (1999)* method will internally convert specified *CIE XYZ*
-        tristimulus values to *sRGB* colourspace array assuming equal
-        energy illuminant *E*.
+    -   *Gaussian* and *Smits (1999)* methods will internally convert
+        specified *CIE XYZ* tristimulus values to *RGB* colourspace array
+        assuming *sRGB* primaries and equal energy illuminant *E*.
 
     References
     ----------
@@ -191,13 +222,74 @@ def XYZ_to_sd(
 
     Examples
     --------
-    *Jakob and Hanika (2019)* reflectance recovery:
+    *Gaussian* reflectance recovery:
 
     >>> import numpy as np
     >>> from colour import MSDS_CMFS, SDS_ILLUMINANTS, SpectralShape
     >>> from colour.colorimetry import sd_to_XYZ_integration
     >>> from colour.utilities import numpy_print_options
     >>> XYZ = np.array([0.20654008, 0.12197225, 0.05136952])
+    >>> cmfs = (
+    ...     MSDS_CMFS["CIE 1931 2 Degree Standard Observer"]
+    ...     .copy()
+    ...     .align(SpectralShape(360, 780, 10))
+    ... )
+    >>> illuminant = SDS_ILLUMINANTS["E"].copy().align(cmfs.shape)
+    >>> sd = XYZ_to_sd(XYZ, method="Gaussian").align(SpectralShape(360, 780, 10))
+    >>> with numpy_print_options(suppress=True):
+    ...     sd  # doctest: +ELLIPSIS
+    SpectralDistribution([[ 360.        ,    0.0450201...],
+                          [ 370.        ,    0.0450201...],
+                          [ 380.        ,    0.0450201...],
+                          [ 390.        ,    0.0450201...],
+                          [ 400.        ,    0.0450201...],
+                          [ 410.        ,    0.0450201...],
+                          [ 420.        ,    0.0450201...],
+                          [ 430.        ,    0.0450201...],
+                          [ 440.        ,    0.0450201...],
+                          [ 450.        ,    0.0449106...],
+                          [ 460.        ,    0.0440152...],
+                          [ 470.        ,    0.0423976...],
+                          [ 480.        ,    0.0403790...],
+                          [ 490.        ,    0.0383067...],
+                          [ 500.        ,    0.0364608...],
+                          [ 510.        ,    0.0350120...],
+                          [ 520.        ,    0.0340596...],
+                          [ 530.        ,    0.0338074...],
+                          [ 540.        ,    0.0350031...],
+                          [ 550.        ,    0.0397867...],
+                          [ 560.        ,    0.0527660...],
+                          [ 570.        ,    0.0811874...],
+                          [ 580.        ,    0.1321498...],
+                          [ 590.        ,    0.2059634...],
+                          [ 600.        ,    0.2892693...],
+                          [ 610.        ,    0.3557119...],
+                          [ 620.        ,    0.3786455...],
+                          [ 630.        ,    0.3786455...],
+                          [ 640.        ,    0.3786454...],
+                          [ 650.        ,    0.3786454...],
+                          [ 660.        ,    0.3786454...],
+                          [ 670.        ,    0.3786454...],
+                          [ 680.        ,    0.3786454...],
+                          [ 690.        ,    0.3786454...],
+                          [ 700.        ,    0.3786454...],
+                          [ 710.        ,    0.3786454...],
+                          [ 720.        ,    0.3786454...],
+                          [ 730.        ,    0.3786454...],
+                          [ 740.        ,    0.3786454...],
+                          [ 750.        ,    0.3786454...],
+                          [ 760.        ,    0.3786454...],
+                          [ 770.        ,    0.3786454...],
+                          [ 780.        ,    0.3786454...]],
+                         LinearInterpolator,
+                         {},
+                         Extrapolator,
+                         {'method': 'Constant', 'left': None, 'right': None})
+    >>> sd_to_XYZ_integration(sd, cmfs, illuminant) / 100  # doctest: +ELLIPSIS
+    array([ 0.2038334...,  0.1254643...,  0.0434193...])
+
+    *Jakob and Hanika (2019)* reflectance recovery:
+
     >>> cmfs = (
     ...     MSDS_CMFS["CIE 1931 2 Degree Standard Observer"]
     ...     .copy()
@@ -506,7 +598,9 @@ def XYZ_to_sd(
 
     function = XYZ_TO_SD_METHODS[method]
 
-    if function is RGB_to_sd_Smits1999:
+    if function is RGB_to_sd_Gaussian:
+        a = XYZ_to_RGB_Gaussian(XYZ)
+    elif function is RGB_to_sd_Smits1999:
         from colour.recovery.smits1999 import XYZ_to_RGB_Smits1999  # noqa: PLC0415
 
         a = XYZ_to_RGB_Smits1999(XYZ)

--- a/colour/recovery/gaussian.py
+++ b/colour/recovery/gaussian.py
@@ -1,0 +1,452 @@
+"""
+Gaussian - Reflectance Recovery
+===============================
+
+Define objects for reflectance recovery using Gaussian basis spectra.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from colour.colorimetry import (
+    CCS_ILLUMINANTS,
+    MSDS_CMFS,
+    SDS_ILLUMINANTS,
+    SPECTRAL_SHAPE_DEFAULT,
+    SpectralDistribution,
+    SpectralShape,
+    sd_constant,
+    sd_gaussian,
+    sd_to_XYZ_integration,
+)
+from colour.models import RGB_Colourspace, RGB_COLOURSPACE_sRGB, XYZ_to_RGB
+from colour.recovery.smits1999 import sd_from_RGB_Smits1999
+from colour.utilities import CanonicalMapping, optional, required
+
+if TYPE_CHECKING:
+    from colour.hints import Domain1, NDArrayFloat, Range1
+
+__author__ = "Colour Developers"
+__copyright__ = "Copyright 2013 Colour Developers"
+__license__ = "BSD-3-Clause - https://opensource.org/licenses/BSD-3-Clause"
+__maintainer__ = "Colour Developers"
+__email__ = "colour-developers@colour-science.org"
+__status__ = "Production"
+
+__all__ = [
+    "PRIMARIES_GAUSSIAN",
+    "WHITEPOINT_NAME_GAUSSIAN",
+    "CCS_WHITEPOINT_GAUSSIAN",
+    "RGB_COLOURSPACE_GAUSSIAN",
+    "XYZ_to_RGB_Gaussian",
+    "sd_gaussian_clamped",
+    "optimise_gaussian_basis_parameters",
+    "generate_gaussian_basis",
+    "SDS_GAUSSIAN_BASIS",
+    "PEAK_WAVELENGTHS_GAUSSIAN_BASIS",
+    "FWHM_GAUSSIAN_BASIS",
+    "RGB_to_sd_Gaussian",
+]
+
+PRIMARIES_GAUSSIAN: NDArrayFloat = RGB_COLOURSPACE_sRGB.primaries
+"""*Gaussian* method implementation colourspace primaries."""
+
+WHITEPOINT_NAME_GAUSSIAN: str = "E"
+"""*Gaussian* method implementation colourspace whitepoint name."""
+
+CCS_WHITEPOINT_GAUSSIAN: NDArrayFloat = CCS_ILLUMINANTS[
+    "CIE 1931 2 Degree Standard Observer"
+][WHITEPOINT_NAME_GAUSSIAN]
+"""*Gaussian* method implementation colourspace whitepoint."""
+
+RGB_COLOURSPACE_GAUSSIAN: RGB_Colourspace = RGB_Colourspace(
+    "Gaussian",
+    PRIMARIES_GAUSSIAN,
+    CCS_WHITEPOINT_GAUSSIAN,
+    WHITEPOINT_NAME_GAUSSIAN,
+)
+"""*Gaussian* colourspace."""
+
+
+def XYZ_to_RGB_Gaussian(XYZ: Domain1) -> Range1:
+    """
+    Convert from *CIE XYZ* tristimulus values to *RGB* colourspace using
+    the conditions required by the *Gaussian* method implementation.
+
+    Parameters
+    ----------
+    XYZ
+        *CIE XYZ* tristimulus values.
+
+    Returns
+    -------
+    :class:`numpy.ndarray`
+        *RGB* colour array.
+
+    Notes
+    -----
+    +------------+-----------------------+---------------+
+    | **Domain** | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``XYZ``    | 1                     | 1             |
+    +------------+-----------------------+---------------+
+
+    +------------+-----------------------+---------------+
+    | **Range**  | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``RGB``    | 1                     | 1             |
+    +------------+-----------------------+---------------+
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> XYZ = np.array([0.21781186, 0.12541048, 0.04697113])
+    >>> XYZ_to_RGB_Gaussian(XYZ)  # doctest: +ELLIPSIS
+    array([ 0.4063959...,  0.0275289...,  0.0398219...])
+    """
+
+    return XYZ_to_RGB(XYZ, RGB_COLOURSPACE_GAUSSIAN)
+
+
+def sd_gaussian_clamped(
+    peak_wavelength: float,
+    fwhm: float,
+    shape: SpectralShape = SPECTRAL_SHAPE_DEFAULT,
+    clamp: str = "none",
+    name: str | None = None,
+) -> SpectralDistribution:
+    """
+    Generate a Gaussian spectral distribution, optionally clamped flat on one
+    side of the peak, with the peak normalized to 1.
+
+    Parameters
+    ----------
+    peak_wavelength
+        Peak wavelength of the Gaussian.
+    fwhm
+        Full width at half maximum.
+    shape
+        Spectral shape for the distribution.
+    clamp
+        Clamping mode: ``"none"`` for symmetric Gaussian, ``"left"`` for flat
+        from start to peak, ``"right"`` for flat from peak to end.
+    name
+        Name for the spectral distribution.
+
+    Returns
+    -------
+    :class:`colour.SpectralDistribution`
+        Clamped Gaussian spectral distribution with peak normalized to 1.
+
+    Examples
+    --------
+    >>> sd = sd_gaussian_clamped(600, 50, clamp="right")
+    >>> sd.name = "Red Gaussian"
+    >>> round(sd[600], 5)
+    1.0
+    >>> round(sd[700], 5)
+    1.0
+    """
+
+    sd = sd_gaussian(peak_wavelength, fwhm, shape, method="FWHM")
+    sd.range = sd.range / sd.range.max()  # Normalize peak to 1
+
+    if clamp == "left":
+        sd[sd.wavelengths[sd.wavelengths <= peak_wavelength]] = 1.0
+    elif clamp == "right":
+        sd[sd.wavelengths[sd.wavelengths >= peak_wavelength]] = 1.0
+
+    sd.name = name or f"Gaussian {peak_wavelength}nm"
+
+    return sd
+
+
+@required("SciPy")
+def optimise_gaussian_basis_parameters(
+    shape: SpectralShape = SPECTRAL_SHAPE_DEFAULT,
+    initial_peaks: dict | None = None,
+    initial_fwhm: dict | None = None,
+) -> tuple[dict, dict]:
+    """
+    Optimise Gaussian basis parameters for colorimetric accuracy.
+
+    This function uses scipy's L-BFGS-B optimizer to find peak wavelengths
+    and FWHM values that minimize the colorimetric error between the basis
+    spectra XYZ values and the target RGB colourspace primaries.
+
+    Parameters
+    ----------
+    shape
+        Spectral shape for the distributions.
+    initial_peaks
+        Initial peak wavelengths for optimization. Default is
+        ``{"red": 600, "green": 540, "blue": 460}``.
+    initial_fwhm
+        Initial FWHM values for optimization. Default is
+        ``{"red": 65, "green": 65, "blue": 65}``.
+
+    Returns
+    -------
+    :class:`tuple`
+        Tuple of (peak_wavelengths, fwhm) dictionaries with optimized values.
+
+    Examples
+    --------
+    >>> peaks, fwhm = optimise_gaussian_basis_parameters()
+    >>> print(f"Red: peak={peaks['red']:.1f}nm, FWHM={fwhm['red']:.1f}nm")
+    ... # doctest: +SKIP
+    """
+
+    from scipy.optimize import minimize  # noqa: PLC0415
+
+    initial_peaks = optional(initial_peaks, {"red": 600, "green": 540, "blue": 460})
+    initial_fwhm = optional(initial_fwhm, {"red": 70, "green": 70, "blue": 70})
+
+    # CMFs and illuminant for XYZ integration
+    cmfs = MSDS_CMFS["CIE 1931 2 Degree Standard Observer"].copy().align(shape)
+    illuminant = SDS_ILLUMINANTS["E"].copy().align(shape)
+
+    # Test XYZ values for round-trip optimization (RGB, CMY, grey)
+    M = RGB_COLOURSPACE_GAUSSIAN.matrix_RGB_to_XYZ
+    test_XYZ = np.array(
+        [
+            np.dot(M, [1, 0, 0]),  # Red
+            np.dot(M, [0, 1, 0]),  # Green
+            np.dot(M, [0, 0, 1]),  # Blue
+            np.dot(M, [0, 1, 1]),  # Cyan
+            np.dot(M, [1, 0, 1]),  # Magenta
+            np.dot(M, [1, 1, 0]),  # Yellow
+            np.dot(M, [0.5, 0.5, 0.5]),  # Grey
+        ]
+    )
+
+    def objective(params: NDArrayFloat) -> float:
+        """Minimize round-trip XYZ error."""
+
+        R_peak, G_peak, B_peak, R_fwhm, G_fwhm, B_fwhm = params
+
+        # Generate basis spectra
+        sd_R = sd_gaussian_clamped(R_peak, R_fwhm, shape, clamp="right")
+        sd_G = sd_gaussian_clamped(G_peak, G_fwhm, shape, clamp="none")
+        sd_B = sd_gaussian_clamped(B_peak, B_fwhm, shape, clamp="left")
+
+        # Secondary colours derived from primaries
+        sd_cyan = sd_G + sd_B
+        sd_cyan.name = "cyan"
+        sd_magenta = sd_R + sd_B
+        sd_magenta.name = "magenta"
+        sd_yellow = sd_R + sd_G
+        sd_yellow.name = "yellow"
+        sd_white = sd_constant(1, shape)
+
+        basis = {
+            "white": sd_white,
+            "cyan": sd_cyan,
+            "magenta": sd_magenta,
+            "yellow": sd_yellow,
+            "red": sd_R,
+            "green": sd_G,
+            "blue": sd_B,
+        }
+
+        # Round-trip error
+        total_error = 0.0
+        for XYZ in test_XYZ:
+            RGB = XYZ_to_RGB(XYZ, RGB_COLOURSPACE_GAUSSIAN)
+            sd = sd_from_RGB_Smits1999(RGB, basis, "optimisation")
+            XYZ_recovered = sd_to_XYZ_integration(sd, cmfs, illuminant) / 100
+            total_error += np.sum((XYZ_recovered - XYZ) ** 2)
+
+        return float(total_error)
+
+    x0 = [
+        initial_peaks["red"],
+        initial_peaks["green"],
+        initial_peaks["blue"],
+        initial_fwhm["red"],
+        initial_fwhm["green"],
+        initial_fwhm["blue"],
+    ]
+
+    bounds = [
+        (580, 650),  # red peak
+        (510, 570),  # green peak
+        (420, 480),  # blue peak
+        (20, 150),  # red fwhm
+        (20, 150),  # green fwhm
+        (20, 150),  # blue fwhm
+    ]
+
+    result = minimize(objective, x0, bounds=bounds, method="L-BFGS-B")
+    R_peak, G_peak, B_peak, R_fwhm, G_fwhm, B_fwhm = result.x
+
+    peak_wavelengths = {
+        "red": float(R_peak),
+        "green": float(G_peak),
+        "blue": float(B_peak),
+    }
+
+    fwhm = {
+        "red": float(R_fwhm),
+        "green": float(G_fwhm),
+        "blue": float(B_fwhm),
+    }
+
+    return peak_wavelengths, fwhm
+
+
+def generate_gaussian_basis(
+    shape: SpectralShape = SPECTRAL_SHAPE_DEFAULT,
+    peak_wavelengths: dict | None = None,
+    fwhm: dict | None = None,
+) -> CanonicalMapping:
+    """
+    Generate a set of Gaussian basis spectral distributions.
+
+    Parameters
+    ----------
+    shape
+        Spectral shape for the distributions.
+    peak_wavelengths
+        Dictionary with peak wavelengths for red, green, and blue.
+    fwhm
+        Dictionary with FWHM values for red, green, and blue.
+
+    Returns
+    -------
+    :class:`colour.utilities.CanonicalMapping`
+        Gaussian basis spectral distributions with keys: white, cyan, magenta,
+        yellow, red, green, blue.
+
+    Examples
+    --------
+    >>> basis = generate_gaussian_basis()
+    >>> sorted(basis.keys())
+    ['blue', 'cyan', 'green', 'magenta', 'red', 'white', 'yellow']
+    """
+
+    peak_wavelengths = optional(peak_wavelengths, PEAK_WAVELENGTHS_GAUSSIAN_BASIS)
+    fwhm = optional(fwhm, FWHM_GAUSSIAN_BASIS)
+
+    # Primary colours with clamping
+    sd_red = sd_gaussian_clamped(
+        peak_wavelengths["red"], fwhm["red"], shape, clamp="right", name="red"
+    )
+    sd_green = sd_gaussian_clamped(
+        peak_wavelengths["green"], fwhm["green"], shape, clamp="none", name="green"
+    )
+    sd_blue = sd_gaussian_clamped(
+        peak_wavelengths["blue"], fwhm["blue"], shape, clamp="left", name="blue"
+    )
+
+    # Secondary colours derived from primaries
+    sd_cyan = sd_green + sd_blue
+    sd_cyan.name = "cyan"
+    sd_magenta = sd_red + sd_blue
+    sd_magenta.name = "magenta"
+    sd_yellow = sd_red + sd_green
+    sd_yellow.name = "yellow"
+
+    # White as constant
+    sd_white = sd_constant(1, shape)
+    sd_white.name = "white"
+
+    return CanonicalMapping(
+        {
+            "white": sd_white,
+            "cyan": sd_cyan,
+            "magenta": sd_magenta,
+            "yellow": sd_yellow,
+            "red": sd_red,
+            "green": sd_green,
+            "blue": sd_blue,
+        }
+    )
+
+
+PEAK_WAVELENGTHS_GAUSSIAN_BASIS: dict = {
+    "red": 619.2,
+    "green": 541.8,
+    "blue": 445.2,
+}
+"""
+Default peak wavelengths for Gaussian basis spectra.
+
+These values are optimized for round-trip colorimetric accuracy using
+:func:`optimise_gaussian_basis_parameters`.
+"""
+
+FWHM_GAUSSIAN_BASIS: dict = {
+    "red": 58.5,
+    "green": 89.4,
+    "blue": 85.4,
+}
+"""
+Default full width at half maximum for Gaussian basis spectra.
+
+These values are optimized for round-trip colorimetric accuracy using
+:func:`optimise_gaussian_basis_parameters`.
+"""
+
+SDS_GAUSSIAN_BASIS: CanonicalMapping = generate_gaussian_basis()
+SDS_GAUSSIAN_BASIS.__doc__ = """
+Gaussian basis spectral distributions for spectral upsampling.
+
+The basis spectra use clamped Gaussians with parameters optimized for round-trip
+colorimetric accuracy with *sRGB* primaries:
+
+- Red: Gaussian centered at 619.2nm, FWHM 58.5nm, clamped flat toward long wavelengths
+- Green: Symmetric Gaussian centered at 541.8nm, FWHM 89.4nm
+- Blue: Gaussian centered at 445.2nm, FWHM 85.4nm, clamped flat toward short wavelengths
+- Cyan, Magenta, Yellow: Derived as C=G+B, M=R+B, Y=R+G
+- White: Constant value of 1
+
+Parameters can be recomputed using :func:`optimise_gaussian_basis_parameters`.
+"""
+
+
+def RGB_to_sd_Gaussian(RGB: Domain1) -> SpectralDistribution:
+    """
+    Recover the spectral distribution of the specified *RGB* colourspace array
+    using Gaussian basis spectra and the *Smits (1999)* decomposition algorithm.
+
+    Parameters
+    ----------
+    RGB
+        *RGB* colourspace array to recover the spectral distribution from.
+
+    Returns
+    -------
+    :class:`colour.SpectralDistribution`
+        Recovered spectral distribution.
+
+    Notes
+    -----
+    +------------+-----------------------+---------------+
+    | **Domain** | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``RGB``    | 1                     | 1             |
+    +------------+-----------------------+---------------+
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from colour import MSDS_CMFS, SDS_ILLUMINANTS, SpectralShape
+    >>> from colour.colorimetry import sd_to_XYZ_integration
+    >>> XYZ = np.array([0.20654008, 0.12197225, 0.05136952])
+    >>> RGB = XYZ_to_RGB_Gaussian(XYZ)
+    >>> cmfs = (
+    ...     MSDS_CMFS["CIE 1931 2 Degree Standard Observer"]
+    ...     .copy()
+    ...     .align(SpectralShape(360, 780, 10))
+    ... )
+    >>> illuminant = SDS_ILLUMINANTS["E"].copy().align(cmfs.shape)
+    >>> sd = RGB_to_sd_Gaussian(RGB)
+    >>> sd_to_XYZ_integration(sd, cmfs, illuminant) / 100  # doctest: +ELLIPSIS
+    array([ 0.2038334...,  0.1254643...,  0.0434193...])
+    """
+
+    return sd_from_RGB_Smits1999(RGB, SDS_GAUSSIAN_BASIS, f"Gaussian - {RGB!r}")

--- a/colour/recovery/smits1999.py
+++ b/colour/recovery/smits1999.py
@@ -13,15 +13,15 @@ References
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from colour.colorimetry import CCS_ILLUMINANTS, SpectralDistribution
-from colour.hints import (  # noqa: TC001
-    Domain1,
-    NDArrayFloat,
-    Range1,
-)
 from colour.models import RGB_Colourspace, RGB_COLOURSPACE_sRGB, XYZ_to_RGB
 from colour.recovery import SDS_SMITS1999
-from colour.utilities import to_domain_1
+from colour.utilities import CanonicalMapping, to_domain_1
+
+if TYPE_CHECKING:
+    from colour.hints import Domain1, NDArrayFloat, Range1
 
 __author__ = "Colour Developers"
 __copyright__ = "Copyright 2013 Colour Developers"
@@ -36,6 +36,7 @@ __all__ = [
     "CCS_WHITEPOINT_SMITS1999",
     "RGB_COLOURSPACE_SMITS1999",
     "XYZ_to_RGB_Smits1999",
+    "sd_from_RGB_Smits1999",
     "RGB_to_sd_Smits1999",
 ]
 
@@ -106,6 +107,91 @@ def XYZ_to_RGB_Smits1999(XYZ: Domain1) -> Range1:
     return XYZ_to_RGB(XYZ, RGB_COLOURSPACE_SMITS1999)
 
 
+def sd_from_RGB_Smits1999(
+    RGB: Domain1,
+    basis: dict | CanonicalMapping,
+    name: str | None = None,
+) -> SpectralDistribution:
+    """
+    Generate a spectral distribution from *RGB* values using the
+    *Smits (1999)* decomposition algorithm.
+
+    Parameters
+    ----------
+    RGB
+        *RGB* colourspace array to recover the spectral distribution from.
+    basis
+        Dictionary of basis spectral distributions with keys: white, cyan,
+        magenta, yellow, red, green, blue.
+    name
+        Name for the resulting spectral distribution.
+
+    Returns
+    -------
+    :class:`colour.SpectralDistribution`
+        Recovered spectral distribution.
+
+    Notes
+    -----
+    +------------+-----------------------+---------------+
+    | **Domain** | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``RGB``    | 1                     | 1             |
+    +------------+-----------------------+---------------+
+
+    References
+    ----------
+    :cite:`Smits1999a`
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from colour.recovery import SDS_SMITS1999
+    >>> sd = sd_from_RGB_Smits1999(np.array([0.4, 0.03, 0.04]), SDS_SMITS1999, "test")
+    >>> sd[380]  # doctest: +ELLIPSIS
+    0.0764...
+    """
+
+    sd_white = basis["white"].copy()
+    sd_cyan = basis["cyan"].copy()
+    sd_magenta = basis["magenta"].copy()
+    sd_yellow = basis["yellow"].copy()
+    sd_red = basis["red"].copy()
+    sd_green = basis["green"].copy()
+    sd_blue = basis["blue"].copy()
+
+    R, G, B = to_domain_1(RGB)
+    sd = sd_white.copy() * 0
+    sd.name = name
+
+    if R <= G and R <= B:
+        sd += sd_white * R
+        if G <= B:
+            sd += sd_cyan * (G - R)
+            sd += sd_blue * (B - G)
+        else:
+            sd += sd_cyan * (B - R)
+            sd += sd_green * (G - B)
+    elif G <= R and G <= B:
+        sd += sd_white * G
+        if R <= B:
+            sd += sd_magenta * (R - G)
+            sd += sd_blue * (B - R)
+        else:
+            sd += sd_magenta * (B - G)
+            sd += sd_red * (R - B)
+    else:
+        sd += sd_white * B
+        if R <= G:
+            sd += sd_yellow * (R - B)
+            sd += sd_green * (G - R)
+        else:
+            sd += sd_yellow * (G - B)
+            sd += sd_red * (R - G)
+
+    return sd
+
+
 def RGB_to_sd_Smits1999(RGB: Domain1) -> SpectralDistribution:
     """
     Recover the spectral distribution of the specified *RGB* colourspace array
@@ -168,41 +254,4 @@ def RGB_to_sd_Smits1999(RGB: Domain1) -> SpectralDistribution:
     array([ 0.1894770...,  0.1126470...,  0.0474420...])
     """
 
-    sd_white = SDS_SMITS1999["white"].copy()
-    sd_cyan = SDS_SMITS1999["cyan"].copy()
-    sd_magenta = SDS_SMITS1999["magenta"].copy()
-    sd_yellow = SDS_SMITS1999["yellow"].copy()
-    sd_red = SDS_SMITS1999["red"].copy()
-    sd_green = SDS_SMITS1999["green"].copy()
-    sd_blue = SDS_SMITS1999["blue"].copy()
-
-    R, G, B = to_domain_1(RGB)
-    sd = sd_white.copy() * 0
-    sd.name = f"Smits (1999) - {RGB!r}"
-
-    if R <= G and R <= B:
-        sd += sd_white * R
-        if G <= B:
-            sd += sd_cyan * (G - R)
-            sd += sd_blue * (B - G)
-        else:
-            sd += sd_cyan * (B - R)
-            sd += sd_green * (G - B)
-    elif G <= R and G <= B:
-        sd += sd_white * G
-        if R <= B:
-            sd += sd_magenta * (R - G)
-            sd += sd_blue * (B - R)
-        else:
-            sd += sd_magenta * (B - G)
-            sd += sd_red * (R - B)
-    else:
-        sd += sd_white * B
-        if R <= G:
-            sd += sd_yellow * (R - B)
-            sd += sd_green * (G - R)
-        else:
-            sd += sd_yellow * (G - B)
-            sd += sd_red * (R - G)
-
-    return sd
+    return sd_from_RGB_Smits1999(RGB, SDS_SMITS1999, f"Smits (1999) - {RGB!r}")

--- a/colour/recovery/tests/test_gaussian.py
+++ b/colour/recovery/tests/test_gaussian.py
@@ -1,0 +1,106 @@
+"""Define the unit tests for the :mod:`colour.recovery.gaussian` module."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from colour.colorimetry import sd_to_XYZ_integration
+from colour.constants import TOLERANCE_ABSOLUTE_TESTS
+from colour.recovery import RGB_to_sd_Gaussian
+from colour.recovery.gaussian import (
+    XYZ_to_RGB_Gaussian,
+    optimise_gaussian_basis_parameters,
+)
+from colour.utilities import domain_range_scale
+
+__author__ = "Colour Developers"
+__copyright__ = "Copyright 2013 Colour Developers"
+__license__ = "BSD-3-Clause - https://opensource.org/licenses/BSD-3-Clause"
+__maintainer__ = "Colour Developers"
+__email__ = "colour-developers@colour-science.org"
+__status__ = "Production"
+
+__all__ = [
+    "TestOptimiseGaussianBasisParameters",
+    "TestRGB_to_sd_Gaussian",
+]
+
+
+class TestOptimiseGaussianBasisParameters:
+    """
+    Define :func:`colour.recovery.gaussian.optimise_gaussian_basis_parameters`
+    definition unit tests methods.
+    """
+
+    def test_optimise_gaussian_basis_parameters(self) -> None:
+        """
+        Test :func:`colour.recovery.gaussian.optimise_gaussian_basis_parameters`
+        definition.
+        """
+
+        peak_wavelengths, fwhm = optimise_gaussian_basis_parameters()
+
+        assert set(peak_wavelengths.keys()) == {"red", "green", "blue"}
+        assert set(fwhm.keys()) == {"red", "green", "blue"}
+
+        assert 580 < peak_wavelengths["red"] < 650
+        assert 510 < peak_wavelengths["green"] < 570
+        assert 420 < peak_wavelengths["blue"] < 480
+
+        assert 20 < fwhm["red"] < 150
+        assert 20 < fwhm["green"] < 150
+        assert 20 < fwhm["blue"] < 150
+
+
+class TestRGB_to_sd_Gaussian:
+    """
+    Define :func:`colour.recovery.gaussian.RGB_to_sd_Gaussian`
+    definition unit tests methods.
+    """
+
+    def test_RGB_to_sd_Gaussian(self) -> None:
+        """
+        Test :func:`colour.recovery.gaussian.RGB_to_sd_Gaussian`
+        definition.
+        """
+
+        sd = RGB_to_sd_Gaussian(
+            XYZ_to_RGB_Gaussian(np.array([0.21781186, 0.12541048, 0.04697113]))
+        )
+        np.testing.assert_allclose(
+            [sd[w] for w in [360, 400, 450, 500, 550, 600, 650, 700, 750, 780]],
+            np.array(
+                [
+                    0.03982193,
+                    0.03982193,
+                    0.03971491,
+                    0.03145787,
+                    0.03554526,
+                    0.30858755,
+                    0.40639599,
+                    0.40639599,
+                    0.40639599,
+                    0.40639599,
+                ]
+            ),
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+    def test_domain_range_scale_RGB_to_sd_Gaussian(self) -> None:
+        """
+        Test :func:`colour.recovery.gaussian.RGB_to_sd_Gaussian`
+        definition domain and range scale support.
+        """
+
+        XYZ_i = np.array([0.20654008, 0.12197225, 0.05136952])
+        RGB_i = XYZ_to_RGB_Gaussian(XYZ_i)
+        XYZ_o = sd_to_XYZ_integration(RGB_to_sd_Gaussian(RGB_i))
+
+        d_r = (("reference", 1, 1), ("1", 1, 0.01), ("100", 100, 1))
+        for scale, factor_a, factor_b in d_r:
+            with domain_range_scale(scale):
+                np.testing.assert_allclose(
+                    sd_to_XYZ_integration(RGB_to_sd_Gaussian(RGB_i * factor_a)),
+                    XYZ_o * factor_b,
+                    atol=TOLERANCE_ABSOLUTE_TESTS,
+                )

--- a/colour/recovery/tests/test_smits1999.py
+++ b/colour/recovery/tests/test_smits1999.py
@@ -6,8 +6,8 @@ import numpy as np
 
 from colour.colorimetry import sd_to_XYZ_integration
 from colour.constants import TOLERANCE_ABSOLUTE_TESTS
-from colour.recovery import RGB_to_sd_Smits1999
-from colour.recovery.smits1999 import XYZ_to_RGB_Smits1999
+from colour.recovery import SDS_SMITS1999, RGB_to_sd_Smits1999
+from colour.recovery.smits1999 import XYZ_to_RGB_Smits1999, sd_from_RGB_Smits1999
 from colour.utilities import domain_range_scale
 
 __author__ = "Colour Developers"
@@ -18,8 +18,79 @@ __email__ = "colour-developers@colour-science.org"
 __status__ = "Production"
 
 __all__ = [
+    "TestSd_from_RGB_Smits1999",
     "TestRGB_to_sd_Smits1999",
 ]
+
+
+class TestSd_from_RGB_Smits1999:
+    """
+    Define :func:`colour.recovery.smits1999.sd_from_RGB_Smits1999`
+    definition unit tests methods.
+    """
+
+    def test_sd_from_RGB_Smits1999(self) -> None:
+        """
+        Test :func:`colour.recovery.smits1999.sd_from_RGB_Smits1999`
+        definition.
+        """
+
+        RGB = np.array([0.4, 0.03, 0.04])
+        sd = sd_from_RGB_Smits1999(RGB, SDS_SMITS1999, "test")
+
+        np.testing.assert_equal(sd.name, "test")
+        np.testing.assert_equal(sd.shape, SDS_SMITS1999["white"].shape)
+
+        np.testing.assert_allclose(
+            sd.values,
+            np.array(
+                [
+                    0.076432,
+                    0.05854,
+                    0.039682,
+                    0.032208,
+                    0.029976,
+                    0.030452,
+                    0.338069,
+                    0.405364,
+                    0.405364,
+                    0.405323,
+                ]
+            ),
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+        RGB_white = np.array([1.0, 1.0, 1.0])
+        sd_white = sd_from_RGB_Smits1999(RGB_white, SDS_SMITS1999, "white")
+        np.testing.assert_allclose(
+            sd_white.values,
+            SDS_SMITS1999["white"].values,
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+        RGB_red = np.array([1.0, 0.0, 0.0])
+        sd_red = sd_from_RGB_Smits1999(RGB_red, SDS_SMITS1999, "red")
+        np.testing.assert_allclose(
+            sd_red.values,
+            SDS_SMITS1999["red"].values,
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+        RGB_green = np.array([0.0, 1.0, 0.0])
+        sd_green = sd_from_RGB_Smits1999(RGB_green, SDS_SMITS1999, "green")
+        np.testing.assert_allclose(
+            sd_green.values,
+            SDS_SMITS1999["green"].values,
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+        RGB_blue = np.array([0.0, 0.0, 1.0])
+        sd_blue = sd_from_RGB_Smits1999(RGB_blue, SDS_SMITS1999, "blue")
+        np.testing.assert_allclose(
+            sd_blue.values,
+            SDS_SMITS1999["blue"].values,
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
 
 
 class TestRGB_to_sd_Smits1999:

--- a/docs/colour.recovery.rst
+++ b/docs/colour.recovery.rst
@@ -113,8 +113,37 @@ Smits (1999)
 .. autosummary::
     :toctree: generated/
 
+    sd_from_RGB_Smits1999
     RGB_to_sd_Smits1999
     SDS_SMITS1999
+
+Gaussian Basis
+~~~~~~~~~~~~~~
+
+``colour.recovery``
+
+.. currentmodule:: colour.recovery
+
+.. autosummary::
+    :toctree: generated/
+
+    RGB_to_sd_Gaussian
+    SDS_GAUSSIAN_BASIS
+
+**Ancillary Objects**
+
+``colour.recovery``
+
+.. currentmodule:: colour.recovery
+
+.. autosummary::
+    :toctree: generated/
+
+    FWHM_GAUSSIAN_BASIS
+    PEAK_WAVELENGTHS_GAUSSIAN_BASIS
+    generate_gaussian_basis
+    optimise_gaussian_basis_parameters
+    sd_gaussian_clamped
 
 Camera RGB Sensitivities Recovery
 ---------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1596,7 +1596,7 @@ Reflectance Recovery
 
 .. code-block:: text
 
-    ['Jakob 2019', 'Mallett 2019', 'Meng 2015', 'Otsu 2018', 'Smits 1999']
+    ['Gaussian', 'Jakob 2019', 'Mallett 2019', 'Meng 2015', 'Otsu 2018', 'Smits 1999']
 
 Camera RGB Sensitivities Recovery
 *********************************


### PR DESCRIPTION
<!--
Thank you for taking the time to create this pull request. If it is the first
time you are contributing to a colour-science repository, a contributing guide
is available to guide the process: https://www.colour-science.org/contributing/.
-->

# Summary

This PR implements support for gaussian-based spectral recovery with `colour.recovery.RGB_to_sd_Gaussian` definition following Smits (1999) method.

The RGB reference colourspace is also *sRGB* but it is possible to reoptimise new basis using different RGB primaries.

# Preflight

<!-- Please mark any checkboxes that do not apply to this pull request as [N/A]. -->

**Code Style and Quality**

- [x] Unit tests have been implemented and passed.
- [x] Pyright static checking has been run and passed.
- [x] Pre-commit hooks have been run and passed.
- [N/A] New transformations have been added to the _Automatic Colour Conversion Graph_.
- [N/A] New transformations have been exported to the relevant namespaces, e.g. `colour`, `colour.models`.

<!-- The unit tests can be invoked with `uv run invoke tests` -->
<!-- Pyright can be started with `uv run pyright --threads --skipunannotated` -->

**Documentation**

- [x] New features are documented along with examples if relevant.
- [x] The documentation is [Sphinx](https://www.sphinx-doc.org/en/master/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant.

<!--
Thank you again!
-->
