### PR TITLE
[BUG] `colour.whiteness` passes `Y` from whitepoint instead from sample to `colour.colorimetry.whiteness_Ganz1979` and `colour.colorimetry.whiteness_CIE2004`.

### DIFF
--- a/colour/colorimetry/whiteness.py
+++ b/colour/colorimetry/whiteness.py
@@ -579,7 +579,7 @@ def whiteness(
     elif function in (whiteness_Ganz1979, whiteness_CIE2004):
         from colour.models import XYZ_to_xy  # noqa: PLC0415
 
-        _X_0, Y_0, _Z_0 = tsplit(XYZ_0)
-        kwargs.update({"xy": XYZ_to_xy(XYZ), "Y": Y_0, "xy_n": XYZ_to_xy(XYZ_0)})
+        _X, Y, _Z = tsplit(XYZ)
+        kwargs.update({"xy": XYZ_to_xy(XYZ), "Y": Y, "xy_n": XYZ_to_xy(XYZ_0)})
 
     return function(**filter_kwargs(function, **kwargs))


### PR DESCRIPTION
# Summary

**Unrelated** to issue #1402 !

When using colour.colorimetry.whiteness wrapper with method either whiteness_Ganz1979 or whiteness_CIE2004, we pass the Y argument from the whitepoint, not from the sample.

This is wrong and should now be fixed.

Before
```python
elif function in (whiteness_Ganz1979, whiteness_CIE2004):
        from colour.models import XYZ_to_xy  # noqa: PLC0415

        _X_0, Y_0, _Z_0 = tsplit(XYZ_0)
        kwargs.update({"xy": XYZ_to_xy(XYZ), "Y": Y_0, "xy_n": XYZ_to_xy(XYZ_0)})
```

Now
```python
elif function in (whiteness_Ganz1979, whiteness_CIE2004):
        from colour.models import XYZ_to_xy  # noqa: PLC0415

        _X, Y, _Z = tsplit(XYZ)
        kwargs.update({"xy": XYZ_to_xy(XYZ), "Y": Y, "xy_n": XYZ_to_xy(XYZ_0)})
```

# Preflight

<!-- Please mark any checkboxes that do not apply to this pull request as [N/A]. -->

**Code Style and Quality**

- [N/A] Unit tests have been implemented and passed.
- [x] Pyright static checking has been run and passed.
- [x] Pre-commit hooks have been run and passed.
- [N/A] New transformations have been added to the _Automatic Colour Conversion Graph_.
- [N/A] New transformations have been exported to the relevant namespaces, e.g. `colour`, `colour.models`.

**Documentation**

- [N/A] New features are documented along with examples if relevant.
- [N/A] The documentation is [Sphinx](https://www.sphinx-doc.org/en/master/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant.