### PR TITLE
PR: Implement support for *Munsell Renotation* conversions via *ONNX*-based *ML* models.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1696,6 +1696,16 @@ Munsell Colour
 
     [ 0.38736945  0.35751656  0.59362   ]
 
+.. code-block:: python
+
+    import colour
+
+    sorted(colour.XYY_TO_MUNSELL_COLOUR_METHODS)
+
+.. code-block:: text
+
+    ['Centore 2014', 'ONNX']
+
 Optical Phenomena - ``colour.phenomena``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/colour/__init__.py
+++ b/colour/__init__.py
@@ -48,10 +48,12 @@ import json
 import os
 import sys
 
+ROOT_COLOUR_SCIENCE: str = os.path.join(os.path.expanduser("~"), ".colour-science")
+"""Root directory for *Colour* data."""
+
 # Loading the "colour-science" JEnv file.
 _JENV_FILE_PATH = os.path.join(
-    os.path.expanduser("~"),
-    ".colour-science",
+    ROOT_COLOUR_SCIENCE,
     "colour-science.jenv",
 )
 
@@ -432,11 +434,17 @@ from .models import (
     xyY_to_XYZ,
 )
 from .notation import (
+    MUNSELL_COLOUR_TO_XYY_METHODS,
     MUNSELL_COLOURS,
+    MUNSELL_SPECIFICATION_TO_XYY_METHODS,
     MUNSELL_VALUE_METHODS,
+    XYY_TO_MUNSELL_COLOUR_METHODS,
+    XYY_TO_MUNSELL_SPECIFICATION_METHODS,
     munsell_colour_to_xyY,
+    munsell_specification_to_xyY,
     munsell_value,
     xyY_to_munsell_colour,
+    xyY_to_munsell_specification,
 )
 from .phenomena import (
     rayleigh_scattering,
@@ -856,11 +864,17 @@ __all__ += [
     "xyY_to_XYZ",
 ]
 __all__ += [
+    "MUNSELL_COLOUR_TO_XYY_METHODS",
     "MUNSELL_COLOURS",
+    "MUNSELL_SPECIFICATION_TO_XYY_METHODS",
     "MUNSELL_VALUE_METHODS",
+    "XYY_TO_MUNSELL_COLOUR_METHODS",
+    "XYY_TO_MUNSELL_SPECIFICATION_METHODS",
     "munsell_colour_to_xyY",
+    "munsell_specification_to_xyY",
     "munsell_value",
     "xyY_to_munsell_colour",
+    "xyY_to_munsell_specification",
 ]
 __all__ += [
     "rayleigh_scattering",

--- a/colour/notation/__init__.py
+++ b/colour/notation/__init__.py
@@ -13,8 +13,13 @@ from .hexadecimal import HEX_to_RGB, RGB_to_HEX
 
 from .css_color_3 import keyword_to_RGB_CSSColor3
 from .munsell import (
+    MUNSELL_COLOUR_TO_XYY_METHODS,
+    MUNSELL_SPECIFICATION_TO_XYY_METHODS,
     MUNSELL_VALUE_METHODS,
+    XYY_TO_MUNSELL_COLOUR_METHODS,
+    XYY_TO_MUNSELL_SPECIFICATION_METHODS,
     munsell_colour_to_xyY,
+    munsell_specification_to_xyY,
     munsell_value,
     munsell_value_ASTMD1535,
     munsell_value_Ladd1955,
@@ -24,6 +29,7 @@ from .munsell import (
     munsell_value_Priest1920,
     munsell_value_Saunderson1944,
     xyY_to_munsell_colour,
+    xyY_to_munsell_specification,
 )
 
 __all__ = [
@@ -43,8 +49,13 @@ __all__ += [
     "keyword_to_RGB_CSSColor3",
 ]
 __all__ += [
+    "MUNSELL_COLOUR_TO_XYY_METHODS",
+    "MUNSELL_SPECIFICATION_TO_XYY_METHODS",
     "MUNSELL_VALUE_METHODS",
+    "XYY_TO_MUNSELL_COLOUR_METHODS",
+    "XYY_TO_MUNSELL_SPECIFICATION_METHODS",
     "munsell_colour_to_xyY",
+    "munsell_specification_to_xyY",
     "munsell_value",
     "munsell_value_ASTMD1535",
     "munsell_value_Ladd1955",
@@ -54,4 +65,5 @@ __all__ += [
     "munsell_value_Priest1920",
     "munsell_value_Saunderson1944",
     "xyY_to_munsell_colour",
+    "xyY_to_munsell_specification",
 ]

--- a/colour/notation/munsell/__init__.py
+++ b/colour/notation/munsell/__init__.py
@@ -1,0 +1,410 @@
+from __future__ import annotations
+
+from .centore2014 import (
+    CCS_ILLUMINANT_MUNSELL,
+    ILLUMINANT_NAME_MUNSELL,
+    MUNSELL_COLOUR_EXTENDED_FORMAT,
+    MUNSELL_COLOUR_FORMAT,
+    MUNSELL_COLOUR_PATTERN,
+    MUNSELL_GRAY_EXTENDED_FORMAT,
+    MUNSELL_GRAY_FORMAT,
+    MUNSELL_GRAY_PATTERN,
+    MUNSELL_HUE_LETTER_CODES,
+    LCHab_to_munsell_specification,
+    bounding_hues_from_renotation,
+    hue_angle_to_hue,
+    hue_to_ASTM_hue,
+    hue_to_hue_angle,
+    interpolation_method_from_renotation_ovoid,
+    is_grey_munsell_colour,
+    is_specification_in_renotation,
+    maximum_chroma_from_renotation,
+    munsell_colour_to_munsell_specification,
+    munsell_colour_to_xyY_Centore2014,
+    munsell_specification_to_munsell_colour,
+    munsell_specification_to_xy,
+    munsell_specification_to_xyY_Centore2014,
+    normalise_munsell_specification,
+    parse_munsell_colour,
+    xy_from_renotation_ovoid,
+    xyY_from_renotation,
+    xyY_to_munsell_colour_Centore2014,
+    xyY_to_munsell_specification_Centore2014,
+)
+from .onnx import (
+    ONNX_MODELS_FROM_XYY,
+    ONNX_MODELS_TO_XYY,
+    munsell_colour_to_xyY_Onnx,
+    munsell_specification_to_xyY_Onnx,
+    xyY_to_munsell_colour_Onnx,
+    xyY_to_munsell_specification_Onnx,
+)
+from .value import (
+    MUNSELL_VALUE_METHODS,
+    munsell_value,
+    munsell_value_ASTMD1535,
+    munsell_value_Ladd1955,
+    munsell_value_McCamy1987,
+    munsell_value_Moon1943,
+    munsell_value_Munsell1933,
+    munsell_value_Priest1920,
+    munsell_value_Saunderson1944,
+)
+
+# isort: split
+
+import typing
+
+if typing.TYPE_CHECKING:
+    from colour.hints import (
+        ArrayLike,
+        Domain1,
+        Literal,
+        NDArrayFloat,
+        NDArrayStr,
+        Range1,
+    )
+
+from colour.utilities import (
+    CanonicalMapping,
+    filter_kwargs,
+    validate_method,
+)
+
+__author__ = "Colour Developers"
+__copyright__ = "Copyright 2013 Colour Developers"
+__license__ = "BSD-3-Clause - https://opensource.org/licenses/BSD-3-Clause"
+__maintainer__ = "Colour Developers"
+__email__ = "colour-developers@colour-science.org"
+__status__ = "Production"
+
+__all__ = [
+    "MUNSELL_GRAY_PATTERN",
+    "MUNSELL_COLOUR_PATTERN",
+    "MUNSELL_GRAY_FORMAT",
+    "MUNSELL_COLOUR_FORMAT",
+    "MUNSELL_GRAY_EXTENDED_FORMAT",
+    "MUNSELL_COLOUR_EXTENDED_FORMAT",
+    "MUNSELL_HUE_LETTER_CODES",
+    "ILLUMINANT_NAME_MUNSELL",
+    "CCS_ILLUMINANT_MUNSELL",
+]
+__all__ += [
+    "munsell_value_Priest1920",
+    "munsell_value_Munsell1933",
+    "munsell_value_Moon1943",
+    "munsell_value_Saunderson1944",
+    "munsell_value_Ladd1955",
+    "munsell_value_McCamy1987",
+    "munsell_value_ASTMD1535",
+    "MUNSELL_VALUE_METHODS",
+    "munsell_value",
+]
+__all__ += [
+    "munsell_specification_to_xyY_Centore2014",
+    "munsell_colour_to_xyY_Centore2014",
+    "xyY_to_munsell_specification_Centore2014",
+    "xyY_to_munsell_colour_Centore2014",
+]
+__all__ += [
+    "ONNX_MODELS_TO_XYY",
+    "ONNX_MODELS_FROM_XYY",
+    "munsell_specification_to_xyY_Onnx",
+    "munsell_colour_to_xyY_Onnx",
+    "xyY_to_munsell_specification_Onnx",
+    "xyY_to_munsell_colour_Onnx",
+]
+__all__ += [
+    "MUNSELL_SPECIFICATION_TO_XYY_METHODS",
+    "MUNSELL_COLOUR_TO_XYY_METHODS",
+    "XYY_TO_MUNSELL_SPECIFICATION_METHODS",
+    "XYY_TO_MUNSELL_COLOUR_METHODS",
+    "munsell_specification_to_xyY",
+    "munsell_colour_to_xyY",
+    "xyY_to_munsell_specification",
+    "xyY_to_munsell_colour",
+]
+__all__ += [
+    "parse_munsell_colour",
+    "is_grey_munsell_colour",
+    "normalise_munsell_specification",
+    "munsell_colour_to_munsell_specification",
+    "munsell_specification_to_munsell_colour",
+    "xyY_from_renotation",
+    "is_specification_in_renotation",
+    "bounding_hues_from_renotation",
+    "hue_to_hue_angle",
+    "hue_angle_to_hue",
+    "hue_to_ASTM_hue",
+    "interpolation_method_from_renotation_ovoid",
+    "xy_from_renotation_ovoid",
+    "LCHab_to_munsell_specification",
+    "maximum_chroma_from_renotation",
+    "munsell_specification_to_xy",
+]
+
+MUNSELL_SPECIFICATION_TO_XYY_METHODS: CanonicalMapping = CanonicalMapping(
+    {
+        "Centore 2014": munsell_specification_to_xyY_Centore2014,
+        "ONNX": munsell_specification_to_xyY_Onnx,
+    }
+)
+"""Supported *Munsell* specification to *CIE xyY* conversion methods."""
+
+MUNSELL_COLOUR_TO_XYY_METHODS: CanonicalMapping = CanonicalMapping(
+    {
+        "Centore 2014": munsell_colour_to_xyY_Centore2014,
+        "ONNX": munsell_colour_to_xyY_Onnx,
+    }
+)
+"""Supported *Munsell* colour to *CIE xyY* conversion methods."""
+
+XYY_TO_MUNSELL_SPECIFICATION_METHODS: CanonicalMapping = CanonicalMapping(
+    {
+        "Centore 2014": xyY_to_munsell_specification_Centore2014,
+        "ONNX": xyY_to_munsell_specification_Onnx,
+    }
+)
+"""Supported *CIE xyY* to *Munsell* specification conversion methods."""
+
+XYY_TO_MUNSELL_COLOUR_METHODS: CanonicalMapping = CanonicalMapping(
+    {
+        "Centore 2014": xyY_to_munsell_colour_Centore2014,
+        "ONNX": xyY_to_munsell_colour_Onnx,
+    }
+)
+"""Supported *CIE xyY* to *Munsell* colour conversion methods."""
+
+
+def munsell_specification_to_xyY(
+    specification: ArrayLike,
+    method: Literal["Centore 2014", "ONNX"] | str = "Centore 2014",
+) -> NDArrayFloat:
+    """
+    Convert specified *Munsell* *Colorlab* specification to *CIE xyY*
+    colourspace.
+
+    Parameters
+    ----------
+    specification
+        *Munsell* *Colorlab* specification.
+    method
+        Computation method.
+
+    Returns
+    -------
+    :class:`numpy.NDArrayFloat`
+        *CIE xyY* colourspace array.
+
+    Notes
+    -----
+    +-------------------+-----------------------+---------------+
+    | **Domain**        | **Scale - Reference** | **Scale - 1** |
+    +===================+=======================+===============+
+    | ``specification`` | ``hue``    : 10       | 1             |
+    |                   |                       |               |
+    |                   | ``value``  : 10       | 1             |
+    |                   |                       |               |
+    |                   | ``chroma`` : 50       | 1             |
+    |                   |                       |               |
+    |                   | ``code``   : 10       | 1             |
+    +-------------------+-----------------------+---------------+
+
+    +-------------------+-----------------------+---------------+
+    | **Range**         | **Scale - Reference** | **Scale - 1** |
+    +===================+=======================+===============+
+    | ``xyY``           | 1                     | 1             |
+    +-------------------+-----------------------+---------------+
+
+    References
+    ----------
+    :cite:`Centore2014m`
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> munsell_specification_to_xyY(np.array([2.1, 8.0, 17.9, 4]))
+    ... # doctest: +ELLIPSIS
+    array([0.4400632..., 0.5522428..., 0.5761962...])
+    >>> munsell_specification_to_xyY(np.array([np.nan, 8.9, np.nan, np.nan]))
+    ... # doctest: +ELLIPSIS
+    array([0.31006  , 0.31616  , 0.7461345...])
+    """
+
+    method = validate_method(method, tuple(MUNSELL_SPECIFICATION_TO_XYY_METHODS))
+
+    return MUNSELL_SPECIFICATION_TO_XYY_METHODS[method](specification)
+
+
+def munsell_colour_to_xyY(
+    munsell_colour: ArrayLike,
+    method: Literal["Centore 2014", "ONNX"] | str = "Centore 2014",
+) -> Range1:
+    """
+    Convert the specified *Munsell* colour to *CIE xyY* colourspace.
+
+    Parameters
+    ----------
+    munsell_colour
+        *Munsell* colour notation formatted as "H V/C" where H is hue,
+        V is value, and C is chroma.
+    method
+        Computation method.
+
+    Returns
+    -------
+    :class:`numpy.NDArrayFloat`
+        *CIE xyY* colourspace array.
+
+    Notes
+    -----
+    +-----------+-----------------------+---------------+
+    | **Range** | **Scale - Reference** | **Scale - 1** |
+    +===========+=======================+===============+
+    | ``xyY``   | 1                     | 1             |
+    +-----------+-----------------------+---------------+
+
+    References
+    ----------
+    :cite:`Centorea`, :cite:`Centore2012a`
+
+    Examples
+    --------
+    >>> munsell_colour_to_xyY("4.2YR 8.1/5.3")  # doctest: +ELLIPSIS
+    array([0.3873694..., 0.3575165..., 0.59362   ])
+    >>> munsell_colour_to_xyY("N8.9")  # doctest: +ELLIPSIS
+    array([0.31006  , 0.31616  , 0.7461345...])
+    """
+
+    method = validate_method(method, tuple(MUNSELL_COLOUR_TO_XYY_METHODS))
+
+    return MUNSELL_COLOUR_TO_XYY_METHODS[method](munsell_colour)
+
+
+def xyY_to_munsell_specification(
+    xyY: ArrayLike,
+    method: Literal["Centore 2014", "ONNX"] | str = "Centore 2014",
+) -> NDArrayFloat:
+    """
+    Convert from *CIE xyY* colourspace to *Munsell* *Colorlab*
+    specification.
+
+    Parameters
+    ----------
+    xyY
+        *CIE xyY* colourspace array.
+    method
+        Computation method.
+
+    Returns
+    -------
+    :class:`numpy.NDArrayFloat`
+        *Munsell* *Colorlab* specification.
+
+    Raises
+    ------
+    ValueError
+        If the specified *CIE xyY* colourspace array is not within
+        MacAdam limits.
+    RuntimeError
+        If the maximum iterations count has been reached without
+        converging to a result.
+
+    Notes
+    -----
+    +-------------------+-----------------------+---------------+
+    | **Domain**        | **Scale - Reference** | **Scale - 1** |
+    +===================+=======================+===============+
+    | ``xyY``           | 1                     | 1             |
+    +-------------------+-----------------------+---------------+
+
+    +-------------------+-----------------------+---------------+
+    | **Range**         | **Scale - Reference** | **Scale - 1** |
+    +===================+=======================+===============+
+    | ``specification`` | ``hue``    : 10       | 1             |
+    |                   |                       |               |
+    |                   | ``value``  : 10       | 1             |
+    |                   |                       |               |
+    |                   | ``chroma`` : 50       | 1             |
+    |                   |                       |               |
+    |                   | ``code``   : 10       | 1             |
+    +-------------------+-----------------------+---------------+
+
+    References
+    ----------
+    :cite:`Centore2014p`
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> xyY = np.array([0.38736945, 0.35751656, 0.59362000])
+    >>> xyY_to_munsell_specification(xyY)  # doctest: +ELLIPSIS
+    array([4.2000019..., 8.0999999..., 5.2999996..., 6.        ])
+    """
+
+    method = validate_method(method, tuple(XYY_TO_MUNSELL_SPECIFICATION_METHODS))
+
+    return XYY_TO_MUNSELL_SPECIFICATION_METHODS[method](xyY)
+
+
+def xyY_to_munsell_colour(
+    xyY: Domain1,
+    hue_decimals: int = 1,
+    value_decimals: int = 1,
+    chroma_decimals: int = 1,
+    method: Literal["Centore 2014", "ONNX"] | str = "Centore 2014",
+) -> str | NDArrayStr:
+    """
+    Convert from *CIE xyY* colourspace to *Munsell* colour notation.
+
+    Parameters
+    ----------
+    xyY
+        *CIE xyY* colourspace array representing chromaticity coordinates
+        and luminance.
+    hue_decimals
+        Number of decimal places for formatting the hue component.
+    value_decimals
+        Number of decimal places for formatting the value component.
+    chroma_decimals
+        Number of decimal places for formatting the chroma component.
+    method
+        Computation method.
+
+    Returns
+    -------
+    :class:`str` or :class:`numpy.NDArrayFloat`
+        *Munsell* colour notation formatted as "H V/C" where H is hue,
+        V is value, and C is chroma.
+
+    Notes
+    -----
+    +------------+-----------------------+---------------+
+    | **Domain** | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``xyY``    | 1                     | 1             |
+    +------------+-----------------------+---------------+
+
+    References
+    ----------
+    :cite:`Centorea`, :cite:`Centore2012a`
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> xyY = np.array([0.38736945, 0.35751656, 0.59362000])
+    >>> xyY_to_munsell_colour(xyY)
+    '4.2YR 8.1/5.3'
+    """
+
+    method = validate_method(method, tuple(XYY_TO_MUNSELL_COLOUR_METHODS))
+
+    return XYY_TO_MUNSELL_COLOUR_METHODS[method](
+        xyY,
+        **filter_kwargs(
+            XYY_TO_MUNSELL_COLOUR_METHODS[method],
+            hue_decimals=hue_decimals,
+            value_decimals=value_decimals,
+            chroma_decimals=chroma_decimals,
+        ),
+    )

--- a/colour/notation/munsell/centore2014.py
+++ b/colour/notation/munsell/centore2014.py
@@ -1,36 +1,13 @@
 """
-Munsell Renotation System
-=========================
+Munsell Renotation System - Centore (2014)
+==========================================
 
-Define objects for *Munsell Renotation System* computations.
+Define *Centore (2014)* objects for *Munsell Renotation System* computations:
 
--   :func:`colour.notation.munsell_value_Priest1920`: Compute *Munsell* value
-    :math:`V` from the specified *luminance* :math:`Y` using
-    *Priest, Gibson and MacNicholas (1920)* method.
--   :func:`colour.notation.munsell_value_Munsell1933`: Compute *Munsell* value
-    :math:`V` from the specified *luminance* :math:`Y` using
-    *Munsell, Sloan and Godlove (1933)* method.
--   :func:`colour.notation.munsell_value_Moon1943`: Compute *Munsell* value
-    :math:`V` from the specified *luminance* :math:`Y` using
-    *Moon and Spencer (1943)* method.
--   :func:`colour.notation.munsell_value_Saunderson1944`: Compute *Munsell*
-    value :math:`V` from the specified *luminance* :math:`Y` using
-    *Saunderson and Milner (1944)* method.
--   :func:`colour.notation.munsell_value_Ladd1955`: Compute *Munsell* value
-    :math:`V` from the specified *luminance* :math:`Y` using
-    *Ladd and Pinney (1955)* method.
--   :func:`colour.notation.munsell_value_McCamy1987`: Compute *Munsell* value
-    :math:`V` from the specified *luminance* :math:`Y` using *McCamy (1987)*
-    method.
--   :func:`colour.notation.munsell_value_ASTMD1535`: Compute *Munsell* value
-    :math:`V` from the specified *luminance* :math:`Y` using *ASTM D1535-08e1*
-    method.
--   :attr:`colour.MUNSELL_VALUE_METHODS`: Supported *Munsell* value
-    computation methods.
--   :func:`colour.munsell_value`: Compute *Munsell* value :math:`V` from
-    specified *luminance* :math:`Y` using the specified method.
--   :func:`colour.munsell_colour_to_xyY`
--   :func:`colour.xyY_to_munsell_colour`
+-   :func:`colour.notation.munsell.centore2014.munsell_specification_to_xyY`
+-   :func:`colour.notation.munsell.centore2014.munsell_colour_to_xyY`
+-   :func:`colour.notation.munsell.centore2014.xyY_to_munsell_specification`
+-   :func:`colour.notation.munsell.centore2014.xyY_to_munsell_colour`
 
 Notes
 -----
@@ -127,9 +104,7 @@ from colour.algebra import (
     cartesian_to_cylindrical,
     euclidean_distance,
     polar_to_cartesian,
-    sdiv,
     sdiv_mode,
-    spow,
 )
 from colour.colorimetry import CCS_ILLUMINANTS, luminance_ASTMD1535
 from colour.constants import (
@@ -143,12 +118,10 @@ if typing.TYPE_CHECKING:
     from colour.hints import (
         Dict,
         Domain1,
-        Domain100,
         Literal,
         NDArrayFloat,
         NDArrayStr,
         Range1,
-        Range10,
         Tuple,
     )
 
@@ -156,9 +129,9 @@ from colour.hints import ArrayLike, NDArrayFloat, cast
 from colour.models import Lab_to_LCHab  # pyright: ignore
 from colour.models import XYZ_to_Lab, XYZ_to_xy, xyY_to_XYZ
 from colour.notation import MUNSELL_COLOURS_ALL
+from colour.notation.munsell.value import munsell_value_ASTMD1535
 from colour.utilities import (
     CACHE_REGISTRY,
-    CanonicalMapping,
     Lookup,
     as_float,
     as_float_array,
@@ -174,11 +147,9 @@ from colour.utilities import (
     is_numeric,
     to_domain_1,
     to_domain_10,
-    to_domain_100,
     tsplit,
     tstack,
     usage_warning,
-    validate_method,
 )
 from colour.volume import is_within_macadam_limits
 
@@ -204,19 +175,10 @@ __all__ = [
     "MUNSELL_HUE_LETTER_CODES",
     "ILLUMINANT_NAME_MUNSELL",
     "CCS_ILLUMINANT_MUNSELL",
-    "munsell_value_Priest1920",
-    "munsell_value_Munsell1933",
-    "munsell_value_Moon1943",
-    "munsell_value_Saunderson1944",
-    "munsell_value_Ladd1955",
-    "munsell_value_McCamy1987",
-    "munsell_value_ASTMD1535",
-    "MUNSELL_VALUE_METHODS",
-    "munsell_value",
-    "munsell_specification_to_xyY",
-    "munsell_colour_to_xyY",
-    "xyY_to_munsell_specification",
-    "xyY_to_munsell_colour",
+    "munsell_specification_to_xyY_Centore2014",
+    "munsell_colour_to_xyY_Centore2014",
+    "xyY_to_munsell_specification_Centore2014",
+    "xyY_to_munsell_colour_Centore2014",
     "parse_munsell_colour",
     "is_grey_munsell_colour",
     "normalise_munsell_specification",
@@ -271,9 +233,6 @@ CCS_ILLUMINANT_MUNSELL: NDArrayFloat = CCS_ILLUMINANTS[
 _CACHE_MUNSELL_SPECIFICATIONS: dict = CACHE_REGISTRY.register_cache(
     f"{__name__}._CACHE_MUNSELL_SPECIFICATIONS"
 )
-_CACHE_MUNSELL_VALUE_ASTM_D1535_08_INTERPOLATOR: dict = CACHE_REGISTRY.register_cache(
-    f"{__name__}._CACHE_MUNSELL_VALUE_ASTM_D1535_08_INTERPOLATOR"
-)
 _CACHE_MUNSELL_MAXIMUM_CHROMAS_FROM_RENOTATION: dict = CACHE_REGISTRY.register_cache(
     f"{__name__}._CACHE_MUNSELL_MAXIMUM_CHROMAS_FROM_RENOTATION"
 )
@@ -326,39 +285,6 @@ def _munsell_specifications() -> NDArrayFloat:
     return munsell_specifications
 
 
-def _munsell_value_ASTMD1535_interpolator() -> Extrapolator:
-    """
-    Return the *Munsell* value interpolator for the *ASTM D1535-08e1*
-    method, caching it if not existing.
-
-    Returns
-    -------
-    :class:`colour.Extrapolator`
-        *Munsell* value interpolator for the *ASTM D1535-08e1* method.
-    """
-
-    global _CACHE_MUNSELL_VALUE_ASTM_D1535_08_INTERPOLATOR  # noqa: PLW0602
-
-    if "ASTM D1535-08 Interpolator" in (
-        _CACHE_MUNSELL_VALUE_ASTM_D1535_08_INTERPOLATOR
-    ):
-        return _CACHE_MUNSELL_VALUE_ASTM_D1535_08_INTERPOLATOR[
-            "ASTM D1535-08 Interpolator"
-        ]
-
-    munsell_values = np.arange(0, 10, 0.001)
-    interpolator = LinearInterpolator(
-        luminance_ASTMD1535(munsell_values), munsell_values
-    )
-    extrapolator = Extrapolator(interpolator)
-
-    _CACHE_MUNSELL_VALUE_ASTM_D1535_08_INTERPOLATOR["ASTM D1535-08 Interpolator"] = (
-        extrapolator
-    )
-
-    return extrapolator
-
-
 def _munsell_maximum_chromas_from_renotation() -> Tuple[
     Tuple[Tuple[float, float], float], ...
 ]:
@@ -401,450 +327,6 @@ def _munsell_maximum_chromas_from_renotation() -> Tuple[
     ] = maximum_chromas_from_renotation
 
     return maximum_chromas_from_renotation
-
-
-def munsell_value_Priest1920(
-    Y: Domain100,
-) -> Range10:
-    """
-    Compute the *Munsell* value :math:`V` from the specified *luminance*
-    :math:`Y` using *Priest et al. (1920)* method.
-
-    Parameters
-    ----------
-    Y
-        *Luminance* :math:`Y`.
-
-    Returns
-    -------
-    :class:`np.float` or :class:`numpy.NDArrayFloat`
-        *Munsell* value :math:`V`.
-
-    Notes
-    -----
-    +------------+-----------------------+---------------+
-    | **Domain** | **Scale - Reference** | **Scale - 1** |
-    +============+=======================+===============+
-    | ``Y``      | 100                   | 1             |
-    +------------+-----------------------+---------------+
-
-    +------------+-----------------------+---------------+
-    | **Range**  | **Scale - Reference** | **Scale - 1** |
-    +============+=======================+===============+
-    | ``V``      | 10                    | 1             |
-    +------------+-----------------------+---------------+
-
-    References
-    ----------
-    :cite:`Wikipedia2007c`
-
-    Examples
-    --------
-    >>> munsell_value_Priest1920(12.23634268)  # doctest: +ELLIPSIS
-    np.float64(3.4980484...)
-    """
-
-    Y = to_domain_100(Y)
-
-    V = 10 * np.sqrt(Y / 100)
-
-    return as_float(from_range_10(V))
-
-
-def munsell_value_Munsell1933(
-    Y: Domain100,
-) -> Range10:
-    """
-    Compute *Munsell* value :math:`V` from the specified *luminance* :math:`Y`
-    using *Munsell et al. (1933)* method.
-
-    Parameters
-    ----------
-    Y
-        *Luminance* :math:`Y`.
-
-    Returns
-    -------
-    :class:`np.float` or :class:`numpy.NDArrayFloat`
-        *Munsell* value :math:`V`.
-
-    Notes
-    -----
-    +------------+-----------------------+---------------+
-    | **Domain** | **Scale - Reference** | **Scale - 1** |
-    +============+=======================+===============+
-    | ``Y``      | 100                   | 1             |
-    +------------+-----------------------+---------------+
-
-    +------------+-----------------------+---------------+
-    | **Range**  | **Scale - Reference** | **Scale - 1** |
-    +============+=======================+===============+
-    | ``V``      | 10                    | 1             |
-    +------------+-----------------------+---------------+
-
-    References
-    ----------
-    :cite:`Wikipedia2007c`
-
-    Examples
-    --------
-    >>> munsell_value_Munsell1933(12.23634268)  # doctest: +ELLIPSIS
-    np.float64(4.1627702...)
-    """
-
-    Y = to_domain_100(Y)
-
-    V = np.sqrt(1.4742 * Y - 0.004743 * (Y * Y))
-
-    return as_float(from_range_10(V))
-
-
-def munsell_value_Moon1943(Y: Domain100) -> Range10:
-    """
-    Compute *Munsell* value :math:`V` from the specified *luminance* :math:`Y`
-    using *Moon and Spencer (1943)* method.
-
-    Parameters
-    ----------
-    Y
-        *Luminance* :math:`Y`.
-
-    Returns
-    -------
-    :class:`np.float` or :class:`numpy.NDArrayFloat`
-        *Munsell* value :math:`V`.
-
-    Notes
-    -----
-    +------------+-----------------------+---------------+
-    | **Domain** | **Scale - Reference** | **Scale - 1** |
-    +============+=======================+===============+
-    | ``Y``      | 100                   | 1             |
-    +------------+-----------------------+---------------+
-
-    +------------+-----------------------+---------------+
-    | **Range**  | **Scale - Reference** | **Scale - 1** |
-    +============+=======================+===============+
-    | ``V``      | 10                    | 1             |
-    +------------+-----------------------+---------------+
-
-    References
-    ----------
-    :cite:`Wikipedia2007c`
-
-    Examples
-    --------
-    >>> munsell_value_Moon1943(12.23634268)  # doctest: +ELLIPSIS
-    np.float64(4.0688120...)
-    """
-
-    Y = to_domain_100(Y)
-
-    V = 1.4 * spow(Y, 0.426)
-
-    return as_float(from_range_10(V))
-
-
-def munsell_value_Saunderson1944(
-    Y: Domain100,
-) -> Range10:
-    """
-    Compute the *Munsell* value :math:`V` from the specified *luminance* :math:`Y`
-    using *Saunderson and Milner (1944)* method.
-
-    Parameters
-    ----------
-    Y
-        *Luminance* :math:`Y`.
-
-    Returns
-    -------
-    :class:`np.float` or :class:`numpy.NDArrayFloat`
-        *Munsell* value :math:`V`.
-
-    Notes
-    -----
-    +------------+-----------------------+---------------+
-    | **Domain** | **Scale - Reference** | **Scale - 1** |
-    +============+=======================+===============+
-    | ``Y``      | 100                   | 1             |
-    +------------+-----------------------+---------------+
-
-    +------------+-----------------------+---------------+
-    | **Range**  | **Scale - Reference** | **Scale - 1** |
-    +============+=======================+===============+
-    | ``V``      | 10                    | 1             |
-    +------------+-----------------------+---------------+
-
-    References
-    ----------
-    :cite:`Wikipedia2007c`
-
-    Examples
-    --------
-    >>> munsell_value_Saunderson1944(12.23634268)  # doctest: +ELLIPSIS
-    np.float64(4.0444736...)
-    """
-
-    Y = to_domain_100(Y)
-
-    V = 2.357 * spow(Y, 0.343) - 1.52
-
-    return as_float(from_range_10(V))
-
-
-def munsell_value_Ladd1955(Y: Domain100) -> Range10:
-    """
-    Compute *Munsell* value :math:`V` from the specified *luminance* :math:`Y`
-    using *Ladd and Pinney (1955)* method.
-
-    Parameters
-    ----------
-    Y
-        *Luminance* :math:`Y`.
-
-    Returns
-    -------
-    :class:`np.float` or :class:`numpy.NDArrayFloat`
-        *Munsell* value :math:`V`.
-
-    Notes
-    -----
-    +------------+-----------------------+---------------+
-    | **Domain** | **Scale - Reference** | **Scale - 1** |
-    +============+=======================+===============+
-    | ``Y``      | 100                   | 1             |
-    +------------+-----------------------+---------------+
-
-    +------------+-----------------------+---------------+
-    | **Range**  | **Scale - Reference** | **Scale - 1** |
-    +============+=======================+===============+
-    | ``V``      | 10                    | 1             |
-    +------------+-----------------------+---------------+
-
-    References
-    ----------
-    :cite:`Wikipedia2007c`
-
-    Examples
-    --------
-    >>> munsell_value_Ladd1955(12.23634268)  # doctest: +ELLIPSIS
-    np.float64(4.0511633...)
-    """
-
-    Y = to_domain_100(Y)
-
-    V = 2.468 * spow(Y, 1 / 3) - 1.636
-
-    return as_float(from_range_10(V))
-
-
-def munsell_value_McCamy1987(
-    Y: Domain100,
-) -> Range10:
-    """
-    Compute *Munsell* value :math:`V` from the specified *luminance* :math:`Y`
-    using *McCamy (1987)* method.
-
-    Parameters
-    ----------
-    Y
-        *Luminance* :math:`Y`.
-
-    Returns
-    -------
-    :class:`np.float` or :class:`numpy.NDArrayFloat`
-        *Munsell* value :math:`V`.
-
-    Notes
-    -----
-    +------------+-----------------------+---------------+
-    | **Domain** | **Scale - Reference** | **Scale - 1** |
-    +============+=======================+===============+
-    | ``Y``      | 100                   | 1             |
-    +------------+-----------------------+---------------+
-
-    +------------+-----------------------+---------------+
-    | **Range**  | **Scale - Reference** | **Scale - 1** |
-    +============+=======================+===============+
-    | ``V``      | 10                    | 1             |
-    +------------+-----------------------+---------------+
-
-    References
-    ----------
-    :cite:`ASTMInternational1989a`
-
-    Examples
-    --------
-    >>> munsell_value_McCamy1987(12.23634268)  # doctest: +ELLIPSIS
-    np.float64(4.0814348...)
-    """
-
-    Y = to_domain_100(Y)
-
-    with sdiv_mode():
-        V = np.where(
-            Y <= 0.9,
-            0.87445 * spow(Y, 0.9967),
-            2.49268 * spow(Y, 1 / 3)
-            - 1.5614
-            - (0.985 / (((0.1073 * Y - 3.084) ** 2) + 7.54))
-            + sdiv(0.0133, spow(Y, 2.3))
-            + 0.0084 * np.sin(4.1 * spow(Y, 1 / 3) + 1)
-            + sdiv(0.0221, Y) * np.sin(0.39 * (Y - 2))
-            - (sdiv(0.0037, 0.44 * Y)) * np.sin(1.28 * (Y - 0.53)),
-        )
-
-    return as_float(from_range_10(V))
-
-
-def munsell_value_ASTMD1535(
-    Y: Domain100,
-) -> Range10:
-    """
-    Compute the *Munsell* value :math:`V` from the specified *luminance*
-    :math:`Y` using an inverse lookup table from *ASTM D1535-08e1* method.
-
-    Parameters
-    ----------
-    Y
-        *Luminance* :math:`Y`.
-
-    Returns
-    -------
-    :class:`np.float` or :class:`numpy.NDArrayFloat`
-        *Munsell* value :math:`V`.
-
-    Notes
-    -----
-    +------------+-----------------------+---------------+
-    | **Domain** | **Scale - Reference** | **Scale - 1** |
-    +============+=======================+===============+
-    | ``Y``      | 100                   | 1             |
-    +------------+-----------------------+---------------+
-
-    +------------+-----------------------+---------------+
-    | **Range**  | **Scale - Reference** | **Scale - 1** |
-    +============+=======================+===============+
-    | ``V``      | 10                    | 1             |
-    +------------+-----------------------+---------------+
-
-    -   The *Munsell* value computation with *ASTM D1535-08e1* method is
-        only defined for domain [0, 100].
-
-    References
-    ----------
-    :cite:`ASTMInternational1989a`
-
-    Examples
-    --------
-    >>> munsell_value_ASTMD1535(12.23634268)  # doctest: +ELLIPSIS
-    np.float64(4.0824437...)
-    """
-
-    Y = to_domain_100(Y)
-
-    V = _munsell_value_ASTMD1535_interpolator()(Y)
-
-    return as_float(from_range_10(V))
-
-
-MUNSELL_VALUE_METHODS: CanonicalMapping = CanonicalMapping(
-    {
-        "Priest 1920": munsell_value_Priest1920,
-        "Munsell 1933": munsell_value_Munsell1933,
-        "Moon 1943": munsell_value_Moon1943,
-        "Saunderson 1944": munsell_value_Saunderson1944,
-        "Ladd 1955": munsell_value_Ladd1955,
-        "McCamy 1987": munsell_value_McCamy1987,
-        "ASTM D1535": munsell_value_ASTMD1535,
-    }
-)
-MUNSELL_VALUE_METHODS.__doc__ = """
-Supported *Munsell* value computation methods.
-
-References
-----------
-:cite:`ASTMInternational1989a`, :cite:`Wikipedia2007c`
-
-Aliases:
-
--   'astm2008': 'ASTM D1535'
-"""
-MUNSELL_VALUE_METHODS["astm2008"] = MUNSELL_VALUE_METHODS["ASTM D1535"]
-
-
-def munsell_value(
-    Y: Domain100,
-    method: (
-        Literal[
-            "ASTM D1535",
-            "Ladd 1955",
-            "McCamy 1987",
-            "Moon 1943",
-            "Munsell 1933",
-            "Priest 1920",
-            "Saunderson 1944",
-        ]
-        | str
-    ) = "ASTM D1535",
-) -> Range10:
-    """
-    Compute the *Munsell* value :math:`V` from the specified *luminance*
-    :math:`Y` using the specified computational method.
-
-    Parameters
-    ----------
-    Y
-        *Luminance* :math:`Y`.
-    method
-        Computation method.
-
-    Returns
-    -------
-    :class:`np.float` or :class:`numpy.NDArrayFloat`
-        *Munsell* value :math:`V`.
-
-    Notes
-    -----
-    +------------+-----------------------+---------------+
-    | **Domain** | **Scale - Reference** | **Scale - 1** |
-    +============+=======================+===============+
-    | ``Y``      | 100                   | 1             |
-    +------------+-----------------------+---------------+
-
-    +------------+-----------------------+---------------+
-    | **Range**  | **Scale - Reference** | **Scale - 1** |
-    +============+=======================+===============+
-    | ``V``      | 10                    | 1             |
-    +------------+-----------------------+---------------+
-
-    References
-    ----------
-    :cite:`ASTMInternational1989a`, :cite:`Wikipedia2007c`
-
-    Examples
-    --------
-    >>> munsell_value(12.23634268)  # doctest: +ELLIPSIS
-    np.float64(4.0824437...)
-    >>> munsell_value(12.23634268, method="Priest 1920")  # doctest: +ELLIPSIS
-    np.float64(3.4980484...)
-    >>> munsell_value(12.23634268, method="Munsell 1933")  # doctest: +ELLIPSIS
-    np.float64(4.1627702...)
-    >>> munsell_value(12.23634268, method="Moon 1943")  # doctest: +ELLIPSIS
-    np.float64(4.0688120...)
-    >>> munsell_value(12.23634268, method="Saunderson 1944")
-    ... # doctest: +ELLIPSIS
-    np.float64(4.0444736...)
-    >>> munsell_value(12.23634268, method="Ladd 1955")  # doctest: +ELLIPSIS
-    np.float64(4.0511633...)
-    >>> munsell_value(12.23634268, method="McCamy 1987")  # doctest: +ELLIPSIS
-    np.float64(4.0814348...)
-    """
-
-    method = validate_method(method, tuple(MUNSELL_VALUE_METHODS))
-
-    return MUNSELL_VALUE_METHODS[method](Y)
 
 
 def _munsell_scale_factor() -> NDArrayFloat:
@@ -940,7 +422,7 @@ def _munsell_specification_to_xyY(specification: ArrayLike) -> NDArrayFloat:
     return tstack([x, y, Y])
 
 
-def munsell_specification_to_xyY(specification: ArrayLike) -> NDArrayFloat:
+def munsell_specification_to_xyY_Centore2014(specification: ArrayLike) -> NDArrayFloat:
     """
     Convert specified *Munsell* *Colorlab* specification to *CIE xyY*
     colourspace.
@@ -981,25 +463,25 @@ def munsell_specification_to_xyY(specification: ArrayLike) -> NDArrayFloat:
 
     Examples
     --------
-    >>> munsell_specification_to_xyY(np.array([2.1, 8.0, 17.9, 4]))
+    >>> munsell_specification_to_xyY_Centore2014(np.array([2.1, 8.0, 17.9, 4]))
     ... # doctest: +ELLIPSIS
     array([0.4400632..., 0.5522428..., 0.5761962...])
-    >>> munsell_specification_to_xyY(np.array([np.nan, 8.9, np.nan, np.nan]))
+    >>> munsell_specification_to_xyY_Centore2014(
+    ...     np.array([np.nan, 8.9, np.nan, np.nan])
+    ... )
     ... # doctest: +ELLIPSIS
     array([0.31006  , 0.31616  , 0.7461345...])
     """
 
     specification = as_float_array(specification)
-    shape = list(specification.shape)
+    shape = specification.shape
 
     xyY = [_munsell_specification_to_xyY(a) for a in np.reshape(specification, (-1, 4))]
 
-    shape[-1] = 3
-
-    return np.reshape(as_float_array(xyY), shape)
+    return np.reshape(as_float_array(xyY), (*shape[:-1], 3))
 
 
-def munsell_colour_to_xyY(munsell_colour: ArrayLike) -> Range1:
+def munsell_colour_to_xyY_Centore2014(munsell_colour: ArrayLike) -> Range1:
     """
     Convert the specified *Munsell* colour to *CIE xyY* colourspace.
 
@@ -1028,20 +510,20 @@ def munsell_colour_to_xyY(munsell_colour: ArrayLike) -> Range1:
 
     Examples
     --------
-    >>> munsell_colour_to_xyY("4.2YR 8.1/5.3")  # doctest: +ELLIPSIS
+    >>> munsell_colour_to_xyY_Centore2014("4.2YR 8.1/5.3")  # doctest: +ELLIPSIS
     array([0.3873694..., 0.3575165..., 0.59362   ])
-    >>> munsell_colour_to_xyY("N8.9")  # doctest: +ELLIPSIS
+    >>> munsell_colour_to_xyY_Centore2014("N8.9")  # doctest: +ELLIPSIS
     array([0.31006  , 0.31616  , 0.7461345...])
     """
 
     munsell_colour = np.array(munsell_colour)
-    shape = list(munsell_colour.shape)
+    shape = munsell_colour.shape
 
     specification = np.array(
         [munsell_colour_to_munsell_specification(a) for a in np.ravel(munsell_colour)]
     )
 
-    return munsell_specification_to_xyY(
+    return munsell_specification_to_xyY_Centore2014(
         from_range_10(np.reshape(specification, (*shape, 4)), _munsell_scale_factor())
     )
 
@@ -1360,7 +842,7 @@ def _xyY_to_munsell_specification(xyY: ArrayLike) -> NDArrayFloat:
     )
 
 
-def xyY_to_munsell_specification(xyY: ArrayLike) -> NDArrayFloat:
+def xyY_to_munsell_specification_Centore2014(xyY: ArrayLike) -> NDArrayFloat:
     """
     Convert from *CIE xyY* colourspace to *Munsell* *Colorlab*
     specification.
@@ -1411,21 +893,19 @@ def xyY_to_munsell_specification(xyY: ArrayLike) -> NDArrayFloat:
     Examples
     --------
     >>> xyY = np.array([0.38736945, 0.35751656, 0.59362000])
-    >>> xyY_to_munsell_specification(xyY)  # doctest: +ELLIPSIS
+    >>> xyY_to_munsell_specification_Centore2014(xyY)  # doctest: +ELLIPSIS
     array([4.2000019..., 8.0999999..., 5.2999996..., 6.        ])
     """
 
     xyY = as_float_array(xyY)
-    shape = list(xyY.shape)
+    shape = xyY.shape
 
     specification = [_xyY_to_munsell_specification(a) for a in np.reshape(xyY, (-1, 3))]
 
-    shape[-1] = 4
-
-    return np.reshape(as_float_array(specification), shape)
+    return np.reshape(as_float_array(specification), (*shape[:-1], 4))
 
 
-def xyY_to_munsell_colour(
+def xyY_to_munsell_colour_Centore2014(
     xyY: Domain1,
     hue_decimals: int = 1,
     value_decimals: int = 1,
@@ -1467,14 +947,14 @@ def xyY_to_munsell_colour(
     Examples
     --------
     >>> xyY = np.array([0.38736945, 0.35751656, 0.59362000])
-    >>> xyY_to_munsell_colour(xyY)
+    >>> xyY_to_munsell_colour_Centore2014(xyY)
     '4.2YR 8.1/5.3'
     """
 
     specification = to_domain_10(
-        xyY_to_munsell_specification(xyY), _munsell_scale_factor()
+        xyY_to_munsell_specification_Centore2014(xyY), _munsell_scale_factor()
     )
-    shape = list(specification.shape)
+    shape = specification.shape
     decimals = (hue_decimals, value_decimals, chroma_decimals)
 
     munsell_colour = np.reshape(
@@ -1487,7 +967,7 @@ def xyY_to_munsell_colour(
         shape[:-1],
     )
 
-    return str(munsell_colour) if shape == [4] else munsell_colour
+    return str(munsell_colour) if shape == (4,) else munsell_colour
 
 
 def parse_munsell_colour(munsell_colour: str) -> NDArrayFloat:

--- a/colour/notation/munsell/onnx.py
+++ b/colour/notation/munsell/onnx.py
@@ -1,0 +1,542 @@
+"""
+Munsell - ONNX
+==============
+
+Define *ONNX* model-based objects for *Munsell Renotation System* conversions.
+
+The models are pre-trained neural networks from the *colour-science/
+learning-munsell* *HuggingFace* repository that perform *Munsell* <-> *CIE xyY*
+conversions with approximately 0.5 :math:`\\Delta E` accuracy.
+"""
+
+from __future__ import annotations
+
+import typing
+
+import numpy as np
+
+if typing.TYPE_CHECKING:
+    from colour.hints import (
+        ArrayLike,
+        Domain1,
+        NDArrayFloat,
+        NDArrayStr,
+        Range1,
+    )
+from colour.notation.munsell.centore2014 import (
+    _munsell_scale_factor,
+    munsell_colour_to_munsell_specification,
+    munsell_specification_to_munsell_colour,
+)
+from colour.utilities import (
+    CACHE_REGISTRY,
+    as_float_array,
+    download_url,
+    from_range_1,
+    from_range_10,
+    optional,
+    required,
+    to_domain_1,
+    to_domain_10,
+)
+
+__author__ = "Colour Developers"
+__copyright__ = "Copyright 2013 Colour Developers"
+__license__ = "BSD-3-Clause - https://opensource.org/licenses/BSD-3-Clause"
+__maintainer__ = "Colour Developers"
+__email__ = "colour-developers@colour-science.org"
+__status__ = "Production"
+
+__all__ = [
+    "HF_REPOSITORY_MUNSELL",
+    "ONNX_MODELS_TO_XYY",
+    "ONNX_MODELS_FROM_XYY",
+    "normalization_parameters",
+    "onnx_inference_session",
+    "munsell_specification_to_xyY_Onnx",
+    "munsell_colour_to_xyY_Onnx",
+    "xyY_to_munsell_specification_Onnx",
+    "xyY_to_munsell_colour_Onnx",
+]
+
+HF_REPOSITORY_MUNSELL: str = "colour-science/learning-munsell"
+"""*HuggingFace* repository for *Munsell* *ONNX* models."""
+
+ONNX_MODELS_TO_XYY: dict = {
+    "model": "models/to_xyY/multi_mlp.onnx",
+    "error_predictor": "models/to_xyY/multi_mlp_multi_error_predictor.onnx",
+    "parameters": "models/to_xyY/multi_mlp_normalization_parameters.npz",
+    "sha256": {
+        "models/to_xyY/multi_mlp.onnx": (
+            "b7b5a0535fd483721d51f76858f643b261def092fc6844f6ede10d21cc999c68"
+        ),
+        "models/to_xyY/multi_mlp.onnx.data": (
+            "9d81a2e06aba8f49a089b4a37efb8170b3f2dbcf1ce126b147b7d2ee5a27d88c"
+        ),
+        "models/to_xyY/multi_mlp_multi_error_predictor.onnx": (
+            "73b3b031051afc086fc08bb48fa1db4a740e86991a2bc1b520c81f7b4c164592"
+        ),
+        "models/to_xyY/multi_mlp_multi_error_predictor.onnx.data": (
+            "b2115cd06dbda1314a3374fa30e4a6ae25720d7935aad580bde72c7dbf9bf2a9"
+        ),
+        "models/to_xyY/multi_mlp_normalization_parameters.npz": (
+            "3c5d462fdefbb7c45cc9d469f73246423466cc2583f2c5094b9d5e76461c3541"
+        ),
+    },
+}
+"""
+*ONNX* model configuration for *Munsell* specification to *CIE xyY*.
+
+Keys
+----
+model
+    Base model filename relative to the *HuggingFace* repository.
+error_predictor
+    Optional error predictor filename for two-stage inference.
+parameters
+    Normalization parameters filename.
+"""
+
+ONNX_MODELS_FROM_XYY: dict = {
+    "model": "models/from_xyY/multi_mlp_class_code.onnx",
+    "error_predictor": (
+        "models/from_xyY/multi_mlp_class_code_aware_multi_error_predictor.onnx"
+    ),
+    "parameters": "models/from_xyY/multi_mlp_class_code_normalization_parameters.npz",
+    "type": "class_code",
+    "sha256": {
+        "models/from_xyY/multi_mlp_class_code.onnx": (
+            "da700d985f15fbc978fd1e3a657a79cc5130d9848a053b095eca94398468a248"
+        ),
+        "models/from_xyY/multi_mlp_class_code.onnx.data": (
+            "ec71887eb1a17c161cc60588125381cf40b18ed9b8001637d0db47c6ac700bc7"
+        ),
+        "models/from_xyY/multi_mlp_class_code_aware_multi_error_predictor.onnx": (
+            "3141aea2175f365eeb5a6a74773aa1939e70b8db8cd4639718a17e22be2e83a7"
+        ),
+        "models/from_xyY/multi_mlp_class_code_aware_multi_error_predictor.onnx.data": (
+            "5a7a2ccb199b5a173d00c90abd44857accd996658aef75ed58a062983e58ceda"
+        ),
+        "models/from_xyY/multi_mlp_class_code_normalization_parameters.npz": (
+            "96f041685cf0fc716dc601c2bd8f29a5c2b06242d5a6cfb3a27334e4e0a53e92"
+        ),
+    },
+}
+"""
+*ONNX* model configuration for *CIE xyY* to *Munsell* specification.
+
+Keys
+----
+model
+    Base model filename relative to the *HuggingFace* repository.
+error_predictor
+    Optional error predictor filename for two-stage inference.
+parameters
+    Normalization parameters filename.
+type
+    Model type identifier for output decoding.
+"""
+
+_CACHE_ONNX_SESSIONS: dict = CACHE_REGISTRY.register_cache(
+    f"{__name__}._CACHE_ONNX_SESSIONS"
+)
+
+_CACHE_NORMALIZATION_PARAMETERS: dict = CACHE_REGISTRY.register_cache(
+    f"{__name__}._CACHE_NORMALIZATION_PARAMETERS"
+)
+
+
+def normalization_parameters(
+    filename: str,
+    sha256: dict | None = None,
+) -> dict:
+    """
+    Download, load and cache normalization parameters.
+
+    Parameters
+    ----------
+    filename
+        Parameters filename relative to the *HuggingFace* repository root.
+    sha256
+        Mapping of filenames to *SHA-256* hashes for download verification.
+
+    Returns
+    -------
+    :class:`dict`
+        Dictionary with ``input_parameters`` and ``output_parameters`` keys.
+    """
+
+    global _CACHE_NORMALIZATION_PARAMETERS  # noqa: PLW0602
+
+    if filename in _CACHE_NORMALIZATION_PARAMETERS:
+        return _CACHE_NORMALIZATION_PARAMETERS[filename]
+
+    url = f"https://huggingface.co/{HF_REPOSITORY_MUNSELL}/resolve/main/{filename}"
+    file_hash = optional(sha256, {}).get(filename)
+    path = download_url(url, sha256=file_hash)
+    data = np.load(path, allow_pickle=True)
+    parameters = {
+        k: data[k].item() if data[k].ndim == 0 else data[k] for k in data.files
+    }
+
+    _CACHE_NORMALIZATION_PARAMETERS[filename] = parameters
+
+    return parameters
+
+
+@required("onnxruntime")
+def onnx_inference_session(
+    filename: str,
+    sha256: dict | None = None,
+) -> typing.Any:
+    """
+    Load and cache an *ONNX* inference session.
+
+    Parameters
+    ----------
+    filename
+        Model filename relative to the *HuggingFace* repository root.
+    sha256
+        Mapping of filenames to *SHA-256* hashes for download verification.
+
+    Returns
+    -------
+    :class:`onnxruntime.InferenceSession`
+        *ONNX* inference session.
+    """
+
+    global _CACHE_ONNX_SESSIONS  # noqa: PLW0602
+
+    if filename in _CACHE_ONNX_SESSIONS:
+        return _CACHE_ONNX_SESSIONS[filename]
+
+    import onnxruntime  # noqa: PLC0415
+
+    url = f"https://huggingface.co/{HF_REPOSITORY_MUNSELL}/resolve/main/{filename}"
+    model_hash = optional(sha256, {}).get(filename)
+    model_path = download_url(url, sha256=model_hash)
+
+    # *ONNX* models store weights in a companion ``.onnx.data`` file.
+    data_filename = f"{filename}.data"
+    data_hash = optional(sha256, {}).get(data_filename)
+    download_url(f"{url}.data", sha256=data_hash)
+
+    session = onnxruntime.InferenceSession(model_path)
+
+    _CACHE_ONNX_SESSIONS[filename] = session
+
+    return session
+
+
+@required("onnxruntime")
+def munsell_specification_to_xyY_Onnx(
+    specification: ArrayLike,
+) -> NDArrayFloat:
+    """
+    Convert specified *Munsell* *Colorlab* specification to *CIE xyY*
+    colourspace using the *ONNX* model.
+
+    Parameters
+    ----------
+    specification
+        *Munsell* *Colorlab* specification.
+
+    Returns
+    -------
+    :class:`numpy.NDArrayFloat`
+        *CIE xyY* colourspace array.
+
+    Notes
+    -----
+    +-------------------+-----------------------+---------------+
+    | **Domain**        | **Scale - Reference** | **Scale - 1** |
+    +===================+=======================+===============+
+    | ``specification`` | ``hue``    : 10       | 1             |
+    |                   |                       |               |
+    |                   | ``value``  : 10       | 1             |
+    |                   |                       |               |
+    |                   | ``chroma`` : 50       | 1             |
+    |                   |                       |               |
+    |                   | ``code``   : 10       | 1             |
+    +-------------------+-----------------------+---------------+
+
+    +-------------------+-----------------------+---------------+
+    | **Range**         | **Scale - Reference** | **Scale - 1** |
+    +===================+=======================+===============+
+    | ``xyY``           | 1                     | 1             |
+    +-------------------+-----------------------+---------------+
+
+    Examples
+    --------
+    >>> munsell_specification_to_xyY_Onnx(  # doctest: +SKIP
+    ...     np.array([2.1, 8.0, 17.9, 4])
+    ... )
+    array([...])
+    """
+
+    specification = to_domain_10(as_float_array(specification), _munsell_scale_factor())
+    shape = specification.shape
+
+    # Normalize input to [0, 1] using model parameters.
+    sha256 = ONNX_MODELS_TO_XYY.get("sha256")
+    input_parameters = normalization_parameters(
+        ONNX_MODELS_TO_XYY["parameters"], sha256=sha256
+    )["input_parameters"]
+    input_data = np.reshape(specification, (-1, 4)).copy()
+    for i, key in enumerate(["hue_range", "value_range", "chroma_range", "code_range"]):
+        minimum, maximum = input_parameters[key]
+        input_data[..., i] = (input_data[..., i] - minimum) / (maximum - minimum)
+    input_data = input_data.astype(np.float32)
+
+    # Base model prediction.
+    session = onnx_inference_session(ONNX_MODELS_TO_XYY["model"], sha256=sha256)
+    input_name = session.get_inputs()[0].name
+    xyY = np.asarray(session.run(None, {input_name: input_data})[0])
+
+    # Optional error correction.
+    if ONNX_MODELS_TO_XYY.get("error_predictor"):
+        error_session = onnx_inference_session(
+            ONNX_MODELS_TO_XYY["error_predictor"], sha256=sha256
+        )
+        error_input_name = error_session.get_inputs()[0].name
+        combined = np.concatenate([input_data, xyY], axis=1).astype(np.float32)
+        error_correction = np.asarray(
+            error_session.run(None, {error_input_name: combined})[0]
+        )
+        xyY = xyY + error_correction
+
+    xyY = from_range_1(xyY, np.array([1, 1, 100]))
+
+    return np.reshape(xyY, (*shape[:-1], 3))
+
+
+@required("onnxruntime")
+def munsell_colour_to_xyY_Onnx(munsell_colour: ArrayLike) -> Range1:
+    """
+    Convert the specified *Munsell* colour to *CIE xyY* colourspace using
+    the *ONNX* model.
+
+    Parameters
+    ----------
+    munsell_colour
+        *Munsell* colour notation formatted as "H V/C" where H is hue,
+        V is value, and C is chroma.
+
+    Returns
+    -------
+    :class:`numpy.NDArrayFloat`
+        *CIE xyY* colourspace array.
+
+    Notes
+    -----
+    +-----------+-----------------------+---------------+
+    | **Range** | **Scale - Reference** | **Scale - 1** |
+    +===========+=======================+===============+
+    | ``xyY``   | 1                     | 1             |
+    +-----------+-----------------------+---------------+
+
+    Examples
+    --------
+    >>> munsell_colour_to_xyY_Onnx("4.2YR 8.1/5.3")  # doctest: +SKIP
+    array([...])
+    """
+
+    munsell_colour = np.array(munsell_colour)
+    shape = munsell_colour.shape
+
+    specification = np.array(
+        [munsell_colour_to_munsell_specification(a) for a in np.ravel(munsell_colour)]
+    )
+
+    return munsell_specification_to_xyY_Onnx(
+        from_range_10(np.reshape(specification, (*shape, 4)), _munsell_scale_factor())
+    )
+
+
+@required("onnxruntime")
+def xyY_to_munsell_specification_Onnx(xyY: ArrayLike) -> NDArrayFloat:
+    """
+    Convert from *CIE xyY* colourspace to *Munsell* *Colorlab*
+    specification using the *ONNX* model.
+
+    Parameters
+    ----------
+    xyY
+        *CIE xyY* colourspace array.
+
+    Returns
+    -------
+    :class:`numpy.NDArrayFloat`
+        *Munsell* *Colorlab* specification.
+
+    Notes
+    -----
+    +-------------------+-----------------------+---------------+
+    | **Domain**        | **Scale - Reference** | **Scale - 1** |
+    +===================+=======================+===============+
+    | ``xyY``           | 1                     | 1             |
+    +-------------------+-----------------------+---------------+
+
+    +-------------------+-----------------------+---------------+
+    | **Range**         | **Scale - Reference** | **Scale - 1** |
+    +===================+=======================+===============+
+    | ``specification`` | ``hue``    : 10       | 1             |
+    |                   |                       |               |
+    |                   | ``value``  : 10       | 1             |
+    |                   |                       |               |
+    |                   | ``chroma`` : 50       | 1             |
+    |                   |                       |               |
+    |                   | ``code``   : 10       | 1             |
+    +-------------------+-----------------------+---------------+
+
+    Examples
+    --------
+    >>> xyY = np.array([0.38736945, 0.35751656, 0.59362000])
+    >>> xyY_to_munsell_specification_Onnx(xyY)  # doctest: +SKIP
+    array([...])
+    """
+
+    xyY = as_float_array(xyY)
+    shape = xyY.shape
+
+    # Normalize input to [0, 1] using model parameters.
+    sha256 = ONNX_MODELS_FROM_XYY.get("sha256")
+    input_parameters = normalization_parameters(
+        ONNX_MODELS_FROM_XYY["parameters"], sha256=sha256
+    )["input_parameters"]
+    input_data = np.reshape(to_domain_1(xyY, np.array([1, 1, 100])), (-1, 3)).copy()
+    for i, key in enumerate(["x_range", "y_range", "Y_range"]):
+        minimum, maximum = input_parameters[key]
+        input_data[..., i] = (input_data[..., i] - minimum) / (maximum - minimum)
+    input_data = input_data.astype(np.float32)
+
+    # Base model prediction.
+    base_session = onnx_inference_session(ONNX_MODELS_FROM_XYY["model"], sha256=sha256)
+    base_input_name = base_session.get_inputs()[0].name
+    base_output = np.asarray(base_session.run(None, {base_input_name: input_data})[0])
+
+    output_parameters = normalization_parameters(
+        ONNX_MODELS_FROM_XYY["parameters"], sha256=sha256
+    )["output_parameters"]
+
+    is_class_code = ONNX_MODELS_FROM_XYY.get("type") == "class_code"
+
+    if is_class_code:
+        # Classification code model outputs (N, 13): 3 normalised regression
+        # values (hue, value, chroma) and 10 logits, i.e., raw scores for each
+        # *Munsell* hue family (R, YR, Y, GY, G, BG, B, PB, P, RP). The
+        # predicted code is the index of the highest logit + 1.
+        normalised_regression = base_output[..., :3]
+        code_logits = base_output[..., 3:]
+    else:
+        normalised_regression = base_output
+
+    # Optional error correction.
+    if ONNX_MODELS_FROM_XYY.get("error_predictor"):
+        error_session = onnx_inference_session(
+            ONNX_MODELS_FROM_XYY["error_predictor"], sha256=sha256
+        )
+        error_input_name = error_session.get_inputs()[0].name
+
+        components = [input_data, normalised_regression]
+        if is_class_code and error_session.get_inputs()[0].shape[-1] == 16:
+            code_idx = np.argmax(code_logits, axis=-1)
+            code_onehot = np.zeros((len(code_idx), 10), dtype=np.float32)
+            code_onehot[np.arange(len(code_idx)), code_idx] = 1.0
+            components.append(code_onehot)
+
+        combined = np.concatenate(components, axis=1).astype(np.float32)
+        error_correction = np.asarray(
+            error_session.run(None, {error_input_name: combined})[0]
+        )
+        normalised_regression = normalised_regression + error_correction
+
+    # Denormalize to Munsell specification.
+    regression_keys = ["hue_range", "value_range", "chroma_range"]
+    if not is_class_code:
+        regression_keys.append("code_range")
+
+    specification = np.empty((*normalised_regression.shape[:-1], 4), dtype=np.float64)
+    for i, key in enumerate(regression_keys):
+        minimum, maximum = output_parameters[key]
+        specification[..., i] = (
+            normalised_regression[..., i] * (maximum - minimum) + minimum
+        )
+
+    if is_class_code:
+        # Code from classification: argmax over the 10 logits yields a
+        # 0-based index, + 1 shifts to the 1-based *Munsell* hue code,
+        # e.g., argmax(...) = 5 + 1 = code 6 (BG).
+        specification[..., 3] = np.argmax(code_logits, axis=-1) + 1.0
+
+    # Clamp specification to valid Munsell ranges — regression can
+    # slightly overshoot at boundaries (e.g. 10.08 instead of 10.0).
+    specification = np.clip(specification, [0, 0, 0, 1], [10, 10, 50, 10])
+
+    specification = from_range_10(specification, _munsell_scale_factor())
+
+    return np.reshape(specification, (*shape[:-1], 4))
+
+
+@required("onnxruntime")
+def xyY_to_munsell_colour_Onnx(
+    xyY: Domain1,
+    hue_decimals: int = 1,
+    value_decimals: int = 1,
+    chroma_decimals: int = 1,
+) -> str | NDArrayStr:
+    """
+    Convert from *CIE xyY* colourspace to *Munsell* colour notation using
+    the *ONNX* model.
+
+    Parameters
+    ----------
+    xyY
+        *CIE xyY* colourspace array.
+    hue_decimals
+        Number of decimal places for formatting the hue component.
+    value_decimals
+        Number of decimal places for formatting the value component.
+    chroma_decimals
+        Number of decimal places for formatting the chroma component.
+
+    Returns
+    -------
+    :class:`str` or :class:`numpy.NDArrayStr`
+        *Munsell* colour notation.
+
+    Notes
+    -----
+    +------------+-----------------------+---------------+
+    | **Domain** | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``xyY``    | 1                     | 1             |
+    +------------+-----------------------+---------------+
+
+    Examples
+    --------
+    >>> xyY = np.array([0.38736945, 0.35751656, 0.59362000])
+    >>> xyY_to_munsell_colour_Onnx(xyY)  # doctest: +SKIP
+    '...'
+    """
+
+    specification = to_domain_10(
+        xyY_to_munsell_specification_Onnx(xyY), _munsell_scale_factor()
+    )
+    shape = specification.shape
+    decimals = (hue_decimals, value_decimals, chroma_decimals)
+
+    specification_flat = np.reshape(specification, (-1, 4)).copy()
+    specification_flat[..., 3] = np.round(specification_flat[..., 3])
+
+    munsell_colour = np.reshape(
+        np.array(
+            [
+                munsell_specification_to_munsell_colour(a, *decimals)
+                for a in specification_flat
+            ]
+        ),
+        shape[:-1],
+    )
+
+    return str(munsell_colour) if shape == (4,) else munsell_colour

--- a/colour/notation/munsell/tests/test__init__.py
+++ b/colour/notation/munsell/tests/test__init__.py
@@ -1,0 +1,313 @@
+"""
+Define the unit tests for the :mod:`colour.notation.munsell` module.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from colour.constants import TOLERANCE_ABSOLUTE_TESTS
+from colour.notation.munsell import (
+    munsell_colour_to_xyY,
+    munsell_colour_to_xyY_Centore2014,
+    munsell_specification_to_xyY,
+    munsell_specification_to_xyY_Centore2014,
+    xyY_to_munsell_colour,
+    xyY_to_munsell_colour_Centore2014,
+    xyY_to_munsell_specification,
+    xyY_to_munsell_specification_Centore2014,
+)
+from colour.utilities import is_onnxruntime_installed, is_scipy_installed
+
+__author__ = "Colour Developers"
+__copyright__ = "Copyright 2013 Colour Developers"
+__license__ = "BSD-3-Clause - https://opensource.org/licenses/BSD-3-Clause"
+__maintainer__ = "Colour Developers"
+__email__ = "colour-developers@colour-science.org"
+__status__ = "Production"
+
+__all__ = [
+    "TestMunsellSpecification_to_xyY",
+    "TestMunsellColour_to_xyY",
+    "TestxyY_to_munsell_specification",
+    "TestxyY_to_munsell_colour",
+]
+
+
+class TestMunsellSpecification_to_xyY:
+    """
+    Define :func:`colour.notation.munsell.munsell_specification_to_xyY`
+    definition unit tests methods.
+    """
+
+    def test_munsell_specification_to_xyY(self) -> None:
+        """
+        Test :func:`colour.notation.munsell.munsell_specification_to_xyY`
+        definition.
+        """
+
+        specification = np.array([7.18927191, 5.34025196, 16.05861170, 3.00000000])
+
+        np.testing.assert_allclose(
+            munsell_specification_to_xyY(specification),
+            munsell_specification_to_xyY_Centore2014(specification),
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+    def test_munsell_specification_to_xyY_Centore2014(self) -> None:
+        """
+        Test :func:`colour.notation.munsell.munsell_specification_to_xyY`
+        definition with the *Centore 2014* method.
+        """
+
+        specification = np.array([7.18927191, 5.34025196, 16.05861170, 3.00000000])
+
+        np.testing.assert_allclose(
+            munsell_specification_to_xyY(specification, method="Centore 2014"),
+            munsell_specification_to_xyY_Centore2014(specification),
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+    @pytest.mark.skipif(
+        not is_onnxruntime_installed(),
+        reason="onnxruntime is not installed",
+    )
+    def test_munsell_specification_to_xyY_Onnx(self) -> None:
+        """
+        Test :func:`colour.notation.munsell.munsell_specification_to_xyY`
+        definition with the *ONNX* method.
+        """
+
+        from colour.notation.munsell import (  # noqa: PLC0415
+            munsell_specification_to_xyY_Onnx,
+        )
+
+        specification = np.array([7.18927191, 5.34025196, 16.05861170, 3.00000000])
+
+        np.testing.assert_allclose(
+            munsell_specification_to_xyY(specification, method="ONNX"),
+            munsell_specification_to_xyY_Onnx(specification),
+            atol=1e-6,
+        )
+
+    def test_munsell_specification_to_xyY_raise_exception(self) -> None:
+        """
+        Test :func:`colour.notation.munsell.munsell_specification_to_xyY`
+        definition raised exception.
+        """
+
+        pytest.raises(
+            ValueError,
+            munsell_specification_to_xyY,
+            np.array([7.18927191, 5.34025196, 16.05861170, 3.00000000]),
+            method="Invalid",
+        )
+
+
+class TestMunsellColour_to_xyY:
+    """
+    Define :func:`colour.notation.munsell.munsell_colour_to_xyY`
+    definition unit tests methods.
+    """
+
+    def test_munsell_colour_to_xyY(self) -> None:
+        """
+        Test :func:`colour.notation.munsell.munsell_colour_to_xyY`
+        definition.
+        """
+
+        np.testing.assert_allclose(
+            munsell_colour_to_xyY("4.2YR 8.1/5.3"),
+            munsell_colour_to_xyY_Centore2014("4.2YR 8.1/5.3"),
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+    def test_munsell_colour_to_xyY_Centore2014(self) -> None:
+        """
+        Test :func:`colour.notation.munsell.munsell_colour_to_xyY`
+        definition with the *Centore 2014* method.
+        """
+
+        np.testing.assert_allclose(
+            munsell_colour_to_xyY("4.2YR 8.1/5.3", method="Centore 2014"),
+            munsell_colour_to_xyY_Centore2014("4.2YR 8.1/5.3"),
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+    @pytest.mark.skipif(
+        not is_onnxruntime_installed(),
+        reason="onnxruntime is not installed",
+    )
+    def test_munsell_colour_to_xyY_Onnx(self) -> None:
+        """
+        Test :func:`colour.notation.munsell.munsell_colour_to_xyY`
+        definition with the *ONNX* method.
+        """
+
+        from colour.notation.munsell import (  # noqa: PLC0415
+            munsell_colour_to_xyY_Onnx,
+        )
+
+        np.testing.assert_allclose(
+            munsell_colour_to_xyY("4.2YR 8.1/5.3", method="ONNX"),
+            munsell_colour_to_xyY_Onnx("4.2YR 8.1/5.3"),
+            atol=1e-6,
+        )
+
+    def test_munsell_colour_to_xyY_raise_exception(self) -> None:
+        """
+        Test :func:`colour.notation.munsell.munsell_colour_to_xyY`
+        definition raised exception.
+        """
+
+        pytest.raises(
+            ValueError,
+            munsell_colour_to_xyY,
+            "4.2YR 8.1/5.3",
+            method="Invalid",
+        )
+
+
+class TestxyY_to_munsell_specification:
+    """
+    Define :func:`colour.notation.munsell.xyY_to_munsell_specification`
+    definition unit tests methods.
+    """
+
+    def test_xyY_to_munsell_specification(self) -> None:
+        """
+        Test :func:`colour.notation.munsell.xyY_to_munsell_specification`
+        definition.
+        """
+
+        if not is_scipy_installed():  # pragma: no cover
+            return
+
+        xyY = np.array([0.16623068, 0.45684550, 0.22399519])
+
+        np.testing.assert_allclose(
+            xyY_to_munsell_specification(xyY),
+            xyY_to_munsell_specification_Centore2014(xyY),
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+    def test_xyY_to_munsell_specification_Centore2014(self) -> None:
+        """
+        Test :func:`colour.notation.munsell.xyY_to_munsell_specification`
+        definition with the *Centore 2014* method.
+        """
+
+        if not is_scipy_installed():  # pragma: no cover
+            return
+
+        xyY = np.array([0.16623068, 0.45684550, 0.22399519])
+
+        np.testing.assert_allclose(
+            xyY_to_munsell_specification(xyY, method="Centore 2014"),
+            xyY_to_munsell_specification_Centore2014(xyY),
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+    @pytest.mark.skipif(
+        not is_onnxruntime_installed(),
+        reason="onnxruntime is not installed",
+    )
+    def test_xyY_to_munsell_specification_Onnx(self) -> None:
+        """
+        Test :func:`colour.notation.munsell.xyY_to_munsell_specification`
+        definition with the *ONNX* method.
+        """
+
+        from colour.notation.munsell import (  # noqa: PLC0415
+            xyY_to_munsell_specification_Onnx,
+        )
+
+        xyY = np.array([0.16623068, 0.45684550, 0.22399519])
+
+        np.testing.assert_allclose(
+            xyY_to_munsell_specification(xyY, method="ONNX"),
+            xyY_to_munsell_specification_Onnx(xyY),
+            atol=1e-6,
+        )
+
+    def test_xyY_to_munsell_specification_raise_exception(self) -> None:
+        """
+        Test :func:`colour.notation.munsell.xyY_to_munsell_specification`
+        definition raised exception.
+        """
+
+        pytest.raises(
+            ValueError,
+            xyY_to_munsell_specification,
+            np.array([0.16623068, 0.45684550, 0.22399519]),
+            method="Invalid",
+        )
+
+
+class TestxyY_to_munsell_colour:
+    """
+    Define :func:`colour.notation.munsell.xyY_to_munsell_colour`
+    definition unit tests methods.
+    """
+
+    def test_xyY_to_munsell_colour(self) -> None:
+        """
+        Test :func:`colour.notation.munsell.xyY_to_munsell_colour`
+        definition.
+        """
+
+        if not is_scipy_installed():  # pragma: no cover
+            return
+
+        xyY = np.array([0.38736945, 0.35751656, 0.59362000])
+
+        assert xyY_to_munsell_colour(xyY) == xyY_to_munsell_colour_Centore2014(xyY)
+
+    def test_xyY_to_munsell_colour_Centore2014(self) -> None:
+        """
+        Test :func:`colour.notation.munsell.xyY_to_munsell_colour`
+        definition with the *Centore 2014* method.
+        """
+
+        if not is_scipy_installed():  # pragma: no cover
+            return
+
+        xyY = np.array([0.38736945, 0.35751656, 0.59362000])
+
+        assert xyY_to_munsell_colour(
+            xyY, method="Centore 2014"
+        ) == xyY_to_munsell_colour_Centore2014(xyY)
+
+    @pytest.mark.skipif(
+        not is_onnxruntime_installed(),
+        reason="onnxruntime is not installed",
+    )
+    def test_xyY_to_munsell_colour_Onnx(self) -> None:
+        """
+        Test :func:`colour.notation.munsell.xyY_to_munsell_colour`
+        definition with the *ONNX* method.
+        """
+
+        from colour.notation.munsell import (  # noqa: PLC0415
+            xyY_to_munsell_colour_Onnx,
+        )
+
+        xyY = np.array([0.38736945, 0.35751656, 0.59362000])
+
+        assert xyY_to_munsell_colour(xyY, method="ONNX") == xyY_to_munsell_colour_Onnx(
+            xyY
+        )
+
+    def test_xyY_to_munsell_colour_raise_exception(self) -> None:
+        """
+        Test :func:`colour.notation.munsell.xyY_to_munsell_colour`
+        definition raised exception.
+        """
+
+        pytest.raises(
+            ValueError,
+            xyY_to_munsell_colour,
+            np.array([0.38736945, 0.35751656, 0.59362000]),
+            method="Invalid",
+        )

--- a/colour/notation/munsell/tests/test_centore2014.py
+++ b/colour/notation/munsell/tests/test_centore2014.py
@@ -1,4 +1,7 @@
-"""Define the unit tests for the :mod:`colour.notation.munsell` module."""
+"""
+Define the unit tests for the
+:mod:`colour.notation.munsell.centore2014` module.
+"""
 
 from __future__ import annotations
 
@@ -14,15 +17,6 @@ from colour.constants import TOLERANCE_ABSOLUTE_TESTS
 if typing.TYPE_CHECKING:
     from colour.hints import NDArrayFloat
 
-from colour.notation import (
-    munsell_value_ASTMD1535,
-    munsell_value_Ladd1955,
-    munsell_value_McCamy1987,
-    munsell_value_Moon1943,
-    munsell_value_Munsell1933,
-    munsell_value_Priest1920,
-    munsell_value_Saunderson1944,
-)
 from colour.notation.munsell import (
     CCS_ILLUMINANT_MUNSELL,
     LCHab_to_munsell_specification,
@@ -35,16 +29,18 @@ from colour.notation.munsell import (
     is_specification_in_renotation,
     maximum_chroma_from_renotation,
     munsell_colour_to_munsell_specification,
-    munsell_colour_to_xyY,
+    munsell_colour_to_xyY_Centore2014,
     munsell_specification_to_munsell_colour,
     munsell_specification_to_xy,
     munsell_specification_to_xyY,
+    munsell_specification_to_xyY_Centore2014,
     normalise_munsell_specification,
     parse_munsell_colour,
     xy_from_renotation_ovoid,
     xyY_from_renotation,
     xyY_to_munsell_colour,
-    xyY_to_munsell_specification,
+    xyY_to_munsell_colour_Centore2014,
+    xyY_to_munsell_specification_Centore2014,
 )
 from colour.utilities import (
     as_array,
@@ -71,17 +67,10 @@ __all__ = [
     "MUNSELL_HUE_TO_ASTM_HUE",
     "MUNSELL_INTERPOLATION_METHODS",
     "MUNSELL_XY_FROM_RENOTATION_OVOID",
-    "TestMunsellValuePriest1920",
-    "TestMunsellValueMunsell1933",
-    "TestMunsellValueMoon1943",
-    "TestMunsellValueSaunderson1944",
-    "TestMunsellValueLadd1955",
-    "TestMunsellValueMcCamy1992",
-    "TestMunsellValueASTMD1535",
-    "TestMunsellSpecification_to_xyY",
-    "TestMunsellColour_to_xyY",
-    "TestxyY_to_munsell_specification",
-    "TestxyY_to_munsell_colour",
+    "TestMunsellSpecification_to_xyY_Centore2014",
+    "TestMunsellColour_to_xyY_Centore2014",
+    "TestxyY_to_munsell_specification_Centore2014",
+    "TestxyY_to_munsell_colour_Centore2014",
     "TestParseMunsellColour",
     "TestIsGreyMunsellColour",
     "TestNormaliseMunsellSpecification",
@@ -1106,612 +1095,17 @@ MUNSELL_XY_FROM_RENOTATION_OVOID: list = [
 ]
 
 
-class TestMunsellValuePriest1920:
+class TestMunsellSpecification_to_xyY_Centore2014:
     """
-    Define :func:`colour.notation.munsell.munsell_value_Priest1920` definition
-    unit tests methods.
-    """
-
-    def test_munsell_value_Priest1920(self) -> None:
-        """
-        Test :func:`colour.notation.munsell.munsell_value_Priest1920`
-        definition.
-        """
-
-        np.testing.assert_allclose(
-            munsell_value_Priest1920(12.23634268),
-            3.498048410185314,
-            atol=TOLERANCE_ABSOLUTE_TESTS,
-        )
-
-        np.testing.assert_allclose(
-            munsell_value_Priest1920(22.89399987),
-            4.7847674833788947,
-            atol=TOLERANCE_ABSOLUTE_TESTS,
-        )
-
-        np.testing.assert_allclose(
-            munsell_value_Priest1920(6.29022535),
-            2.5080321668591092,
-            atol=TOLERANCE_ABSOLUTE_TESTS,
-        )
-
-    def test_n_dimensional_munsell_value_Priest1920(self) -> None:
-        """
-        Test :func:`colour.notation.munsell.munsell_value_Priest1920`
-        definition n-dimensional arrays support.
-        """
-
-        Y = 12.23634268
-        V = munsell_value_Priest1920(Y)
-
-        V = np.tile(V, 6)
-        Y = np.tile(Y, 6)
-        np.testing.assert_allclose(
-            munsell_value_Priest1920(Y), V, atol=TOLERANCE_ABSOLUTE_TESTS
-        )
-
-        V = np.reshape(V, (2, 3))
-        Y = np.reshape(Y, (2, 3))
-        np.testing.assert_allclose(
-            munsell_value_Priest1920(Y), V, atol=TOLERANCE_ABSOLUTE_TESTS
-        )
-
-        V = np.reshape(V, (2, 3, 1))
-        Y = np.reshape(Y, (2, 3, 1))
-        np.testing.assert_allclose(
-            munsell_value_Priest1920(Y), V, atol=TOLERANCE_ABSOLUTE_TESTS
-        )
-
-    def test_domain_range_scale_munsell_value_Priest1920(self) -> None:
-        """
-        Test :func:`colour.notation.munsell.munsell_value_Priest1920`
-        definition domain and range scale support.
-        """
-
-        Y = 12.23634268
-        V = munsell_value_Priest1920(Y)
-
-        d_r = (("reference", 1, 1), ("1", 0.01, 0.1), ("100", 1, 10))
-        for scale, factor_a, factor_b in d_r:
-            with domain_range_scale(scale):
-                np.testing.assert_allclose(
-                    munsell_value_Priest1920(Y * factor_a),
-                    V * factor_b,
-                    atol=TOLERANCE_ABSOLUTE_TESTS,
-                )
-
-    @ignore_numpy_errors
-    def test_nan_munsell_value_Priest1920(self) -> None:
-        """
-        Test :func:`colour.notation.munsell.munsell_value_Priest1920`
-        definition nan support.
-        """
-
-        munsell_value_Priest1920(np.array([-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan]))
-
-
-class TestMunsellValueMunsell1933:
-    """
-    Define :func:`colour.notation.munsell.munsell_value_Munsell1933`
+    Define
+    :func:`colour.notation.munsell.munsell_specification_to_xyY_Centore2014`
     definition unit tests methods.
     """
 
-    def test_munsell_value_Munsell1933(self) -> None:
+    def test_munsell_specification_to_xyY_Centore2014(self) -> None:
         """
-        Test :func:`colour.notation.munsell.munsell_value_Munsell1933`
-        definition.
-        """
-
-        np.testing.assert_allclose(
-            munsell_value_Munsell1933(12.23634268),
-            4.1627702416858083,
-            atol=TOLERANCE_ABSOLUTE_TESTS,
-        )
-
-        np.testing.assert_allclose(
-            munsell_value_Munsell1933(22.89399987),
-            5.5914543020790592,
-            atol=TOLERANCE_ABSOLUTE_TESTS,
-        )
-
-        np.testing.assert_allclose(
-            munsell_value_Munsell1933(6.29022535),
-            3.0141971134091761,
-            atol=TOLERANCE_ABSOLUTE_TESTS,
-        )
-
-    def test_n_dimensional_munsell_value_Munsell1933(self) -> None:
-        """
-        Test :func:`colour.notation.munsell.munsell_value_Munsell1933`
-        definition n-dimensional arrays support.
-        """
-
-        Y = 12.23634268
-        V = munsell_value_Munsell1933(Y)
-
-        V = np.tile(V, 6)
-        Y = np.tile(Y, 6)
-        np.testing.assert_allclose(
-            munsell_value_Munsell1933(Y), V, atol=TOLERANCE_ABSOLUTE_TESTS
-        )
-
-        V = np.reshape(V, (2, 3))
-        Y = np.reshape(Y, (2, 3))
-        np.testing.assert_allclose(
-            munsell_value_Munsell1933(Y), V, atol=TOLERANCE_ABSOLUTE_TESTS
-        )
-
-        V = np.reshape(V, (2, 3, 1))
-        Y = np.reshape(Y, (2, 3, 1))
-        np.testing.assert_allclose(
-            munsell_value_Munsell1933(Y), V, atol=TOLERANCE_ABSOLUTE_TESTS
-        )
-
-    def test_domain_range_scale_munsell_value_Munsell1933(self) -> None:
-        """
-        Test :func:`colour.notation.munsell.munsell_value_Munsell1933`
-        definition domain and range scale support.
-        """
-
-        Y = 12.23634268
-        V = munsell_value_Munsell1933(Y)
-
-        d_r = (("reference", 1, 1), ("1", 0.01, 0.1), ("100", 1, 10))
-        for scale, factor_a, factor_b in d_r:
-            with domain_range_scale(scale):
-                np.testing.assert_allclose(
-                    munsell_value_Munsell1933(Y * factor_a),
-                    V * factor_b,
-                    atol=TOLERANCE_ABSOLUTE_TESTS,
-                )
-
-    @ignore_numpy_errors
-    def test_nan_munsell_value_Munsell1933(self) -> None:
-        """
-        Test :func:`colour.notation.munsell.munsell_value_Munsell1933`
-        definition nan support.
-        """
-
-        munsell_value_Munsell1933(np.array([-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan]))
-
-
-class TestMunsellValueMoon1943:
-    """
-    Define :func:`colour.notation.munsell.munsell_value_Moon1943` definition
-    unit tests methods.
-    """
-
-    def test_munsell_value_Moon1943(self) -> None:
-        """
-        Test :func:`colour.notation.munsell.munsell_value_Moon1943`
-        definition.
-        """
-
-        np.testing.assert_allclose(
-            munsell_value_Moon1943(12.23634268),
-            4.0688120634976421,
-            atol=TOLERANCE_ABSOLUTE_TESTS,
-        )
-
-        np.testing.assert_allclose(
-            munsell_value_Moon1943(22.89399987),
-            5.3133627855494412,
-            atol=TOLERANCE_ABSOLUTE_TESTS,
-        )
-
-        np.testing.assert_allclose(
-            munsell_value_Moon1943(6.29022535),
-            3.0645015037679695,
-            atol=TOLERANCE_ABSOLUTE_TESTS,
-        )
-
-    def test_n_dimensional_munsell_value_Moon1943(self) -> None:
-        """
-        Test :func:`colour.notation.munsell.munsell_value_Moon1943`
-        definition n-dimensional arrays support.
-        """
-
-        Y = 12.23634268
-        V = munsell_value_Moon1943(Y)
-
-        V = np.tile(V, 6)
-        Y = np.tile(Y, 6)
-        np.testing.assert_allclose(
-            munsell_value_Moon1943(Y), V, atol=TOLERANCE_ABSOLUTE_TESTS
-        )
-
-        V = np.reshape(V, (2, 3))
-        Y = np.reshape(Y, (2, 3))
-        np.testing.assert_allclose(
-            munsell_value_Moon1943(Y), V, atol=TOLERANCE_ABSOLUTE_TESTS
-        )
-
-        V = np.reshape(V, (2, 3, 1))
-        Y = np.reshape(Y, (2, 3, 1))
-        np.testing.assert_allclose(
-            munsell_value_Moon1943(Y), V, atol=TOLERANCE_ABSOLUTE_TESTS
-        )
-
-    def test_domain_range_scale_munsell_value_Moon1943(self) -> None:
-        """
-        Test :func:`colour.notation.munsell.munsell_value_Moon1943`
-        definition domain and range scale support.
-        """
-
-        Y = 12.23634268
-        V = munsell_value_Moon1943(Y)
-
-        d_r = (("reference", 1, 1), ("1", 0.01, 0.1), ("100", 1, 10))
-        for scale, factor_a, factor_b in d_r:
-            with domain_range_scale(scale):
-                np.testing.assert_allclose(
-                    munsell_value_Moon1943(Y * factor_a),
-                    V * factor_b,
-                    atol=TOLERANCE_ABSOLUTE_TESTS,
-                )
-
-    @ignore_numpy_errors
-    def test_nan_munsell_value_Moon1943(self) -> None:
-        """
-        Test :func:`colour.notation.munsell.munsell_value_Moon1943`
-        definition nan support.
-        """
-
-        munsell_value_Moon1943(np.array([-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan]))
-
-
-class TestMunsellValueSaunderson1944:
-    """
-    Define :func:`colour.notation.munsell.munsell_value_Saunderson1944`
-    definition unit tests methods.
-    """
-
-    def test_munsell_value_Saunderson1944(self) -> None:
-        """
-        Test :func:`colour.notation.munsell.munsell_value_Saunderson1944`
-        definition.
-        """
-
-        np.testing.assert_allclose(
-            munsell_value_Saunderson1944(12.23634268),
-            4.0444736723175119,
-            atol=TOLERANCE_ABSOLUTE_TESTS,
-        )
-
-        np.testing.assert_allclose(
-            munsell_value_Saunderson1944(22.89399987),
-            5.3783324022305923,
-            atol=TOLERANCE_ABSOLUTE_TESTS,
-        )
-
-        np.testing.assert_allclose(
-            munsell_value_Saunderson1944(6.29022535),
-            2.9089633927316823,
-            atol=TOLERANCE_ABSOLUTE_TESTS,
-        )
-
-    def test_n_dimensional_munsell_value_Saunderson1944(self) -> None:
-        """
-        Test :func:`colour.notation.munsell.munsell_value_Saunderson1944`
-        definition n-dimensional arrays support.
-        """
-
-        Y = 12.23634268
-        V = munsell_value_Saunderson1944(Y)
-
-        V = np.tile(V, 6)
-        Y = np.tile(Y, 6)
-        np.testing.assert_allclose(
-            munsell_value_Saunderson1944(Y), V, atol=TOLERANCE_ABSOLUTE_TESTS
-        )
-
-        V = np.reshape(V, (2, 3))
-        Y = np.reshape(Y, (2, 3))
-        np.testing.assert_allclose(
-            munsell_value_Saunderson1944(Y), V, atol=TOLERANCE_ABSOLUTE_TESTS
-        )
-
-        V = np.reshape(V, (2, 3, 1))
-        Y = np.reshape(Y, (2, 3, 1))
-        np.testing.assert_allclose(
-            munsell_value_Saunderson1944(Y), V, atol=TOLERANCE_ABSOLUTE_TESTS
-        )
-
-    def test_domain_range_scale_munsell_value_Saunderson1944(self) -> None:
-        """
-        Test :func:`colour.notation.munsell.munsell_value_Saunderson1944`
-        definition domain and range scale support.
-        """
-
-        Y = 12.23634268
-        V = munsell_value_Saunderson1944(Y)
-
-        d_r = (("reference", 1, 1), ("1", 0.01, 0.1), ("100", 1, 10))
-        for scale, factor_a, factor_b in d_r:
-            with domain_range_scale(scale):
-                np.testing.assert_allclose(
-                    munsell_value_Saunderson1944(Y * factor_a),
-                    V * factor_b,
-                    atol=TOLERANCE_ABSOLUTE_TESTS,
-                )
-
-    @ignore_numpy_errors
-    def test_nan_munsell_value_Saunderson1944(self) -> None:
-        """
-        Test :func:`colour.notation.munsell.munsell_value_Saunderson1944`
-        definition nan support.
-        """
-
-        munsell_value_Saunderson1944(
-            np.array([-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan])
-        )
-
-
-class TestMunsellValueLadd1955:
-    """
-    Define :func:`colour.notation.munsell.munsell_value_Ladd1955` definition
-    unit tests methods.
-    """
-
-    def test_munsell_value_Ladd1955(self) -> None:
-        """
-        Test :func:`colour.notation.munsell.munsell_value_Ladd1955`
-        definition.
-        """
-
-        np.testing.assert_allclose(
-            munsell_value_Ladd1955(12.23634268),
-            4.0511633044287088,
-            atol=TOLERANCE_ABSOLUTE_TESTS,
-        )
-
-        np.testing.assert_allclose(
-            munsell_value_Ladd1955(22.89399987),
-            5.3718647913936772,
-            atol=TOLERANCE_ABSOLUTE_TESTS,
-        )
-
-        np.testing.assert_allclose(
-            munsell_value_Ladd1955(6.29022535),
-            2.9198269939751613,
-            atol=TOLERANCE_ABSOLUTE_TESTS,
-        )
-
-    def test_n_dimensional_munsell_value_Ladd1955(self) -> None:
-        """
-        Test :func:`colour.notation.munsell.munsell_value_Ladd1955`
-        definition n-dimensional arrays support.
-        """
-
-        Y = 12.23634268
-        V = munsell_value_Ladd1955(Y)
-
-        V = np.tile(V, 6)
-        Y = np.tile(Y, 6)
-        np.testing.assert_allclose(
-            munsell_value_Ladd1955(Y), V, atol=TOLERANCE_ABSOLUTE_TESTS
-        )
-
-        V = np.reshape(V, (2, 3))
-        Y = np.reshape(Y, (2, 3))
-        np.testing.assert_allclose(
-            munsell_value_Ladd1955(Y), V, atol=TOLERANCE_ABSOLUTE_TESTS
-        )
-
-        V = np.reshape(V, (2, 3, 1))
-        Y = np.reshape(Y, (2, 3, 1))
-        np.testing.assert_allclose(
-            munsell_value_Ladd1955(Y), V, atol=TOLERANCE_ABSOLUTE_TESTS
-        )
-
-    def test_domain_range_scale_munsell_value_Ladd1955(self) -> None:
-        """
-        Test :func:`colour.notation.munsell.munsell_value_Ladd1955`
-        definition domain and range scale support.
-        """
-
-        Y = 12.23634268
-        V = munsell_value_Ladd1955(Y)
-
-        d_r = (("reference", 1, 1), ("1", 0.01, 0.1), ("100", 1, 10))
-        for scale, factor_a, factor_b in d_r:
-            with domain_range_scale(scale):
-                np.testing.assert_allclose(
-                    munsell_value_Ladd1955(Y * factor_a),
-                    V * factor_b,
-                    atol=TOLERANCE_ABSOLUTE_TESTS,
-                )
-
-    @ignore_numpy_errors
-    def test_nan_munsell_value_Ladd1955(self) -> None:
-        """
-        Test :func:`colour.notation.munsell.munsell_value_Ladd1955`
-        definition nan support.
-        """
-
-        munsell_value_Ladd1955(np.array([-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan]))
-
-
-class TestMunsellValueMcCamy1992:
-    """
-    Define :func:`colour.notation.munsell.munsell_value_McCamy1987` definition
-    unit tests methods.
-    """
-
-    def test_munsell_value_McCamy1987(self) -> None:
-        """
-        Test :func:`colour.notation.munsell.munsell_value_McCamy1987`
-        definition.
-        """
-
-        np.testing.assert_allclose(
-            munsell_value_McCamy1987(12.23634268),
-            4.081434853194113,
-            atol=TOLERANCE_ABSOLUTE_TESTS,
-        )
-
-        np.testing.assert_allclose(
-            munsell_value_McCamy1987(22.89399987),
-            5.394083970919982,
-            atol=TOLERANCE_ABSOLUTE_TESTS,
-        )
-
-        np.testing.assert_allclose(
-            munsell_value_McCamy1987(6.29022535),
-            2.9750160800320096,
-            atol=TOLERANCE_ABSOLUTE_TESTS,
-        )
-
-    def test_n_dimensional_munsell_value_McCamy1987(self) -> None:
-        """
-        Test :func:`colour.notation.munsell.munsell_value_McCamy1987`
-        definition n-dimensional arrays support.
-        """
-
-        Y = 12.23634268
-        V = munsell_value_McCamy1987(Y)
-
-        V = np.tile(V, 6)
-        Y = np.tile(Y, 6)
-        np.testing.assert_allclose(
-            munsell_value_McCamy1987(Y), V, atol=TOLERANCE_ABSOLUTE_TESTS
-        )
-
-        V = np.reshape(V, (2, 3))
-        Y = np.reshape(Y, (2, 3))
-        np.testing.assert_allclose(
-            munsell_value_McCamy1987(Y), V, atol=TOLERANCE_ABSOLUTE_TESTS
-        )
-
-        V = np.reshape(V, (2, 3, 1))
-        Y = np.reshape(Y, (2, 3, 1))
-        np.testing.assert_allclose(
-            munsell_value_McCamy1987(Y), V, atol=TOLERANCE_ABSOLUTE_TESTS
-        )
-
-    def test_domain_range_scale_munsell_value_McCamy1987(self) -> None:
-        """
-        Test :func:`colour.notation.munsell.munsell_value_McCamy1987`
-        definition domain and range scale support.
-        """
-
-        Y = 12.23634268
-        V = munsell_value_McCamy1987(Y)
-
-        d_r = (("reference", 1, 1), ("1", 0.01, 0.1), ("100", 1, 10))
-        for scale, factor_a, factor_b in d_r:
-            with domain_range_scale(scale):
-                np.testing.assert_allclose(
-                    munsell_value_McCamy1987(Y * factor_a),
-                    V * factor_b,
-                    atol=TOLERANCE_ABSOLUTE_TESTS,
-                )
-
-    @ignore_numpy_errors
-    def test_nan_munsell_value_McCamy1987(self) -> None:
-        """
-        Test :func:`colour.notation.munsell.munsell_value_McCamy1987`
-        definition nan support.
-        """
-
-        munsell_value_McCamy1987(np.array([-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan]))
-
-
-class TestMunsellValueASTMD1535:
-    """
-    Define :func:`colour.notation.munsell.munsell_value_ASTMD1535`
-    definition unit tests methods.
-    """
-
-    def test_munsell_value_ASTMD1535(self) -> None:
-        """
-        Test :func:`colour.notation.munsell.munsell_value_ASTMD1535`
-        definition.
-        """
-
-        np.testing.assert_allclose(
-            munsell_value_ASTMD1535(12.23634268),
-            4.0824437076525664,
-            atol=TOLERANCE_ABSOLUTE_TESTS,
-        )
-
-        np.testing.assert_allclose(
-            munsell_value_ASTMD1535(22.89399987),
-            5.3913268228155395,
-            atol=TOLERANCE_ABSOLUTE_TESTS,
-        )
-
-        np.testing.assert_allclose(
-            munsell_value_ASTMD1535(6.29022535),
-            2.9761930839606454,
-            atol=TOLERANCE_ABSOLUTE_TESTS,
-        )
-
-    def test_n_dimensional_munsell_value_ASTMD1535(self) -> None:
-        """
-        Test :func:`colour.notation.munsell.munsell_value_ASTMD1535`
-        definition n-dimensional arrays support.
-        """
-
-        Y = 12.23634268
-        V = munsell_value_ASTMD1535(Y)
-
-        V = np.tile(V, 6)
-        Y = np.tile(Y, 6)
-        np.testing.assert_allclose(
-            munsell_value_ASTMD1535(Y), V, atol=TOLERANCE_ABSOLUTE_TESTS
-        )
-
-        V = np.reshape(V, (2, 3))
-        Y = np.reshape(Y, (2, 3))
-        np.testing.assert_allclose(
-            munsell_value_ASTMD1535(Y), V, atol=TOLERANCE_ABSOLUTE_TESTS
-        )
-
-        V = np.reshape(V, (2, 3, 1))
-        Y = np.reshape(Y, (2, 3, 1))
-        np.testing.assert_allclose(
-            munsell_value_ASTMD1535(Y), V, atol=TOLERANCE_ABSOLUTE_TESTS
-        )
-
-    def test_domain_range_scale_munsell_value_ASTMD1535(self) -> None:
-        """
-        Test :func:`colour.notation.munsell.munsell_value_ASTMD1535`
-        definition domain and range scale support.
-        """
-
-        Y = 12.23634268
-        V = munsell_value_ASTMD1535(Y)
-
-        d_r = (("reference", 1, 1), ("1", 0.01, 0.1), ("100", 1, 10))
-        for scale, factor_a, factor_b in d_r:
-            with domain_range_scale(scale):
-                np.testing.assert_allclose(
-                    munsell_value_ASTMD1535(Y * factor_a),
-                    V * factor_b,
-                    atol=TOLERANCE_ABSOLUTE_TESTS,
-                )
-
-    @ignore_numpy_errors
-    def test_nan_munsell_value_ASTMD1535(self) -> None:
-        """
-        Test :func:`colour.notation.munsell.munsell_value_ASTMD1535`
-        definition nan support.
-        """
-
-        munsell_value_ASTMD1535(np.array([-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan]))
-
-
-class TestMunsellSpecification_to_xyY:
-    """
-    Define :func:`colour.notation.munsell.munsell_specification_to_xyY`
-    definition unit tests methods.
-    """
-
-    def test_munsell_specification_to_xyY(self) -> None:
-        """
-        Test :func:`colour.notation.munsell.munsell_specification_to_xyY`
+        Test
+        :func:`colour.notation.munsell.munsell_specification_to_xyY_Centore2014`
         definition.
         """
 
@@ -1720,7 +1114,7 @@ class TestMunsellSpecification_to_xyY:
             as_float_array(list(MUNSELL_SPECIFICATIONS[..., 1])),
         )
         np.testing.assert_allclose(
-            munsell_specification_to_xyY(specification),
+            munsell_specification_to_xyY_Centore2014(specification),
             xyY,
             atol=TOLERANCE_ABSOLUTE_TESTS,
         )
@@ -1734,24 +1128,27 @@ class TestMunsellSpecification_to_xyY:
         specification = tstack([nan_array, specification, nan_array, nan_array])
 
         np.testing.assert_allclose(
-            munsell_specification_to_xyY(specification),
+            munsell_specification_to_xyY_Centore2014(specification),
             xyY,
             atol=TOLERANCE_ABSOLUTE_TESTS,
         )
 
-    def test_n_dimensional_munsell_specification_to_xyY(self) -> None:
+    def test_n_dimensional_munsell_specification_to_xyY_Centore2014(
+        self,
+    ) -> None:
         """
-        Test :func:`colour.notation.munsell.munsell_specification_to_xyY`
+        Test
+        :func:`colour.notation.munsell.munsell_specification_to_xyY_Centore2014`
         definition n-dimensional arrays support.
         """
 
         specification = np.array([7.18927191, 5.34025196, 16.05861170, 3.00000000])
-        xyY = munsell_specification_to_xyY(specification)
+        xyY = munsell_specification_to_xyY_Centore2014(specification)
 
         specification = np.tile(specification, (6, 1))
         xyY = np.tile(xyY, (6, 1))
         np.testing.assert_allclose(
-            munsell_specification_to_xyY(specification),
+            munsell_specification_to_xyY_Centore2014(specification),
             xyY,
             atol=TOLERANCE_ABSOLUTE_TESTS,
         )
@@ -1759,18 +1156,18 @@ class TestMunsellSpecification_to_xyY:
         specification = np.reshape(specification, (2, 3, 4))
         xyY = np.reshape(xyY, (2, 3, 3))
         np.testing.assert_allclose(
-            munsell_specification_to_xyY(specification),
+            munsell_specification_to_xyY_Centore2014(specification),
             xyY,
             atol=TOLERANCE_ABSOLUTE_TESTS,
         )
 
         specification = np.array([np.nan, 8.9, np.nan, np.nan])
-        xyY = munsell_specification_to_xyY(specification)
+        xyY = munsell_specification_to_xyY_Centore2014(specification)
 
         specification = np.tile(specification, (6, 1))
         xyY = np.tile(xyY, (6, 1))
         np.testing.assert_allclose(
-            munsell_specification_to_xyY(specification),
+            munsell_specification_to_xyY_Centore2014(specification),
             xyY,
             atol=TOLERANCE_ABSOLUTE_TESTS,
         )
@@ -1778,19 +1175,22 @@ class TestMunsellSpecification_to_xyY:
         specification = np.reshape(specification, (2, 3, 4))
         xyY = np.reshape(xyY, (2, 3, 3))
         np.testing.assert_allclose(
-            munsell_specification_to_xyY(specification),
+            munsell_specification_to_xyY_Centore2014(specification),
             xyY,
             atol=TOLERANCE_ABSOLUTE_TESTS,
         )
 
-    def test_domain_range_scale_munsell_specification_to_xyY(self) -> None:
+    def test_domain_range_scale_munsell_specification_to_xyY_Centore2014(
+        self,
+    ) -> None:
         """
-        Test :func:`colour.notation.munsell.munsell_specification_to_xyY`
+        Test
+        :func:`colour.notation.munsell.munsell_specification_to_xyY_Centore2014`
         definition domain and range scale support.
         """
 
         specification = np.array([7.18927191, 5.34025196, 16.05861170, 3.00000000])
-        xyY = munsell_specification_to_xyY(specification)
+        xyY = munsell_specification_to_xyY_Centore2014(specification)
 
         d_r = (
             ("reference", 1, 1),
@@ -1800,15 +1200,16 @@ class TestMunsellSpecification_to_xyY:
         for scale, factor_a, factor_b in d_r:
             with domain_range_scale(scale):
                 np.testing.assert_allclose(
-                    munsell_specification_to_xyY(specification * factor_a),
+                    munsell_specification_to_xyY_Centore2014(specification * factor_a),
                     xyY * factor_b,
                     atol=TOLERANCE_ABSOLUTE_TESTS,
                 )
 
     @ignore_numpy_errors
-    def test_nan_munsell_specification_to_xyY(self) -> None:
+    def test_nan_munsell_specification_to_xyY_Centore2014(self) -> None:
         """
-        Test :func:`colour.notation.munsell.munsell_specification_to_xyY`
+        Test
+        :func:`colour.notation.munsell.munsell_specification_to_xyY_Centore2014`
         definition nan support.
         """
 
@@ -1816,23 +1217,27 @@ class TestMunsellSpecification_to_xyY:
         cases = np.array(list(set(product(cases, repeat=4))))
         for case in cases:
             with contextlib.suppress(AssertionError, TypeError, ValueError):
-                munsell_specification_to_xyY(case)
+                munsell_specification_to_xyY_Centore2014(case)
 
 
-class TestMunsellColour_to_xyY:
+class TestMunsellColour_to_xyY_Centore2014:
     """
-    Define :func:`colour.notation.munsell.munsell_colour_to_xyY` definition
-    unit tests methods.
+    Define
+    :func:`colour.notation.munsell.munsell_colour_to_xyY_Centore2014`
+    definition unit tests methods.
     """
 
-    def test_domain_range_scale_munsell_colour_to_xyY(self) -> None:
+    def test_domain_range_scale_munsell_colour_to_xyY_Centore2014(
+        self,
+    ) -> None:
         """
-        Test :func:`colour.notation.munsell.munsell_colour_to_xyY` definition
-        domain and range scale support.
+        Test
+        :func:`colour.notation.munsell.munsell_colour_to_xyY_Centore2014`
+        definition domain and range scale support.
         """
 
         munsell_colour = "4.2YR 8.1/5.3"
-        xyY = munsell_colour_to_xyY(munsell_colour)
+        xyY = munsell_colour_to_xyY_Centore2014(munsell_colour)
 
         d_r = (
             ("reference", 1),
@@ -1842,24 +1247,27 @@ class TestMunsellColour_to_xyY:
         for scale, factor in d_r:
             with domain_range_scale(scale):
                 np.testing.assert_allclose(
-                    munsell_colour_to_xyY(munsell_colour),
+                    munsell_colour_to_xyY_Centore2014(munsell_colour),
                     xyY * factor,
                     atol=TOLERANCE_ABSOLUTE_TESTS,
                 )
 
-    def test_n_dimensional_munsell_colour_to_xyY(self) -> None:
+    def test_n_dimensional_munsell_colour_to_xyY_Centore2014(
+        self,
+    ) -> None:
         """
-        Test :func:`colour.notation.munsell.munsell_colour_to_xyY` definition
-        n-dimensional arrays support.
+        Test
+        :func:`colour.notation.munsell.munsell_colour_to_xyY_Centore2014`
+        definition n-dimensional arrays support.
         """
 
         munsell_colour = "4.2YR 8.1/5.3"
-        xyY = munsell_colour_to_xyY(munsell_colour)
+        xyY = munsell_colour_to_xyY_Centore2014(munsell_colour)
 
         munsell_colour = np.tile(munsell_colour, 6)
         xyY = np.tile(xyY, (6, 1))
         np.testing.assert_allclose(
-            munsell_colour_to_xyY(munsell_colour),
+            munsell_colour_to_xyY_Centore2014(munsell_colour),
             xyY,
             atol=TOLERANCE_ABSOLUTE_TESTS,
         )
@@ -1867,18 +1275,18 @@ class TestMunsellColour_to_xyY:
         munsell_colour = np.reshape(munsell_colour, (2, 3))
         xyY = np.reshape(xyY, (2, 3, 3))
         np.testing.assert_allclose(
-            munsell_colour_to_xyY(munsell_colour),
+            munsell_colour_to_xyY_Centore2014(munsell_colour),
             xyY,
             atol=TOLERANCE_ABSOLUTE_TESTS,
         )
 
         munsell_colour = "N8.9"
-        xyY = munsell_colour_to_xyY(munsell_colour)
+        xyY = munsell_colour_to_xyY_Centore2014(munsell_colour)
 
         munsell_colour = np.tile(munsell_colour, 6)
         xyY = np.tile(xyY, (6, 1))
         np.testing.assert_allclose(
-            munsell_colour_to_xyY(munsell_colour),
+            munsell_colour_to_xyY_Centore2014(munsell_colour),
             xyY,
             atol=TOLERANCE_ABSOLUTE_TESTS,
         )
@@ -1886,21 +1294,23 @@ class TestMunsellColour_to_xyY:
         munsell_colour = np.reshape(munsell_colour, (2, 3))
         xyY = np.reshape(xyY, (2, 3, 3))
         np.testing.assert_allclose(
-            munsell_colour_to_xyY(munsell_colour),
+            munsell_colour_to_xyY_Centore2014(munsell_colour),
             xyY,
             atol=TOLERANCE_ABSOLUTE_TESTS,
         )
 
 
-class TestxyY_to_munsell_specification:
+class TestxyY_to_munsell_specification_Centore2014:
     """
-    Define :func:`colour.notation.munsell.xyY_to_munsell_specification`
+    Define
+    :func:`colour.notation.munsell.xyY_to_munsell_specification_Centore2014`
     definition unit tests methods.
     """
 
-    def test_xyY_to_munsell_specification(self) -> None:
+    def test_xyY_to_munsell_specification_Centore2014(self) -> None:
         """
-        Test :func:`colour.notation.munsell.xyY_to_munsell_specification`
+        Test
+        :func:`colour.notation.munsell.xyY_to_munsell_specification_Centore2014`
         definition.
         """
 
@@ -1913,7 +1323,7 @@ class TestxyY_to_munsell_specification:
         )
 
         np.testing.assert_allclose(
-            xyY_to_munsell_specification(xyY),
+            xyY_to_munsell_specification_Centore2014(xyY),
             specification,
             atol=5e-5,
         )
@@ -1927,14 +1337,17 @@ class TestxyY_to_munsell_specification:
         specification = tstack([nan_array, specification, nan_array, nan_array])
 
         np.testing.assert_allclose(
-            xyY_to_munsell_specification(xyY),
+            xyY_to_munsell_specification_Centore2014(xyY),
             specification,
             atol=0.00001,
         )
 
-    def test_n_dimensional_xyY_to_munsell_specification(self) -> None:
+    def test_n_dimensional_xyY_to_munsell_specification_Centore2014(
+        self,
+    ) -> None:
         """
-        Test :func:`colour.notation.munsell.xyY_to_munsell_specification`
+        Test
+        :func:`colour.notation.munsell.xyY_to_munsell_specification_Centore2014`
         definition n-dimensional arrays support.
         """
 
@@ -1942,12 +1355,12 @@ class TestxyY_to_munsell_specification:
             return
 
         xyY = [0.16623068, 0.45684550, 0.22399519]
-        specification = xyY_to_munsell_specification(xyY)
+        specification = xyY_to_munsell_specification_Centore2014(xyY)
 
         xyY = np.tile(xyY, (6, 1))
         specification = np.tile(specification, (6, 1))
         np.testing.assert_allclose(
-            xyY_to_munsell_specification(xyY),
+            xyY_to_munsell_specification_Centore2014(xyY),
             specification,
             atol=TOLERANCE_ABSOLUTE_TESTS,
         )
@@ -1955,14 +1368,17 @@ class TestxyY_to_munsell_specification:
         xyY = np.reshape(xyY, (2, 3, 3))
         specification = np.reshape(specification, (2, 3, 4))
         np.testing.assert_allclose(
-            xyY_to_munsell_specification(xyY),
+            xyY_to_munsell_specification_Centore2014(xyY),
             specification,
             atol=TOLERANCE_ABSOLUTE_TESTS,
         )
 
-    def test_raise_exception_xyY_to_munsell_specification(self) -> None:
+    def test_raise_exception_xyY_to_munsell_specification_Centore2014(
+        self,
+    ) -> None:
         """
-        Test :func:`colour.notation.munsell.xyY_to_munsell_specification`
+        Test
+        :func:`colour.notation.munsell.xyY_to_munsell_specification_Centore2014`
         definition raised exception.
         """
 
@@ -1971,13 +1387,16 @@ class TestxyY_to_munsell_specification:
 
         pytest.raises(
             RuntimeError,
-            xyY_to_munsell_specification,
+            xyY_to_munsell_specification_Centore2014,
             np.array([0.90615118, 0.57945103, 0.91984064]),
         )
 
-    def test_domain_range_scale_xyY_to_munsell_specification(self) -> None:
+    def test_domain_range_scale_xyY_to_munsell_specification_Centore2014(
+        self,
+    ) -> None:
         """
-        Test :func:`colour.notation.munsell.xyY_to_munsell_specification`
+        Test
+        :func:`colour.notation.munsell.xyY_to_munsell_specification_Centore2014`
         definition domain and range scale support.
         """
 
@@ -1985,7 +1404,7 @@ class TestxyY_to_munsell_specification:
             return
 
         xyY = [0.16623068, 0.45684550, 0.22399519]
-        specification = xyY_to_munsell_specification(xyY)
+        specification = xyY_to_munsell_specification_Centore2014(xyY)
 
         d_r = (
             ("reference", 1, 1),
@@ -1995,15 +1414,16 @@ class TestxyY_to_munsell_specification:
         for scale, factor_a, factor_b in d_r:
             with domain_range_scale(scale):
                 np.testing.assert_allclose(
-                    xyY_to_munsell_specification(xyY * factor_a),
+                    xyY_to_munsell_specification_Centore2014(xyY * factor_a),
                     specification * factor_b,
                     atol=2e-5,
                 )
 
     @ignore_numpy_errors
-    def test_nan_xyY_to_munsell_specification(self) -> None:
+    def test_nan_xyY_to_munsell_specification_Centore2014(self) -> None:
         """
-        Test :func:`colour.notation.munsell.xyY_to_munsell_specification`
+        Test
+        :func:`colour.notation.munsell.xyY_to_munsell_specification_Centore2014`
         definition nan support.
         """
 
@@ -2014,26 +1434,30 @@ class TestxyY_to_munsell_specification:
         cases = np.array(list(set(product(cases, repeat=3))))
         for case in cases:
             with contextlib.suppress(AssertionError, TypeError, ValueError):
-                xyY_to_munsell_specification(case)
+                xyY_to_munsell_specification_Centore2014(case)
 
 
-class TestxyY_to_munsell_colour:
+class TestxyY_to_munsell_colour_Centore2014:
     """
-    Define :func:`colour.notation.munsell.xyY_to_munsell_colour` definition
-    unit tests methods.
+    Define
+    :func:`colour.notation.munsell.xyY_to_munsell_colour_Centore2014`
+    definition unit tests methods.
     """
 
-    def test_domain_range_scale_xyY_to_munsell_colour(self) -> None:
+    def test_domain_range_scale_xyY_to_munsell_colour_Centore2014(
+        self,
+    ) -> None:
         """
-        Test :func:`colour.notation.munsell.xyY_to_munsell_colour` definition
-        domain and range scale support.
+        Test
+        :func:`colour.notation.munsell.xyY_to_munsell_colour_Centore2014`
+        definition domain and range scale support.
         """
 
         if not is_scipy_installed():  # pragma: no cover
             return
 
         xyY = np.array([0.38736945, 0.35751656, 0.59362000])
-        munsell_colour = xyY_to_munsell_colour(xyY)
+        munsell_colour = xyY_to_munsell_colour_Centore2014(xyY)
 
         d_r = (
             ("reference", 1),
@@ -2042,38 +1466,41 @@ class TestxyY_to_munsell_colour:
         )
         for scale, factor in d_r:
             with domain_range_scale(scale):
-                assert xyY_to_munsell_colour(xyY * factor) == munsell_colour
+                assert xyY_to_munsell_colour_Centore2014(xyY * factor) == munsell_colour
 
-    def test_n_dimensional_xyY_to_munsell_colour(self) -> None:
+    def test_n_dimensional_xyY_to_munsell_colour_Centore2014(
+        self,
+    ) -> None:
         """
-        Test :func:`colour.notation.munsell.xyY_to_munsell_colour` definition
-        n-dimensional arrays support.
+        Test
+        :func:`colour.notation.munsell.xyY_to_munsell_colour_Centore2014`
+        definition n-dimensional arrays support.
         """
 
         if not is_scipy_installed():  # pragma: no cover
             return
 
         xyY = [0.16623068, 0.45684550, 0.22399519]
-        munsell_colour = xyY_to_munsell_colour(xyY)
+        munsell_colour = xyY_to_munsell_colour_Centore2014(xyY)
 
         xyY = np.tile(xyY, (6, 1))
         munsell_colour = np.tile(munsell_colour, 6)
-        np.testing.assert_equal(xyY_to_munsell_colour(xyY), munsell_colour)
+        np.testing.assert_equal(xyY_to_munsell_colour_Centore2014(xyY), munsell_colour)
 
         xyY = np.reshape(xyY, (2, 3, 3))
         munsell_colour = np.reshape(munsell_colour, (2, 3))
-        np.testing.assert_equal(xyY_to_munsell_colour(xyY), munsell_colour)
+        np.testing.assert_equal(xyY_to_munsell_colour_Centore2014(xyY), munsell_colour)
 
         xyY = [*list(CCS_ILLUMINANT_MUNSELL), 1.0]
-        munsell_colour = xyY_to_munsell_colour(xyY)
+        munsell_colour = xyY_to_munsell_colour_Centore2014(xyY)
 
         xyY = np.tile(xyY, (6, 1))
         munsell_colour = np.tile(munsell_colour, 6)
-        np.testing.assert_equal(xyY_to_munsell_colour(xyY), munsell_colour)
+        np.testing.assert_equal(xyY_to_munsell_colour_Centore2014(xyY), munsell_colour)
 
         xyY = np.reshape(xyY, (2, 3, 3))
         munsell_colour = np.reshape(munsell_colour, (2, 3))
-        np.testing.assert_equal(xyY_to_munsell_colour(xyY), munsell_colour)
+        np.testing.assert_equal(xyY_to_munsell_colour_Centore2014(xyY), munsell_colour)
 
 
 class TestParseMunsellColour:

--- a/colour/notation/munsell/tests/test_onnx.py
+++ b/colour/notation/munsell/tests/test_onnx.py
@@ -1,0 +1,390 @@
+"""
+Define the unit tests for the :mod:`colour.notation.munsell.onnx` module.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from itertools import product
+
+import numpy as np
+import pytest
+
+from colour.constants import TOLERANCE_ABSOLUTE_TESTS
+from colour.notation.munsell import (
+    munsell_colour_to_xyY_Onnx,
+    munsell_specification_to_xyY_Onnx,
+    xyY_to_munsell_colour_Onnx,
+    xyY_to_munsell_specification_Onnx,
+)
+from colour.notation.munsell.tests.test_centore2014 import (
+    MUNSELL_SPECIFICATIONS,
+)
+from colour.utilities import (
+    as_float_array,
+    domain_range_scale,
+    ignore_numpy_errors,
+    is_onnxruntime_installed,
+)
+
+__author__ = "Colour Developers"
+__copyright__ = "Copyright 2013 Colour Developers"
+__license__ = "BSD-3-Clause - https://opensource.org/licenses/BSD-3-Clause"
+__maintainer__ = "Colour Developers"
+__email__ = "colour-developers@colour-science.org"
+__status__ = "Production"
+
+__all__ = [
+    "TestMunsellSpecification_to_xyY_Onnx",
+    "TestMunsellColour_to_xyY_Onnx",
+    "TestxyY_to_munsell_specification_Onnx",
+    "TestxyY_to_munsell_colour_Onnx",
+]
+
+
+@pytest.mark.skipif(
+    not is_onnxruntime_installed(), reason="onnxruntime is not installed"
+)
+class TestMunsellSpecification_to_xyY_Onnx:
+    """
+    Define
+    :func:`colour.notation.munsell.munsell_specification_to_xyY_Onnx`
+    definition unit tests methods.
+    """
+
+    def test_munsell_specification_to_xyY_Onnx(self) -> None:
+        """
+        Test
+        :func:`colour.notation.munsell.munsell_specification_to_xyY_Onnx`
+        definition.
+        """
+
+        specification, xyY = (
+            as_float_array(list(MUNSELL_SPECIFICATIONS[..., 0])),
+            as_float_array(list(MUNSELL_SPECIFICATIONS[..., 1])),
+        )
+        np.testing.assert_allclose(
+            munsell_specification_to_xyY_Onnx(specification),
+            xyY,
+            atol=5e-2,
+        )
+
+    def test_n_dimensional_munsell_specification_to_xyY_Onnx(
+        self,
+    ) -> None:
+        """
+        Test
+        :func:`colour.notation.munsell.munsell_specification_to_xyY_Onnx`
+        definition n-dimensional arrays support.
+        """
+
+        specification = np.array([7.18927191, 5.34025196, 16.05861170, 3.00000000])
+        xyY = munsell_specification_to_xyY_Onnx(specification)
+
+        specification = np.tile(specification, (6, 1))
+        xyY = np.tile(xyY, (6, 1))
+        np.testing.assert_allclose(
+            munsell_specification_to_xyY_Onnx(specification),
+            xyY,
+            atol=1e-6,
+        )
+
+        specification = np.reshape(specification, (2, 3, 4))
+        xyY = np.reshape(xyY, (2, 3, 3))
+        np.testing.assert_allclose(
+            munsell_specification_to_xyY_Onnx(specification),
+            xyY,
+            atol=1e-6,
+        )
+
+        specification = np.array([np.nan, 8.9, np.nan, np.nan])
+        xyY = munsell_specification_to_xyY_Onnx(specification)
+
+        specification = np.tile(specification, (6, 1))
+        xyY = np.tile(xyY, (6, 1))
+        np.testing.assert_allclose(
+            munsell_specification_to_xyY_Onnx(specification),
+            xyY,
+            atol=1e-6,
+        )
+
+        specification = np.reshape(specification, (2, 3, 4))
+        xyY = np.reshape(xyY, (2, 3, 3))
+        np.testing.assert_allclose(
+            munsell_specification_to_xyY_Onnx(specification),
+            xyY,
+            atol=1e-6,
+        )
+
+    def test_domain_range_scale_munsell_specification_to_xyY_Onnx(
+        self,
+    ) -> None:
+        """
+        Test
+        :func:`colour.notation.munsell.munsell_specification_to_xyY_Onnx`
+        definition domain and range scale support.
+        """
+
+        specification = np.array([7.18927191, 5.34025196, 16.05861170, 3.00000000])
+        xyY = munsell_specification_to_xyY_Onnx(specification)
+
+        d_r = (
+            ("reference", 1, 1),
+            ("1", np.array([0.1, 0.1, 1 / 50, 0.1]), 1),
+            ("100", np.array([10, 10, 2, 10]), np.array([1, 1, 100])),
+        )
+        for scale, factor_a, factor_b in d_r:
+            with domain_range_scale(scale):
+                np.testing.assert_allclose(
+                    munsell_specification_to_xyY_Onnx(specification * factor_a),
+                    xyY * factor_b,
+                    atol=TOLERANCE_ABSOLUTE_TESTS,
+                )
+
+    @ignore_numpy_errors
+    def test_nan_munsell_specification_to_xyY_Onnx(self) -> None:
+        """
+        Test
+        :func:`colour.notation.munsell.munsell_specification_to_xyY_Onnx`
+        definition nan support.
+        """
+
+        cases = [-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan]
+        cases = np.array(list(set(product(cases, repeat=4))))
+        for case in cases:
+            with contextlib.suppress(AssertionError, TypeError, ValueError):
+                munsell_specification_to_xyY_Onnx(case)
+
+
+@pytest.mark.skipif(
+    not is_onnxruntime_installed(), reason="onnxruntime is not installed"
+)
+class TestMunsellColour_to_xyY_Onnx:
+    """
+    Define :func:`colour.notation.munsell.munsell_colour_to_xyY_Onnx`
+    definition unit tests methods.
+    """
+
+    def test_domain_range_scale_munsell_colour_to_xyY_Onnx(
+        self,
+    ) -> None:
+        """
+        Test
+        :func:`colour.notation.munsell.munsell_colour_to_xyY_Onnx`
+        definition domain and range scale support.
+        """
+
+        munsell_colour = "4.2YR 8.1/5.3"
+        xyY = munsell_colour_to_xyY_Onnx(munsell_colour)
+
+        d_r = (
+            ("reference", 1),
+            ("1", 1),
+            ("100", np.array([1, 1, 100])),
+        )
+        for scale, factor in d_r:
+            with domain_range_scale(scale):
+                np.testing.assert_allclose(
+                    munsell_colour_to_xyY_Onnx(munsell_colour),
+                    xyY * factor,
+                    atol=TOLERANCE_ABSOLUTE_TESTS,
+                )
+
+    def test_n_dimensional_munsell_colour_to_xyY_Onnx(self) -> None:
+        """
+        Test :func:`colour.notation.munsell.munsell_colour_to_xyY_Onnx`
+        definition n-dimensional arrays support.
+        """
+
+        munsell_colour = "4.2YR 8.1/5.3"
+        xyY = munsell_colour_to_xyY_Onnx(munsell_colour)
+
+        munsell_colour = np.tile(munsell_colour, 6)
+        xyY = np.tile(xyY, (6, 1))
+        np.testing.assert_allclose(
+            munsell_colour_to_xyY_Onnx(munsell_colour),
+            xyY,
+            atol=1e-6,
+        )
+
+        munsell_colour = np.reshape(munsell_colour, (2, 3))
+        xyY = np.reshape(xyY, (2, 3, 3))
+        np.testing.assert_allclose(
+            munsell_colour_to_xyY_Onnx(munsell_colour),
+            xyY,
+            atol=1e-6,
+        )
+
+        munsell_colour = "N8.9"
+        xyY = munsell_colour_to_xyY_Onnx(munsell_colour)
+
+        munsell_colour = np.tile(munsell_colour, 6)
+        xyY = np.tile(xyY, (6, 1))
+        np.testing.assert_allclose(
+            munsell_colour_to_xyY_Onnx(munsell_colour),
+            xyY,
+            atol=1e-6,
+        )
+
+        munsell_colour = np.reshape(munsell_colour, (2, 3))
+        xyY = np.reshape(xyY, (2, 3, 3))
+        np.testing.assert_allclose(
+            munsell_colour_to_xyY_Onnx(munsell_colour),
+            xyY,
+            atol=1e-6,
+        )
+
+
+@pytest.mark.skipif(
+    not is_onnxruntime_installed(), reason="onnxruntime is not installed"
+)
+class TestxyY_to_munsell_specification_Onnx:
+    """
+    Define
+    :func:`colour.notation.munsell.xyY_to_munsell_specification_Onnx`
+    definition unit tests methods.
+    """
+
+    def test_xyY_to_munsell_specification_Onnx(self) -> None:
+        """
+        Test
+        :func:`colour.notation.munsell.xyY_to_munsell_specification_Onnx`
+        definition.
+        """
+
+        specification, xyY = (
+            as_float_array(list(MUNSELL_SPECIFICATIONS[..., 0])),
+            as_float_array(list(MUNSELL_SPECIFICATIONS[..., 1])),
+        )
+
+        np.testing.assert_allclose(
+            xyY_to_munsell_specification_Onnx(xyY),
+            specification,
+            atol=1,
+        )
+
+    def test_n_dimensional_xyY_to_munsell_specification_Onnx(
+        self,
+    ) -> None:
+        """
+        Test
+        :func:`colour.notation.munsell.xyY_to_munsell_specification_Onnx`
+        definition n-dimensional arrays support.
+        """
+
+        xyY = np.array([0.16623068, 0.45684550, 0.22399519])
+        specification = xyY_to_munsell_specification_Onnx(xyY)
+
+        xyY = np.tile(xyY, (6, 1))
+        specification = np.tile(specification, (6, 1))
+        np.testing.assert_allclose(
+            xyY_to_munsell_specification_Onnx(xyY),
+            specification,
+            atol=1e-6,
+        )
+
+        xyY = np.reshape(xyY, (2, 3, 3))
+        specification = np.reshape(specification, (2, 3, 4))
+        np.testing.assert_allclose(
+            xyY_to_munsell_specification_Onnx(xyY),
+            specification,
+            atol=1e-6,
+        )
+
+    def test_domain_range_scale_xyY_to_munsell_specification_Onnx(
+        self,
+    ) -> None:
+        """
+        Test
+        :func:`colour.notation.munsell.xyY_to_munsell_specification_Onnx`
+        definition domain and range scale support.
+        """
+
+        xyY = [0.16623068, 0.45684550, 0.22399519]
+        specification = xyY_to_munsell_specification_Onnx(xyY)
+
+        d_r = (
+            ("reference", 1, 1),
+            ("1", 1, np.array([0.1, 0.1, 1 / 50, 0.1])),
+            ("100", np.array([1, 1, 100]), np.array([10, 10, 2, 10])),
+        )
+        for scale, factor_a, factor_b in d_r:
+            with domain_range_scale(scale):
+                np.testing.assert_allclose(
+                    xyY_to_munsell_specification_Onnx(xyY * factor_a),
+                    specification * factor_b,
+                    atol=TOLERANCE_ABSOLUTE_TESTS,
+                )
+
+    @ignore_numpy_errors
+    def test_nan_xyY_to_munsell_specification_Onnx(self) -> None:
+        """
+        Test
+        :func:`colour.notation.munsell.xyY_to_munsell_specification_Onnx`
+        definition nan support.
+        """
+
+        cases = [-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan]
+        cases = np.array(list(set(product(cases, repeat=3))))
+        for case in cases:
+            with contextlib.suppress(AssertionError, TypeError, ValueError):
+                xyY_to_munsell_specification_Onnx(case)
+
+
+@pytest.mark.skipif(
+    not is_onnxruntime_installed(), reason="onnxruntime is not installed"
+)
+class TestxyY_to_munsell_colour_Onnx:
+    """
+    Define :func:`colour.notation.munsell.xyY_to_munsell_colour_Onnx`
+    definition unit tests methods.
+    """
+
+    def test_domain_range_scale_xyY_to_munsell_colour_Onnx(
+        self,
+    ) -> None:
+        """
+        Test
+        :func:`colour.notation.munsell.xyY_to_munsell_colour_Onnx`
+        definition domain and range scale support.
+        """
+
+        xyY = np.array([0.38736945, 0.35751656, 0.59362000])
+        munsell_colour = xyY_to_munsell_colour_Onnx(xyY)
+
+        d_r = (
+            ("reference", 1),
+            ("1", 1),
+            ("100", np.array([1, 1, 100])),
+        )
+        for scale, factor in d_r:
+            with domain_range_scale(scale):
+                assert xyY_to_munsell_colour_Onnx(xyY * factor) == munsell_colour
+
+    def test_n_dimensional_xyY_to_munsell_colour_Onnx(self) -> None:
+        """
+        Test :func:`colour.notation.munsell.xyY_to_munsell_colour_Onnx`
+        definition n-dimensional arrays support.
+        """
+
+        xyY = [0.16623068, 0.45684550, 0.22399519]
+        munsell_colour = xyY_to_munsell_colour_Onnx(xyY)
+
+        xyY = np.tile(xyY, (6, 1))
+        munsell_colour = np.tile(munsell_colour, 6)
+        np.testing.assert_equal(xyY_to_munsell_colour_Onnx(xyY), munsell_colour)
+
+        xyY = np.reshape(xyY, (2, 3, 3))
+        munsell_colour = np.reshape(munsell_colour, (2, 3))
+        np.testing.assert_equal(xyY_to_munsell_colour_Onnx(xyY), munsell_colour)
+
+        xyY = [0.38736945, 0.35751656, 0.59362000]
+        munsell_colour = xyY_to_munsell_colour_Onnx(xyY)
+
+        xyY = np.tile(xyY, (6, 1))
+        munsell_colour = np.tile(munsell_colour, 6)
+        np.testing.assert_equal(xyY_to_munsell_colour_Onnx(xyY), munsell_colour)
+
+        xyY = np.reshape(xyY, (2, 3, 3))
+        munsell_colour = np.reshape(munsell_colour, (2, 3))
+        np.testing.assert_equal(xyY_to_munsell_colour_Onnx(xyY), munsell_colour)

--- a/colour/notation/munsell/tests/test_value.py
+++ b/colour/notation/munsell/tests/test_value.py
@@ -1,0 +1,634 @@
+"""Define the unit tests for the :mod:`colour.notation.munsell.value` module."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from colour.constants import TOLERANCE_ABSOLUTE_TESTS
+from colour.notation import (
+    munsell_value_ASTMD1535,
+    munsell_value_Ladd1955,
+    munsell_value_McCamy1987,
+    munsell_value_Moon1943,
+    munsell_value_Munsell1933,
+    munsell_value_Priest1920,
+    munsell_value_Saunderson1944,
+)
+from colour.utilities import (
+    domain_range_scale,
+    ignore_numpy_errors,
+)
+
+__author__ = "Colour Developers"
+__copyright__ = "Copyright 2013 Colour Developers"
+__license__ = "BSD-3-Clause - https://opensource.org/licenses/BSD-3-Clause"
+__maintainer__ = "Colour Developers"
+__email__ = "colour-developers@colour-science.org"
+__status__ = "Production"
+
+__all__ = [
+    "TestMunsellValuePriest1920",
+    "TestMunsellValueMunsell1933",
+    "TestMunsellValueMoon1943",
+    "TestMunsellValueSaunderson1944",
+    "TestMunsellValueLadd1955",
+    "TestMunsellValueMcCamy1992",
+    "TestMunsellValueASTMD1535",
+]
+
+
+class TestMunsellValuePriest1920:
+    """
+    Define :func:`colour.notation.munsell.munsell_value_Priest1920` definition
+    unit tests methods.
+    """
+
+    def test_munsell_value_Priest1920(self) -> None:
+        """
+        Test :func:`colour.notation.munsell.munsell_value_Priest1920`
+        definition.
+        """
+
+        np.testing.assert_allclose(
+            munsell_value_Priest1920(12.23634268),
+            3.498048410185314,
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+        np.testing.assert_allclose(
+            munsell_value_Priest1920(22.89399987),
+            4.7847674833788947,
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+        np.testing.assert_allclose(
+            munsell_value_Priest1920(6.29022535),
+            2.5080321668591092,
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+    def test_n_dimensional_munsell_value_Priest1920(self) -> None:
+        """
+        Test :func:`colour.notation.munsell.munsell_value_Priest1920`
+        definition n-dimensional arrays support.
+        """
+
+        Y = 12.23634268
+        V = munsell_value_Priest1920(Y)
+
+        V = np.tile(V, 6)
+        Y = np.tile(Y, 6)
+        np.testing.assert_allclose(
+            munsell_value_Priest1920(Y), V, atol=TOLERANCE_ABSOLUTE_TESTS
+        )
+
+        V = np.reshape(V, (2, 3))
+        Y = np.reshape(Y, (2, 3))
+        np.testing.assert_allclose(
+            munsell_value_Priest1920(Y), V, atol=TOLERANCE_ABSOLUTE_TESTS
+        )
+
+        V = np.reshape(V, (2, 3, 1))
+        Y = np.reshape(Y, (2, 3, 1))
+        np.testing.assert_allclose(
+            munsell_value_Priest1920(Y), V, atol=TOLERANCE_ABSOLUTE_TESTS
+        )
+
+    def test_domain_range_scale_munsell_value_Priest1920(self) -> None:
+        """
+        Test :func:`colour.notation.munsell.munsell_value_Priest1920`
+        definition domain and range scale support.
+        """
+
+        Y = 12.23634268
+        V = munsell_value_Priest1920(Y)
+
+        d_r = (("reference", 1, 1), ("1", 0.01, 0.1), ("100", 1, 10))
+        for scale, factor_a, factor_b in d_r:
+            with domain_range_scale(scale):
+                np.testing.assert_allclose(
+                    munsell_value_Priest1920(Y * factor_a),
+                    V * factor_b,
+                    atol=TOLERANCE_ABSOLUTE_TESTS,
+                )
+
+    @ignore_numpy_errors
+    def test_nan_munsell_value_Priest1920(self) -> None:
+        """
+        Test :func:`colour.notation.munsell.munsell_value_Priest1920`
+        definition nan support.
+        """
+
+        munsell_value_Priest1920(np.array([-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan]))
+
+
+class TestMunsellValueMunsell1933:
+    """
+    Define :func:`colour.notation.munsell.munsell_value_Munsell1933`
+    definition unit tests methods.
+    """
+
+    def test_munsell_value_Munsell1933(self) -> None:
+        """
+        Test :func:`colour.notation.munsell.munsell_value_Munsell1933`
+        definition.
+        """
+
+        np.testing.assert_allclose(
+            munsell_value_Munsell1933(12.23634268),
+            4.1627702416858083,
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+        np.testing.assert_allclose(
+            munsell_value_Munsell1933(22.89399987),
+            5.5914543020790592,
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+        np.testing.assert_allclose(
+            munsell_value_Munsell1933(6.29022535),
+            3.0141971134091761,
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+    def test_n_dimensional_munsell_value_Munsell1933(self) -> None:
+        """
+        Test :func:`colour.notation.munsell.munsell_value_Munsell1933`
+        definition n-dimensional arrays support.
+        """
+
+        Y = 12.23634268
+        V = munsell_value_Munsell1933(Y)
+
+        V = np.tile(V, 6)
+        Y = np.tile(Y, 6)
+        np.testing.assert_allclose(
+            munsell_value_Munsell1933(Y), V, atol=TOLERANCE_ABSOLUTE_TESTS
+        )
+
+        V = np.reshape(V, (2, 3))
+        Y = np.reshape(Y, (2, 3))
+        np.testing.assert_allclose(
+            munsell_value_Munsell1933(Y), V, atol=TOLERANCE_ABSOLUTE_TESTS
+        )
+
+        V = np.reshape(V, (2, 3, 1))
+        Y = np.reshape(Y, (2, 3, 1))
+        np.testing.assert_allclose(
+            munsell_value_Munsell1933(Y), V, atol=TOLERANCE_ABSOLUTE_TESTS
+        )
+
+    def test_domain_range_scale_munsell_value_Munsell1933(self) -> None:
+        """
+        Test :func:`colour.notation.munsell.munsell_value_Munsell1933`
+        definition domain and range scale support.
+        """
+
+        Y = 12.23634268
+        V = munsell_value_Munsell1933(Y)
+
+        d_r = (("reference", 1, 1), ("1", 0.01, 0.1), ("100", 1, 10))
+        for scale, factor_a, factor_b in d_r:
+            with domain_range_scale(scale):
+                np.testing.assert_allclose(
+                    munsell_value_Munsell1933(Y * factor_a),
+                    V * factor_b,
+                    atol=TOLERANCE_ABSOLUTE_TESTS,
+                )
+
+    @ignore_numpy_errors
+    def test_nan_munsell_value_Munsell1933(self) -> None:
+        """
+        Test :func:`colour.notation.munsell.munsell_value_Munsell1933`
+        definition nan support.
+        """
+
+        munsell_value_Munsell1933(np.array([-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan]))
+
+
+class TestMunsellValueMoon1943:
+    """
+    Define :func:`colour.notation.munsell.munsell_value_Moon1943` definition
+    unit tests methods.
+    """
+
+    def test_munsell_value_Moon1943(self) -> None:
+        """
+        Test :func:`colour.notation.munsell.munsell_value_Moon1943`
+        definition.
+        """
+
+        np.testing.assert_allclose(
+            munsell_value_Moon1943(12.23634268),
+            4.0688120634976421,
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+        np.testing.assert_allclose(
+            munsell_value_Moon1943(22.89399987),
+            5.3133627855494412,
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+        np.testing.assert_allclose(
+            munsell_value_Moon1943(6.29022535),
+            3.0645015037679695,
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+    def test_n_dimensional_munsell_value_Moon1943(self) -> None:
+        """
+        Test :func:`colour.notation.munsell.munsell_value_Moon1943`
+        definition n-dimensional arrays support.
+        """
+
+        Y = 12.23634268
+        V = munsell_value_Moon1943(Y)
+
+        V = np.tile(V, 6)
+        Y = np.tile(Y, 6)
+        np.testing.assert_allclose(
+            munsell_value_Moon1943(Y), V, atol=TOLERANCE_ABSOLUTE_TESTS
+        )
+
+        V = np.reshape(V, (2, 3))
+        Y = np.reshape(Y, (2, 3))
+        np.testing.assert_allclose(
+            munsell_value_Moon1943(Y), V, atol=TOLERANCE_ABSOLUTE_TESTS
+        )
+
+        V = np.reshape(V, (2, 3, 1))
+        Y = np.reshape(Y, (2, 3, 1))
+        np.testing.assert_allclose(
+            munsell_value_Moon1943(Y), V, atol=TOLERANCE_ABSOLUTE_TESTS
+        )
+
+    def test_domain_range_scale_munsell_value_Moon1943(self) -> None:
+        """
+        Test :func:`colour.notation.munsell.munsell_value_Moon1943`
+        definition domain and range scale support.
+        """
+
+        Y = 12.23634268
+        V = munsell_value_Moon1943(Y)
+
+        d_r = (("reference", 1, 1), ("1", 0.01, 0.1), ("100", 1, 10))
+        for scale, factor_a, factor_b in d_r:
+            with domain_range_scale(scale):
+                np.testing.assert_allclose(
+                    munsell_value_Moon1943(Y * factor_a),
+                    V * factor_b,
+                    atol=TOLERANCE_ABSOLUTE_TESTS,
+                )
+
+    @ignore_numpy_errors
+    def test_nan_munsell_value_Moon1943(self) -> None:
+        """
+        Test :func:`colour.notation.munsell.munsell_value_Moon1943`
+        definition nan support.
+        """
+
+        munsell_value_Moon1943(np.array([-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan]))
+
+
+class TestMunsellValueSaunderson1944:
+    """
+    Define :func:`colour.notation.munsell.munsell_value_Saunderson1944`
+    definition unit tests methods.
+    """
+
+    def test_munsell_value_Saunderson1944(self) -> None:
+        """
+        Test :func:`colour.notation.munsell.munsell_value_Saunderson1944`
+        definition.
+        """
+
+        np.testing.assert_allclose(
+            munsell_value_Saunderson1944(12.23634268),
+            4.0444736723175119,
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+        np.testing.assert_allclose(
+            munsell_value_Saunderson1944(22.89399987),
+            5.3783324022305923,
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+        np.testing.assert_allclose(
+            munsell_value_Saunderson1944(6.29022535),
+            2.9089633927316823,
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+    def test_n_dimensional_munsell_value_Saunderson1944(self) -> None:
+        """
+        Test :func:`colour.notation.munsell.munsell_value_Saunderson1944`
+        definition n-dimensional arrays support.
+        """
+
+        Y = 12.23634268
+        V = munsell_value_Saunderson1944(Y)
+
+        V = np.tile(V, 6)
+        Y = np.tile(Y, 6)
+        np.testing.assert_allclose(
+            munsell_value_Saunderson1944(Y), V, atol=TOLERANCE_ABSOLUTE_TESTS
+        )
+
+        V = np.reshape(V, (2, 3))
+        Y = np.reshape(Y, (2, 3))
+        np.testing.assert_allclose(
+            munsell_value_Saunderson1944(Y), V, atol=TOLERANCE_ABSOLUTE_TESTS
+        )
+
+        V = np.reshape(V, (2, 3, 1))
+        Y = np.reshape(Y, (2, 3, 1))
+        np.testing.assert_allclose(
+            munsell_value_Saunderson1944(Y), V, atol=TOLERANCE_ABSOLUTE_TESTS
+        )
+
+    def test_domain_range_scale_munsell_value_Saunderson1944(self) -> None:
+        """
+        Test :func:`colour.notation.munsell.munsell_value_Saunderson1944`
+        definition domain and range scale support.
+        """
+
+        Y = 12.23634268
+        V = munsell_value_Saunderson1944(Y)
+
+        d_r = (("reference", 1, 1), ("1", 0.01, 0.1), ("100", 1, 10))
+        for scale, factor_a, factor_b in d_r:
+            with domain_range_scale(scale):
+                np.testing.assert_allclose(
+                    munsell_value_Saunderson1944(Y * factor_a),
+                    V * factor_b,
+                    atol=TOLERANCE_ABSOLUTE_TESTS,
+                )
+
+    @ignore_numpy_errors
+    def test_nan_munsell_value_Saunderson1944(self) -> None:
+        """
+        Test :func:`colour.notation.munsell.munsell_value_Saunderson1944`
+        definition nan support.
+        """
+
+        munsell_value_Saunderson1944(
+            np.array([-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan])
+        )
+
+
+class TestMunsellValueLadd1955:
+    """
+    Define :func:`colour.notation.munsell.munsell_value_Ladd1955` definition
+    unit tests methods.
+    """
+
+    def test_munsell_value_Ladd1955(self) -> None:
+        """
+        Test :func:`colour.notation.munsell.munsell_value_Ladd1955`
+        definition.
+        """
+
+        np.testing.assert_allclose(
+            munsell_value_Ladd1955(12.23634268),
+            4.0511633044287088,
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+        np.testing.assert_allclose(
+            munsell_value_Ladd1955(22.89399987),
+            5.3718647913936772,
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+        np.testing.assert_allclose(
+            munsell_value_Ladd1955(6.29022535),
+            2.9198269939751613,
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+    def test_n_dimensional_munsell_value_Ladd1955(self) -> None:
+        """
+        Test :func:`colour.notation.munsell.munsell_value_Ladd1955`
+        definition n-dimensional arrays support.
+        """
+
+        Y = 12.23634268
+        V = munsell_value_Ladd1955(Y)
+
+        V = np.tile(V, 6)
+        Y = np.tile(Y, 6)
+        np.testing.assert_allclose(
+            munsell_value_Ladd1955(Y), V, atol=TOLERANCE_ABSOLUTE_TESTS
+        )
+
+        V = np.reshape(V, (2, 3))
+        Y = np.reshape(Y, (2, 3))
+        np.testing.assert_allclose(
+            munsell_value_Ladd1955(Y), V, atol=TOLERANCE_ABSOLUTE_TESTS
+        )
+
+        V = np.reshape(V, (2, 3, 1))
+        Y = np.reshape(Y, (2, 3, 1))
+        np.testing.assert_allclose(
+            munsell_value_Ladd1955(Y), V, atol=TOLERANCE_ABSOLUTE_TESTS
+        )
+
+    def test_domain_range_scale_munsell_value_Ladd1955(self) -> None:
+        """
+        Test :func:`colour.notation.munsell.munsell_value_Ladd1955`
+        definition domain and range scale support.
+        """
+
+        Y = 12.23634268
+        V = munsell_value_Ladd1955(Y)
+
+        d_r = (("reference", 1, 1), ("1", 0.01, 0.1), ("100", 1, 10))
+        for scale, factor_a, factor_b in d_r:
+            with domain_range_scale(scale):
+                np.testing.assert_allclose(
+                    munsell_value_Ladd1955(Y * factor_a),
+                    V * factor_b,
+                    atol=TOLERANCE_ABSOLUTE_TESTS,
+                )
+
+    @ignore_numpy_errors
+    def test_nan_munsell_value_Ladd1955(self) -> None:
+        """
+        Test :func:`colour.notation.munsell.munsell_value_Ladd1955`
+        definition nan support.
+        """
+
+        munsell_value_Ladd1955(np.array([-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan]))
+
+
+class TestMunsellValueMcCamy1992:
+    """
+    Define :func:`colour.notation.munsell.munsell_value_McCamy1987` definition
+    unit tests methods.
+    """
+
+    def test_munsell_value_McCamy1987(self) -> None:
+        """
+        Test :func:`colour.notation.munsell.munsell_value_McCamy1987`
+        definition.
+        """
+
+        np.testing.assert_allclose(
+            munsell_value_McCamy1987(12.23634268),
+            4.081434853194113,
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+        np.testing.assert_allclose(
+            munsell_value_McCamy1987(22.89399987),
+            5.394083970919982,
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+        np.testing.assert_allclose(
+            munsell_value_McCamy1987(6.29022535),
+            2.9750160800320096,
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+    def test_n_dimensional_munsell_value_McCamy1987(self) -> None:
+        """
+        Test :func:`colour.notation.munsell.munsell_value_McCamy1987`
+        definition n-dimensional arrays support.
+        """
+
+        Y = 12.23634268
+        V = munsell_value_McCamy1987(Y)
+
+        V = np.tile(V, 6)
+        Y = np.tile(Y, 6)
+        np.testing.assert_allclose(
+            munsell_value_McCamy1987(Y), V, atol=TOLERANCE_ABSOLUTE_TESTS
+        )
+
+        V = np.reshape(V, (2, 3))
+        Y = np.reshape(Y, (2, 3))
+        np.testing.assert_allclose(
+            munsell_value_McCamy1987(Y), V, atol=TOLERANCE_ABSOLUTE_TESTS
+        )
+
+        V = np.reshape(V, (2, 3, 1))
+        Y = np.reshape(Y, (2, 3, 1))
+        np.testing.assert_allclose(
+            munsell_value_McCamy1987(Y), V, atol=TOLERANCE_ABSOLUTE_TESTS
+        )
+
+    def test_domain_range_scale_munsell_value_McCamy1987(self) -> None:
+        """
+        Test :func:`colour.notation.munsell.munsell_value_McCamy1987`
+        definition domain and range scale support.
+        """
+
+        Y = 12.23634268
+        V = munsell_value_McCamy1987(Y)
+
+        d_r = (("reference", 1, 1), ("1", 0.01, 0.1), ("100", 1, 10))
+        for scale, factor_a, factor_b in d_r:
+            with domain_range_scale(scale):
+                np.testing.assert_allclose(
+                    munsell_value_McCamy1987(Y * factor_a),
+                    V * factor_b,
+                    atol=TOLERANCE_ABSOLUTE_TESTS,
+                )
+
+    @ignore_numpy_errors
+    def test_nan_munsell_value_McCamy1987(self) -> None:
+        """
+        Test :func:`colour.notation.munsell.munsell_value_McCamy1987`
+        definition nan support.
+        """
+
+        munsell_value_McCamy1987(np.array([-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan]))
+
+
+class TestMunsellValueASTMD1535:
+    """
+    Define :func:`colour.notation.munsell.munsell_value_ASTMD1535`
+    definition unit tests methods.
+    """
+
+    def test_munsell_value_ASTMD1535(self) -> None:
+        """
+        Test :func:`colour.notation.munsell.munsell_value_ASTMD1535`
+        definition.
+        """
+
+        np.testing.assert_allclose(
+            munsell_value_ASTMD1535(12.23634268),
+            4.0824437076525664,
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+        np.testing.assert_allclose(
+            munsell_value_ASTMD1535(22.89399987),
+            5.3913268228155395,
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+        np.testing.assert_allclose(
+            munsell_value_ASTMD1535(6.29022535),
+            2.9761930839606454,
+            atol=TOLERANCE_ABSOLUTE_TESTS,
+        )
+
+    def test_n_dimensional_munsell_value_ASTMD1535(self) -> None:
+        """
+        Test :func:`colour.notation.munsell.munsell_value_ASTMD1535`
+        definition n-dimensional arrays support.
+        """
+
+        Y = 12.23634268
+        V = munsell_value_ASTMD1535(Y)
+
+        V = np.tile(V, 6)
+        Y = np.tile(Y, 6)
+        np.testing.assert_allclose(
+            munsell_value_ASTMD1535(Y), V, atol=TOLERANCE_ABSOLUTE_TESTS
+        )
+
+        V = np.reshape(V, (2, 3))
+        Y = np.reshape(Y, (2, 3))
+        np.testing.assert_allclose(
+            munsell_value_ASTMD1535(Y), V, atol=TOLERANCE_ABSOLUTE_TESTS
+        )
+
+        V = np.reshape(V, (2, 3, 1))
+        Y = np.reshape(Y, (2, 3, 1))
+        np.testing.assert_allclose(
+            munsell_value_ASTMD1535(Y), V, atol=TOLERANCE_ABSOLUTE_TESTS
+        )
+
+    def test_domain_range_scale_munsell_value_ASTMD1535(self) -> None:
+        """
+        Test :func:`colour.notation.munsell.munsell_value_ASTMD1535`
+        definition domain and range scale support.
+        """
+
+        Y = 12.23634268
+        V = munsell_value_ASTMD1535(Y)
+
+        d_r = (("reference", 1, 1), ("1", 0.01, 0.1), ("100", 1, 10))
+        for scale, factor_a, factor_b in d_r:
+            with domain_range_scale(scale):
+                np.testing.assert_allclose(
+                    munsell_value_ASTMD1535(Y * factor_a),
+                    V * factor_b,
+                    atol=TOLERANCE_ABSOLUTE_TESTS,
+                )
+
+    @ignore_numpy_errors
+    def test_nan_munsell_value_ASTMD1535(self) -> None:
+        """
+        Test :func:`colour.notation.munsell.munsell_value_ASTMD1535`
+        definition nan support.
+        """
+
+        munsell_value_ASTMD1535(np.array([-1.0, 0.0, 1.0, -np.inf, np.inf, np.nan]))

--- a/colour/notation/munsell/value.py
+++ b/colour/notation/munsell/value.py
@@ -1,0 +1,574 @@
+"""
+Munsell Value
+=============
+
+Define *Munsell* value computation objects:
+
+-   :func:`colour.notation.munsell_value_Priest1920`: Compute *Munsell* value
+    :math:`V` from the specified *luminance* :math:`Y` using
+    *Priest, Gibson and MacNicholas (1920)* method.
+-   :func:`colour.notation.munsell_value_Munsell1933`: Compute *Munsell* value
+    :math:`V` from the specified *luminance* :math:`Y` using
+    *Munsell, Sloan and Godlove (1933)* method.
+-   :func:`colour.notation.munsell_value_Moon1943`: Compute *Munsell* value
+    :math:`V` from the specified *luminance* :math:`Y` using
+    *Moon and Spencer (1943)* method.
+-   :func:`colour.notation.munsell_value_Saunderson1944`: Compute *Munsell*
+    value :math:`V` from the specified *luminance* :math:`Y` using
+    *Saunderson and Milner (1944)* method.
+-   :func:`colour.notation.munsell_value_Ladd1955`: Compute *Munsell* value
+    :math:`V` from the specified *luminance* :math:`Y` using
+    *Ladd and Pinney (1955)* method.
+-   :func:`colour.notation.munsell_value_McCamy1987`: Compute *Munsell* value
+    :math:`V` from the specified *luminance* :math:`Y` using *McCamy (1987)*
+    method.
+-   :func:`colour.notation.munsell_value_ASTMD1535`: Compute *Munsell* value
+    :math:`V` from the specified *luminance* :math:`Y` using *ASTM D1535-08e1*
+    method.
+-   :attr:`colour.MUNSELL_VALUE_METHODS`: Supported *Munsell* value
+    computation methods.
+-   :func:`colour.munsell_value`: Compute *Munsell* value :math:`V` from
+    specified *luminance* :math:`Y` using the specified method.
+
+References
+----------
+-   :cite:`ASTMInternational1989a` : ASTM International. (1989). ASTM D1535-89
+    - Standard Practice for Specifying Color by the Munsell System (pp. 1-29).
+    Retrieved September 25, 2014, from
+    http://www.astm.org/DATABASE.CART/HISTORICAL/D1535-89.htm
+-   :cite:`Wikipedia2007c` : Nayatani, Y., Sobagaki, H., & Yano, K. H. T.
+    (1995). Lightness dependency of chroma scales of a nonlinear
+    color-appearance model and its latest formulation. Color Research &
+    Application, 20(3), 156-167. doi:10.1002/col.5080200305
+"""
+
+from __future__ import annotations
+
+import typing
+
+import numpy as np
+
+from colour.algebra import (
+    Extrapolator,
+    LinearInterpolator,
+    sdiv,
+    sdiv_mode,
+    spow,
+)
+from colour.colorimetry import luminance_ASTMD1535
+
+if typing.TYPE_CHECKING:
+    from colour.hints import (
+        Domain100,
+        Literal,
+        Range10,
+    )
+
+from colour.utilities import (
+    CACHE_REGISTRY,
+    CanonicalMapping,
+    as_float,
+    from_range_10,
+    to_domain_100,
+    validate_method,
+)
+
+__author__ = "Colour Developers"
+__copyright__ = "Copyright 2013 Colour Developers"
+__license__ = "BSD-3-Clause - https://opensource.org/licenses/BSD-3-Clause"
+__maintainer__ = "Colour Developers"
+__email__ = "colour-developers@colour-science.org"
+__status__ = "Production"
+
+__all__ = [
+    "munsell_value_Priest1920",
+    "munsell_value_Munsell1933",
+    "munsell_value_Moon1943",
+    "munsell_value_Saunderson1944",
+    "munsell_value_Ladd1955",
+    "munsell_value_McCamy1987",
+    "munsell_value_ASTMD1535",
+    "MUNSELL_VALUE_METHODS",
+    "munsell_value",
+]
+
+_CACHE_MUNSELL_VALUE_ASTM_D1535_08_INTERPOLATOR: dict = CACHE_REGISTRY.register_cache(
+    f"{__name__}._CACHE_MUNSELL_VALUE_ASTM_D1535_08_INTERPOLATOR"
+)
+
+
+def _munsell_value_ASTMD1535_interpolator() -> Extrapolator:
+    """
+    Return the *Munsell* value interpolator for the *ASTM D1535-08e1*
+    method, caching it if not existing.
+
+    Returns
+    -------
+    :class:`colour.Extrapolator`
+        *Munsell* value interpolator for the *ASTM D1535-08e1* method.
+    """
+
+    global _CACHE_MUNSELL_VALUE_ASTM_D1535_08_INTERPOLATOR  # noqa: PLW0602
+
+    if "ASTM D1535-08 Interpolator" in (
+        _CACHE_MUNSELL_VALUE_ASTM_D1535_08_INTERPOLATOR
+    ):
+        return _CACHE_MUNSELL_VALUE_ASTM_D1535_08_INTERPOLATOR[
+            "ASTM D1535-08 Interpolator"
+        ]
+
+    munsell_values = np.arange(0, 10, 0.001)
+    interpolator = LinearInterpolator(
+        luminance_ASTMD1535(munsell_values), munsell_values
+    )
+    extrapolator = Extrapolator(interpolator)
+
+    _CACHE_MUNSELL_VALUE_ASTM_D1535_08_INTERPOLATOR["ASTM D1535-08 Interpolator"] = (
+        extrapolator
+    )
+
+    return extrapolator
+
+
+def munsell_value_Priest1920(
+    Y: Domain100,
+) -> Range10:
+    """
+    Compute the *Munsell* value :math:`V` from the specified *luminance*
+    :math:`Y` using *Priest et al. (1920)* method.
+
+    Parameters
+    ----------
+    Y
+        *Luminance* :math:`Y`.
+
+    Returns
+    -------
+    :class:`np.float` or :class:`numpy.NDArrayFloat`
+        *Munsell* value :math:`V`.
+
+    Notes
+    -----
+    +------------+-----------------------+---------------+
+    | **Domain** | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``Y``      | 100                   | 1             |
+    +------------+-----------------------+---------------+
+
+    +------------+-----------------------+---------------+
+    | **Range**  | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``V``      | 10                    | 1             |
+    +------------+-----------------------+---------------+
+
+    References
+    ----------
+    :cite:`Wikipedia2007c`
+
+    Examples
+    --------
+    >>> munsell_value_Priest1920(12.23634268)  # doctest: +ELLIPSIS
+    np.float64(3.4980484...)
+    """
+
+    Y = to_domain_100(Y)
+
+    V = 10 * np.sqrt(Y / 100)
+
+    return as_float(from_range_10(V))
+
+
+def munsell_value_Munsell1933(
+    Y: Domain100,
+) -> Range10:
+    """
+    Compute *Munsell* value :math:`V` from the specified *luminance* :math:`Y`
+    using *Munsell et al. (1933)* method.
+
+    Parameters
+    ----------
+    Y
+        *Luminance* :math:`Y`.
+
+    Returns
+    -------
+    :class:`np.float` or :class:`numpy.NDArrayFloat`
+        *Munsell* value :math:`V`.
+
+    Notes
+    -----
+    +------------+-----------------------+---------------+
+    | **Domain** | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``Y``      | 100                   | 1             |
+    +------------+-----------------------+---------------+
+
+    +------------+-----------------------+---------------+
+    | **Range**  | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``V``      | 10                    | 1             |
+    +------------+-----------------------+---------------+
+
+    References
+    ----------
+    :cite:`Wikipedia2007c`
+
+    Examples
+    --------
+    >>> munsell_value_Munsell1933(12.23634268)  # doctest: +ELLIPSIS
+    np.float64(4.1627702...)
+    """
+
+    Y = to_domain_100(Y)
+
+    V = np.sqrt(1.4742 * Y - 0.004743 * (Y * Y))
+
+    return as_float(from_range_10(V))
+
+
+def munsell_value_Moon1943(Y: Domain100) -> Range10:
+    """
+    Compute *Munsell* value :math:`V` from the specified *luminance* :math:`Y`
+    using *Moon and Spencer (1943)* method.
+
+    Parameters
+    ----------
+    Y
+        *Luminance* :math:`Y`.
+
+    Returns
+    -------
+    :class:`np.float` or :class:`numpy.NDArrayFloat`
+        *Munsell* value :math:`V`.
+
+    Notes
+    -----
+    +------------+-----------------------+---------------+
+    | **Domain** | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``Y``      | 100                   | 1             |
+    +------------+-----------------------+---------------+
+
+    +------------+-----------------------+---------------+
+    | **Range**  | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``V``      | 10                    | 1             |
+    +------------+-----------------------+---------------+
+
+    References
+    ----------
+    :cite:`Wikipedia2007c`
+
+    Examples
+    --------
+    >>> munsell_value_Moon1943(12.23634268)  # doctest: +ELLIPSIS
+    np.float64(4.0688120...)
+    """
+
+    Y = to_domain_100(Y)
+
+    V = 1.4 * spow(Y, 0.426)
+
+    return as_float(from_range_10(V))
+
+
+def munsell_value_Saunderson1944(
+    Y: Domain100,
+) -> Range10:
+    """
+    Compute the *Munsell* value :math:`V` from the specified *luminance* :math:`Y`
+    using *Saunderson and Milner (1944)* method.
+
+    Parameters
+    ----------
+    Y
+        *Luminance* :math:`Y`.
+
+    Returns
+    -------
+    :class:`np.float` or :class:`numpy.NDArrayFloat`
+        *Munsell* value :math:`V`.
+
+    Notes
+    -----
+    +------------+-----------------------+---------------+
+    | **Domain** | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``Y``      | 100                   | 1             |
+    +------------+-----------------------+---------------+
+
+    +------------+-----------------------+---------------+
+    | **Range**  | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``V``      | 10                    | 1             |
+    +------------+-----------------------+---------------+
+
+    References
+    ----------
+    :cite:`Wikipedia2007c`
+
+    Examples
+    --------
+    >>> munsell_value_Saunderson1944(12.23634268)  # doctest: +ELLIPSIS
+    np.float64(4.0444736...)
+    """
+
+    Y = to_domain_100(Y)
+
+    V = 2.357 * spow(Y, 0.343) - 1.52
+
+    return as_float(from_range_10(V))
+
+
+def munsell_value_Ladd1955(Y: Domain100) -> Range10:
+    """
+    Compute *Munsell* value :math:`V` from the specified *luminance* :math:`Y`
+    using *Ladd and Pinney (1955)* method.
+
+    Parameters
+    ----------
+    Y
+        *Luminance* :math:`Y`.
+
+    Returns
+    -------
+    :class:`np.float` or :class:`numpy.NDArrayFloat`
+        *Munsell* value :math:`V`.
+
+    Notes
+    -----
+    +------------+-----------------------+---------------+
+    | **Domain** | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``Y``      | 100                   | 1             |
+    +------------+-----------------------+---------------+
+
+    +------------+-----------------------+---------------+
+    | **Range**  | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``V``      | 10                    | 1             |
+    +------------+-----------------------+---------------+
+
+    References
+    ----------
+    :cite:`Wikipedia2007c`
+
+    Examples
+    --------
+    >>> munsell_value_Ladd1955(12.23634268)  # doctest: +ELLIPSIS
+    np.float64(4.0511633...)
+    """
+
+    Y = to_domain_100(Y)
+
+    V = 2.468 * spow(Y, 1 / 3) - 1.636
+
+    return as_float(from_range_10(V))
+
+
+def munsell_value_McCamy1987(
+    Y: Domain100,
+) -> Range10:
+    """
+    Compute *Munsell* value :math:`V` from the specified *luminance* :math:`Y`
+    using *McCamy (1987)* method.
+
+    Parameters
+    ----------
+    Y
+        *Luminance* :math:`Y`.
+
+    Returns
+    -------
+    :class:`np.float` or :class:`numpy.NDArrayFloat`
+        *Munsell* value :math:`V`.
+
+    Notes
+    -----
+    +------------+-----------------------+---------------+
+    | **Domain** | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``Y``      | 100                   | 1             |
+    +------------+-----------------------+---------------+
+
+    +------------+-----------------------+---------------+
+    | **Range**  | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``V``      | 10                    | 1             |
+    +------------+-----------------------+---------------+
+
+    References
+    ----------
+    :cite:`ASTMInternational1989a`
+
+    Examples
+    --------
+    >>> munsell_value_McCamy1987(12.23634268)  # doctest: +ELLIPSIS
+    np.float64(4.0814348...)
+    """
+
+    Y = to_domain_100(Y)
+
+    with sdiv_mode():
+        V = np.where(
+            Y <= 0.9,
+            0.87445 * spow(Y, 0.9967),
+            2.49268 * spow(Y, 1 / 3)
+            - 1.5614
+            - (0.985 / (((0.1073 * Y - 3.084) ** 2) + 7.54))
+            + sdiv(0.0133, spow(Y, 2.3))
+            + 0.0084 * np.sin(4.1 * spow(Y, 1 / 3) + 1)
+            + sdiv(0.0221, Y) * np.sin(0.39 * (Y - 2))
+            - (sdiv(0.0037, 0.44 * Y)) * np.sin(1.28 * (Y - 0.53)),
+        )
+
+    return as_float(from_range_10(V))
+
+
+def munsell_value_ASTMD1535(
+    Y: Domain100,
+) -> Range10:
+    """
+    Compute the *Munsell* value :math:`V` from the specified *luminance*
+    :math:`Y` using an inverse lookup table from *ASTM D1535-08e1* method.
+
+    Parameters
+    ----------
+    Y
+        *Luminance* :math:`Y`.
+
+    Returns
+    -------
+    :class:`np.float` or :class:`numpy.NDArrayFloat`
+        *Munsell* value :math:`V`.
+
+    Notes
+    -----
+    +------------+-----------------------+---------------+
+    | **Domain** | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``Y``      | 100                   | 1             |
+    +------------+-----------------------+---------------+
+
+    +------------+-----------------------+---------------+
+    | **Range**  | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``V``      | 10                    | 1             |
+    +------------+-----------------------+---------------+
+
+    -   The *Munsell* value computation with *ASTM D1535-08e1* method is
+        only defined for domain [0, 100].
+
+    References
+    ----------
+    :cite:`ASTMInternational1989a`
+
+    Examples
+    --------
+    >>> munsell_value_ASTMD1535(12.23634268)  # doctest: +ELLIPSIS
+    np.float64(4.0824437...)
+    """
+
+    Y = to_domain_100(Y)
+
+    V = _munsell_value_ASTMD1535_interpolator()(Y)
+
+    return as_float(from_range_10(V))
+
+
+MUNSELL_VALUE_METHODS: CanonicalMapping = CanonicalMapping(
+    {
+        "Priest 1920": munsell_value_Priest1920,
+        "Munsell 1933": munsell_value_Munsell1933,
+        "Moon 1943": munsell_value_Moon1943,
+        "Saunderson 1944": munsell_value_Saunderson1944,
+        "Ladd 1955": munsell_value_Ladd1955,
+        "McCamy 1987": munsell_value_McCamy1987,
+        "ASTM D1535": munsell_value_ASTMD1535,
+    }
+)
+MUNSELL_VALUE_METHODS.__doc__ = """
+Supported *Munsell* value computation methods.
+
+References
+----------
+:cite:`ASTMInternational1989a`, :cite:`Wikipedia2007c`
+
+Aliases:
+
+-   'astm2008': 'ASTM D1535'
+"""
+MUNSELL_VALUE_METHODS["astm2008"] = MUNSELL_VALUE_METHODS["ASTM D1535"]
+
+
+def munsell_value(
+    Y: Domain100,
+    method: (
+        Literal[
+            "ASTM D1535",
+            "Ladd 1955",
+            "McCamy 1987",
+            "Moon 1943",
+            "Munsell 1933",
+            "Priest 1920",
+            "Saunderson 1944",
+        ]
+        | str
+    ) = "ASTM D1535",
+) -> Range10:
+    """
+    Compute the *Munsell* value :math:`V` from the specified *luminance*
+    :math:`Y` using the specified computational method.
+
+    Parameters
+    ----------
+    Y
+        *Luminance* :math:`Y`.
+    method
+        Computation method.
+
+    Returns
+    -------
+    :class:`np.float` or :class:`numpy.NDArrayFloat`
+        *Munsell* value :math:`V`.
+
+    Notes
+    -----
+    +------------+-----------------------+---------------+
+    | **Domain** | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``Y``      | 100                   | 1             |
+    +------------+-----------------------+---------------+
+
+    +------------+-----------------------+---------------+
+    | **Range**  | **Scale - Reference** | **Scale - 1** |
+    +============+=======================+===============+
+    | ``V``      | 10                    | 1             |
+    +------------+-----------------------+---------------+
+
+    References
+    ----------
+    :cite:`ASTMInternational1989a`, :cite:`Wikipedia2007c`
+
+    Examples
+    --------
+    >>> munsell_value(12.23634268)  # doctest: +ELLIPSIS
+    np.float64(4.0824437...)
+    >>> munsell_value(12.23634268, method="Priest 1920")  # doctest: +ELLIPSIS
+    np.float64(3.4980484...)
+    >>> munsell_value(12.23634268, method="Munsell 1933")  # doctest: +ELLIPSIS
+    np.float64(4.1627702...)
+    >>> munsell_value(12.23634268, method="Moon 1943")  # doctest: +ELLIPSIS
+    np.float64(4.0688120...)
+    >>> munsell_value(12.23634268, method="Saunderson 1944")
+    ... # doctest: +ELLIPSIS
+    np.float64(4.0444736...)
+    >>> munsell_value(12.23634268, method="Ladd 1955")  # doctest: +ELLIPSIS
+    np.float64(4.0511633...)
+    >>> munsell_value(12.23634268, method="McCamy 1987")  # doctest: +ELLIPSIS
+    np.float64(4.0814348...)
+    """
+
+    method = validate_method(method, tuple(MUNSELL_VALUE_METHODS))
+
+    return MUNSELL_VALUE_METHODS[method](Y)

--- a/colour/utilities/__init__.py
+++ b/colour/utilities/__init__.py
@@ -46,6 +46,7 @@ from .requirements import (
     is_imageio_installed,
     is_matplotlib_installed,
     is_networkx_installed,
+    is_onnxruntime_installed,
     is_opencolorio_installed,
     is_openimageio_installed,
     is_pandas_installed,
@@ -147,6 +148,7 @@ from .array import (
     tstack,
     zeros,
 )
+from .common import download_url, hash_sha256
 from .metrics import metric_mse, metric_psnr
 from .network import (
     ControlFlowNode,
@@ -201,6 +203,7 @@ __all__ += [
     "is_matplotlib_installed",
     "is_networkx_installed",
     "is_opencolorio_installed",
+    "is_onnxruntime_installed",
     "is_openimageio_installed",
     "is_pandas_installed",
     "is_pydot_installed",
@@ -298,6 +301,10 @@ __all__ += [
 __all__ += [
     "metric_mse",
     "metric_psnr",
+]
+__all__ += [
+    "hash_sha256",
+    "download_url",
 ]
 __all__ += [
     "ControlFlowNode",

--- a/colour/utilities/common.py
+++ b/colour/utilities/common.py
@@ -19,16 +19,20 @@ numpyerrors.html
 from __future__ import annotations
 
 import functools
+import hashlib
 import inspect
 import os
 import re
 import types
 import typing
 import unicodedata
+import urllib.error
+import urllib.request
 import warnings
 from contextlib import contextmanager
 from copy import copy
 from pprint import pformat
+from urllib.parse import urlparse
 
 import numpy as np
 
@@ -86,6 +90,8 @@ __all__ = [
     "optional",
     "slugify",
     "int_digest",
+    "hash_sha256",
+    "download_url",
 ]
 
 _CACHING_ENABLED: bool = not as_bool(
@@ -1128,3 +1134,129 @@ if is_xxhash_installed():
     int_digest = xxhash.xxh3_64_intdigest
 else:
     int_digest = hash  # pragma: no cover
+
+
+def hash_sha256(filename: str, chunk_size: int = 2**16) -> str:
+    """
+    Compute the *SHA-256* hash of given file.
+
+    Parameters
+    ----------
+    filename
+        File to compute the hash of.
+    chunk_size
+        Chunk size to read from the file.
+
+    Returns
+    -------
+    :class:`str`
+        *SHA-256* hash of the file.
+    """
+
+    sha256 = hashlib.sha256()
+
+    with open(filename, "rb") as file_object:
+        while True:
+            chunk = file_object.read(chunk_size)
+            if not chunk:
+                break
+
+            sha256.update(chunk)
+
+    return sha256.hexdigest()
+
+
+def download_url(
+    url: str,
+    cache_dir: str | None = None,
+    sha256: str | None = None,
+    retries: int = 6,
+) -> str:
+    """
+    Download a file from *url* and cache it locally.
+
+    Parameters
+    ----------
+    url
+        URL to download.
+    cache_dir
+        Override directory for caching. Defaults to
+        :attr:`colour.ROOT_COLOUR_SCIENCE`.
+    sha256
+        Expected *SHA-256* hash of the file. If provided, the downloaded
+        file will be verified and re-downloaded on mismatch.
+    retries
+        Number of retries in case of network errors or hash mismatches.
+
+    Returns
+    -------
+    :class:`str`
+        Absolute path to the cached file.
+    """
+
+    import colour  # noqa: PLC0415
+
+    root = cache_dir if cache_dir is not None else colour.ROOT_COLOUR_SCIENCE
+
+    parsed = urlparse(url)
+    relative = parsed.path.lstrip("/")
+
+    # Strip the HuggingFace URL prefix to get a clean local path,
+    # e.g., ``colour-science/learning-munsell/resolve/main/models/...``
+    # becomes ``learning-munsell/models/...``.
+    prefix = "colour-science/"
+    relative = relative.removeprefix(prefix)
+
+    resolve_main = "/resolve/main/"
+    if resolve_main in relative:
+        parts = relative.split(resolve_main, 1)
+        relative = f"{parts[0]}/{parts[1]}"
+
+    local_path = os.path.join(root, relative)
+
+    if os.path.isfile(local_path):
+        if sha256 is not None and hash_sha256(local_path) != sha256.lower():
+            os.remove(local_path)
+        else:
+            return local_path
+
+    os.makedirs(os.path.dirname(local_path), exist_ok=True)
+
+    attempt = 0
+    while attempt < retries:
+        try:
+            with (
+                urllib.request.urlopen(url) as response,  # noqa: S310
+                open(local_path, "wb") as out_file,
+            ):
+                while True:
+                    chunk = response.read(2**16)
+                    if not chunk:
+                        break
+                    out_file.write(chunk)
+
+            if sha256 is not None:
+                actual_hash = hash_sha256(local_path)
+                if actual_hash != sha256.lower():
+                    file_size = os.path.getsize(local_path)
+                    os.remove(local_path)
+
+                    message = (
+                        f'"SHA-256" hash of "{local_path}" file '
+                        f"({file_size} bytes) does not match the "
+                        f"expected hash: "
+                        f"{actual_hash} != {sha256.lower()}"
+                    )
+                    raise ValueError(message)  # noqa: TRY301
+        except (urllib.error.URLError, OSError, ValueError):
+            attempt += 1
+            if attempt == retries:
+                raise
+
+            import time  # noqa: PLC0415
+
+            time.sleep(min(2**attempt, 2**8))
+        else:
+            return local_path
+
+    return local_path

--- a/colour/utilities/requirements.py
+++ b/colour/utilities/requirements.py
@@ -40,6 +40,7 @@ __all__ = [
     "is_scipy_installed",
     "is_tqdm_installed",
     "is_trimesh_installed",
+    "is_onnxruntime_installed",
     "is_xxhash_installed",
     "REQUIREMENTS_TO_CALLABLE",
     "required",
@@ -475,6 +476,43 @@ def is_trimesh_installed(raise_exception: bool = False) -> bool:
         return True
 
 
+def is_onnxruntime_installed(raise_exception: bool = False) -> bool:
+    """
+    Determine whether *ONNX Runtime* is installed and available.
+
+    Parameters
+    ----------
+    raise_exception
+        Whether to raise an exception if *ONNX Runtime* is unavailable.
+
+    Returns
+    -------
+    :class:`bool`
+        Whether *ONNX Runtime* is installed.
+
+    Raises
+    ------
+    :class:`ImportError`
+        If *ONNX Runtime* is not installed.
+    """
+
+    try:  # pragma: no cover
+        import onnxruntime  # noqa: F401, PLC0415
+    except ImportError as exception:  # pragma: no cover
+        if raise_exception:
+            error = (
+                '"ONNX Runtime" related API features are not available: '
+                f'"{exception}".\nSee the installation guide for more information: '
+                "https://www.colour-science.org/installation-guide/"
+            )
+
+            raise ImportError(error) from exception
+
+        return False
+    else:
+        return True
+
+
 def is_xxhash_installed(raise_exception: bool = False) -> bool:
     """
     Determine whether *xxhash* is installed and available.
@@ -522,6 +560,7 @@ REQUIREMENTS_TO_CALLABLE: CanonicalMapping = CanonicalMapping(
         "OpenColorIO": is_opencolorio_installed,
         "Pandas": is_pandas_installed,
         "Pydot": is_pydot_installed,
+        "onnxruntime": is_onnxruntime_installed,
         "SciPy": is_scipy_installed,
         "tqdm": is_tqdm_installed,
         "trimesh": is_trimesh_installed,
@@ -540,6 +579,7 @@ def required(
         "OpenImageIO",
         "Matplotlib",
         "NetworkX",
+        "onnxruntime",
         "OpenColorIO",
         "Pandas",
         "Pydot",

--- a/colour/utilities/tests/test_common.py
+++ b/colour/utilities/tests/test_common.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import os
+import shutil
+import tempfile
 import typing
 import unicodedata
 import warnings
@@ -19,9 +22,11 @@ from colour.utilities import (
     attest,
     batch,
     caching_enable,
+    download_url,
     filter_kwargs,
     filter_mapping,
     first_item,
+    hash_sha256,
     ignore_python_warnings,
     int_digest,
     is_caching_enabled,
@@ -621,3 +626,91 @@ class TestIntDigest:
         assert int_digest(np.array([1, 2, 3]).tobytes()) == 8964613590703056768
 
         assert int_digest(repr((1, 2, 3))) == 5069958125469218295
+
+
+class TestHashSha256:
+    """
+    Define :func:`colour.utilities.common.hash_sha256` definition unit
+    tests methods.
+    """
+
+    def test_hash_sha256(self) -> None:
+        """Test :func:`colour.utilities.common.hash_sha256` definition."""
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".txt") as f:
+            f.write(b"colour-science")
+            temp_path = f.name
+
+        try:
+            digest = hash_sha256(temp_path)
+            assert len(digest) == 64
+            assert digest == hash_sha256(temp_path, chunk_size=4)
+        finally:
+            os.remove(temp_path)
+
+
+class TestDownloadUrl:
+    """
+    Define :func:`colour.utilities.common.download_url` definition unit
+    tests methods.
+    """
+
+    def test_download_url(self) -> None:
+        """Test :func:`colour.utilities.common.download_url` definition."""
+
+        cache_dir = tempfile.mkdtemp()
+
+        try:
+            path = download_url(
+                "https://huggingface.co/colour-science/"
+                "learning-munsell/resolve/main/"
+                "models/to_xyY/"
+                "multi_mlp_normalization_parameters.npz",
+                cache_dir=cache_dir,
+            )
+
+            assert os.path.isfile(path)
+            assert "learning-munsell" in path
+            assert "/resolve/main/" not in path
+            assert "colour-science/" not in path
+
+            # Cached second call returns same path.
+            assert (
+                download_url(
+                    "https://huggingface.co/colour-science/"
+                    "learning-munsell/resolve/main/"
+                    "models/to_xyY/"
+                    "multi_mlp_normalization_parameters.npz",
+                    cache_dir=cache_dir,
+                )
+                == path
+            )
+
+            # SHA-256 verification.
+            sha = hash_sha256(path)
+            assert (
+                download_url(
+                    "https://huggingface.co/colour-science/"
+                    "learning-munsell/resolve/main/"
+                    "models/to_xyY/"
+                    "multi_mlp_normalization_parameters.npz",
+                    cache_dir=cache_dir,
+                    sha256=sha,
+                )
+                == path
+            )
+
+            # Wrong SHA-256 triggers re-download and raises.
+            pytest.raises(
+                ValueError,
+                download_url,
+                "https://huggingface.co/colour-science/"
+                "learning-munsell/resolve/main/"
+                "models/to_xyY/"
+                "multi_mlp_normalization_parameters.npz",
+                cache_dir,
+                "0" * 64,
+                1,
+            )
+        finally:
+            shutil.rmtree(cache_dir)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1431,6 +1431,16 @@ Munsell Colour
 
     [0.38736945  0.35751656  0.59362   ]
 
+.. code-block:: python
+
+    import colour
+
+    sorted(colour.XYY_TO_MUNSELL_COLOUR_METHODS)
+
+.. code-block:: text
+
+    ['Centore 2014', 'ONNX']
+
 Optical Phenomena - ``colour.phenomena``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,12 +53,14 @@ optional = [
     "imageio>=2,<3",
     "matplotlib>=3.9",
     "networkx>=3.3,<4",
+    "onnxruntime>=1,<2",
     "opencolorio>=2,<3; python_version < '3.14'",
     "openimageio>=3,<4",
     "pandas>=2.2,<3",
     "pydot>=3,<4",
     "scipy>=1.13.0,<2",
     "tqdm>=4,<5",
+    "trimesh>=4,<5",
     "xxhash>=3,<4",
 ]
 docs = [
@@ -67,9 +69,6 @@ docs = [
     "restructuredtext-lint",
     "sphinx",
     "sphinxcontrib-bibtex",
-]
-meshing = [
-    "trimesh>=4,<5",
 ]
 
 [project.urls]


### PR DESCRIPTION
<!--
Thank you for taking the time to create this pull request. If it is the first
time you are contributing to a colour-science repository, a contributing guide
is available to guide the process: https://www.colour-science.org/contributing/.
-->

# Summary

<!-- Please write a summary describing the changes that this PR implements. -->

Refactor `colour.notation.munsell` from a single module into a package and add *ONNX*-based *Munsell Renotation System* conversions using pre-trained neural networks from the [colour-science/learning-munsell](https://huggingface.co/colour-science/learning-munsell) *HuggingFace* repository.

## Changes

**ONNX-based conversions:**

- `munsell_specification_to_xyY_Onnx`
- `munsell_colour_to_xyY_Onnx`
- `xyY_to_munsell_specification_Onnx`
- `xyY_to_munsell_colour_Onnx`

Models support optional two-stage error correction and classification-based hue code prediction.

**Module restructuring:**

- Split `munsell.py` into a `munsell/` package with `centore2014.py` (existing algorithmic implementation), `value.py` (value functions), and `__init__.py` (public API).

**New utilities:**

- `colour.utilities.models.download_url`: download and cache remote files (e.g., *HuggingFace* model weights).

## Performance

| Conversion                          | Speedup |
|---------------------------|----------|
| *xyY* -> *Munsell* Colour | ~742x     |
| *Munsell* Colour -> *xyY* | ~27x       |

## Comparison

*CIE xyY to Munsell Specification Round-Trip -- Classification Code + Code-Aware Multi-Error Predictor*

<img width="2540" height="759" alt="image" src="https://github.com/user-attachments/assets/d6b1c8a9-a8b9-452b-bc96-2ade92c1a978" />

# Preflight

<!-- Please mark any checkboxes that do not apply to this pull request as [N/A]. -->

**Code Style and Quality**

- [X] Unit tests have been implemented and passed.
- [X] Pyright static checking has been run and passed.
- [X] Pre-commit hooks have been run and passed.
- [N/A] New transformations have been added to the _Automatic Colour Conversion Graph_.
- [X] New transformations have been exported to the relevant namespaces, e.g. `colour`, `colour.models`.

<!-- The unit tests can be invoked with `uv run invoke tests` -->
<!-- Pyright can be started with `uv run pyright --threads --skipunannotated` -->

**Documentation**

- [X] New features are documented along with examples if relevant.
- [X] The documentation is [Sphinx](https://www.sphinx-doc.org/en/master/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant.

<!--
Thank you again!
-->