### PR TITLE
PR: Add TPS-3D colour correction method

### DIFF
--- a/colour/characterisation/__init__.py
+++ b/colour/characterisation/__init__.py
@@ -17,9 +17,11 @@ from .correction import (
     apply_matrix_colour_correction_Cheung2004,
     apply_matrix_colour_correction_Finlayson2015,
     apply_matrix_colour_correction_Vandermonde,
+    apply_tps3d,
     colour_correction,
     colour_correction_Cheung2004,
     colour_correction_Finlayson2015,
+    colour_correction_TPS3D,
     colour_correction_Vandermonde,
     matrix_augmented_Cheung2004,
     matrix_colour_correction,
@@ -29,9 +31,7 @@ from .correction import (
     polynomial_expansion,
     polynomial_expansion_Finlayson2015,
     polynomial_expansion_Vandermonde,
-    apply_tps3d, 
-    colour_correction_TPS3D, 
-    tps3d_parameters
+    tps3d_parameters,
 )
 
 # isort: split

--- a/colour/characterisation/__init__.py
+++ b/colour/characterisation/__init__.py
@@ -29,6 +29,9 @@ from .correction import (
     polynomial_expansion,
     polynomial_expansion_Finlayson2015,
     polynomial_expansion_Vandermonde,
+    apply_tps3d, 
+    colour_correction_TPS3D, 
+    tps3d_parameters
 )
 
 # isort: split
@@ -79,6 +82,9 @@ __all__ += [
     "polynomial_expansion",
     "polynomial_expansion_Finlayson2015",
     "polynomial_expansion_Vandermonde",
+    "apply_tps3d",
+    "colour_correction_TPS3D",
+    "tps3d_parameters",
 ]
 __all__ += [
     "best_illuminant",

--- a/colour/characterisation/correction.py
+++ b/colour/characterisation/correction.py
@@ -118,6 +118,9 @@ __all__ = [
     "colour_correction_Vandermonde",
     "COLOUR_CORRECTION_METHODS",
     "colour_correction",
+    "tps3d_parameters",
+    "apply_tps3d",
+    "colour_correction_TPS3D",
 ]
 
 
@@ -1404,11 +1407,255 @@ def colour_correction_Vandermonde(
     )
 
 
+
+
+# =============================================================================
+# TPS-3D (Thin-Plate Spline in RGB)
+# =============================================================================
+
+def _tps3d_kernel_bookstein(r: np.ndarray, eps: float = 1e-12) -> np.ndarray:
+    """
+    Bookstein TPS kernel (commonly used in TPS): phi(r) = r^2 log(r^2)
+    which is equivalent to 2 * r^2 * log(r).
+
+    Notes
+    -----
+    - We use r^2 log(r^2) for numerical stability and to avoid extra factors.
+    - r is Euclidean distance in the (R,G,B) space.
+
+    References
+    ----------
+    Thin plate spline radial basis kernel: phi(r) = r^2 log r. See e.g. Wikipedia.
+    """
+    r2 = np.maximum(r * r, eps)
+    return r2 * np.log(r2)
+
+
+def _tps3d_kernel_polyharmonic_3d(r: np.ndarray) -> np.ndarray:
+    """
+    Polyharmonic spline kernel for 3D with m=2 is proportional to r.
+
+    Notes
+    -----
+    This is the *theoretical* 3D biharmonic fundamental solution form used in
+    polyharmonic splines. Some "TPS-3D" implementations still use the 2D
+    thin-plate kernel (Bookstein) but compute distances in 3D.
+
+    We keep this as an option; default remains Bookstein to match common TPS usage.
+    """
+    return r
+
+
+def _pairwise_distances_euclidean(A: np.ndarray, B: np.ndarray) -> np.ndarray:
+    """
+    Compute pairwise Euclidean distances between A (M,3) and B (N,3) without SciPy.
+    Returns (M,N).
+    """
+    # (M,1,3) - (1,N,3) -> (M,N,3)
+    D = A[:, None, :] - B[None, :, :]
+    return np.sqrt(np.sum(D * D, axis=-1))
+
+
+def tps3d_parameters(
+    source_points: ArrayLike,
+    destination_points: ArrayLike,
+    *,
+    smoothing: float = 0.0,
+    kernel: Literal["Bookstein", "Polyharmonic 3D"] | str = "Bookstein",
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """
+    Fit TPS-3D parameters that warp RGB source_points -> destination_points.
+
+    Parameters
+    ----------
+    source_points
+        (N,3) measured RGB points (e.g., detected ColorChecker swatches).
+    destination_points
+        (N,3) reference RGB points (e.g., ideal ColorChecker swatches).
+    smoothing
+        Non-negative regularization added to diag(K) to improve conditioning
+        (useful with noise / near-collinear points).
+    kernel
+        Kernel choice:
+        - "Bookstein": phi(r) = r^2 log(r^2)  (classic TPS kernel)
+        - "Polyharmonic 3D": phi(r) = r       (3D polyharmonic option)
+
+    Returns
+    -------
+    W, A, ctrl
+        W : (N,3) non-linear weights
+        A : (4,3) affine coefficients for [1, R, G, B]
+        ctrl : (N,3) control points (source_points), returned for reuse
+    """
+    ctrl = as_float_array(source_points)
+    dest = as_float_array(destination_points)
+
+    if ctrl.ndim != 2 or ctrl.shape[1] != 3:
+        raise ValueError('"source_points" must be an (N, 3) array!')
+    if dest.shape != ctrl.shape:
+        raise ValueError('"destination_points" must have the same shape as "source_points"!')
+
+    N = ctrl.shape[0]
+    if N < 4:
+        raise ValueError("TPS-3D requires at least 4 control points!")
+
+    kernel = validate_method(kernel, ("Bookstein", "Polyharmonic 3D"))
+
+    # P: (N,4) -> [1, R, G, B]
+    P = np.hstack([np.ones((N, 1)), ctrl])
+
+    # K: (N,N) from pairwise distances
+    r = _pairwise_distances_euclidean(ctrl, ctrl)
+    if kernel == "Bookstein":
+        K = _tps3d_kernel_bookstein(r)
+        np.fill_diagonal(K, 0.0)
+    else:
+        K = _tps3d_kernel_polyharmonic_3d(r)
+        np.fill_diagonal(K, 0.0)
+
+    if smoothing < 0:
+        raise ValueError('"smoothing" must be >= 0!')
+    if smoothing > 0:
+        K = K + np.eye(N) * smoothing
+
+    O = np.zeros((4, 4))
+    L = np.block([[K, P], [P.T, O]])
+
+    V = np.vstack([dest, np.zeros((4, 3))])
+
+    # Solve L * params = V
+    # Use solve when possible; fallback to lstsq for robustness.
+    try:
+        params = np.linalg.solve(L, V)
+    except np.linalg.LinAlgError:
+        params = np.linalg.lstsq(L, V, rcond=None)[0]
+
+    W = params[:N, :]
+    A = params[N:, :]
+
+    return W, A, ctrl
+
+
+def apply_tps3d(
+    RGB: ArrayLike,
+    W: np.ndarray,
+    A: np.ndarray,
+    ctrl: np.ndarray,
+    *,
+    kernel: Literal["Bookstein", "Polyharmonic 3D"] | str = "Bookstein",
+    clip: bool = True,
+    chunk_size: int = 250_000,
+) -> NDArrayFloat:
+    """
+    Apply pre-fitted TPS-3D to an arbitrary RGB array (… , 3).
+
+    Parameters
+    ----------
+    RGB
+        RGB array to warp. Can be (M,3) or (H,W,3) etc.
+    W, A, ctrl
+        TPS parameters from tps3d_parameters.
+    kernel
+        Same kernel used during fitting.
+    clip
+        Whether to clip to [0, 1].
+    chunk_size
+        Process pixels in chunks to avoid huge (M,N) temporary arrays for images.
+
+    Returns
+    -------
+    :class:`numpy.ndarray`
+        Warped RGB array with same shape as input.
+    """
+    kernel = validate_method(kernel, ("Bookstein", "Polyharmonic 3D"))
+
+    RGB = as_float_array(RGB)
+    shape = RGB.shape
+
+    if shape[-1] != 3:
+        raise ValueError('"RGB" last dimension must be 3!')
+
+    pixels = RGB.reshape((-1, 3))
+    M = pixels.shape[0]
+
+    out = np.empty_like(pixels)
+
+    # Precompute affine input [1, R, G, B]
+    # Do it chunked to keep memory stable.
+    for start in range(0, M, chunk_size):
+        end = min(start + chunk_size, M)
+        X = pixels[start:end]
+
+        P_all = np.hstack([np.ones((X.shape[0], 1)), X])  # (m,4)
+        r = _pairwise_distances_euclidean(X, ctrl)        # (m,N)
+
+        if kernel == "Bookstein":
+            U = _tps3d_kernel_bookstein(r)
+        else:
+            U = _tps3d_kernel_polyharmonic_3d(r)
+
+        out[start:end] = U @ W + P_all @ A
+
+    if clip:
+        out = np.clip(out, 0.0, 1.0)
+
+    return out.reshape(shape)
+
+
+def colour_correction_TPS3D(
+    RGB: ArrayLike,
+    M_T: ArrayLike,
+    M_R: ArrayLike,
+    *,
+    smoothing: float = 0.0,
+    kernel: Literal["Bookstein", "Polyharmonic 3D"] | str = "Bookstein",
+    clip: bool = True,
+    chunk_size: int = 250_000,
+) -> NDArrayFloat:
+    """
+    Perform colour correction using TPS-3D warping in RGB space.
+
+    Parameters
+    ----------
+    RGB
+        RGB array to colour correct (… , 3).
+    M_T
+        Source control points (N,3): measured RGBs (e.g., extracted swatches).
+    M_R
+        Destination control points (N,3): reference RGBs (e.g., ideal swatches).
+    smoothing
+        Regularization added to diag(K) for stability.
+    kernel
+        "Bookstein" (classic TPS) or "Polyharmonic 3D".
+    clip
+        Clip output to [0, 1].
+    chunk_size
+        Chunk size for large images.
+
+    Returns
+    -------
+    :class:`numpy.ndarray`
+        Colour corrected RGB array.
+
+    References
+    ----------
+    The TPS-3D warping approach for RGB calibration is described by Menesatti et al. (2012),
+    based on a TPS formulation originally popularized by Bookstein (1989).
+    """
+    W, A, ctrl = tps3d_parameters(M_T, M_R, smoothing=smoothing, kernel=kernel)
+    return apply_tps3d(
+        RGB, W, A, ctrl, kernel=kernel, clip=clip, chunk_size=chunk_size
+    )
+
+
+
+
 COLOUR_CORRECTION_METHODS = CanonicalMapping(
     {
         "Cheung 2004": colour_correction_Cheung2004,
         "Finlayson 2015": colour_correction_Finlayson2015,
         "Vandermonde": colour_correction_Vandermonde,
+        "TPS-3D": colour_correction_TPS3D,
     }
 )
 COLOUR_CORRECTION_METHODS.__doc__ = """
@@ -1426,7 +1673,7 @@ def colour_correction(
     M_T: ArrayLike,
     M_R: ArrayLike,
     method: (
-        Literal["Cheung 2004", "Finlayson 2015", "Vandermonde"] | str
+        Literal["Cheung 2004", "Finlayson 2015", "Vandermonde", "TPS-3D"] | str
     ) = "Cheung 2004",
     **kwargs: Any,
 ) -> NDArrayFloat:

--- a/colour/characterisation/correction.py
+++ b/colour/characterisation/correction.py
@@ -1407,11 +1407,10 @@ def colour_correction_Vandermonde(
     )
 
 
-
-
 # =============================================================================
 # TPS-3D (Thin-Plate Spline in RGB)
 # =============================================================================
+
 
 def _tps3d_kernel_bookstein(r: np.ndarray, eps: float = 1e-12) -> np.ndarray:
     """
@@ -1491,13 +1490,17 @@ def tps3d_parameters(
     dest = as_float_array(destination_points)
 
     if ctrl.ndim != 2 or ctrl.shape[1] != 3:
-        raise ValueError('"source_points" must be an (N, 3) array!')
+        message = '"source_points" must be an (N, 3) array!'
+        raise ValueError(message)
+
     if dest.shape != ctrl.shape:
-        raise ValueError('"destination_points" must have the same shape as "source_points"!')
+        message = '"destination_points" must have the same shape as "source_points"!'
+        raise ValueError(message)
 
     N = ctrl.shape[0]
     if N < 4:
-        raise ValueError("TPS-3D requires at least 4 control points!")
+        message = "TPS-3D requires at least 4 control points!"
+        raise ValueError(message)
 
     kernel = validate_method(kernel, ("Bookstein", "Polyharmonic 3D"))
 
@@ -1514,12 +1517,14 @@ def tps3d_parameters(
         np.fill_diagonal(K, 0.0)
 
     if smoothing < 0:
-        raise ValueError('"smoothing" must be >= 0!')
+        message = '"smoothing" must be >= 0!'
+        raise ValueError(message)
+
     if smoothing > 0:
         K = K + np.eye(N) * smoothing
 
-    O = np.zeros((4, 4))
-    L = np.block([[K, P], [P.T, O]])
+    Z = np.zeros((4, 4))
+    L = np.block([[K, P], [P.T, Z]])
 
     V = np.vstack([dest, np.zeros((4, 3))])
 
@@ -1573,7 +1578,8 @@ def apply_tps3d(
     shape = RGB.shape
 
     if shape[-1] != 3:
-        raise ValueError('"RGB" last dimension must be 3!')
+        message = '"RGB" last dimension must be 3!'
+        raise ValueError(message)
 
     pixels = RGB.reshape((-1, 3))
     M = pixels.shape[0]
@@ -1587,7 +1593,7 @@ def apply_tps3d(
         X = pixels[start:end]
 
         P_all = np.hstack([np.ones((X.shape[0], 1)), X])  # (m,4)
-        r = _pairwise_distances_euclidean(X, ctrl)        # (m,N)
+        r = _pairwise_distances_euclidean(X, ctrl)  # (m,N)
 
         if kernel == "Bookstein":
             U = _tps3d_kernel_bookstein(r)
@@ -1639,15 +1645,11 @@ def colour_correction_TPS3D(
 
     References
     ----------
-    The TPS-3D warping approach for RGB calibration is described by Menesatti et al. (2012),
-    based on a TPS formulation originally popularized by Bookstein (1989).
+    The TPS-3D warping approach for RGB calibration is described by Menesatti et al.
+    (2012), based on a TPS formulation originally popularized by Bookstein (1989).
     """
     W, A, ctrl = tps3d_parameters(M_T, M_R, smoothing=smoothing, kernel=kernel)
-    return apply_tps3d(
-        RGB, W, A, ctrl, kernel=kernel, clip=clip, chunk_size=chunk_size
-    )
-
-
+    return apply_tps3d(RGB, W, A, ctrl, kernel=kernel, clip=clip, chunk_size=chunk_size)
 
 
 COLOUR_CORRECTION_METHODS = CanonicalMapping(

--- a/colour/characterisation/tests/test_correction_tps3d.py
+++ b/colour/characterisation/tests/test_correction_tps3d.py
@@ -1,26 +1,30 @@
+"""
+Unit tests for the TPS-3D colour correction method.
+"""
+
 import numpy as np
 
 from colour.characterisation.correction import (
-    tps3d_parameters,
     apply_tps3d,
     colour_correction_TPS3D,
+    tps3d_parameters,
 )
 
 
-def test_tps3d_maps_control_points():
-    # 24 pontos "tipo ColorChecker", mas aleatórios fixos.
+def test_tps3d_maps_control_points() -> None:
+    """Control points should map exactly to their targets."""
     rng = np.random.default_rng(42)
     M_T = rng.random((24, 3))
-    M_R = np.clip(M_T * 0.85 + 0.05, 0, 1)  # transformação simples
+    M_R = np.clip(M_T * 0.85 + 0.05, 0, 1)
 
     W, A, ctrl = tps3d_parameters(M_T, M_R, smoothing=1e-10)
     mapped = apply_tps3d(M_T, W, A, ctrl, clip=False, chunk_size=1024)
 
-    # Deve bater bem nos pontos de controle
     assert np.max(np.abs(mapped - M_R)) < 1e-6
 
 
-def test_tps3d_identity_is_identity():
+def test_tps3d_identity_is_identity() -> None:
+    """Identity mapping should leave data unchanged."""
     rng = np.random.default_rng(123)
     M_T = rng.random((24, 3))
     W, A, ctrl = tps3d_parameters(M_T, M_T, smoothing=1e-12)
@@ -31,7 +35,8 @@ def test_tps3d_identity_is_identity():
     assert np.max(np.abs(out - img)) < 1e-6
 
 
-def test_colour_correction_tps3d_shape():
+def test_colour_correction_tps3d_shape() -> None:
+    """Colour correction should preserve the input shape."""
     rng = np.random.default_rng(7)
     M_T = rng.random((24, 3))
     M_R = rng.random((24, 3))

--- a/colour/characterisation/tests/test_correction_tps3d.py
+++ b/colour/characterisation/tests/test_correction_tps3d.py
@@ -1,0 +1,41 @@
+import numpy as np
+
+from colour.characterisation.correction import (
+    tps3d_parameters,
+    apply_tps3d,
+    colour_correction_TPS3D,
+)
+
+
+def test_tps3d_maps_control_points():
+    # 24 pontos "tipo ColorChecker", mas aleatórios fixos.
+    rng = np.random.default_rng(42)
+    M_T = rng.random((24, 3))
+    M_R = np.clip(M_T * 0.85 + 0.05, 0, 1)  # transformação simples
+
+    W, A, ctrl = tps3d_parameters(M_T, M_R, smoothing=1e-10)
+    mapped = apply_tps3d(M_T, W, A, ctrl, clip=False, chunk_size=1024)
+
+    # Deve bater bem nos pontos de controle
+    assert np.max(np.abs(mapped - M_R)) < 1e-6
+
+
+def test_tps3d_identity_is_identity():
+    rng = np.random.default_rng(123)
+    M_T = rng.random((24, 3))
+    W, A, ctrl = tps3d_parameters(M_T, M_T, smoothing=1e-12)
+
+    img = rng.random((16, 17, 3))
+    out = apply_tps3d(img, W, A, ctrl, clip=False, chunk_size=1024)
+
+    assert np.max(np.abs(out - img)) < 1e-6
+
+
+def test_colour_correction_tps3d_shape():
+    rng = np.random.default_rng(7)
+    M_T = rng.random((24, 3))
+    M_R = rng.random((24, 3))
+    img = rng.random((10, 11, 3))
+
+    out = colour_correction_TPS3D(img, M_T, M_R, smoothing=1e-8, chunk_size=1024)
+    assert out.shape == img.shape

--- a/colour/examples/plotting/examples_section_plots.py
+++ b/colour/examples/plotting/examples_section_plots.py
@@ -125,7 +125,7 @@ for i, RGB in zip(np.arange(0.5, 0.9, 0.1), section_colours, strict=True):
     plot_RGB_colourspace_section(
         colourspace="sRGB",
         model="DIN99",
-        origin=i,  # pyright: ignore
+        origin=i,
         section_colours=RGB,
         section_opacity=0.15,
         contour_colours=RGB,

--- a/colour/examples/plotting/examples_section_plots.py
+++ b/colour/examples/plotting/examples_section_plots.py
@@ -125,7 +125,7 @@ for i, RGB in zip(np.arange(0.5, 0.9, 0.1), section_colours, strict=True):
     plot_RGB_colourspace_section(
         colourspace="sRGB",
         model="DIN99",
-        origin=i,
+        origin=float(i),
         section_colours=RGB,
         section_opacity=0.15,
         contour_colours=RGB,

--- a/colour/geometry/section.py
+++ b/colour/geometry/section.py
@@ -149,7 +149,7 @@ def close_chord(vertices: ArrayLike) -> NDArrayFloat:
 
 def unique_vertices(
     vertices: ArrayLike,
-    decimals: int = np.finfo(DTYPE_FLOAT_DEFAULT).precision - 1,  # pyright: ignore
+    decimals: int = np.finfo(DTYPE_FLOAT_DEFAULT).precision - 1,
 ) -> NDArrayFloat:
     """
     Return the unique vertices from the specified vertices after rounding.

--- a/colour/geometry/section.py
+++ b/colour/geometry/section.py
@@ -22,7 +22,6 @@ import typing
 import numpy as np
 
 from colour.algebra import linear_conversion
-from colour.constants import DTYPE_FLOAT_DEFAULT
 
 if typing.TYPE_CHECKING:
     from colour.hints import ArrayLike, Literal, NDArrayFloat
@@ -149,7 +148,7 @@ def close_chord(vertices: ArrayLike) -> NDArrayFloat:
 
 def unique_vertices(
     vertices: ArrayLike,
-    decimals: int = np.finfo(DTYPE_FLOAT_DEFAULT).precision - 1,
+    decimals: int = int(np.finfo(np.float64).precision - 1),
 ) -> NDArrayFloat:
     """
     Return the unique vertices from the specified vertices after rounding.

--- a/colour/hints/__init__.py
+++ b/colour/hints/__init__.py
@@ -173,23 +173,14 @@ Range100_100_360: TypeAlias = Annotated[NDArrayFloat, (100, 100, 360)]
 
 class ProtocolInterpolator(Protocol):  # noqa: D101  # pragma: no cover
     @property
-    def x(self) -> NDArray:  # noqa: D102
-        ...
-
-    @x.setter
-    def x(self, value: ArrayLike, /) -> None: ...
+    def x(self) -> Any: ...  # noqa: D102
 
     @property
-    def y(self) -> NDArray:  # noqa: D102
-        ...
+    def y(self) -> Any: ...  # noqa: D102
 
-    @y.setter
-    def y(self, value: ArrayLike, /) -> None: ...
+    def __init__(self, *args: Any, **kwargs: Any) -> None: ...  # noqa: D102
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None: ...  # pragma: no cover
-
-    def __call__(self, x: NDArrayFloat) -> NDArray:  # noqa: D102
-        ...  # pragma: no cover
+    def __call__(self, x: Any, /, *args: Any, **kwargs: Any) -> Any: ...  # noqa: D102
 
 
 class ProtocolExtrapolator(Protocol):  # noqa: D101  # pragma: no cover

--- a/colour/hints/__init__.py
+++ b/colour/hints/__init__.py
@@ -178,7 +178,7 @@ class ProtocolInterpolator(Protocol):  # noqa: D101  # pragma: no cover
     @property
     def y(self) -> Any: ...  # noqa: D102
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None: ...  # noqa: D102
+    def __init__(self, *args: Any, **kwargs: Any) -> None: ...
 
     def __call__(self, x: Any, /, *args: Any, **kwargs: Any) -> Any: ...  # noqa: D102
 

--- a/colour/plotting/quality.py
+++ b/colour/plotting/quality.py
@@ -183,11 +183,17 @@ def plot_colour_quality_bars(
         hatches = (
             [next(patterns) * hatching_repeat] * (count_Q_as + 1)
             if hatching
-            else list(np.where(y < 0, next(patterns), None))  # pyright: ignore
+            else list(np.where(y < 0, next(patterns), None))
         )
 
         for j, bar in enumerate(bars.patches):
-            bar.set_hatch(hatches[j])
+            hatch = hatches[j]
+            try:
+                hatch = hatch.item()  # numpy scalar -> python scalar
+            except Exception:
+                pass
+            bar.set_hatch(str(hatch))
+
 
         if labels:
             label_rectangles(

--- a/colour/plotting/quality.py
+++ b/colour/plotting/quality.py
@@ -182,10 +182,12 @@ def plot_colour_quality_bars(
             zorder=CONSTANTS_COLOUR_STYLE.zorder.background_polygon,
         )
 
+        pattern = next(patterns)
+
         hatches = (
-            [next(patterns) * hatching_repeat] * (count_Q_as + 1)
+            [pattern * hatching_repeat] * (count_Q_as + 1)
             if hatching
-            else list(np.where(y < 0, next(patterns), None))
+            else list(np.where(y < 0, pattern, ""))
         )
 
         for j, bar in enumerate(bars.patches):

--- a/colour/plotting/quality.py
+++ b/colour/plotting/quality.py
@@ -23,6 +23,8 @@ if typing.TYPE_CHECKING:
     from matplotlib.figure import Figure
     from matplotlib.axes import Axes
 
+from contextlib import suppress
+
 import numpy as np
 
 from colour.colorimetry import (
@@ -188,12 +190,9 @@ def plot_colour_quality_bars(
 
         for j, bar in enumerate(bars.patches):
             hatch = hatches[j]
-            try:
+            with suppress(AttributeError):
                 hatch = hatch.item()  # numpy scalar -> python scalar
-            except Exception:
-                pass
             bar.set_hatch(str(hatch))
-
 
         if labels:
             label_rectangles(

--- a/conftest.py
+++ b/conftest.py
@@ -14,4 +14,3 @@ def pytest_configure(config) -> None:
             config.option.numprocesses = 0
         if getattr(config.option, "dist", None):
             config.option.dist = "no"
-

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,17 @@
+# conftest.py
+from __future__ import annotations
+
+import os
+import sys
+
+
+def pytest_configure(config) -> None:
+    # GitHub Actions + Linux: desabilita xdist para evitar deadlocks/child processes
+    # que podem travar o fim da suite e estourar 6h.
+    if os.environ.get("GITHUB_ACTIONS") == "true" and sys.platform.startswith("linux"):
+        # Se xdist estiver ativo, forçamos execução single-process.
+        if getattr(config.option, "numprocesses", None):
+            config.option.numprocesses = 0
+        if getattr(config.option, "dist", None):
+            config.option.dist = "no"
+

--- a/conftest.py
+++ b/conftest.py
@@ -1,15 +1,29 @@
-# conftest.py
+"""
+Pytest Configuration
+====================
+
+Project-level pytest configuration and hooks.
+"""
+
 from __future__ import annotations
 
 import os
 import sys
+from typing import Any
 
 
-def pytest_configure(config) -> None:
-    # GitHub Actions + Linux: desabilita xdist para evitar deadlocks/child processes
-    # que podem travar o fim da suite e estourar 6h.
+def pytest_configure(config: Any) -> None:
+    """
+    Configure pytest for the project test suite.
+
+    Notes
+    -----
+    GitHub Actions on Linux occasionally hangs near the end of the suite when
+    running with xdist enabled (e.g., ``-n 2``). This hook forces a single-process
+    run in that environment to avoid deadlocks / stuck workers and CI timeouts.
+    """
     if os.environ.get("GITHUB_ACTIONS") == "true" and sys.platform.startswith("linux"):
-        # Se xdist estiver ativo, forçamos execução single-process.
+        # Disable xdist / parallel execution.
         if getattr(config.option, "numprocesses", None):
             config.option.numprocesses = 0
         if getattr(config.option, "dist", None):

--- a/docs/colour.characterisation.rst
+++ b/docs/colour.characterisation.rst
@@ -93,6 +93,9 @@ Colour Fitting
     colour_correction_Cheung2004
     colour_correction_Finlayson2015
     colour_correction_Vandermonde
+    colour_correction_TPS3D
+    apply_tps3d
+    tps3d_parameters
     matrix_augmented_Cheung2004
     matrix_colour_correction_Cheung2004
     matrix_colour_correction_Finlayson2015


### PR DESCRIPTION
**Implementation of the method:**

The TPS-3D warping approach for RGB calibration is described by Menesatti et al.
(2012), based on a TPS formulation originally popularized by Bookstein (1989).

# Summary

This PR adds a new colour correction method, TPS-3D, implementing a thin-plate spline RGB warping from measured to reference control points (e.g., ColorChecker swatches). The implementation is NumPy-only (no SciPy dependency), supports large images via chunked evaluation, and includes unit tests validating: (i) exact mapping of control points, (ii) identity behaviour, and (iii) shape preservation.

Additionally, this PR fixes a few Pyright-related typing issues (Interpolator protocol compatibility) and removes now-unnecessary pyright: ignore comments, plus a small plotting typing fix ensuring hatch values are passed as strings.


**Code Style and Quality**

- [ X] Unit tests have been implemented and passed.
- [X] Pyright static checking has been run and passed.
- [X] Pre-commit hooks have been run and passed.
- [N/A] New transformations have been added to the _Automatic Colour Conversion Graph_.
- [X] New transformations have been exported to the relevant namespaces, e.g. `colour`, `colour.models`.


**Documentation**

- [X] New features are documented along with examples if relevant.
- [X] The documentation is [Sphinx](https://www.sphinx-doc.org/en/master/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant.


## How TPS-3D (Thin-Plate Spline in RGB) Works (Math + Implementation Walkthrough)


This PR adds a **TPS-3D (Thin-Plate Spline) warp in RGB space** for colour correction. It learns a smooth non-linear mapping:

```
- f : R^3 -> R^3
- x = [R, G, B] -> y = [R', G', B']
```

so that measured RGB values (e.g., from a colour chart) are mapped to reference RGB values.

---

### 1) Control points (measured -> reference)

We use N paired 3D RGB samples:

- Source/control points (measured):   x_i in R^3
- Destination/targets (reference):    y_i in R^3

Typical example: N = 24 (ColorChecker24).

---

### 2) TPS model = affine + radial basis

TPS represents the mapping as an affine term plus a radial-basis term:


```
f(x) = A^T * p(x) + sum_{i=1..N} w_i * U(||x - x_i||)
```


Where:

p(x) = [1, R, G, B]^T (affine basis)

A is a (4 x 3) matrix of affine coefficients (one column per output channel)

W is a (N x 3) matrix of TPS weights (non-linear part)

U(r) is the TPS kernel function

||x - x_i|| is the Euclidean distance in RGB space

Kernel used (as implemented):

```
U(r) = 2 * r^2 * log(r)
```

(with an epsilon guard for r -> 0 to avoid log(0)).

3) Build the TPS linear system (Bookstein-style)

We build two matrices:

P matrix (affine design), shape (N x 4):

```
P = [
  1  R1  G1  B1
  ...
  1  RN  GN  BN
]
```


K matrix (pairwise kernel distances), shape (N x N):

```
K_ij = U( ||x_i - x_j|| )
```

Then assemble the block system:

```
L = [ K   P  ]
    [ P^T 0  ]     shape: (N+4) x (N+4)

V = [ Y ]
    [ 0 ]           shape: (N+4) x 3
```

Where Y is the stacked target RGB values (N x 3).

We solve:

```
L * Theta = V
```

And unpack:

W = Theta[0:N, :] (N x 3) non-linear weights

A = Theta[N:N+4, :] (4 x 3) affine coefficients


4) Optional smoothing (regularisation)

To improve robustness under noisy control points, the implementation supports smoothing:

```
K <- K + lambda * I
```

lambda = 0 -> exact interpolation (up to numerical precision)

lambda > 0 -> smoother fit (less sensitive / more stable)

5) Apply the warp to pixels

For each pixel x (in linear RGB):

Compute p(x) = [1, R, G, B]

Compute distances r_i = ||x - x_i|| and u_i = U(r_i)

Evaluate:

```
f(x) = u(x) * W + p(x)^T * A
```

Where:

u(x) = [U(r_1), ..., U(r_N)] (1 x N)

W is (N x 3)

p(x)^T is (1 x 4)

A is (4 x 3)

The implementation batches pixels by reshaping RGB to (M x 3), applies the mapping, then reshapes back. Output is clipped to [0, 1].

References

Bookstein (1989): Principal warps / thin-plate splines.
Menesatti et al. (2012): TPS-3D RGB calibration via thin-plate spline warping.
