### PR TITLE
Add wavelengths_strip to plotting functions with wavelengths on x axis.

### DIFF
--- a/colour/plotting/__init__.py
+++ b/colour/plotting/__init__.py
@@ -85,6 +85,7 @@ from .colorimetry import (
     plot_single_luminance_function,
     plot_single_sd,
     plot_visible_spectrum,
+    plot_visible_spectrum_colours,
 )
 from .diagrams import (
     LABELS_CHROMATICITY_DIAGRAM_DEFAULT,
@@ -212,6 +213,7 @@ __all__ += [
     "plot_single_luminance_function",
     "plot_single_sd",
     "plot_visible_spectrum",
+    "plot_visible_spectrum_colours",
 ]
 __all__ += [
     "LABELS_CHROMATICITY_DIAGRAM_DEFAULT",

--- a/colour/plotting/colorimetry.py
+++ b/colour/plotting/colorimetry.py
@@ -10,6 +10,7 @@ Define the colorimetry plotting objects:
 -   :func:`colour.plotting.plot_multi_cmfs`
 -   :func:`colour.plotting.plot_single_illuminant_sd`
 -   :func:`colour.plotting.plot_multi_illuminant_sds`
+-   :func:`colour.plotting.plot_visible_spectrum_colours`
 -   :func:`colour.plotting.plot_visible_spectrum`
 -   :func:`colour.plotting.plot_single_lightness_function`
 -   :func:`colour.plotting.plot_multi_lightness_functions`
@@ -35,8 +36,8 @@ import numpy as np
 if typing.TYPE_CHECKING:
     from collections.abc import ValuesView
 
-import matplotlib.colors as mcolors
 from matplotlib.patches import Polygon
+from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 if typing.TYPE_CHECKING:
     from matplotlib.figure import Figure
@@ -105,6 +106,7 @@ __all__ = [
     "plot_multi_cmfs",
     "plot_single_illuminant_sd",
     "plot_multi_illuminant_sds",
+    "plot_visible_spectrum_colours",
     "plot_visible_spectrum",
     "plot_single_lightness_function",
     "plot_multi_lightness_functions",
@@ -115,18 +117,18 @@ __all__ = [
 ]
 
 
-def _wavelengths_strip(
+def _wavelengths_to_RGB(
     wavelengths: NDArrayFloat,
     cmfs: MultiSpectralDistributions,
     out_of_gamut_clipping: bool = True,
 ) -> NDArrayFloat:
     """
-    Return the plotting colours for given wavelengths.
+    Return the plotting *RGB* colours for the specified wavelengths.
 
     Parameters
     ----------
     wavelengths
-        Wavelengths to convert to plotting colours.
+        Wavelengths to convert to *RGB* plotting colours.
     cmfs
         Colour matching functions used to compute the wavelengths colours.
     out_of_gamut_clipping
@@ -135,7 +137,7 @@ def _wavelengths_strip(
     Returns
     -------
     :class:`numpy.ndarray`
-        Wavelengths plotting colours.
+        Wavelengths *RGB* plotting colours.
     """
 
     RGB = XYZ_to_plotting_colourspace(
@@ -150,62 +152,75 @@ def _wavelengths_strip(
     return normalise_maximum(RGB)
 
 
-def _plot_wavelengths_strip(
-    axes: Axes,
-    x_min: float,
-    x_max: float,
-    y_min: float,
-    y_max: float,
-    cmfs: MultiSpectralDistributions,
+@override_style()
+def plot_visible_spectrum_colours(
+    cmfs: (
+        MultiSpectralDistributions | str | Sequence[MultiSpectralDistributions | str]
+    ) = "CIE 1931 2 Degree Standard Observer",
     out_of_gamut_clipping: bool = True,
-) -> float:
+    **kwargs: Any,
+) -> Tuple[Figure, Axes]:
     """
-    Plot the wavelength colours strip under the *x* axis.
+    Plot the visible spectrum colours using the specified standard observer
+    *CIE XYZ* colour matching functions.
 
     Parameters
     ----------
-    axes
-        Axes to plot the wavelength colours strip onto.
-    x_min
-        Minimum wavelength to plot.
-    x_max
-        Maximum wavelength to plot.
-    y_min
-        Minimum current *y* limit.
-    y_max
-        Maximum current *y* limit.
     cmfs
-        Colour matching functions used to compute the wavelengths colours.
+        Standard observer colour matching functions used for computing the
+        spectrum domain and colours. ``cmfs`` can be of any type or form
+        supported by the :func:`colour.plotting.common.filter_cmfs` definition.
     out_of_gamut_clipping
-        Whether to clip out of gamut colours.
+        Whether to clip out of gamut colours. Otherwise, the colours will
+        be offset by the absolute minimal colour, resulting in rendering
+        on a gray background that is less saturated and smoother.
+
+    Other Parameters
+    ----------------
+    kwargs
+        {:func:`colour.plotting.artist`, :func:`colour.plotting.render`},
+        See the documentation of the previously listed definitions.
 
     Returns
     -------
-    :class:`float`
-        Updated minimum *y* limit including the wavelength colours strip.
+    :class:`tuple`
+        Current figure and axes.
+
+    Examples
+    --------
+    >>> plot_visible_spectrum_colours()  # doctest: +ELLIPSIS
+    (<Figure size ... with 1 Axes>, <...Axes...>)
     """
 
-    scale = y_max - y_min
-    if np.isclose(scale, 0):
-        scale = max(np.abs(y_min), np.abs(y_max), 1)
+    _figure, axes = artist(**kwargs)
 
-    strip_thickness = scale * 0.05
-    strip_padding = strip_thickness * 0.5
-    strip_y_max = -strip_padding
-    strip_y_min = strip_y_max - strip_thickness
+    cmfs = cast("MultiSpectralDistributions", first_item(filter_cmfs(cmfs).values()))
+
+    x_min, x_max, y_min, y_max = kwargs.get(
+        "bounding_box",
+        (
+            float(np.min(cmfs.wavelengths)),
+            float(np.max(cmfs.wavelengths)),
+            0.0,
+            1.0,
+        ),
+    )
 
     x_visible_min = max(x_min, float(np.min(cmfs.wavelengths)))
     x_visible_max = min(x_max, float(np.max(cmfs.wavelengths)))
 
-    def _plot_non_visible_wavelengths(x_start: float, x_end: float) -> None:
+    for x_start, x_end in (
+        (x_min, min(x_max, x_visible_min)),
+        (max(x_min, x_visible_max), x_max),
+    ):
         if x_start >= x_end:
-            return
+            continue
 
         axes.bar(
             x_start,
-            strip_thickness,
+            y_max - y_min,
             width=x_end - x_start,
-            bottom=strip_y_min,
+            bottom=y_min,
             color=CONSTANTS_COLOUR_STYLE.colour.bright,
             alpha=0.5,
             align="edge",
@@ -215,59 +230,40 @@ def _plot_wavelengths_strip(
             zorder=CONSTANTS_COLOUR_STYLE.zorder.background_polygon,
         )
 
-    _plot_non_visible_wavelengths(x_min, min(x_max, x_visible_min))
-    _plot_non_visible_wavelengths(max(x_min, x_visible_max), x_max)
-
-    if x_visible_min >= x_visible_max:
-        axes.plot(
-            [x_min, x_max],
-            [strip_y_max, strip_y_max],
-            color=axes.spines["bottom"].get_edgecolor(),
-            linewidth=axes.spines["bottom"].get_linewidth(),
-            solid_capstyle="butt",
-            zorder=CONSTANTS_COLOUR_STYLE.zorder.foreground_line,
+    if x_visible_min < x_visible_max:
+        wavelengths_edges = np.linspace(
+            x_visible_min,
+            x_visible_max,
+            max(int(np.ceil(x_visible_max - x_visible_min)), 1) + 1,
+        )
+        wavelengths = 0.5 * (wavelengths_edges[:-1] + wavelengths_edges[1:])
+        RGB = CONSTANTS_COLOUR_STYLE.colour.colourspace.cctf_encoding(
+            _wavelengths_to_RGB(wavelengths, cmfs, out_of_gamut_clipping)
         )
 
-        return min(y_min, strip_y_min)
+        axes.bar(
+            wavelengths_edges[:-1],
+            np.full(wavelengths.shape, y_max - y_min),
+            width=np.diff(wavelengths_edges),
+            bottom=y_min,
+            color=RGB,
+            align="edge",
+            linewidth=0,
+            edgecolor="none",
+            antialiased=False,
+            zorder=CONSTANTS_COLOUR_STYLE.zorder.background_polygon,
+        )
 
-    wavelengths_edges = np.linspace(
-        x_visible_min,
-        x_visible_max,
-        max(int(np.ceil(x_visible_max - x_visible_min)), 1) + 1,
-    )
-    wavelengths = 0.5 * (wavelengths_edges[:-1] + wavelengths_edges[1:])
-    RGB = _wavelengths_strip(wavelengths, cmfs, out_of_gamut_clipping)
-    RGB = CONSTANTS_COLOUR_STYLE.colour.colourspace.cctf_encoding(RGB)
+    axes.set_yticks([])
 
-    axes.bar(
-        wavelengths_edges[:-1],
-        np.full(wavelengths.shape, strip_thickness),
-        width=np.diff(wavelengths_edges),
-        bottom=strip_y_min,
-        color=np.clip(
-            0.6 * RGB
-            + 0.4 * np.array([mcolors.to_rgb(CONSTANTS_COLOUR_STYLE.colour.brighter)]),
-            0,
-            1,
-        ),
-        alpha=1.0,
-        align="edge",
-        linewidth=0,
-        edgecolor="none",
-        antialiased=False,
-        zorder=CONSTANTS_COLOUR_STYLE.zorder.background_polygon,
-    )
+    settings: Dict[str, Any] = {
+        "axes": axes,
+        "bounding_box": (x_min, x_max, y_min, y_max),
+        "y_label": None,
+    }
+    settings.update(kwargs)
 
-    axes.plot(
-        [x_min, x_max],
-        [strip_y_max, strip_y_max],
-        color=axes.spines["bottom"].get_edgecolor(),
-        linewidth=axes.spines["bottom"].get_linewidth(),
-        solid_capstyle="butt",
-        zorder=CONSTANTS_COLOUR_STYLE.zorder.foreground_line,
-    )
-
-    return min(y_min, strip_y_min)
+    return render(**settings)
 
 
 @override_style()
@@ -279,7 +275,7 @@ def plot_single_sd(
     out_of_gamut_clipping: bool = True,
     modulate_colours_with_sd_amplitude: bool = False,
     equalize_sd_amplitude: bool = False,
-    wavelengths_strip: bool = False,
+    show_visible_spectrum: bool = False,
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
@@ -307,8 +303,8 @@ def plot_single_sd(
         wavelength colour is modulated by the spectral distribution
         amplitude. The usual 5% margin above the spectral distribution is
         also omitted.
-    wavelengths_strip
-        Whether to draw a wavelength colour strip along the *x* axis.
+    show_visible_spectrum
+        Whether to display the visible spectrum colours below the *x* axis.
 
     Other Parameters
     ----------------
@@ -359,7 +355,7 @@ def plot_single_sd(
     ]
     values = sd[wavelengths]
 
-    RGB = _wavelengths_strip(wavelengths, cmfs, out_of_gamut_clipping)
+    RGB = _wavelengths_to_RGB(wavelengths, cmfs, out_of_gamut_clipping)
 
     if modulate_colours_with_sd_amplitude:
         with sdiv_mode():
@@ -406,17 +402,6 @@ def plot_single_sd(
         zorder=CONSTANTS_COLOUR_STYLE.zorder.midground_line,
     )
 
-    if wavelengths_strip:
-        y_min = _plot_wavelengths_strip(
-            axes,
-            x_min,
-            x_max,
-            y_min,
-            y_max,
-            cmfs,
-            out_of_gamut_clipping,
-        )
-
     settings: Dict[str, Any] = {
         "axes": axes,
         "bounding_box": (x_min, x_max, y_min, y_max),
@@ -425,6 +410,21 @@ def plot_single_sd(
         "y_label": "Spectral Distribution",
     }
     settings.update(kwargs)
+
+    if show_visible_spectrum:
+        visible_spectrum_axes = make_axes_locatable(axes).append_axes(
+            "bottom", size="5%", pad=0.08, sharex=axes
+        )
+        plot_visible_spectrum_colours(
+            cmfs=cmfs,
+            out_of_gamut_clipping=out_of_gamut_clipping,
+            axes=visible_spectrum_axes,
+            bounding_box=(x_min, x_max, 0, 1),
+            x_label=settings.pop("x_label", None),
+            show=False,
+        )
+        axes.tick_params(axis="x", bottom=False, labelbottom=False, which="both")
+        axes.set_xlabel("")
 
     return render(**settings)
 
@@ -438,6 +438,7 @@ def plot_multi_sds(
         | ValuesView
     ),
     plot_kwargs: dict | List[dict] | None = None,
+    show_visible_spectrum: bool = False,
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
@@ -477,8 +478,8 @@ def plot_multi_sds(
             illuminant. Alternatively, it is possible to use the
             :func:`matplotlib.pyplot.plot` definition ``color`` argument
             with pre-computed values. The default is *True*.
-        -   ``wavelengths_strip`` : Whether to draw a wavelength
-            colour strip along the *x* axis. The default is *False*.
+    show_visible_spectrum
+        Whether to display the visible spectrum colours below the *x* axis.
 
     Other Parameters
     ----------------
@@ -540,7 +541,6 @@ def plot_multi_sds(
             "illuminant": SDS_ILLUMINANTS["E"],
             "use_sd_colours": False,
             "normalise_sd_colours": False,
-            "wavelengths_strip": False,
         }
         for sd in sds_converted
     ]
@@ -550,7 +550,10 @@ def plot_multi_sds(
             plot_settings_collection, plot_kwargs, len(sds_converted)
         )
 
-    show_wavelengths_strip = False
+    visible_spectrum_cmfs = cast(
+        "MultiSpectralDistributions",
+        first_item(filter_cmfs("CIE 1931 2 Degree Standard Observer").values()),
+    )
     x_limit_min, x_limit_max, y_limit_min, y_limit_max = [], [], [], []
     for i, sd in enumerate(sds_converted):
         plot_settings = plot_settings_collection[i]
@@ -565,8 +568,7 @@ def plot_multi_sds(
         )
         normalise_sd_colours = plot_settings.pop("normalise_sd_colours")
         use_sd_colours = plot_settings.pop("use_sd_colours")
-        wavelengths_strip = plot_settings.pop("wavelengths_strip")
-        show_wavelengths_strip = show_wavelengths_strip or wavelengths_strip
+        visible_spectrum_cmfs = cmfs
 
         wavelengths, values = sd.wavelengths, sd.values
 
@@ -594,21 +596,6 @@ def plot_multi_sds(
         max(y_limit_max) * 1.05,
     )
 
-    if show_wavelengths_strip:
-        bounding_box = (
-            bounding_box[0],
-            bounding_box[1],
-            _plot_wavelengths_strip(
-                axes,
-                bounding_box[0],
-                bounding_box[1],
-                bounding_box[2],
-                bounding_box[3],
-                cast("MultiSpectralDistributions", cmfs),
-            ),
-            bounding_box[3],
-        )
-
     settings: Dict[str, Any] = {
         "axes": axes,
         "bounding_box": bounding_box,
@@ -617,6 +604,20 @@ def plot_multi_sds(
         "y_label": "Spectral Distribution",
     }
     settings.update(kwargs)
+
+    if show_visible_spectrum:
+        visible_spectrum_axes = make_axes_locatable(axes).append_axes(
+            "bottom", size="5%", pad=0.08, sharex=axes
+        )
+        plot_visible_spectrum_colours(
+            cmfs=visible_spectrum_cmfs,
+            axes=visible_spectrum_axes,
+            bounding_box=(bounding_box[0], bounding_box[1], 0, 1),
+            x_label=settings.pop("x_label", None),
+            show=False,
+        )
+        axes.tick_params(axis="x", bottom=False, labelbottom=False, which="both")
+        axes.set_xlabel("")
 
     return render(**settings)
 
@@ -676,7 +677,7 @@ def plot_multi_cmfs(
     cmfs: (
         MultiSpectralDistributions | str | Sequence[MultiSpectralDistributions | str]
     ),
-    wavelengths_strip: bool = False,
+    show_visible_spectrum: bool = False,
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
@@ -688,8 +689,8 @@ def plot_multi_cmfs(
         Colour matching functions to plot. ``cmfs`` elements can be of any
         type or form supported by the
         :func:`colour.plotting.common.filter_cmfs` definition.
-    wavelengths_strip
-        Whether to draw a wavelength colour strip along the *x* axis.
+    show_visible_spectrum
+        Whether to display the visible spectrum colours below the *x* axis.
 
     Other Parameters
     ----------------
@@ -755,21 +756,6 @@ def plot_multi_cmfs(
         max(y_limit_max) + np.abs(np.max(y_limit_max)) * 0.05,
     )
 
-    if wavelengths_strip:
-        bounding_box = (
-            bounding_box[0],
-            bounding_box[1],
-            _plot_wavelengths_strip(
-                axes,
-                bounding_box[0],
-                bounding_box[1],
-                bounding_box[2],
-                bounding_box[3],
-                cmfs[0],
-            ),
-            bounding_box[3],
-        )
-
     cmfs_display_names = ", ".join([cmfs_i.display_name for cmfs_i in cmfs])
     title = f"{cmfs_display_names} - Colour Matching Functions"
 
@@ -782,6 +768,20 @@ def plot_multi_cmfs(
         "y_label": "Tristimulus Values",
     }
     settings.update(kwargs)
+
+    if show_visible_spectrum:
+        visible_spectrum_axes = make_axes_locatable(axes).append_axes(
+            "bottom", size="5%", pad=0.08, sharex=axes
+        )
+        plot_visible_spectrum_colours(
+            cmfs=cmfs[0],
+            axes=visible_spectrum_axes,
+            bounding_box=(bounding_box[0], bounding_box[1], 0, 1),
+            x_label=settings.pop("x_label", None),
+            show=False,
+        )
+        axes.tick_params(axis="x", bottom=False, labelbottom=False, which="both")
+        axes.set_xlabel("")
 
     return render(**settings)
 
@@ -888,21 +888,15 @@ def plot_multi_illuminant_sds(
         :alt: plot_multi_illuminant_sds
     """
 
-    wavelengths_strip = kwargs.pop("wavelengths_strip", False)
-
     if "plot_kwargs" not in kwargs:
         kwargs["plot_kwargs"] = {}
 
     SD_E = SDS_ILLUMINANTS["E"]
     if isinstance(kwargs["plot_kwargs"], dict):
         kwargs["plot_kwargs"]["illuminant"] = SD_E
-        if wavelengths_strip:
-            kwargs["plot_kwargs"]["wavelengths_strip"] = True
     else:
         for i in range(len(kwargs["plot_kwargs"])):
             kwargs["plot_kwargs"][i]["illuminant"] = SD_E
-            if wavelengths_strip:
-                kwargs["plot_kwargs"][i]["wavelengths_strip"] = True
 
     illuminants = cast(
         "List[SpectralDistribution]",
@@ -982,6 +976,7 @@ def plot_visible_spectrum(
     settings: Dict[str, Any] = {"bounding_box": bounding_box, "y_label": None}
     settings.update(kwargs)
     settings["show"] = False
+    settings["show_visible_spectrum"] = False
 
     _figure, axes = plot_single_sd(
         sd_ones(cmfs.shape),

--- a/colour/plotting/colorimetry.py
+++ b/colour/plotting/colorimetry.py
@@ -35,6 +35,7 @@ import numpy as np
 if typing.TYPE_CHECKING:
     from collections.abc import ValuesView
 
+import matplotlib.colors as mcolors
 from matplotlib.patches import Polygon
 
 if typing.TYPE_CHECKING:
@@ -62,6 +63,7 @@ if typing.TYPE_CHECKING:
         Any,
         Callable,
         Dict,
+        NDArrayFloat,
         Sequence,
         Tuple,
     )
@@ -113,6 +115,161 @@ __all__ = [
 ]
 
 
+def _wavelengths_strip(
+    wavelengths: NDArrayFloat,
+    cmfs: MultiSpectralDistributions,
+    out_of_gamut_clipping: bool = True,
+) -> NDArrayFloat:
+    """
+    Return the plotting colours for given wavelengths.
+
+    Parameters
+    ----------
+    wavelengths
+        Wavelengths to convert to plotting colours.
+    cmfs
+        Colour matching functions used to compute the wavelengths colours.
+    out_of_gamut_clipping
+        Whether to clip out of gamut colours.
+
+    Returns
+    -------
+    :class:`numpy.ndarray`
+        Wavelengths plotting colours.
+    """
+
+    RGB = XYZ_to_plotting_colourspace(
+        wavelength_to_XYZ(wavelengths, cmfs),
+        CCS_ILLUMINANTS["CIE 1931 2 Degree Standard Observer"]["E"],
+        apply_cctf_encoding=False,
+    )
+
+    if not out_of_gamut_clipping:
+        RGB += np.abs(np.min(RGB))
+
+    return normalise_maximum(RGB)
+
+
+def _plot_wavelengths_strip(
+    axes: Axes,
+    x_min: float,
+    x_max: float,
+    y_min: float,
+    y_max: float,
+    cmfs: MultiSpectralDistributions,
+    out_of_gamut_clipping: bool = True,
+) -> float:
+    """
+    Plot the wavelength colours strip under the *x* axis.
+
+    Parameters
+    ----------
+    axes
+        Axes to plot the wavelength colours strip onto.
+    x_min
+        Minimum wavelength to plot.
+    x_max
+        Maximum wavelength to plot.
+    y_min
+        Minimum current *y* limit.
+    y_max
+        Maximum current *y* limit.
+    cmfs
+        Colour matching functions used to compute the wavelengths colours.
+    out_of_gamut_clipping
+        Whether to clip out of gamut colours.
+
+    Returns
+    -------
+    :class:`float`
+        Updated minimum *y* limit including the wavelength colours strip.
+    """
+
+    scale = y_max - y_min
+    if np.isclose(scale, 0):
+        scale = max(np.abs(y_min), np.abs(y_max), 1)
+
+    strip_thickness = scale * 0.05
+    strip_padding = strip_thickness * 0.5
+    strip_y_max = -strip_padding
+    strip_y_min = strip_y_max - strip_thickness
+
+    x_visible_min = max(x_min, float(np.min(cmfs.wavelengths)))
+    x_visible_max = min(x_max, float(np.max(cmfs.wavelengths)))
+
+    def _plot_non_visible_wavelengths(x_start: float, x_end: float) -> None:
+        if x_start >= x_end:
+            return
+
+        axes.bar(
+            x_start,
+            strip_thickness,
+            width=x_end - x_start,
+            bottom=strip_y_min,
+            color=CONSTANTS_COLOUR_STYLE.colour.bright,
+            alpha=0.5,
+            align="edge",
+            hatch=CONSTANTS_COLOUR_STYLE.hatch.patterns[-1],
+            edgecolor=CONSTANTS_COLOUR_STYLE.colour.light,
+            linewidth=0,
+            zorder=CONSTANTS_COLOUR_STYLE.zorder.background_polygon,
+        )
+
+    _plot_non_visible_wavelengths(x_min, min(x_max, x_visible_min))
+    _plot_non_visible_wavelengths(max(x_min, x_visible_max), x_max)
+
+    if x_visible_min >= x_visible_max:
+        axes.plot(
+            [x_min, x_max],
+            [strip_y_max, strip_y_max],
+            color=axes.spines["bottom"].get_edgecolor(),
+            linewidth=axes.spines["bottom"].get_linewidth(),
+            solid_capstyle="butt",
+            zorder=CONSTANTS_COLOUR_STYLE.zorder.foreground_line,
+        )
+
+        return min(y_min, strip_y_min)
+
+    wavelengths_edges = np.linspace(
+        x_visible_min,
+        x_visible_max,
+        max(int(np.ceil(x_visible_max - x_visible_min)), 1) + 1,
+    )
+    wavelengths = 0.5 * (wavelengths_edges[:-1] + wavelengths_edges[1:])
+    RGB = _wavelengths_strip(wavelengths, cmfs, out_of_gamut_clipping)
+    RGB = CONSTANTS_COLOUR_STYLE.colour.colourspace.cctf_encoding(RGB)
+
+    axes.bar(
+        wavelengths_edges[:-1],
+        np.full(wavelengths.shape, strip_thickness),
+        width=np.diff(wavelengths_edges),
+        bottom=strip_y_min,
+        color=np.clip(
+            0.6 * RGB
+            + 0.4 * np.array([mcolors.to_rgb(CONSTANTS_COLOUR_STYLE.colour.brighter)]),
+            0,
+            1,
+        ),
+        alpha=1.0,
+        align="edge",
+        linewidth=0,
+        edgecolor="none",
+        antialiased=False,
+        zorder=CONSTANTS_COLOUR_STYLE.zorder.background_polygon,
+    )
+
+    axes.plot(
+        [x_min, x_max],
+        [strip_y_max, strip_y_max],
+        color=axes.spines["bottom"].get_edgecolor(),
+        linewidth=axes.spines["bottom"].get_linewidth(),
+        solid_capstyle="butt",
+        zorder=CONSTANTS_COLOUR_STYLE.zorder.foreground_line,
+    )
+
+    return min(y_min, strip_y_min)
+
+
 @override_style()
 def plot_single_sd(
     sd: SpectralDistribution,
@@ -122,6 +279,7 @@ def plot_single_sd(
     out_of_gamut_clipping: bool = True,
     modulate_colours_with_sd_amplitude: bool = False,
     equalize_sd_amplitude: bool = False,
+    wavelengths_strip: bool = False,
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
@@ -149,6 +307,8 @@ def plot_single_sd(
         wavelength colour is modulated by the spectral distribution
         amplitude. The usual 5% margin above the spectral distribution is
         also omitted.
+    wavelengths_strip
+        Whether to draw a wavelength colour strip along the *x* axis.
 
     Other Parameters
     ----------------
@@ -199,16 +359,7 @@ def plot_single_sd(
     ]
     values = sd[wavelengths]
 
-    RGB = XYZ_to_plotting_colourspace(
-        wavelength_to_XYZ(wavelengths, cmfs),
-        CCS_ILLUMINANTS["CIE 1931 2 Degree Standard Observer"]["E"],
-        apply_cctf_encoding=False,
-    )
-
-    if not out_of_gamut_clipping:
-        RGB += np.abs(np.min(RGB))
-
-    RGB = normalise_maximum(RGB)
+    RGB = _wavelengths_strip(wavelengths, cmfs, out_of_gamut_clipping)
 
     if modulate_colours_with_sd_amplitude:
         with sdiv_mode():
@@ -254,6 +405,17 @@ def plot_single_sd(
         color=CONSTANTS_COLOUR_STYLE.colour.dark,
         zorder=CONSTANTS_COLOUR_STYLE.zorder.midground_line,
     )
+
+    if wavelengths_strip:
+        y_min = _plot_wavelengths_strip(
+            axes,
+            x_min,
+            x_max,
+            y_min,
+            y_max,
+            cmfs,
+            out_of_gamut_clipping,
+        )
 
     settings: Dict[str, Any] = {
         "axes": axes,
@@ -315,6 +477,8 @@ def plot_multi_sds(
             illuminant. Alternatively, it is possible to use the
             :func:`matplotlib.pyplot.plot` definition ``color`` argument
             with pre-computed values. The default is *True*.
+        -   ``wavelengths_strip`` : Whether to draw a wavelength
+            colour strip along the *x* axis. The default is *False*.
 
     Other Parameters
     ----------------
@@ -376,6 +540,7 @@ def plot_multi_sds(
             "illuminant": SDS_ILLUMINANTS["E"],
             "use_sd_colours": False,
             "normalise_sd_colours": False,
+            "wavelengths_strip": False,
         }
         for sd in sds_converted
     ]
@@ -385,6 +550,7 @@ def plot_multi_sds(
             plot_settings_collection, plot_kwargs, len(sds_converted)
         )
 
+    show_wavelengths_strip = False
     x_limit_min, x_limit_max, y_limit_min, y_limit_max = [], [], [], []
     for i, sd in enumerate(sds_converted):
         plot_settings = plot_settings_collection[i]
@@ -399,6 +565,8 @@ def plot_multi_sds(
         )
         normalise_sd_colours = plot_settings.pop("normalise_sd_colours")
         use_sd_colours = plot_settings.pop("use_sd_colours")
+        wavelengths_strip = plot_settings.pop("wavelengths_strip")
+        show_wavelengths_strip = show_wavelengths_strip or wavelengths_strip
 
         wavelengths, values = sd.wavelengths, sd.values
 
@@ -425,6 +593,22 @@ def plot_multi_sds(
         min(y_limit_min),
         max(y_limit_max) * 1.05,
     )
+
+    if show_wavelengths_strip:
+        bounding_box = (
+            bounding_box[0],
+            bounding_box[1],
+            _plot_wavelengths_strip(
+                axes,
+                bounding_box[0],
+                bounding_box[1],
+                bounding_box[2],
+                bounding_box[3],
+                cast("MultiSpectralDistributions", cmfs),
+            ),
+            bounding_box[3],
+        )
+
     settings: Dict[str, Any] = {
         "axes": axes,
         "bounding_box": bounding_box,
@@ -492,6 +676,7 @@ def plot_multi_cmfs(
     cmfs: (
         MultiSpectralDistributions | str | Sequence[MultiSpectralDistributions | str]
     ),
+    wavelengths_strip: bool = False,
     **kwargs: Any,
 ) -> Tuple[Figure, Axes]:
     """
@@ -503,6 +688,8 @@ def plot_multi_cmfs(
         Colour matching functions to plot. ``cmfs`` elements can be of any
         type or form supported by the
         :func:`colour.plotting.common.filter_cmfs` definition.
+    wavelengths_strip
+        Whether to draw a wavelength colour strip along the *x* axis.
 
     Other Parameters
     ----------------
@@ -567,6 +754,22 @@ def plot_multi_cmfs(
         min(y_limit_min) - np.abs(np.min(y_limit_min)) * 0.05,
         max(y_limit_max) + np.abs(np.max(y_limit_max)) * 0.05,
     )
+
+    if wavelengths_strip:
+        bounding_box = (
+            bounding_box[0],
+            bounding_box[1],
+            _plot_wavelengths_strip(
+                axes,
+                bounding_box[0],
+                bounding_box[1],
+                bounding_box[2],
+                bounding_box[3],
+                cmfs[0],
+            ),
+            bounding_box[3],
+        )
+
     cmfs_display_names = ", ".join([cmfs_i.display_name for cmfs_i in cmfs])
     title = f"{cmfs_display_names} - Colour Matching Functions"
 
@@ -685,15 +888,21 @@ def plot_multi_illuminant_sds(
         :alt: plot_multi_illuminant_sds
     """
 
+    wavelengths_strip = kwargs.pop("wavelengths_strip", False)
+
     if "plot_kwargs" not in kwargs:
         kwargs["plot_kwargs"] = {}
 
     SD_E = SDS_ILLUMINANTS["E"]
     if isinstance(kwargs["plot_kwargs"], dict):
         kwargs["plot_kwargs"]["illuminant"] = SD_E
+        if wavelengths_strip:
+            kwargs["plot_kwargs"]["wavelengths_strip"] = True
     else:
         for i in range(len(kwargs["plot_kwargs"])):
             kwargs["plot_kwargs"][i]["illuminant"] = SD_E
+            if wavelengths_strip:
+                kwargs["plot_kwargs"][i]["wavelengths_strip"] = True
 
     illuminants = cast(
         "List[SpectralDistribution]",

--- a/colour/plotting/tests/test_colorimetry.py
+++ b/colour/plotting/tests/test_colorimetry.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import numpy as np
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
+from matplotlib.patches import Rectangle
 
 from colour.colorimetry import SpectralDistribution
 from colour.plotting import (
@@ -46,6 +48,27 @@ __all__ = [
 ]
 
 
+def _wavelengths_strip_patches(
+    axes: Axes, hatched: bool | None = None
+) -> list[Rectangle]:
+    strip_patches = [
+        patch
+        for patch in axes.patches
+        if isinstance(patch, Rectangle)
+        and patch.get_y() < 0
+        and patch.get_y() + patch.get_height() < 0
+    ]
+
+    if hatched is None:
+        return strip_patches
+
+    return [
+        patch
+        for patch in strip_patches
+        if (patch.get_hatch() not in (None, "")) is hatched
+    ]
+
+
 class TestPlotSingleSd:
     """
     Define :func:`colour.plotting.colorimetry.plot_single_sd` definition unit
@@ -73,6 +96,7 @@ class TestPlotSingleSd:
             out_of_gamut_clipping=False,
             modulate_colours_with_sd_amplitude=True,
             equalize_sd_amplitude=True,
+            wavelengths_strip=True,
         )
 
         assert isinstance(figure, Figure)
@@ -115,7 +139,11 @@ class TestPlotMultiSds:
 
         figure, axes = plot_multi_sds(
             [sd_1, sd_2],
-            plot_kwargs={"use_sd_colours": True, "normalise_sd_colours": True},
+            plot_kwargs={
+                "use_sd_colours": True,
+                "normalise_sd_colours": True,
+                "wavelengths_strip": True,
+            },
         )
 
         assert isinstance(figure, Figure)
@@ -128,6 +156,54 @@ class TestPlotMultiSds:
 
         assert isinstance(figure, Figure)
         assert isinstance(axes, Axes)
+
+    def test_plot_multi_sds_extended_domain_wavelengths_strip(self) -> None:
+        """
+        Test :func:`colour.plotting.colorimetry.plot_multi_sds` definition
+        with spectra extending outside the visible domain and wavelength
+        colours enabled.
+        """
+
+        sd_1 = SpectralDistribution(
+            {wavelength: 0.5 for wavelength in range(300, 1001, 10)},
+            name="Extended",
+        )
+        sd_2 = SpectralDistribution(
+            {wavelength: 0.25 for wavelength in range(400, 701, 10)},
+            name="Visible",
+        )
+
+        figure, axes = plot_multi_sds(
+            [sd_1, sd_2],
+            plot_kwargs={"wavelengths_strip": True},
+        )
+
+        assert isinstance(figure, Figure)
+        assert isinstance(axes, Axes)
+
+        visible_strip_patches = _wavelengths_strip_patches(axes, hatched=False)
+        non_visible_strip_patches = _wavelengths_strip_patches(axes, hatched=True)
+
+        np.testing.assert_allclose(
+            (
+                min(patch.get_x() for patch in visible_strip_patches),
+                max(
+                    patch.get_x() + patch.get_width() for patch in visible_strip_patches
+                ),
+            ),
+            (360, 830),
+        )
+        assert len(non_visible_strip_patches) == 2
+        np.testing.assert_allclose(
+            [
+                (
+                    patch.get_x(),
+                    patch.get_x() + patch.get_width(),
+                )
+                for patch in non_visible_strip_patches
+            ],
+            [(300, 360), (830, 1000)],
+        )
 
 
 class TestPlotSingleCmfs:
@@ -158,7 +234,8 @@ class TestPlotMultiCmfs:
             [
                 "CIE 1931 2 Degree Standard Observer",
                 "CIE 1964 10 Degree Standard Observer",
-            ]
+            ],
+            wavelengths_strip=True,
         )
 
         assert isinstance(figure, Figure)
@@ -203,6 +280,14 @@ class TestPlotMultiIlluminantSds:
         figure, axes = plot_multi_illuminant_sds(
             ["A", "B", "C"],
             plot_kwargs=[{"use_sd_colours": True, "normalise_sd_colours": True}] * 3,
+        )
+
+        assert isinstance(figure, Figure)
+        assert isinstance(axes, Axes)
+
+        figure, axes = plot_multi_illuminant_sds(
+            ["A", "B", "C"],
+            wavelengths_strip=True,
         )
 
         assert isinstance(figure, Figure)

--- a/colour/plotting/tests/test_colorimetry.py
+++ b/colour/plotting/tests/test_colorimetry.py
@@ -22,6 +22,7 @@ from colour.plotting import (
     plot_single_luminance_function,
     plot_single_sd,
     plot_visible_spectrum,
+    plot_visible_spectrum_colours,
 )
 
 __author__ = "Colour Developers"
@@ -38,6 +39,7 @@ __all__ = [
     "TestPlotMultiCmfs",
     "TestPlotSingleIlluminantSd",
     "TestPlotMultiIlluminantSds",
+    "TestPlotVisibleSpectrumColours",
     "TestPlotVisibleSpectrum",
     "TestPlotSingleLightnessFunction",
     "TestPlotMultiLightnessFunctions",
@@ -48,16 +50,14 @@ __all__ = [
 ]
 
 
-def _wavelengths_strip_patches(
+def _visible_spectrum_axes(figure: Figure, axes: Axes) -> Axes:
+    return next(axis for axis in figure.axes if axis is not axes)
+
+
+def _visible_spectrum_patches(
     axes: Axes, hatched: bool | None = None
 ) -> list[Rectangle]:
-    strip_patches = [
-        patch
-        for patch in axes.patches
-        if isinstance(patch, Rectangle)
-        and patch.get_y() < 0
-        and patch.get_y() + patch.get_height() < 0
-    ]
+    strip_patches = [patch for patch in axes.patches if isinstance(patch, Rectangle)]
 
     if hatched is None:
         return strip_patches
@@ -96,11 +96,12 @@ class TestPlotSingleSd:
             out_of_gamut_clipping=False,
             modulate_colours_with_sd_amplitude=True,
             equalize_sd_amplitude=True,
-            wavelengths_strip=True,
+            show_visible_spectrum=True,
         )
 
         assert isinstance(figure, Figure)
         assert isinstance(axes, Axes)
+        assert len(figure.axes) == 2
 
 
 class TestPlotMultiSds:
@@ -142,12 +143,13 @@ class TestPlotMultiSds:
             plot_kwargs={
                 "use_sd_colours": True,
                 "normalise_sd_colours": True,
-                "wavelengths_strip": True,
             },
+            show_visible_spectrum=True,
         )
 
         assert isinstance(figure, Figure)
         assert isinstance(axes, Axes)
+        assert len(figure.axes) == 2
 
         figure, axes = plot_multi_sds(
             [sd_1, sd_2],
@@ -157,7 +159,7 @@ class TestPlotMultiSds:
         assert isinstance(figure, Figure)
         assert isinstance(axes, Axes)
 
-    def test_plot_multi_sds_extended_domain_wavelengths_strip(self) -> None:
+    def test_plot_multi_sds_extended_domain_visible_spectrum(self) -> None:
         """
         Test :func:`colour.plotting.colorimetry.plot_multi_sds` definition
         with spectra extending outside the visible domain and wavelength
@@ -175,14 +177,19 @@ class TestPlotMultiSds:
 
         figure, axes = plot_multi_sds(
             [sd_1, sd_2],
-            plot_kwargs={"wavelengths_strip": True},
+            show_visible_spectrum=True,
         )
 
         assert isinstance(figure, Figure)
         assert isinstance(axes, Axes)
 
-        visible_strip_patches = _wavelengths_strip_patches(axes, hatched=False)
-        non_visible_strip_patches = _wavelengths_strip_patches(axes, hatched=True)
+        visible_spectrum_axes = _visible_spectrum_axes(figure, axes)
+        visible_strip_patches = _visible_spectrum_patches(
+            visible_spectrum_axes, hatched=False
+        )
+        non_visible_strip_patches = _visible_spectrum_patches(
+            visible_spectrum_axes, hatched=True
+        )
 
         np.testing.assert_allclose(
             (
@@ -235,11 +242,12 @@ class TestPlotMultiCmfs:
                 "CIE 1931 2 Degree Standard Observer",
                 "CIE 1964 10 Degree Standard Observer",
             ],
-            wavelengths_strip=True,
+            show_visible_spectrum=True,
         )
 
         assert isinstance(figure, Figure)
         assert isinstance(axes, Axes)
+        assert len(figure.axes) == 2
 
 
 class TestPlotSingleIlluminantSd:
@@ -287,11 +295,44 @@ class TestPlotMultiIlluminantSds:
 
         figure, axes = plot_multi_illuminant_sds(
             ["A", "B", "C"],
-            wavelengths_strip=True,
+            show_visible_spectrum=True,
         )
 
         assert isinstance(figure, Figure)
         assert isinstance(axes, Axes)
+        assert len(figure.axes) == 2
+
+
+class TestPlotVisibleSpectrumColours:
+    """
+    Define :func:`colour.plotting.colorimetry.plot_visible_spectrum_colours`
+    definition unit tests methods.
+    """
+
+    def test_plot_visible_spectrum_colours(self) -> None:
+        """
+        Test :func:`colour.plotting.colorimetry.plot_visible_spectrum_colours`
+        definition.
+        """
+
+        figure, axes = plot_visible_spectrum_colours(bounding_box=(300, 1000, 0, 1))
+
+        assert isinstance(figure, Figure)
+        assert isinstance(axes, Axes)
+
+        visible_strip_patches = _visible_spectrum_patches(axes, hatched=False)
+        non_visible_strip_patches = _visible_spectrum_patches(axes, hatched=True)
+
+        np.testing.assert_allclose(
+            (
+                min(patch.get_x() for patch in visible_strip_patches),
+                max(
+                    patch.get_x() + patch.get_width() for patch in visible_strip_patches
+                ),
+            ),
+            (360, 830),
+        )
+        assert len(non_visible_strip_patches) == 2
 
 
 class TestPlotVisibleSpectrum:


### PR DESCRIPTION
# Summary

Add a boolean parameter to plotting functions with wavelength on x-axis called wavelengths_strip to add the visible spectrum to the xaxis. If wavelengths go beyond visible interval (UV or IR), those areas are shown for visual cleanliness with a striped gray filling.

See [wavelengths_strip_plots.html](https://github.com/user-attachments/files/26730434/wavelengths_strip_plots.html) for how plots would look like with the argument activated.

As you can see e.g. for the very first plot (below minimal code example), the hues of the wavelengths strip might be slightly different to that of the spectrum itself as I wanted to desaturate the RGB colours of the wavelengths strip a bit. This can be easily changed but I felt that this made the plots visually too heavy. Happy to revert if wanted.

```python
import numpy as np

def gaussian(x, mu, sigma):
    x = np.asarray(x, dtype=float)
    return np.exp(-0.5 * ((x - mu) / sigma) ** 2)

def make_red_reflectance(start=300, stop=1000, step=10):
    wl = np.arange(start, stop + step, step)

    # Low reflectance in blue/green, rising toward red
    r = (
        0.03
        + 0.82 * gaussian(wl, mu=660, sigma=40)
    )
    r = np.clip(r, 0.0, 1.0)

    return {int(w): float(v) for w, v in zip(wl, r)}

data_1 = make_red_reflectance()

from colour import SpectralDistribution
sd_1 = SpectralDistribution(data_1, name="Custom 1")

from colour.plotting import plot_single_sd

plot_single_sd(sd_1, wavelengths_strip=True)
```

# Preflight

<!-- Please mark any checkboxes that do not apply to this pull request as [N/A]. -->

**Code Style and Quality**

- [x] Unit tests have been implemented and passed.
- [x] Pyright static checking has been run and passed.
- [x] Pre-commit hooks have been run and passed.
- [N/A] New transformations have been added to the _Automatic Colour Conversion Graph_.
- [N/A] New transformations have been exported to the relevant namespaces, e.g. `colour`, `colour.models`.

<!-- The unit tests can be invoked with `uv run invoke tests` -->
<!-- Pyright can be started with `uv run pyright --threads --skipunannotated` -->

**Documentation**

- [N/A] New features are documented along with examples if relevant.
- [x] The documentation is [Sphinx](https://www.sphinx-doc.org/en/master/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant.
