### PR TITLE
PR: Enable *DIN99* method selection in `colour.difference.delta_E_DIN99` definition.

### DIFF
--- a/colour/difference/__init__.py
+++ b/colour/difference/__init__.py
@@ -257,6 +257,39 @@ def delta_E(
         :math:`k_L=2,\\ k_C=k_H=1,\\ k_1=0.048,\\ k_2=0.014,\\ k_E=2,\\ k_{CH}=0.5`
         weights are used instead of
         :math:`k_L=k_C=k_H=1,\\ k_1=0.045,\\ k_2=0.015,\\ k_E=k_{CH}=1.0`.
+    kwargs
+        See the documentation of the available delta E definitions.
+
+        Arguments for the conversion definitions are passed as keyword
+        arguments whose names are those of the delta E definitions and
+        values set as dictionaries. For example, when computing delta E
+        DIN99, passing arguments to the :func:`colour.delta_E_DIN99`
+        definition is done as follows::
+
+            delta_E(
+                a,
+                b,
+                "DIN99",
+                False,
+                delta_E_DIN99={"method": "DIN99b"},
+            )
+
+        It is also possible to pass keyword arguments directly to the
+        various delta E definitions irrespective of their name. This is
+        ``dangerous`` and could cause unexpected behaviour, consider the
+        following conversion::
+
+            delta_E(
+                a,
+                b,
+                "DIN99",
+                "method"="DIN99b",
+            )
+
+        Because both the :func:`colour.delta_E` and
+        :func:`colour.delta_E_DIN99` definitions have an *method*
+        argument, this will raise a an exception in the
+        :func:`colour.delta_E` definition.
 
     Returns
     -------
@@ -315,9 +348,13 @@ def delta_E(
 
     function = DELTA_E_METHODS[method]
 
-    return function(
-        a, b, additional_data=additional_data, **filter_kwargs(function, **kwargs)
-    )
+    # Layer 1: filter direct kwargs by target function signature
+    filtered_kwargs = filter_kwargs(function, **kwargs)
+
+    # Layer 2: merge in function-name-keyed dict (overrides)
+    filtered_kwargs.update(kwargs.get(function.__name__, {}))
+
+    return function(a, b, additional_data=additional_data, **filtered_kwargs)
 
 
 __all__ += [

--- a/colour/difference/din99.py
+++ b/colour/difference/din99.py
@@ -24,12 +24,15 @@ if typing.TYPE_CHECKING:
 from dataclasses import dataclass, field
 
 from colour.algebra import euclidean_distance
+from colour.hints import Domain100, Literal, NDArrayFloat  # noqa: TC001
 from colour.models import Lab_to_DIN99
+from colour.models.din99 import DIN99_METHODS
 from colour.utilities import (
     MixinDataclassArithmetic,
     as_float,
     as_float_array,
     get_domain_range_scale,
+    validate_method,
 )
 
 __author__ = "Colour Developers"
@@ -96,6 +99,9 @@ def delta_E_DIN99(
     Lab_2: Domain100,
     textiles: bool = False,
     additional_data: bool = False,
+    method: (
+        Literal["ASTMD2244-07", "DIN99", "DIN99b", "DIN99c", "DIN99d"] | str
+    ) = "DIN99",
 ) -> NDArrayFloat | DeltaE_Specification_DIN99:
     """
     Compute the colour difference :math:`\\Delta E_{DIN99}` between two
@@ -113,6 +119,9 @@ def delta_E_DIN99(
         :math:`k_E=1,\\ k_{CH}=1`.
     additional_data
         Whether to output additional data.
+    method
+        Computation method to convert from *CIE L\\*a\\*b\\** colourspace to
+        *DIN99* colourspace.
 
     Returns
     -------
@@ -148,15 +157,19 @@ def delta_E_DIN99(
     DeltaE_Specification_DIN99(dE=np.float64(1.1772166...), \
 dL=np.float64(-0.1750930...), da=np.float64(-0.5804045...), \
 db=np.float64(-1.0091144...))
+    >>> delta_E_DIN99(Lab_1, Lab_2, method="DIN99b")  # doctest: +ELLIPSIS
+    np.float64(1.7113129...)
     """
+
+    method = validate_method(method, tuple(DIN99_METHODS))
 
     k_E = 2 if textiles else 1
     k_CH = 0.5 if textiles else 1
 
     factor = 100 if get_domain_range_scale() == "1" else 1
 
-    Lab_99_1 = Lab_to_DIN99(Lab_1, k_E, k_CH) * factor
-    Lab_99_2 = Lab_to_DIN99(Lab_2, k_E, k_CH) * factor
+    Lab_99_1 = Lab_to_DIN99(Lab_1, k_E, k_CH, method) * factor
+    Lab_99_2 = Lab_to_DIN99(Lab_2, k_E, k_CH, method) * factor
 
     dE = euclidean_distance(Lab_99_1, Lab_99_2)
 

--- a/colour/difference/din99.py
+++ b/colour/difference/din99.py
@@ -81,6 +81,7 @@ def delta_E_DIN99(
     textiles: bool = ...,
     *,
     additional_data: Literal[False] = False,
+    method: str = ...,
 ) -> NDArrayFloat: ...
 
 
@@ -91,6 +92,7 @@ def delta_E_DIN99(
     textiles: bool = ...,
     *,
     additional_data: Literal[True],
+    method: str = ...,
 ) -> DeltaE_Specification_DIN99: ...
 
 

--- a/colour/difference/din99.py
+++ b/colour/difference/din99.py
@@ -24,7 +24,7 @@ if typing.TYPE_CHECKING:
 from dataclasses import dataclass, field
 
 from colour.algebra import euclidean_distance
-from colour.hints import Domain100, Literal, NDArrayFloat  # noqa: TC001
+from colour.hints import Domain100, NDArrayFloat  # noqa: TC001
 from colour.models import Lab_to_DIN99
 from colour.models.din99 import DIN99_METHODS
 from colour.utilities import (
@@ -122,6 +122,7 @@ def delta_E_DIN99(
     method
         Computation method to convert from *CIE L\\*a\\*b\\** colourspace to
         *DIN99* colourspace.
+        See `colour.models.din99.DIN99_METHODS` for supported values.
 
     Returns
     -------


### PR DESCRIPTION
# Summary

A very small PR to enable selecting the Lab → DIN99 conversion variant when computing ΔE_DIN99.

Both colour.difference.delta_E and colour.models.Lab_to_DIN99 expose a method parameter, which makes it impossible to forward the conversion method via the existing **kwargs mechanism without a keyword collision.

To resolve this, a dedicated din99_method parameter is added to colour.difference.delta_E_DIN99. The parameter defaults to "DIN99", matching the normative DIN99 definition used by Lab_to_DIN99.

The provided value is validated against DIN99_METHODS, which remains the single source of truth for supported DIN99 variants.

# Preflight

<!-- Please mark any checkboxes that do not apply to this pull request as [N/A]. -->

**Code Style and Quality**

- [N/A] Unit tests have been implemented and passed.
- [x] Pyright static checking has been run and passed.
- [x] Pre-commit hooks have been run and passed.
- [N/A] New transformations have been added to the _Automatic Colour Conversion Graph_.
- [N/A] New transformations have been exported to the relevant namespaces, e.g. `colour`, `colour.models`.


```
TOTAL                                                                          44613   9996    78%
============================= slowest 5 durations =============================
78.73s call     colour/recovery/tests/test_gaussian.py::TestOptimiseGaussianBasisParameters::test_optimise_gaussian_basis_parameters
21.09s call     colour/recovery/tests/test_jakob2019.py::TestLUT3D_Jakob2019::test_size
16.30s call     colour/notation/tests/test_munsell.py::TestxyY_to_munsell_specification::test_xyY_to_munsell_specification
6.93s call     colour/io/luts/lut.py::colour.io.luts.lut.LUT3D.invert
6.55s call     colour/recovery/jakob2019.py::colour.recovery.jakob2019.LUT3D_Jakob2019.write
=========================== short test summary info ===========================
FAILED colour/io/image.py::colour.io.image.read_image_Imageio
FAILED colour/io/tests/test_image.py::TestWriteImageImageio::test_write_image_Imageio_exr
FAILED colour/io/tests/test_image.py::TestReadImageImageio::test_read_image_Imageio
==== 3 failed, 3697 passed, 17 skipped, 225 warnings in 112.27s (0:01:52) =====
```


```
===============================================================================
*                                                                             *
*   Checking codebase with "Pyright"...                                       *
*                                                                             *
===============================================================================
0 errors, 0 warnings, 0 informations
```

**Documentation**

- [x] New features are documented along with examples if relevant.
- [x] The documentation is [Sphinx](https://www.sphinx-doc.org/en/master/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant.

<!--
Thank you again!
-->
