### PR TITLE
PR: Use deepcopy for `colour.convert` kwargs

### DIFF
--- a/colour/graph/conversion.py
+++ b/colour/graph/conversion.py
@@ -17,7 +17,7 @@ import re
 import sys
 import textwrap
 import typing
-from copy import copy
+from copy import deepcopy
 from dataclasses import dataclass
 from functools import partial
 from pprint import pformat
@@ -2230,7 +2230,7 @@ SDS_ILLUMINANTS["FL2"], XYZ_to_sRGB={"illuminant": illuminant})
 
     conversion_path_list = conversion_path(source, target)
 
-    verbose_kwargs = copy(kwargs)
+    verbose_kwargs = deepcopy(kwargs)
     for i, conversion_function in enumerate(conversion_path_list):
         conversion_function_name = _lower_order_function(conversion_function).__name__
 


### PR DESCRIPTION
# Summary

`colour.convert` is currently using `verbose_kwargs = copy(kwargs)`. This may creates issues as `copy(kwargs)` is shallow, thus nested dicts are shared between kwargs and verbose_kwargs.

Example

```
import colour
import numpy as np

data = np.array(
    [
        0.0641,
        0.0645,
        0.0562,
        0.0537,
        0.0559,
        0.0651,
        0.0705,
        0.0772,
        0.0870,
        0.1128,
        0.1360,
        0.1511,
        0.1688,
        0.1996,
        0.2397,
        0.2852,
    ]
)

conversion_kwargs = dict(
    sd_to_XYZ={
        "cmfs": colour.MSDS_CMFS["CIE 1964 10 Degree Standard Observer"],
        "illuminant": colour.SDS_ILLUMINANTS["D65"],
        "method": "Integration",
        "shape": colour.SpectralShape(400, 700, 20),
    }
)

colour.convert(
    data,
    "Spectral Distribution",
    "CIE XYZ",
    from_reference_scale=False,
    to_reference_scale=True,
    **conversion_kwargs
)
```

After above calls, conversion_kwargs contain following keys
```
conversion_kwargs['sd_to_XYZ'].keys()
dict_keys(['cmfs', 'illuminant', 'method', 'shape', 'return'])
```

The return key in `conversion_kwargs['sd_to_XYZ']` was added during the `colour.convert` call.

When calling another conversion, we now get an error during the computation of the hashing key, as it does not correctly handle the type of the new "return" parameter. 
```
colour.convert(
    data,
    "Spectral Distribution",
    "CIE XYZ",
    from_reference_scale=False,
    to_reference_scale=True,
    **conversion_kwargs
)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[6], line 1
----> 1 colour.convert(
      2     curves[0],
      3     "Spectral Distribution",
      4     "CIE XYZ",
      5     from_reference_scale=False,
      6     to_reference_scale=True,
      7     **conversion_kwargs,
      8 )

File ~/dev/gitlab/mcs-reworked-core-calculation/.venv/lib/python3.14/site-packages/colour/graph/conversion.py:2250, in convert(a, source, target, from_reference_scale, to_reference_scale, **kwargs)
   2247 filtered_kwargs.update(kwargs.get(conversion_function_name, {}))
   2249 with domain_range_scale("1"):
-> 2250     a = conversion_function(a, **filtered_kwargs)
   2252 # Scale output from scale-1 to reference on last iteration
   2253 if i == len(conversion_path_list) - 1 and to_reference_scale:

File ~/dev/gitlab/mcs-reworked-core-calculation/.venv/lib/python3.14/site-packages/colour/colorimetry/tristimulus_values.py:1275, in sd_to_XYZ(sd, cmfs, illuminant, k, method, **kwargs)
   1271 method = validate_method(method, tuple(SD_TO_XYZ_METHODS))
   1273 global _CACHE_SD_TO_XYZ  # noqa: PLW0602
-> 1275 hash_key = hash(
   1276     (
   1277         (
   1278             sd
   1279             if isinstance(sd, (SpectralDistribution, MultiSpectralDistributions))
   1280             else int_digest(np.asarray(sd).tobytes())
   1281         ),
   1282         cmfs,
   1283         illuminant,
   1284         k,
   1285         method,
   1286         tuple(kwargs.items()),
   1287         get_domain_range_scale(),
   1288     )
   1289 )
   1291 if is_caching_enabled() and hash_key in _CACHE_SD_TO_XYZ:
   1292     return np.copy(_CACHE_SD_TO_XYZ[hash_key])

TypeError: unhashable type: 'numpy.ndarray'
```

I think the easiest option is the proposed fix. Simply changing to a deepcopy for the `verbose_kwargs `. If we want to keep the mutation of the given `conversion_kwargs` dict, we would need to update the hashing functions for all conversions (as we always store the return key during a call to colour.convert for the respective conversion function.

# Preflight

<!-- Please mark any checkboxes that do not apply to this pull request as [N/A]. -->

**Code Style and Quality**

- [N/A] Unit tests have been implemented and passed.
- [N/A] Pyright static checking has been run and passed.
- [x] Pre-commit hooks have been run and passed.
- [N/A] New transformations have been added to the _Automatic Colour Conversion Graph_.
- [N/A] New transformations have been exported to the relevant namespaces, e.g. `colour`, `colour.models`.

<!-- The unit tests can be invoked with `uv run invoke tests` -->
<!-- Pyright can be started with `uv run pyright --threads --skipunannotated` -->

**Documentation**

- [N/A] New features are documented along with examples if relevant.
- [N/A] The documentation is [Sphinx](https://www.sphinx-doc.org/en/master/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant.
