### PR TITLE
PR: Avoid mutating submodule `__all__` lists

### DIFF
--- a/colour/blindness/__init__.py
+++ b/colour/blindness/__init__.py
@@ -6,7 +6,7 @@ from .machado2009 import (
     msds_cmfs_anomalous_trichromacy_Machado2009,
 )
 
-__all__ = datasets.__all__
+__all__ = list(datasets.__all__)
 __all__ += [
     "matrix_anomalous_trichromacy_Machado2009",
     "matrix_cvd_Machado2009",

--- a/colour/corresponding/__init__.py
+++ b/colour/corresponding/__init__.py
@@ -12,7 +12,7 @@ from .prediction import (
     corresponding_chromaticities_prediction_Zhai2018,
 )
 
-__all__ = datasets.__all__
+__all__ = list(datasets.__all__)
 __all__ += [
     "CORRESPONDING_CHROMATICITIES_PREDICTION_MODELS",
     "CorrespondingChromaticitiesPrediction",

--- a/colour/io/__init__.py
+++ b/colour/io/__init__.py
@@ -51,7 +51,7 @@ from .uprtek_sekonic import (
 )
 from .xrite import read_sds_from_xrite_file
 
-__all__ = luts.__all__
+__all__ = list(luts.__all__)
 __all__ += [
     "MAPPING_BIT_DEPTH",
     "READ_IMAGE_METHODS",

--- a/colour/plotting/__init__.py
+++ b/colour/plotting/__init__.py
@@ -163,7 +163,7 @@ from .volume import (  # noqa: RUF100
     plot_RGB_scatter,
 )
 
-__all__ = datasets.__all__
+__all__ = list(datasets.__all__)
 __all__ += [
     "CONSTANTS_ARROW_STYLE",
     "CONSTANTS_COLOUR_STYLE",

--- a/colour/quality/__init__.py
+++ b/colour/quality/__init__.py
@@ -30,7 +30,7 @@ from .tm3018 import (
     colour_fidelity_index_ANSIIESTM3018,
 )
 
-__all__ = datasets.__all__
+__all__ = list(datasets.__all__)
 __all__ += [
     "ColourRendering_Specification_CIE2017",
     "colour_fidelity_index_CIE2017",

--- a/colour/recovery/__init__.py
+++ b/colour/recovery/__init__.py
@@ -76,7 +76,7 @@ from .smits1999 import (
     RGB_to_sd_Smits1999,
 )
 
-__all__ = datasets.__all__
+__all__ = list(datasets.__all__)
 __all__ += [
     "LUT3D_Jakob2019",
     "XYZ_to_sd_Jakob2019",

--- a/colour/tests/__init__.py
+++ b/colour/tests/__init__.py
@@ -1,0 +1,12 @@
+"""Define the unit tests for the :mod:`colour` package."""
+
+from __future__ import annotations
+
+__author__ = "Colour Developers"
+__copyright__ = "Copyright 2013 Colour Developers"
+__license__ = "BSD-3-Clause - https://opensource.org/licenses/BSD-3-Clause"
+__maintainer__ = "Colour Developers"
+__email__ = "colour-developers@colour-science.org"
+__status__ = "Production"
+
+__all__ = []

--- a/colour/tests/test__all__.py
+++ b/colour/tests/test__all__.py
@@ -1,0 +1,48 @@
+"""Define the unit tests for package public API lists."""
+
+from __future__ import annotations
+
+from importlib import import_module
+
+import pytest
+
+__author__ = "Colour Developers"
+__copyright__ = "Copyright 2013 Colour Developers"
+__license__ = "BSD-3-Clause - https://opensource.org/licenses/BSD-3-Clause"
+__maintainer__ = "Colour Developers"
+__email__ = "colour-developers@colour-science.org"
+__status__ = "Production"
+
+__all__ = [
+    "TestPackageAll",
+]
+
+
+class TestPackageAll:
+    """Define the package public API list unit tests methods."""
+
+    @pytest.mark.parametrize(
+        ("package_name", "submodule_name"),
+        [
+            ("colour.blindness", "colour.blindness.datasets"),
+            ("colour.corresponding", "colour.corresponding.datasets"),
+            ("colour.io", "colour.io.luts"),
+            ("colour.plotting", "colour.plotting.datasets"),
+            ("colour.quality", "colour.quality.datasets"),
+            ("colour.recovery", "colour.recovery.datasets"),
+            ("colour.volume", "colour.volume.datasets"),
+        ],
+    )
+    def test_package_all_does_not_mutate_submodule_all(
+        self,
+        package_name: str,
+        submodule_name: str,
+    ) -> None:
+        """Test that package ``__all__`` does not mutate submodule ``__all__``."""
+
+        package = import_module(package_name)
+        submodule = import_module(submodule_name)
+
+        assert package.__all__ is not submodule.__all__
+        assert set(submodule.__all__).issubset(package.__all__)
+        assert all(hasattr(submodule, name) for name in submodule.__all__)

--- a/colour/volume/__init__.py
+++ b/colour/volume/__init__.py
@@ -20,7 +20,7 @@ from .rgb import (
     RGB_colourspace_volume_MonteCarlo,
 )
 
-__all__ = datasets.__all__
+__all__ = list(datasets.__all__)
 __all__ += [
     "is_within_macadam_limits",
 ]


### PR DESCRIPTION
# Summary

This fixes package initializers that reused mutable `__all__` lists imported from submodules before appending package-level exports.

Modules should use `__all__` only to explicitly declare their own public API.

Without this change, we see this (somewhat unexpected) behavior:

```python
import colour.quality as quality
import colour.quality.datasets as quality_datasets

print(quality.__all__ is quality_datasets.__all__)
print("ColourRendering_Specification_CIE2017" in quality_datasets.__all__)
print(hasattr(quality_datasets, "ColourRendering_Specification_CIE2017"))
```

Output:
```
True
True
False
```

# Preflight

**Code Style and Quality**

- [x] Unit tests have been implemented and passed.
- [x] Pyright static checking has been run and passed.
- [x] Pre-commit hooks have been run and passed.
- [n/a] New transformations have been added to the _Automatic Colour Conversion Graph_.
- [n/a] New transformations have been exported to the relevant namespaces, e.g. `colour`, `colour.models`.

**Documentation**

- [n/a] New features are documented along with examples if relevant.
- [n/a] The documentation is [Sphinx](https://www.sphinx-doc.org/en/master/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant.
