### PR TITLE
PR: Add `colour.recovery.RGB_to_msds_Smits1999`, `colour.recovery.RGB_to_msds_Gaussian` and `colour.XYZ_to_msds` definitions.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1863,6 +1863,32 @@ Reflectance Recovery
 
     ['Gaussian', 'Jakob 2019', 'Mallett 2019', 'Meng 2015', 'Otsu 2018', 'Smits 1999']
 
+.. code-block:: python
+
+    import colour
+
+    colour.XYZ_to_msds(
+        [
+            [0.20654008, 0.12197225, 0.05136952],
+            [0.14223761, 0.23042375, 0.10498415],
+            [0.07820260, 0.06157595, 0.28106183],
+        ]
+    ).shape
+
+.. code-block:: text
+
+    (3, 421)
+
+.. code-block:: python
+
+    import colour
+
+    sorted(colour.XYZ_TO_MSDS_METHODS)
+
+.. code-block:: text
+
+    ['Gaussian', 'Smits 1999']
+
 Camera RGB Sensitivities Recovery
 *********************************
 

--- a/colour/__init__.py
+++ b/colour/__init__.py
@@ -454,7 +454,7 @@ from .quality import (
     colour_rendering_index,
     spectral_similarity_index,
 )
-from .recovery import XYZ_TO_SD_METHODS, XYZ_to_sd
+from .recovery import XYZ_TO_MSDS_METHODS, XYZ_TO_SD_METHODS, XYZ_to_msds, XYZ_to_sd
 from .temperature import (
     CCT_TO_UV_METHODS,
     CCT_TO_XY_METHODS,
@@ -878,7 +878,9 @@ __all__ += [
     "spectral_similarity_index",
 ]
 __all__ += [
+    "XYZ_TO_MSDS_METHODS",
     "XYZ_TO_SD_METHODS",
+    "XYZ_to_msds",
     "XYZ_to_sd",
 ]
 __all__ += [

--- a/colour/recovery/__init__.py
+++ b/colour/recovery/__init__.py
@@ -24,7 +24,7 @@ import typing
 
 if typing.TYPE_CHECKING:
     from colour.colorimetry import SpectralDistribution
-    from colour.hints import Any, ArrayLike, Literal
+    from colour.hints import Any, ArrayLike, Literal, NDArrayFloat
 
 from colour.utilities import (
     CanonicalMapping,
@@ -38,11 +38,12 @@ from .datasets import *  # noqa: F403
 from .gaussian import (
     CCS_WHITEPOINT_GAUSSIAN,
     FWHM_GAUSSIAN_BASIS,
+    MSDS_GAUSSIAN_BASIS,
     PEAK_WAVELENGTHS_GAUSSIAN_BASIS,
     PRIMARIES_GAUSSIAN,
     RGB_COLOURSPACE_GAUSSIAN,
-    SDS_GAUSSIAN_BASIS,
     WHITEPOINT_NAME_GAUSSIAN,
+    RGB_to_msds_Gaussian,
     RGB_to_sd_Gaussian,
     XYZ_to_RGB_Gaussian,
     generate_gaussian_basis,
@@ -70,7 +71,10 @@ from .otsu2018 import (
     Tree_Otsu2018,
     XYZ_to_sd_Otsu2018,
 )
-from .smits1999 import RGB_to_sd_Smits1999, sd_from_RGB_Smits1999
+from .smits1999 import (
+    RGB_to_msds_Smits1999,
+    RGB_to_sd_Smits1999,
+)
 
 __all__ = datasets.__all__
 __all__ += [
@@ -97,17 +101,18 @@ __all__ += [
     "XYZ_to_sd_Otsu2018",
 ]
 __all__ += [
+    "RGB_to_msds_Smits1999",
     "RGB_to_sd_Smits1999",
-    "sd_from_RGB_Smits1999",
 ]
 __all__ += [
     "CCS_WHITEPOINT_GAUSSIAN",
     "FWHM_GAUSSIAN_BASIS",
+    "MSDS_GAUSSIAN_BASIS",
     "PEAK_WAVELENGTHS_GAUSSIAN_BASIS",
     "PRIMARIES_GAUSSIAN",
     "RGB_COLOURSPACE_GAUSSIAN",
+    "RGB_to_msds_Gaussian",
     "RGB_to_sd_Gaussian",
-    "SDS_GAUSSIAN_BASIS",
     "WHITEPOINT_NAME_GAUSSIAN",
     "XYZ_to_RGB_Gaussian",
     "generate_gaussian_basis",
@@ -281,7 +286,7 @@ def XYZ_to_sd(
                           [ 760.        ,    0.3786454...],
                           [ 770.        ,    0.3786454...],
                           [ 780.        ,    0.3786454...]],
-                         LinearInterpolator,
+                         SpragueInterpolator,
                          {},
                          Extrapolator,
                          {'method': 'Constant', 'left': None, 'right': None})
@@ -615,4 +620,100 @@ def XYZ_to_sd(
 __all__ += [
     "XYZ_TO_SD_METHODS",
     "XYZ_to_sd",
+]
+
+XYZ_TO_MSDS_METHODS: CanonicalMapping = CanonicalMapping(
+    {
+        "Gaussian": RGB_to_msds_Gaussian,
+        "Smits 1999": RGB_to_msds_Smits1999,
+    }
+)
+XYZ_TO_MSDS_METHODS.__doc__ = """
+Supported multi-spectral distributions recovery methods.
+
+References
+----------
+:cite:`Smits1999a`
+"""
+
+
+def XYZ_to_msds(
+    XYZ: ArrayLike,
+    method: (Literal["Gaussian", "Smits 1999"] | str) = "Gaussian",
+) -> NDArrayFloat:
+    """
+    Recover spectral values from the specified *CIE XYZ* tristimulus values
+    using the specified method.
+
+    Parameters
+    ----------
+    XYZ
+        *CIE XYZ* tristimulus values to recover the spectral values from.
+        The last dimension must be size 3.
+    method
+        Computation method.
+
+    Returns
+    -------
+    :class:`numpy.ndarray`
+        Recovered spectral values with shape ``(*XYZ.shape[:-1], wavelengths)``.
+
+    Notes
+    -----
+    +------------+-----------------------+---------------+
+    | **Domain** | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``XYZ``    | 1                     | 1             |
+    +------------+-----------------------+---------------+
+
+    -   Both methods will internally convert specified *CIE XYZ* tristimulus
+        values to *RGB* colourspace array assuming *sRGB* primaries and equal
+        energy illuminant *E*.
+
+    References
+    ----------
+    :cite:`Smits1999a`
+
+    Examples
+    --------
+    *Gaussian* reflectance recovery:
+
+    >>> import numpy as np
+    >>> XYZ = np.array(
+    ...     [
+    ...         [0.20654008, 0.12197225, 0.05136952],
+    ...         [0.14223761, 0.23042375, 0.10498415],
+    ...         [0.07820260, 0.06157595, 0.28106183],
+    ...     ]
+    ... )
+    >>> XYZ_to_msds(XYZ, method="Gaussian").shape
+    (3, 421)
+    >>> XYZ_to_msds(XYZ, method="Gaussian")[0, 300]  # doctest: +ELLIPSIS
+    0.3786...
+
+    *Smits (1999)* reflectance recovery:
+
+    >>> XYZ_to_msds(XYZ, method="Smits 1999").shape
+    (3, 10)
+    >>> XYZ_to_msds(XYZ, method="Smits 1999")[0, 6]  # doctest: +ELLIPSIS
+    0.3207...
+    """
+
+    method = validate_method(method, tuple(XYZ_TO_MSDS_METHODS))
+
+    function = XYZ_TO_MSDS_METHODS[method]
+
+    if function is RGB_to_msds_Gaussian:
+        a = XYZ_to_RGB_Gaussian(XYZ)
+    else:  # RGB_to_msds_Smits1999
+        from colour.recovery.smits1999 import XYZ_to_RGB_Smits1999  # noqa: PLC0415
+
+        a = XYZ_to_RGB_Smits1999(XYZ)
+
+    return function(a)
+
+
+__all__ += [
+    "XYZ_TO_MSDS_METHODS",
+    "XYZ_to_msds",
 ]

--- a/colour/recovery/datasets/__init__.py
+++ b/colour/recovery/datasets/__init__.py
@@ -12,7 +12,7 @@ from .otsu2018 import (
     SELECTOR_ARRAY_OTSU2018,
     SPECTRAL_SHAPE_OTSU2018,
 )
-from .smits1999 import SDS_SMITS1999
+from .smits1999 import MSDS_SMITS1999, SDS_SMITS1999
 
 __all__ = [
     "BASIS_FUNCTIONS_DYER2017",
@@ -29,5 +29,6 @@ __all__ += [
     "SPECTRAL_SHAPE_OTSU2018",
 ]
 __all__ += [
+    "MSDS_SMITS1999",
     "SDS_SMITS1999",
 ]

--- a/colour/recovery/datasets/smits1999.py
+++ b/colour/recovery/datasets/smits1999.py
@@ -14,7 +14,7 @@ References
 from __future__ import annotations
 
 from colour.algebra import LinearInterpolator
-from colour.colorimetry.spectrum import SpectralDistribution
+from colour.colorimetry import MultiSpectralDistributions, SpectralDistribution
 from colour.utilities import CanonicalMapping
 
 __author__ = "Colour Developers"
@@ -27,6 +27,7 @@ __status__ = "Production"
 __all__ = [
     "DATA_SMITS1999",
     "SDS_SMITS1999",
+    "MSDS_SMITS1999",
 ]
 
 DATA_SMITS1999: dict = {
@@ -118,13 +119,27 @@ DATA_SMITS1999: dict = {
 
 SDS_SMITS1999: CanonicalMapping = CanonicalMapping(
     {
-        "white": SpectralDistribution(DATA_SMITS1999["white"], name="white"),
-        "cyan": SpectralDistribution(DATA_SMITS1999["cyan"], name="cyan"),
-        "magenta": SpectralDistribution(DATA_SMITS1999["magenta"], name="magenta"),
-        "yellow": SpectralDistribution(DATA_SMITS1999["yellow"], name="yellow"),
-        "red": SpectralDistribution(DATA_SMITS1999["red"], name="red"),
-        "green": SpectralDistribution(DATA_SMITS1999["green"], name="green"),
-        "blue": SpectralDistribution(DATA_SMITS1999["blue"], name="blue"),
+        "white": SpectralDistribution(
+            DATA_SMITS1999["white"], name="white", interpolator=LinearInterpolator
+        ),
+        "cyan": SpectralDistribution(
+            DATA_SMITS1999["cyan"], name="cyan", interpolator=LinearInterpolator
+        ),
+        "magenta": SpectralDistribution(
+            DATA_SMITS1999["magenta"], name="magenta", interpolator=LinearInterpolator
+        ),
+        "yellow": SpectralDistribution(
+            DATA_SMITS1999["yellow"], name="yellow", interpolator=LinearInterpolator
+        ),
+        "red": SpectralDistribution(
+            DATA_SMITS1999["red"], name="red", interpolator=LinearInterpolator
+        ),
+        "green": SpectralDistribution(
+            DATA_SMITS1999["green"], name="green", interpolator=LinearInterpolator
+        ),
+        "blue": SpectralDistribution(
+            DATA_SMITS1999["blue"], name="blue", interpolator=LinearInterpolator
+        ),
     }
 )
 SDS_SMITS1999.__doc__ = """
@@ -135,7 +150,16 @@ References
 :cite:`Smits1999a`
 """
 
-# Using linear interpolation to preserve the shape of the basis spectral
-# distributions once combined and interpolated.
-for _sd in SDS_SMITS1999.values():
-    _sd.interpolator = LinearInterpolator
+MSDS_SMITS1999: MultiSpectralDistributions = MultiSpectralDistributions(
+    list(SDS_SMITS1999.values()),
+    labels=list(SDS_SMITS1999.keys()),
+    name="Smits (1999)",
+    interpolator=LinearInterpolator,
+)
+MSDS_SMITS1999.__doc__ = """
+*Smits (1999)* multi-spectral distributions.
+
+References
+----------
+:cite:`Smits1999a`
+"""

--- a/colour/recovery/gaussian.py
+++ b/colour/recovery/gaussian.py
@@ -16,18 +16,19 @@ from colour.colorimetry import (
     MSDS_CMFS,
     SDS_ILLUMINANTS,
     SPECTRAL_SHAPE_DEFAULT,
+    MultiSpectralDistributions,
     SpectralDistribution,
     SpectralShape,
+    msds_to_XYZ_integration,
     sd_constant,
     sd_gaussian,
-    sd_to_XYZ_integration,
 )
 from colour.models import RGB_Colourspace, RGB_COLOURSPACE_sRGB, XYZ_to_RGB
-from colour.recovery.smits1999 import sd_from_RGB_Smits1999
-from colour.utilities import CanonicalMapping, optional, required
+from colour.recovery.smits1999 import RGB_to_msds_Smits1999, RGB_to_sd_Smits1999
+from colour.utilities import as_float, optional, required
 
 if TYPE_CHECKING:
-    from colour.hints import Domain1, NDArrayFloat, Range1
+    from colour.hints import ArrayLike, Domain1, DTypeFloat, NDArrayFloat, Range1
 
 __author__ = "Colour Developers"
 __copyright__ = "Copyright 2013 Colour Developers"
@@ -45,9 +46,10 @@ __all__ = [
     "sd_gaussian_clamped",
     "optimise_gaussian_basis_parameters",
     "generate_gaussian_basis",
-    "SDS_GAUSSIAN_BASIS",
+    "MSDS_GAUSSIAN_BASIS",
     "PEAK_WAVELENGTHS_GAUSSIAN_BASIS",
     "FWHM_GAUSSIAN_BASIS",
+    "RGB_to_msds_Gaussian",
     "RGB_to_sd_Gaussian",
 ]
 
@@ -167,26 +169,29 @@ def sd_gaussian_clamped(
 @required("SciPy")
 def optimise_gaussian_basis_parameters(
     shape: SpectralShape = SPECTRAL_SHAPE_DEFAULT,
-    initial_peaks: dict | None = None,
+    initial_peak_wavelengths: dict | None = None,
     initial_fwhm: dict | None = None,
+    optimisation_kwargs: dict | None = None,
 ) -> tuple[dict, dict]:
     """
     Optimise Gaussian basis parameters for colorimetric accuracy.
 
-    This function uses scipy's L-BFGS-B optimizer to find peak wavelengths
-    and FWHM values that minimize the colorimetric error between the basis
-    spectra XYZ values and the target RGB colourspace primaries.
+    This function finds the peak wavelengths and FWHM values that minimize the
+    colorimetric error between the basis spectra tristimulus values and the
+    target *RGB* colourspace primaries.
 
     Parameters
     ----------
     shape
         Spectral shape for the distributions.
-    initial_peaks
+    initial_peak_wavelengths
         Initial peak wavelengths for optimization. Default is
         ``{"red": 600, "green": 540, "blue": 460}``.
     initial_fwhm
         Initial FWHM values for optimization. Default is
         ``{"red": 65, "green": 65, "blue": 65}``.
+    optimisation_kwargs
+        Parameters for :func:`scipy.optimize.minimize` definition.
 
     Returns
     -------
@@ -196,13 +201,15 @@ def optimise_gaussian_basis_parameters(
     Examples
     --------
     >>> peaks, fwhm = optimise_gaussian_basis_parameters()
-    >>> print(f"Red: peak={peaks['red']:.1f}nm, FWHM={fwhm['red']:.1f}nm")
+    >>> print(f"Red: peak={peak_wavelengths['red']:.1f}nm, FWHM={fwhm['red']:.1f}nm")
     ... # doctest: +SKIP
     """
 
     from scipy.optimize import minimize  # noqa: PLC0415
 
-    initial_peaks = optional(initial_peaks, {"red": 600, "green": 540, "blue": 460})
+    initial_peak_wavelengths = optional(
+        initial_peak_wavelengths, {"red": 600, "green": 540, "blue": 460}
+    )
     initial_fwhm = optional(initial_fwhm, {"red": 70, "green": 70, "blue": 70})
 
     # CMFs and illuminant for XYZ integration
@@ -223,10 +230,10 @@ def optimise_gaussian_basis_parameters(
         ]
     )
 
-    def objective(params: NDArrayFloat) -> float:
+    def objective(parameters: NDArrayFloat) -> DTypeFloat:
         """Minimize round-trip XYZ error."""
 
-        R_peak, G_peak, B_peak, R_fwhm, G_fwhm, B_fwhm = params
+        R_peak, G_peak, B_peak, R_fwhm, G_fwhm, B_fwhm = parameters
 
         # Generate basis spectra
         sd_R = sd_gaussian_clamped(R_peak, R_fwhm, shape, clamp="right")
@@ -242,30 +249,29 @@ def optimise_gaussian_basis_parameters(
         sd_yellow.name = "yellow"
         sd_white = sd_constant(1, shape)
 
-        basis = {
-            "white": sd_white,
-            "cyan": sd_cyan,
-            "magenta": sd_magenta,
-            "yellow": sd_yellow,
-            "red": sd_R,
-            "green": sd_G,
-            "blue": sd_B,
-        }
+        basis = MultiSpectralDistributions(
+            [sd_white, sd_cyan, sd_magenta, sd_yellow, sd_R, sd_G, sd_B],
+            labels=["white", "cyan", "magenta", "yellow", "red", "green", "blue"],
+            name="Gaussian Basis (Optimisation)",
+        )
 
-        # Round-trip error
-        total_error = 0.0
-        for XYZ in test_XYZ:
-            RGB = XYZ_to_RGB(XYZ, RGB_COLOURSPACE_GAUSSIAN)
-            sd = sd_from_RGB_Smits1999(RGB, basis, "optimisation")
-            XYZ_recovered = sd_to_XYZ_integration(sd, cmfs, illuminant) / 100
-            total_error += np.sum((XYZ_recovered - XYZ) ** 2)
+        msds = MultiSpectralDistributions(
+            np.transpose(
+                RGB_to_msds_Smits1999(
+                    XYZ_to_RGB(test_XYZ, RGB_COLOURSPACE_GAUSSIAN), basis
+                )
+            ),
+            basis.wavelengths,
+            labels=[str(i) for i in range(len(test_XYZ))],
+        )
+        XYZ_recovered = msds_to_XYZ_integration(msds, cmfs, illuminant) / 100
 
-        return float(total_error)
+        return as_float(np.sum((XYZ_recovered - test_XYZ) ** 2))
 
     x0 = [
-        initial_peaks["red"],
-        initial_peaks["green"],
-        initial_peaks["blue"],
+        initial_peak_wavelengths["red"],
+        initial_peak_wavelengths["green"],
+        initial_peak_wavelengths["blue"],
         initial_fwhm["red"],
         initial_fwhm["green"],
         initial_fwhm["blue"],
@@ -280,7 +286,14 @@ def optimise_gaussian_basis_parameters(
         (20, 150),  # blue fwhm
     ]
 
-    result = minimize(objective, x0, bounds=bounds, method="L-BFGS-B")
+    optimisation_settings = {
+        "method": "L-BFGS-B",
+        "bounds": bounds,
+    }
+    if optimisation_kwargs is not None:
+        optimisation_settings.update(optimisation_kwargs)
+
+    result = minimize(objective, x0, **optimisation_settings)
     R_peak, G_peak, B_peak, R_fwhm, G_fwhm, B_fwhm = result.x
 
     peak_wavelengths = {
@@ -302,9 +315,9 @@ def generate_gaussian_basis(
     shape: SpectralShape = SPECTRAL_SHAPE_DEFAULT,
     peak_wavelengths: dict | None = None,
     fwhm: dict | None = None,
-) -> CanonicalMapping:
+) -> MultiSpectralDistributions:
     """
-    Generate a set of Gaussian basis spectral distributions.
+    Generate a set of Gaussian basis multi-spectral distributions.
 
     Parameters
     ----------
@@ -317,14 +330,14 @@ def generate_gaussian_basis(
 
     Returns
     -------
-    :class:`colour.utilities.CanonicalMapping`
-        Gaussian basis spectral distributions with keys: white, cyan, magenta,
-        yellow, red, green, blue.
+    :class:`colour.MultiSpectralDistributions`
+        Gaussian basis multi-spectral distributions with signals: white, cyan,
+        magenta, yellow, red, green, blue.
 
     Examples
     --------
     >>> basis = generate_gaussian_basis()
-    >>> sorted(basis.keys())
+    >>> sorted(basis.labels)
     ['blue', 'cyan', 'green', 'magenta', 'red', 'white', 'yellow']
     """
 
@@ -354,16 +367,12 @@ def generate_gaussian_basis(
     sd_white = sd_constant(1, shape)
     sd_white.name = "white"
 
-    return CanonicalMapping(
-        {
-            "white": sd_white,
-            "cyan": sd_cyan,
-            "magenta": sd_magenta,
-            "yellow": sd_yellow,
-            "red": sd_red,
-            "green": sd_green,
-            "blue": sd_blue,
-        }
+    sds = [sd_white, sd_cyan, sd_magenta, sd_yellow, sd_red, sd_green, sd_blue]
+
+    return MultiSpectralDistributions(
+        sds,
+        labels=[sd.name for sd in sds],
+        name="Gaussian Basis",
     )
 
 
@@ -391,9 +400,9 @@ These values are optimized for round-trip colorimetric accuracy using
 :func:`optimise_gaussian_basis_parameters`.
 """
 
-SDS_GAUSSIAN_BASIS: CanonicalMapping = generate_gaussian_basis()
-SDS_GAUSSIAN_BASIS.__doc__ = """
-Gaussian basis spectral distributions for spectral upsampling.
+MSDS_GAUSSIAN_BASIS: MultiSpectralDistributions = generate_gaussian_basis()
+MSDS_GAUSSIAN_BASIS.__doc__ = """
+Gaussian basis multi-spectral distributions for spectral upsampling.
 
 The basis spectra use clamped Gaussians with parameters optimized for round-trip
 colorimetric accuracy with *sRGB* primaries:
@@ -406,6 +415,49 @@ colorimetric accuracy with *sRGB* primaries:
 
 Parameters can be recomputed using :func:`optimise_gaussian_basis_parameters`.
 """
+
+
+def RGB_to_msds_Gaussian(RGB: ArrayLike) -> NDArrayFloat:
+    """
+    Recover spectral values from *RGB* colourspace array using *Gaussian*
+    basis spectra and the *Smits (1999)* decomposition algorithm.
+
+    Parameters
+    ----------
+    RGB
+        *RGB* colourspace array to recover spectral values from. The last
+        dimension must be size 3.
+
+    Returns
+    -------
+    :class:`numpy.ndarray`
+        Recovered spectral values with shape ``(*RGB.shape[:-1], wavelengths)``.
+
+    Notes
+    -----
+    +------------+-----------------------+---------------+
+    | **Domain** | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``RGB``    | 1                     | 1             |
+    +------------+-----------------------+---------------+
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> RGB = np.array(
+    ...     [
+    ...         [0.45623196, 0.03080455, 0.04093343],
+    ...         [0.05438271, 0.29877169, 0.07188444],
+    ...         [0.01863137, 0.05139773, 0.28887675],
+    ...     ]
+    ... )
+    >>> RGB_to_msds_Gaussian(RGB).shape
+    (3, 421)
+    >>> RGB_to_msds_Gaussian(RGB)[0, 300]  # doctest: +ELLIPSIS
+    0.4562...
+    """
+
+    return RGB_to_msds_Smits1999(RGB, MSDS_GAUSSIAN_BASIS)
 
 
 def RGB_to_sd_Gaussian(RGB: Domain1) -> SpectralDistribution:
@@ -449,4 +501,4 @@ def RGB_to_sd_Gaussian(RGB: Domain1) -> SpectralDistribution:
     array([ 0.2038334...,  0.1254643...,  0.0434193...])
     """
 
-    return sd_from_RGB_Smits1999(RGB, SDS_GAUSSIAN_BASIS, f"Gaussian - {RGB!r}")
+    return RGB_to_sd_Smits1999(RGB, MSDS_GAUSSIAN_BASIS, f"Gaussian - {RGB!r}")

--- a/colour/recovery/smits1999.py
+++ b/colour/recovery/smits1999.py
@@ -15,13 +15,24 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from colour.colorimetry import CCS_ILLUMINANTS, SpectralDistribution
+import numpy as np
+
+from colour.colorimetry import (
+    CCS_ILLUMINANTS,
+    MultiSpectralDistributions,
+    SpectralDistribution,
+)
 from colour.models import RGB_Colourspace, RGB_COLOURSPACE_sRGB, XYZ_to_RGB
-from colour.recovery import SDS_SMITS1999
-from colour.utilities import CanonicalMapping, to_domain_1
+from colour.recovery import MSDS_SMITS1999
+from colour.utilities import (
+    as_float_array,
+    optional,
+    to_domain_1,
+    tsplit,
+)
 
 if TYPE_CHECKING:
-    from colour.hints import Domain1, NDArrayFloat, Range1
+    from colour.hints import ArrayLike, Domain1, NDArrayFloat, Range1
 
 __author__ = "Colour Developers"
 __copyright__ = "Copyright 2013 Colour Developers"
@@ -36,7 +47,7 @@ __all__ = [
     "CCS_WHITEPOINT_SMITS1999",
     "RGB_COLOURSPACE_SMITS1999",
     "XYZ_to_RGB_Smits1999",
-    "sd_from_RGB_Smits1999",
+    "RGB_to_msds_Smits1999",
     "RGB_to_sd_Smits1999",
 ]
 
@@ -57,7 +68,7 @@ RGB_COLOURSPACE_SMITS1999 = RGB_Colourspace(
     CCS_WHITEPOINT_SMITS1999,
     WHITEPOINT_NAME_SMITS1999,
 )
-RGB_COLOURSPACE_sRGB.__doc__ = """
+RGB_COLOURSPACE_SMITS1999.__doc__ = """
 *Smits (1999)* colourspace.
 
 References
@@ -107,29 +118,29 @@ def XYZ_to_RGB_Smits1999(XYZ: Domain1) -> Range1:
     return XYZ_to_RGB(XYZ, RGB_COLOURSPACE_SMITS1999)
 
 
-def sd_from_RGB_Smits1999(
-    RGB: Domain1,
-    basis: dict | CanonicalMapping,
-    name: str | None = None,
-) -> SpectralDistribution:
+def RGB_to_msds_Smits1999(
+    RGB: ArrayLike,
+    basis: MultiSpectralDistributions | None = None,
+) -> NDArrayFloat:
     """
-    Generate a spectral distribution from *RGB* values using the
+    Recover spectral values from *RGB* colourspace array using the
     *Smits (1999)* decomposition algorithm.
+
+    This is a vectorised implementation supporting multi-dimensional arrays.
 
     Parameters
     ----------
     RGB
-        *RGB* colourspace array to recover the spectral distribution from.
+        *RGB* colourspace array to recover spectral values from. The last
+        dimension must be size 3.
     basis
-        Dictionary of basis spectral distributions with keys: white, cyan,
-        magenta, yellow, red, green, blue.
-    name
-        Name for the resulting spectral distribution.
+        Multi-spectral distributions basis with signals: white, cyan, magenta,
+        yellow, red, green, blue. Defaults to :attr:`MSDS_SMITS1999`.
 
     Returns
     -------
-    :class:`colour.SpectralDistribution`
-        Recovered spectral distribution.
+    :class:`numpy.ndarray`
+        Recovered spectral values with shape ``(*RGB.shape[:-1], wavelengths)``.
 
     Notes
     -----
@@ -146,61 +157,100 @@ def sd_from_RGB_Smits1999(
     Examples
     --------
     >>> import numpy as np
-    >>> from colour.recovery import SDS_SMITS1999
-    >>> sd = sd_from_RGB_Smits1999(np.array([0.4, 0.03, 0.04]), SDS_SMITS1999, "test")
-    >>> sd[380]  # doctest: +ELLIPSIS
-    0.0764...
+    >>> RGB = np.array(
+    ...     [
+    ...         [0.45623196, 0.03080455, 0.04093343],
+    ...         [0.05438271, 0.29877169, 0.07188444],
+    ...         [0.01863137, 0.05139773, 0.28887675],
+    ...     ]
+    ... )
+    >>> RGB_to_msds_Smits1999(RGB).shape
+    (3, 10)
+    >>> RGB_to_msds_Smits1999(RGB)[0, 0]  # doctest: +ELLIPSIS
+    0.0829...
     """
 
-    sd_white = basis["white"].copy()
-    sd_cyan = basis["cyan"].copy()
-    sd_magenta = basis["magenta"].copy()
-    sd_yellow = basis["yellow"].copy()
-    sd_red = basis["red"].copy()
-    sd_green = basis["green"].copy()
-    sd_blue = basis["blue"].copy()
+    basis = optional(basis, MSDS_SMITS1999)
 
-    R, G, B = to_domain_1(RGB)
-    sd = sd_white.copy() * 0
-    sd.name = name
+    RGB = to_domain_1(as_float_array(RGB))
+    shape = RGB.shape
+    RGB = np.atleast_2d(RGB.reshape(-1, 3))
 
-    if R <= G and R <= B:
-        sd += sd_white * R
-        if G <= B:
-            sd += sd_cyan * (G - R)
-            sd += sd_blue * (B - G)
-        else:
-            sd += sd_cyan * (B - R)
-            sd += sd_green * (G - B)
-    elif G <= R and G <= B:
-        sd += sd_white * G
-        if R <= B:
-            sd += sd_magenta * (R - G)
-            sd += sd_blue * (B - R)
-        else:
-            sd += sd_magenta * (B - G)
-            sd += sd_red * (R - B)
-    else:
-        sd += sd_white * B
-        if R <= G:
-            sd += sd_yellow * (R - B)
-            sd += sd_green * (G - R)
-        else:
-            sd += sd_yellow * (G - B)
-            sd += sd_red * (R - G)
+    R, G, B = tsplit(RGB)
 
-    return sd
+    labels = list(basis.labels)
+    white = basis.values[:, labels.index("white")]
+    cyan = basis.values[:, labels.index("cyan")]
+    magenta = basis.values[:, labels.index("magenta")]
+    yellow = basis.values[:, labels.index("yellow")]
+    red = basis.values[:, labels.index("red")]
+    green = basis.values[:, labels.index("green")]
+    blue = basis.values[:, labels.index("blue")]
+
+    R = R[..., np.newaxis]
+    G = G[..., np.newaxis]
+    B = B[..., np.newaxis]
+
+    # if R <= G and R <= B:
+    #     sd += white * R
+    #     if G <= B:
+    #         sd += cyan * (G - R) + blue * (B - G)
+    #     else:
+    #         sd += cyan * (B - R) + green * (G - B)
+    R_le_G_le_B = (R <= G) & (R <= B) & (G <= B)
+    R_le_B_lt_G = (R <= G) & (R <= B) & (G > B)
+
+    # elif G <= R and G <= B:
+    #     sd += white * G
+    #     if R <= B:
+    #         sd += magenta * (R - G) + blue * (B - R)
+    #     else:
+    #         sd += magenta * (B - G) + red * (R - B)
+    G_lt_R_le_B = (G < R) & (G <= B) & (R <= B)
+    G_le_B_lt_R = (G < R) & (G <= B) & (R > B)
+
+    # else:  # B < R and B < G
+    #     sd += white * B
+    #     if R <= G:
+    #         sd += yellow * (R - B) + green * (G - R)
+    #     else:
+    #         sd += yellow * (G - B) + red * (R - G)
+    B_lt_R_le_G = (B < R) & (B < G) & (R <= G)
+    B_lt_G_lt_R = (B < R) & (B < G) & (R > G)
+
+    spectra = np.select(
+        [R_le_G_le_B, R_le_B_lt_G, G_lt_R_le_B, G_le_B_lt_R, B_lt_R_le_G, B_lt_G_lt_R],
+        [
+            white * R + cyan * (G - R) + blue * (B - G),
+            white * R + cyan * (B - R) + green * (G - B),
+            white * G + magenta * (R - G) + blue * (B - R),
+            white * G + magenta * (B - G) + red * (R - B),
+            white * B + yellow * (R - B) + green * (G - R),
+            white * B + yellow * (G - B) + red * (R - G),
+        ],
+    )
+
+    return np.reshape(spectra, [*list(shape[:-1]), len(white)])
 
 
-def RGB_to_sd_Smits1999(RGB: Domain1) -> SpectralDistribution:
+def RGB_to_sd_Smits1999(
+    RGB: Domain1,
+    basis: MultiSpectralDistributions | None = None,
+    name: str | None = None,
+) -> SpectralDistribution:
     """
-    Recover the spectral distribution of the specified *RGB* colourspace array
-    using the *Smits (1999)* method.
+    Generate a spectral distribution from *RGB* values using the
+    *Smits (1999)* decomposition algorithm.
 
     Parameters
     ----------
     RGB
         *RGB* colourspace array to recover the spectral distribution from.
+    basis
+        Multi-spectral distributions basis with signals: white, cyan, magenta,
+        yellow, red, green, blue. Defaults to :attr:`MSDS_SMITS1999`.
+    name
+        Name for the resulting spectral distribution.
 
     Returns
     -------
@@ -254,4 +304,15 @@ def RGB_to_sd_Smits1999(RGB: Domain1) -> SpectralDistribution:
     array([ 0.1894770...,  0.1126470...,  0.0474420...])
     """
 
-    return sd_from_RGB_Smits1999(RGB, SDS_SMITS1999, f"Smits (1999) - {RGB!r}")
+    basis = optional(basis, MSDS_SMITS1999)
+    name = optional(name, f"Smits (1999) - {RGB!r}")
+
+    values = RGB_to_msds_Smits1999(RGB, basis)
+
+    return SpectralDistribution(
+        values,
+        basis.wavelengths,
+        name=name,
+        interpolator=basis.interpolator,
+        interpolator_kwargs=basis.interpolator_kwargs,
+    )

--- a/colour/recovery/tests/test__init__.py
+++ b/colour/recovery/tests/test__init__.py
@@ -13,7 +13,10 @@ from colour.colorimetry import (
     sd_to_XYZ_integration,
 )
 from colour.constants import TOLERANCE_ABSOLUTE_TESTS
-from colour.recovery import XYZ_to_sd
+from colour.models import XYZ_to_RGB
+from colour.recovery import MSDS_GAUSSIAN_BASIS, XYZ_to_msds, XYZ_to_sd
+from colour.recovery.gaussian import RGB_COLOURSPACE_GAUSSIAN
+from colour.recovery.smits1999 import RGB_to_msds_Smits1999
 from colour.utilities import domain_range_scale, is_scipy_installed
 
 __author__ = "Colour Developers"
@@ -24,6 +27,7 @@ __email__ = "colour-developers@colour-science.org"
 __status__ = "Production"
 
 __all__ = [
+    "TestXYZ_to_msds",
     "TestXYZ_to_sd",
 ]
 
@@ -88,3 +92,246 @@ class TestXYZ_to_sd:
                         value * factor_b,
                         atol=TOLERANCE_ABSOLUTE_TESTS,
                     )
+
+
+class TestXYZ_to_msds:
+    """
+    Define :func:`colour.recovery.XYZ_to_msds` definition unit tests
+    methods.
+    """
+
+    def test_XYZ_to_msds(self) -> None:
+        """
+        Test :func:`colour.recovery.XYZ_to_msds` definition.
+        """
+
+        XYZ = np.array(
+            [
+                [0.20654008, 0.12197225, 0.05136952],
+                [0.14222010, 0.23042768, 0.10495772],
+                [0.07818780, 0.06157201, 0.28099326],
+            ]
+        )
+
+        # Gaussian method
+        msds_gaussian = XYZ_to_msds(XYZ, method="Gaussian")
+        assert msds_gaussian.shape == (3, 421)
+
+        # Test with interpolated basis at 10nm for full array comparison
+        basis_10nm = MSDS_GAUSSIAN_BASIS.copy().align(SpectralShape(360, 780, 10))
+        RGB = XYZ_to_RGB(XYZ, RGB_COLOURSPACE_GAUSSIAN)
+        msds_gaussian_10nm = RGB_to_msds_Smits1999(RGB, basis_10nm)
+
+        assert msds_gaussian_10nm.shape == (3, 43)
+
+        np.testing.assert_allclose(
+            msds_gaussian_10nm,
+            np.array(
+                [
+                    [
+                        0.04502017,
+                        0.04502017,
+                        0.04502017,
+                        0.04502017,
+                        0.04502017,
+                        0.04502017,
+                        0.04502017,
+                        0.04502017,
+                        0.04502017,
+                        0.04491066,
+                        0.04401528,
+                        0.04239764,
+                        0.04037903,
+                        0.03830670,
+                        0.03646088,
+                        0.03501204,
+                        0.03405960,
+                        0.03380749,
+                        0.03500319,
+                        0.03978677,
+                        0.05276604,
+                        0.08118748,
+                        0.13214985,
+                        0.20596348,
+                        0.28926932,
+                        0.35571195,
+                        0.37864559,
+                        0.37864550,
+                        0.37864548,
+                        0.37864548,
+                        0.37864547,
+                        0.37864547,
+                        0.37864547,
+                        0.37864547,
+                        0.37864547,
+                        0.37864547,
+                        0.37864547,
+                        0.37864547,
+                        0.37864547,
+                        0.37864547,
+                        0.37864547,
+                        0.37864547,
+                        0.37864547,
+                    ],
+                    [
+                        0.07907520,
+                        0.07908202,
+                        0.07910307,
+                        0.07916350,
+                        0.07932472,
+                        0.07972432,
+                        0.08064378,
+                        0.08260607,
+                        0.08648611,
+                        0.09328813,
+                        0.10285906,
+                        0.11714063,
+                        0.13830854,
+                        0.16737772,
+                        0.20321625,
+                        0.24209054,
+                        0.27810408,
+                        0.30456680,
+                        0.31590278,
+                        0.30938808,
+                        0.28600905,
+                        0.25008935,
+                        0.20787601,
+                        0.16570663,
+                        0.12847670,
+                        0.09887699,
+                        0.07746070,
+                        0.06326777,
+                        0.05461559,
+                        0.04974938,
+                        0.04721892,
+                        0.04600037,
+                        0.04545631,
+                        0.04523086,
+                        0.04514410,
+                        0.04511307,
+                        0.04510275,
+                        0.04509956,
+                        0.04509864,
+                        0.04509839,
+                        0.04509833,
+                        0.04509831,
+                        0.04509831,
+                    ],
+                    [
+                        0.31783484,
+                        0.31783582,
+                        0.31783884,
+                        0.31784751,
+                        0.31787064,
+                        0.31792797,
+                        0.31805989,
+                        0.31834143,
+                        0.31889811,
+                        0.31728417,
+                        0.29748230,
+                        0.26127506,
+                        0.21657221,
+                        0.17172394,
+                        0.13314246,
+                        0.10401617,
+                        0.08435713,
+                        0.07202445,
+                        0.06408687,
+                        0.05795909,
+                        0.05201651,
+                        0.04567674,
+                        0.03911964,
+                        0.03287472,
+                        0.02746332,
+                        0.02319338,
+                        0.02011362,
+                        0.01807529,
+                        0.01683340,
+                        0.01613510,
+                        0.01577202,
+                        0.01559718,
+                        0.01551912,
+                        0.01548677,
+                        0.01547433,
+                        0.01546987,
+                        0.01546839,
+                        0.01546793,
+                        0.01546780,
+                        0.01546777,
+                        0.01546776,
+                        0.01546776,
+                        0.01546776,
+                    ],
+                ]
+            ),
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+        # Smits 1999 method - native 10 wavelengths
+        msds_smits = XYZ_to_msds(XYZ, method="Smits 1999")
+        assert msds_smits.shape == (3, 10)
+
+        np.testing.assert_allclose(
+            msds_smits,
+            np.array(
+                [
+                    [
+                        0.07878305,
+                        0.06220187,
+                        0.04462067,
+                        0.03522208,
+                        0.03241491,
+                        0.03301050,
+                        0.32071155,
+                        0.38361649,
+                        0.38361649,
+                        0.38356492,
+                    ],
+                    [
+                        0.07808712,
+                        0.07712225,
+                        0.08553484,
+                        0.26638946,
+                        0.31507478,
+                        0.30136579,
+                        0.09098278,
+                        0.04509831,
+                        0.04509831,
+                        0.04568835,
+                    ],
+                    [
+                        0.31671107,
+                        0.31561096,
+                        0.28928249,
+                        0.14182485,
+                        0.05421900,
+                        0.05422828,
+                        0.02160523,
+                        0.02519571,
+                        0.02820109,
+                        0.02854381,
+                    ],
+                ]
+            ),
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+    def test_domain_range_scale_XYZ_to_msds(self) -> None:
+        """
+        Test :func:`colour.recovery.XYZ_to_msds` definition domain
+        and range scale support.
+        """
+
+        XYZ = np.array([0.20654008, 0.12197225, 0.05136952])
+
+        msds_reference = XYZ_to_msds(XYZ, method="Gaussian")
+
+        d_r = (("reference", 1), ("1", 1), ("100", 100))
+        for scale, factor in d_r:
+            with domain_range_scale(scale):
+                np.testing.assert_allclose(
+                    XYZ_to_msds(XYZ * factor, method="Gaussian"),
+                    msds_reference,
+                    atol=TOLERANCE_ABSOLUTE_TESTS,
+                )

--- a/colour/recovery/tests/test_gaussian.py
+++ b/colour/recovery/tests/test_gaussian.py
@@ -4,13 +4,18 @@ from __future__ import annotations
 
 import numpy as np
 
-from colour.colorimetry import sd_to_XYZ_integration
+from colour.colorimetry import SpectralShape, sd_to_XYZ_integration
 from colour.constants import TOLERANCE_ABSOLUTE_TESTS
-from colour.recovery import RGB_to_sd_Gaussian
+from colour.recovery import (
+    MSDS_GAUSSIAN_BASIS,
+    RGB_to_msds_Gaussian,
+    RGB_to_sd_Gaussian,
+)
 from colour.recovery.gaussian import (
     XYZ_to_RGB_Gaussian,
     optimise_gaussian_basis_parameters,
 )
+from colour.recovery.smits1999 import RGB_to_msds_Smits1999, RGB_to_sd_Smits1999
 from colour.utilities import domain_range_scale
 
 __author__ = "Colour Developers"
@@ -22,6 +27,7 @@ __status__ = "Production"
 
 __all__ = [
     "TestOptimiseGaussianBasisParameters",
+    "TestRGB_to_msds_Gaussian",
     "TestRGB_to_sd_Gaussian",
 ]
 
@@ -52,6 +58,187 @@ class TestOptimiseGaussianBasisParameters:
         assert 20 < fwhm["blue"] < 150
 
 
+class TestRGB_to_msds_Gaussian:
+    """
+    Define :func:`colour.recovery.gaussian.RGB_to_msds_Gaussian`
+    definition unit tests methods.
+    """
+
+    def test_RGB_to_msds_Gaussian(self) -> None:
+        """
+        Test :func:`colour.recovery.gaussian.RGB_to_msds_Gaussian`
+        definition.
+        """
+
+        RGB = np.array(
+            [
+                [0.45623196, 0.03080455, 0.04093343],
+                [0.05438271, 0.29877169, 0.07188444],
+                [0.01863137, 0.05139773, 0.28887675],
+            ]
+        )
+
+        msds = RGB_to_msds_Gaussian(RGB)
+
+        assert msds.shape == (3, 421)
+
+        np.testing.assert_allclose(
+            msds[0, 0],
+            0.04093343,
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+        # Test with interpolated basis at 10nm for full array comparison
+        basis_10nm = MSDS_GAUSSIAN_BASIS.copy().align(SpectralShape(360, 780, 10))
+        msds_10nm = RGB_to_msds_Smits1999(RGB, basis_10nm)
+
+        assert msds_10nm.shape == (3, 43)
+
+        np.testing.assert_allclose(
+            msds_10nm,
+            np.array(
+                [
+                    [
+                        0.04093343,
+                        0.04093343,
+                        0.04093343,
+                        0.04093343,
+                        0.04093343,
+                        0.04093343,
+                        0.04093343,
+                        0.04093343,
+                        0.04093343,
+                        0.04084525,
+                        0.04012429,
+                        0.03882177,
+                        0.03719640,
+                        0.03552793,
+                        0.03404295,
+                        0.03288422,
+                        0.03215853,
+                        0.03213766,
+                        0.03377829,
+                        0.03974954,
+                        0.05574525,
+                        0.09069168,
+                        0.15332485,
+                        0.24403290,
+                        0.34640307,
+                        0.42805033,
+                        0.45623205,
+                        0.45623198,
+                        0.45623197,
+                        0.45623196,
+                        0.45623196,
+                        0.45623196,
+                        0.45623196,
+                        0.45623196,
+                        0.45623196,
+                        0.45623196,
+                        0.45623196,
+                        0.45623196,
+                        0.45623196,
+                        0.45623196,
+                        0.45623196,
+                        0.45623196,
+                        0.45623196,
+                    ],
+                    [
+                        0.07188700,
+                        0.07189318,
+                        0.07191223,
+                        0.07196693,
+                        0.07211287,
+                        0.07247458,
+                        0.07330686,
+                        0.07508309,
+                        0.07859523,
+                        0.08486765,
+                        0.09447427,
+                        0.10910571,
+                        0.13039297,
+                        0.15888928,
+                        0.19327721,
+                        0.23001130,
+                        0.26371592,
+                        0.28838793,
+                        0.29907506,
+                        0.29340939,
+                        0.27236240,
+                        0.23990137,
+                        0.20171291,
+                        0.16355061,
+                        0.12985387,
+                        0.10306177,
+                        0.08367645,
+                        0.07082935,
+                        0.06299757,
+                        0.05859277,
+                        0.05630225,
+                        0.05519924,
+                        0.05470676,
+                        0.05450270,
+                        0.05442416,
+                        0.05439607,
+                        0.05438673,
+                        0.05438384,
+                        0.05438300,
+                        0.05438278,
+                        0.05438273,
+                        0.05438271,
+                        0.05438271,
+                    ],
+                    [
+                        0.28887709,
+                        0.28887792,
+                        0.28888048,
+                        0.28888781,
+                        0.28890738,
+                        0.28895587,
+                        0.28906746,
+                        0.28930561,
+                        0.28977650,
+                        0.28828524,
+                        0.27050461,
+                        0.23801562,
+                        0.19787879,
+                        0.15755668,
+                        0.12279327,
+                        0.09646683,
+                        0.07862931,
+                        0.06741228,
+                        0.06023255,
+                        0.05479642,
+                        0.04964374,
+                        0.04422333,
+                        0.03865246,
+                        0.03336054,
+                        0.02877976,
+                        0.02516679,
+                        0.02256133,
+                        0.02083706,
+                        0.01978655,
+                        0.01919586,
+                        0.01888874,
+                        0.01874085,
+                        0.01867482,
+                        0.01864746,
+                        0.01863693,
+                        0.01863316,
+                        0.01863191,
+                        0.01863152,
+                        0.01863141,
+                        0.01863138,
+                        0.01863137,
+                        0.01863137,
+                        0.01863137,
+                    ],
+                ]
+            ),
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+
 class TestRGB_to_sd_Gaussian:
     """
     Define :func:`colour.recovery.gaussian.RGB_to_sd_Gaussian`
@@ -64,23 +251,66 @@ class TestRGB_to_sd_Gaussian:
         definition.
         """
 
-        sd = RGB_to_sd_Gaussian(
-            XYZ_to_RGB_Gaussian(np.array([0.21781186, 0.12541048, 0.04697113]))
-        )
+        XYZ = np.array([0.20654008, 0.12197225, 0.05136952])
+        RGB = XYZ_to_RGB_Gaussian(XYZ)
+
+        sd = RGB_to_sd_Gaussian(RGB)
+
+        assert sd.values.shape == (421,)
+
+        # Test with interpolated basis at 10nm for full array comparison
+        basis_10nm = MSDS_GAUSSIAN_BASIS.copy().align(SpectralShape(360, 780, 10))
+        sd_10nm = RGB_to_sd_Smits1999(RGB, basis_10nm, "test")
+
+        assert sd_10nm.values.shape == (43,)
+
         np.testing.assert_allclose(
-            [sd[w] for w in [360, 400, 450, 500, 550, 600, 650, 700, 750, 780]],
+            sd_10nm.values,
             np.array(
                 [
-                    0.03982193,
-                    0.03982193,
-                    0.03971491,
-                    0.03145787,
-                    0.03554526,
-                    0.30858755,
-                    0.40639599,
-                    0.40639599,
-                    0.40639599,
-                    0.40639599,
+                    0.04502017,
+                    0.04502017,
+                    0.04502017,
+                    0.04502017,
+                    0.04502017,
+                    0.04502017,
+                    0.04502017,
+                    0.04502017,
+                    0.04502017,
+                    0.04491066,
+                    0.04401528,
+                    0.04239764,
+                    0.04037903,
+                    0.03830670,
+                    0.03646088,
+                    0.03501204,
+                    0.03405960,
+                    0.03380749,
+                    0.03500319,
+                    0.03978677,
+                    0.05276604,
+                    0.08118748,
+                    0.13214985,
+                    0.20596348,
+                    0.28926932,
+                    0.35571195,
+                    0.37864559,
+                    0.37864550,
+                    0.37864548,
+                    0.37864548,
+                    0.37864547,
+                    0.37864547,
+                    0.37864547,
+                    0.37864547,
+                    0.37864547,
+                    0.37864547,
+                    0.37864547,
+                    0.37864547,
+                    0.37864547,
+                    0.37864547,
+                    0.37864547,
+                    0.37864547,
+                    0.37864547,
                 ]
             ),
             atol=TOLERANCE_ABSOLUTE_TESTS,

--- a/colour/recovery/tests/test_smits1999.py
+++ b/colour/recovery/tests/test_smits1999.py
@@ -6,8 +6,13 @@ import numpy as np
 
 from colour.colorimetry import sd_to_XYZ_integration
 from colour.constants import TOLERANCE_ABSOLUTE_TESTS
-from colour.recovery import SDS_SMITS1999, RGB_to_sd_Smits1999
-from colour.recovery.smits1999 import XYZ_to_RGB_Smits1999, sd_from_RGB_Smits1999
+from colour.recovery import (
+    MSDS_SMITS1999,
+    SDS_SMITS1999,
+    RGB_to_msds_Smits1999,
+    RGB_to_sd_Smits1999,
+)
+from colour.recovery.smits1999 import XYZ_to_RGB_Smits1999
 from colour.utilities import domain_range_scale
 
 __author__ = "Colour Developers"
@@ -18,25 +23,128 @@ __email__ = "colour-developers@colour-science.org"
 __status__ = "Production"
 
 __all__ = [
+    "TestMsds_from_RGB_Smits1999",
+    "TestRGB_to_msds_Smits1999",
     "TestSd_from_RGB_Smits1999",
     "TestRGB_to_sd_Smits1999",
 ]
 
 
-class TestSd_from_RGB_Smits1999:
+class TestMsds_from_RGB_Smits1999:
     """
-    Define :func:`colour.recovery.smits1999.sd_from_RGB_Smits1999`
+    Define :func:`colour.recovery.smits1999.RGB_to_msds_Smits1999`
     definition unit tests methods.
     """
 
-    def test_sd_from_RGB_Smits1999(self) -> None:
+    def test_RGB_to_msds_Smits1999(self) -> None:
         """
-        Test :func:`colour.recovery.smits1999.sd_from_RGB_Smits1999`
+        Test :func:`colour.recovery.smits1999.RGB_to_msds_Smits1999`
+        definition.
+        """
+
+        RGB = np.array(
+            [
+                [0.45623196, 0.03080455, 0.04093343],
+                [0.05438271, 0.29877169, 0.07188444],
+                [0.01863137, 0.05139773, 0.28887675],
+            ]
+        )
+
+        msds = RGB_to_msds_Smits1999(RGB, MSDS_SMITS1999)
+
+        assert msds.shape == (3, 10)
+
+        np.testing.assert_allclose(
+            msds,
+            np.array(
+                [
+                    [
+                        0.08296164,
+                        0.06232130,
+                        0.04061129,
+                        0.03304071,
+                        0.03077991,
+                        0.03126229,
+                        0.38501744,
+                        0.46241991,
+                        0.46241991,
+                        0.46237838,
+                    ],
+                    [
+                        0.07137689,
+                        0.07087984,
+                        0.07808527,
+                        0.25193903,
+                        0.29874044,
+                        0.28556823,
+                        0.09612190,
+                        0.05438271,
+                        0.05438271,
+                        0.05494993,
+                    ],
+                    [
+                        0.28792653,
+                        0.28699596,
+                        0.26315510,
+                        0.13032190,
+                        0.05140576,
+                        0.05141694,
+                        0.02382727,
+                        0.02739435,
+                        0.03010161,
+                        0.03041033,
+                    ],
+                ]
+            ),
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+
+class TestRGB_to_msds_Smits1999:
+    """
+    Define :func:`colour.recovery.smits1999.RGB_to_msds_Smits1999`
+    definition unit tests methods.
+    """
+
+    def test_RGB_to_msds_Smits1999(self) -> None:
+        """
+        Test :func:`colour.recovery.smits1999.RGB_to_msds_Smits1999`
+        definition.
+        """
+
+        RGB = np.array(
+            [
+                [0.45623196, 0.03080455, 0.04093343],
+                [0.05438271, 0.29877169, 0.07188444],
+                [0.01863137, 0.05139773, 0.28887675],
+            ]
+        )
+
+        msds = RGB_to_msds_Smits1999(RGB)
+
+        assert msds.shape == (3, 10)
+
+        np.testing.assert_allclose(
+            msds[0, 0],
+            0.08296164,
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+
+class TestSd_from_RGB_Smits1999:
+    """
+    Define :func:`colour.recovery.smits1999.RGB_to_sd_Smits1999`
+    definition unit tests methods.
+    """
+
+    def test_RGB_to_sd_Smits1999(self) -> None:
+        """
+        Test :func:`colour.recovery.smits1999.RGB_to_sd_Smits1999`
         definition.
         """
 
         RGB = np.array([0.4, 0.03, 0.04])
-        sd = sd_from_RGB_Smits1999(RGB, SDS_SMITS1999, "test")
+        sd = RGB_to_sd_Smits1999(RGB, MSDS_SMITS1999, "test")
 
         np.testing.assert_equal(sd.name, "test")
         np.testing.assert_equal(sd.shape, SDS_SMITS1999["white"].shape)
@@ -61,7 +169,7 @@ class TestSd_from_RGB_Smits1999:
         )
 
         RGB_white = np.array([1.0, 1.0, 1.0])
-        sd_white = sd_from_RGB_Smits1999(RGB_white, SDS_SMITS1999, "white")
+        sd_white = RGB_to_sd_Smits1999(RGB_white, MSDS_SMITS1999, "white")
         np.testing.assert_allclose(
             sd_white.values,
             SDS_SMITS1999["white"].values,
@@ -69,7 +177,7 @@ class TestSd_from_RGB_Smits1999:
         )
 
         RGB_red = np.array([1.0, 0.0, 0.0])
-        sd_red = sd_from_RGB_Smits1999(RGB_red, SDS_SMITS1999, "red")
+        sd_red = RGB_to_sd_Smits1999(RGB_red, MSDS_SMITS1999, "red")
         np.testing.assert_allclose(
             sd_red.values,
             SDS_SMITS1999["red"].values,
@@ -77,7 +185,7 @@ class TestSd_from_RGB_Smits1999:
         )
 
         RGB_green = np.array([0.0, 1.0, 0.0])
-        sd_green = sd_from_RGB_Smits1999(RGB_green, SDS_SMITS1999, "green")
+        sd_green = RGB_to_sd_Smits1999(RGB_green, MSDS_SMITS1999, "green")
         np.testing.assert_allclose(
             sd_green.values,
             SDS_SMITS1999["green"].values,
@@ -85,7 +193,7 @@ class TestSd_from_RGB_Smits1999:
         )
 
         RGB_blue = np.array([0.0, 0.0, 1.0])
-        sd_blue = sd_from_RGB_Smits1999(RGB_blue, SDS_SMITS1999, "blue")
+        sd_blue = RGB_to_sd_Smits1999(RGB_blue, MSDS_SMITS1999, "blue")
         np.testing.assert_allclose(
             sd_blue.values,
             SDS_SMITS1999["blue"].values,

--- a/docs/colour.recovery.rst
+++ b/docs/colour.recovery.rst
@@ -16,6 +16,8 @@ CIE XYZ Colourspace to Spectral
 
     XYZ_to_sd
     XYZ_TO_SD_METHODS
+    XYZ_to_msds
+    XYZ_TO_MSDS_METHODS
 
 Jakob and Hanika (2019)
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -113,8 +115,9 @@ Smits (1999)
 .. autosummary::
     :toctree: generated/
 
-    sd_from_RGB_Smits1999
+    RGB_to_msds_Smits1999
     RGB_to_sd_Smits1999
+    MSDS_SMITS1999
     SDS_SMITS1999
 
 Gaussian Basis
@@ -127,8 +130,9 @@ Gaussian Basis
 .. autosummary::
     :toctree: generated/
 
+    RGB_to_msds_Gaussian
     RGB_to_sd_Gaussian
-    SDS_GAUSSIAN_BASIS
+    MSDS_GAUSSIAN_BASIS
 
 **Ancillary Objects**
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1598,6 +1598,32 @@ Reflectance Recovery
 
     ['Gaussian', 'Jakob 2019', 'Mallett 2019', 'Meng 2015', 'Otsu 2018', 'Smits 1999']
 
+.. code-block:: python
+
+    import colour
+
+    colour.XYZ_to_msds(
+        [
+            [0.20654008, 0.12197225, 0.05136952],
+            [0.14223761, 0.23042375, 0.10498415],
+            [0.07820260, 0.06157595, 0.28106183],
+        ]
+    ).shape
+
+.. code-block:: text
+
+    (3, 421)
+
+.. code-block:: python
+
+    import colour
+
+    sorted(colour.XYZ_TO_MSDS_METHODS)
+
+.. code-block:: text
+
+    ['Gaussian', 'Smits 1999']
+
 Camera RGB Sensitivities Recovery
 *********************************
 


### PR DESCRIPTION
<!--
Thank you for taking the time to create this pull request. If it is the first
time you are contributing to a colour-science repository, a contributing guide
is available to guide the process: https://www.colour-science.org/contributing/.
-->

# Summary

This PR adds the `colour.recovery.RGB_to_msds_Smits1999`, `colour.recovery.RGB_to_msds_Gaussian` and `colour.XYZ_to_msds` definitions enabling vectorised upsampling.

# Preflight

<!-- Please mark any checkboxes that do not apply to this pull request as [N/A]. -->

**Code Style and Quality**

- [x] Unit tests have been implemented and passed.
- [x] Pyright static checking has been run and passed.
- [x] Pre-commit hooks have been run and passed.
- [N/A] New transformations have been added to the _Automatic Colour Conversion Graph_.
- [x] New transformations have been exported to the relevant namespaces, e.g. `colour`, `colour.models`.

<!-- The unit tests can be invoked with `uv run invoke tests` -->
<!-- Pyright can be started with `uv run pyright --threads --skipunannotated` -->

**Documentation**

- [x] New features are documented along with examples if relevant.
- [x] The documentation is [Sphinx](https://www.sphinx-doc.org/en/master/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant.

<!--
Thank you again!
-->
